### PR TITLE
added sound effects

### DIFF
--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -465,16 +465,25 @@ class Audio:
 
     @_list.command(name="sfx", pass_context=True)
     async def list_sfx(self, ctx):
-        msg = "Available local sound effects: \n\n```"
+        msgs = ["Available local sound effects: \n\n```\n"]
         files = self.get_local_sfx()
+        m = 0
+        maxm = 1980
         if files:
             for i, d in enumerate(files.keys()):
-                if i % 4 == 0 and i != 0:
-                    msg = msg + d + "\n"
-                else:
-                    msg = msg + d + "\t"
-            msg += "```"
-            await self.bot.send_message(ctx.message.author, msg)
+                if len(d) < maxm: #how did you get a filename this large?
+                    if len(msgs[m]) + len(d) > maxm:
+                        msgs[m] += "```"
+                        m += 1
+                        msgs.append("```\n")
+                    if i % 4 == 0 and i != 0:
+                        msgs[m] += d + "\n"
+                    else:
+                        msgs[m] += d + "\t"
+            msgs[m] += "```"
+            for msg in msgs:
+                await self.bot.send_message(ctx.message.author, msg)
+                await asyncio.sleep(1)
         else:
             await self.bot.say("There are no local sound effects.")
 

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -552,7 +552,7 @@ class Audio:
         else:
             await self.bot.say("Volume must be between 0 and 1. Example: 0.40")
 
-    @audioset.command(name="sfx", pass_context=True)
+    @audioset.command(name="sfx", pass_context=True, no_pm=True)
     async def _sfx(self, ctx):
         """Enables/Disables sound effects usage in the server"""
         #default on.

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -222,7 +222,7 @@ class Audio:
         Supported files are mp3, flac, wav"""
         #sound effects default enabled
         server = ctx.message.server
-        if self.settings["SERVER_SFX_ON"].get(server.id,None) is None:
+        if server.id not in self.settings["SERVER_SFX_ON"]:
             self.settings["SERVER_SFX_ON"][server.id] = True
         if not self.settings["SERVER_SFX_ON"][server.id]:
             await self.bot.say("Sound effects are not enabled on this server")
@@ -575,7 +575,7 @@ class Audio:
         """Enables/Disables sound effects usage in the server"""
         #default on.
         server = ctx.message.server
-        if self.settings["SERVER_SFX_ON"].get(server.id,None) is None:
+        if server.id not in self.settings["SERVER_SFX_ON"]:
             self.settings["SERVER_SFX_ON"][server.id] = True
         else:
             self.settings["SERVER_SFX_ON"][server.id] = not self.settings["SERVER_SFX_ON"][server.id]

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -258,7 +258,7 @@ class Audio:
             else:
                 await self.bot.say("There is no sound effect with that name.")
         else:
-            await self.bot.say("There are no valid sound effects in the data/audio/sfx folder.")
+            await self.bot.say("There are no valid sound effects in the `data/audio/sfx` folder.")
 
     def get_local_sfx(self):
         filenames = {}
@@ -325,7 +325,7 @@ class Audio:
         """Stops audio activity
         """
         msg = ctx.message
-        if self.music_player.is_playing():
+        if self.music_player.is_playing() or self.sfx_player.is_playing():
             if await self.is_alone_or_admin(msg):
                 await self.close_audio()
             else:

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -148,6 +148,8 @@ class Audio:
                 self.music_player.stop()
             else:
                 await self.vote_skip(msg)
+        elif self.sfx_player.is_playing():
+            self.sfx_player.stop()
 
     async def vote_skip(self, msg):
         v_channel = msg.server.me.voice_channel
@@ -211,7 +213,7 @@ class Audio:
             await self.bot.say("There are no valid playlists in the localtracks folder.\nIf you're the owner, see {}".format(help_link))
 
     @commands.command(pass_context=True, no_pm=True)
-    async def sfx(self, ctx, name : str):
+    async def sfx(self, ctx, *, name : str):
         """Plays a local sound file
 
         For bot's owner:
@@ -337,8 +339,8 @@ class Audio:
         self.queue = []
         self.playlist = []
         self.current = -1
-        if self.music_player.is_playing(): self.music_player.stop()
-        if self.sfx_player.is_playing(): self.sfx_player.stop()
+        if not self.music_player.is_done(): self.music_player.stop()
+        if not self.sfx_player.is_done(): self.sfx_player.stop()
         await asyncio.sleep(1)
         if self.bot.voice: await self.bot.voice.disconnect()
 
@@ -421,7 +423,9 @@ class Audio:
     @commands.command()
     async def resume(self):
         """Resumes paused song."""
-        if not self.music_player.is_playing():
+        if self.sfx_player.is_playing():
+            self.sfx_player.stop()
+        elif not self.music_player.is_playing():
             self.music_player.paused = False
             self.music_player.resume()
             await self.bot.say("Resuming song.")

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -522,10 +522,14 @@ class Audio:
     async def audioset(self, ctx):
         """Changes audio module settings"""
         if ctx.invoked_subcommand is None:
+            server = ctx.message.server
             await send_cmd_help(ctx)
             msg = "```"
             for k, v in self.settings.items():
-                msg += str(k) + ": " + str(v) + "\n"
+                if type(v) is dict and server.id in v:
+                    msg += str(k) + ": " + str(v[server.id]) + "\n"
+                else:
+                    msg += str(k) + ": " + str(v) + "\n"
             msg += "```"
             await self.bot.say(msg)
 

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -87,7 +87,8 @@ class Audio:
                     self.playlist = []
                     self.queue.append(link)
                     self.music_player.paused = False
-                    if self.music_player.is_playing(): self.music_player.stop()
+                    if not self.sfx_player.is_done(): self.sfx_player.stop()
+                    if not self.music_player.is_done(): self.music_player.stop()
                     await self.bot.say("Playing requested link...")
                 else:
                     self.playlist = []
@@ -647,12 +648,12 @@ class Audio:
             await asyncio.sleep(1)
         if self.downloader["ID"]:
             try:
-                if self.music_player.is_playing(): self.music_player.stop()
                 # sfx_player should only ever get stuck as much as music_player does
                 # when it happens to music_player, the reponsibility is put on the user to !stop
                 # so we'll do the same with sfx_player. a timeout could be placed here though.
                 while self.sfx_player.is_playing():
                     await asyncio.sleep(.5)
+                if not self.music_player.is_done(): self.music_player.stop()
                 self.music_player = self.bot.voice.create_ffmpeg_player(path + self.downloader["ID"], options='''-filter:a "volume={}"'''.format(self.settings["VOLUME"]))
                 self.music_player.paused = False
                 self.music_player.start()
@@ -929,6 +930,9 @@ class EmptyPlayer(): #dummy player
 
     def is_playing(self):
         return False
+
+    def is_done(self):
+        return True
 
 class MaximumLength(Exception):
     def __init__(self, m):


### PR DESCRIPTION
`!sfx` - plays the specified sound file from the `data/audio/sfx` directory
`!audioset sfx` - toggles sfx for server
`!list sfx` - lists sound effects

Gives responsibility of `!stop`-ping a stuck player to the user, like the other audio commands do
- [x] add >2k character support to `!list sfx`
- [x] list only the sfx toggle for the current server
- [ ] add other extensions to the supported list?
- [ ] add some default sfx?
- [x] don't require multiword sfx to be put in "qoutes"
- [ ] ~~sfx playing while song is playing~~ (probably will never support)
- [ ] disable/enable sfx usage per person :P 
- [ ] case-insensitive (requested by Kowlin)
