### PR TITLE
This will give Red's instance an title and saves it's PID in red.pid

### DIFF
--- a/startRedLoop.bat
+++ b/startRedLoop.bat
@@ -2,6 +2,12 @@
 chcp 65001
 :Start
 
+set get_pid_title=Red%DATE:/=-%@%TIME::=-%
+TITLE %get_pid_title%
+for /F "tokens=1-2" %%A in ('tasklist.exe /nh /fi "windowtitle eq %get_pid_title%"') do set red_pid=%%B
+TITLE Red - Discordbot @ %red_pid%
+echo %red_pid%> red.pid
+
 python red.py
 timeout 3
 


### PR DESCRIPTION
It enables the possibility to kill Red started from the startRedLoop.bat on Windows

Example code:

``` python
@bot.command(pass_context=True)
@checks.is_owner()
async def shutdown(ctx, hold: str=None):
    """Shuts down Red"""
    if hold == "-h":
        try:
            f = open("red.pid","r")
            bat_pid = f.readline()
            await bot.say("Kill bot? y/n")
            print(str(os.getpid()))
            print(bat_pid)
            response = await bot.wait_for_message(author=ctx.message.author)
            response = response.content.lower().strip()
            if response == "y":
                try:
                    if sys.platform == "linux" or sys.platform == "linux2":
                        # linux *not able to test
                        """
                            start on runlevel [2345]
                            stop on runlevel [016]

                            respawn
                            chdir /home/username/Red-DiscordBot
                            setuid username
                            setgid username
                            exec python3.5 red.py --no-prompt

                            post-start script
                                PID=`status app_name | egrep -oi '([0-9]+)$' | head -n1`
                                echo $PID > /home/username/Red-DiscordBot/red.pid
                            end script

                            post-stop script
                                rm -f /home/username/Red-DiscordBot/red.pid
                            end script 
                        """
                        await bot.logout()
                        #os.popen('kill -9  #'+str(bat_pid))
                    elif sys.platform == "darwin":
                        # OS X
                        await bot.logout()
                        #os.popen('kill -9 '+str(bat_pid))
                    elif sys.platform == "win32":
                        # Windows... 
                        await bot.logout()
                        os.popen('TASKKILL /PID '+str(bat_pid)+'/F')
                except Exception as e:
                   print("Kill PID error")
                   print (e)
                   await bot.logout()
        except Exception as e:
           await bot.say("read PID error")            
           print (e)
           return
    else:
        await bot.logout()
```
