### PR TITLE
removed message that doesn't make sense

### DIFF
--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -307,8 +307,6 @@ class Audio:
 
             else:
                 await self.bot.say("I'm already playing a playlist.")
-        else:
-            await self.bot.say("That link is now allowed.")
 
     async def is_alone_or_admin(self, message): #Direct control. fix everything
         author = message.author


### PR DESCRIPTION
When user does !queue link/search when not in a voice channel, the bot says

> I'm already playing music for other people. 

or 

> You need to be in a voice channel. 

then

> That link is now allowed.

The last message doesn't make sense and causes confusion
