### PR TITLE
more specific owner check

### DIFF
--- a/cogs/utils/checks.py
+++ b/cogs/utils/checks.py
@@ -12,7 +12,7 @@ from __main__ import settings
 #
 
 def is_owner_check(ctx):
-    return ctx.message.author.id == settings.owner
+    return ctx.message.author.id == settings.owner and settings.owner != "id_here"
 
 def is_owner():
     return commands.check(is_owner_check)


### PR DESCRIPTION
in case someone can hijack a message and replace their author.id with "id_here", then use !debug to do whatever they want
although..
if they know the owner, they could just replace it with the owner's id ¯\_(ツ)_/¯
