### PR TITLE
[OKAY MAYBE MERGE] Multivoice (rewrite)

### DIFF
--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -288,6 +288,12 @@ class Audio:
         volume = self.get_server_settings(server)["VOLUME"] / 100
         options = '-filter "volume=volume={}"'.format(volume)
 
+        try:
+            voice_client.audio_player.process.kill()
+            log.debug("killed old player")
+        except AttributeError:
+            pass
+
         log.debug("making player on sid {}".format(server.id))
 
         voice_client.audio_player = voice_client.create_ffmpeg_player(
@@ -384,6 +390,12 @@ class Audio:
         except asyncio.futures.TimeoutError as e:
             log.exception(e)
             raise ConnectTimeout("We timed out connecting to a voice channel")
+
+    def _kill_player(self, server):
+        try:
+            self.voice_client(server).audio_player.process.kill()
+        except AttributeError:
+            pass
 
     def _load_playlist(self, server, name):
         try:
@@ -654,6 +666,7 @@ class Audio:
 
         if hasattr(voice_client, 'audio_player'):
             voice_client.audio_player.stop()
+            self._kill_player(server)
             del voice_client.audio_player
 
     def _valid_playlist_name(self, name):

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -260,7 +260,7 @@ class Audio:
         self.queue[server.id]["QUEUE"] = deque()
         self.queue[server.id]["TEMP_QUEUE"] = deque()
 
-    def _create_ffmpeg_player(self, server, filename):
+    async def _create_ffmpeg_player(self, server, filename):
         """This function will guarantee we have a valid voice client,
             even if one doesn't exist previously."""
         voice_channel_id = self.queue[server.id]["VOICE_CHANNEL_ID"]
@@ -549,7 +549,7 @@ class Audio:
         else:
             log.debug("cache hit on song id {}".format(song.id))
 
-        voice_client = self._create_ffmpeg_player(server, song.id)
+        voice_client = await self._create_ffmpeg_player(server, song.id)
         # That ^ creates the audio_player property
 
         voice_client.audio_player.start()

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -571,6 +571,19 @@ class Audio:
         self._set_queue_repeat(server, True)
         self._set_queue(server, songlist)
 
+    def _player_count(self):
+        count = 0
+        queue = copy.deepcopy(self.queue)
+        for sid in queue:
+            server = self.bot.get_server(sid)
+            try:
+                vc = self.voice_client(server)
+                if vc.audio_player.is_playing():
+                    count += 1
+            except:
+                pass
+        return count
+
     def _playlist_exists(self, server, name):
         try:
             server = server.id
@@ -772,15 +785,8 @@ class Audio:
     @audiostat.command(name="servers")
     async def audiostat_servers(self):
         """Number of servers currently playing."""
-        count = 0
-        queue = copy.deepcopy(self.queue)
-        for server in queue:
-            vc = self.voice_client(server)
-            try:
-                if vc.audio_player.is_playing():
-                    count += 1
-            except:
-                pass
+
+        count = self._player_count()
 
         await self.bot.say("Currently playing music in {} servers.".format(
             count))

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -917,7 +917,7 @@ class Audio:
                 log.debug("calling _play on the normal queue")
                 song = await self._play(sid, url)
                 if repeat:
-                    queue.appendleft(url)
+                    queue.append(url)
             else:
                 song = None
             self.queue[server.id]["NOW_PLAYING"] = song
@@ -940,9 +940,10 @@ class Audio:
     async def queue_scheduler(self):
         while self == self.bot.get_cog('Audio'):
             tasks = []
-            for sid in self.queue:
-                if len(self.queue[sid]["QUEUE"]) == 0 and \
-                        len(self.queue[sid]["TEMP_QUEUE"]) == 0:
+            queue = copy.deepcopy(self.queue)
+            for sid in queue:
+                if len(queue[sid]["QUEUE"]) == 0 and \
+                        len(queue[sid]["TEMP_QUEUE"]) == 0:
                     continue
                 # log.debug("scheduler found a non-empty queue"
                 #           " for sid: {}".format(sid))
@@ -950,6 +951,7 @@ class Audio:
                     self.bot.loop.create_task(self.queue_manager(sid)))
                 completed = [t.done() for t in tasks]
                 while not all(completed):
+                    completed = [t.done() for t in tasks]
                     await asyncio.sleep(0.5)
             await asyncio.sleep(1)
 

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -949,10 +949,10 @@ class Audio:
                 #           " for sid: {}".format(sid))
                 tasks.append(
                     self.bot.loop.create_task(self.queue_manager(sid)))
+            completed = [t.done() for t in tasks]
+            while not all(completed):
                 completed = [t.done() for t in tasks]
-                while not all(completed):
-                    completed = [t.done() for t in tasks]
-                    await asyncio.sleep(0.5)
+                await asyncio.sleep(0.5)
             await asyncio.sleep(1)
 
     def save_settings(self):

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -1025,7 +1025,7 @@ class Audio:
     async def _shuffle(self, ctx):
         """Shuffles the current queue"""
         server = ctx.message.server
-        if server not in self.queue:
+        if server.id not in self.queue:
             await self.bot.say("I have nothing in queue to shuffle.")
             return
 
@@ -1218,10 +1218,12 @@ class Audio:
         if before.mute != after.mute:
             vc = self.voice_client(server)
             if after.mute and vc.audio_player.is_playing():
+                log.debug("Just got muted, pausing")
                 vc.audio_player.pause()
             elif not after.mute and \
                     (not vc.audio_player.is_playing() and
                      not vc.audio_player.is_done()):
+                log.debug("just got unmuted, resuming")
                 vc.audio_player.resume()
 
 

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -13,6 +13,9 @@ import copy
 import asyncio
 import math
 
+__author__ = "tekulvw"
+__version__ = "0.0.1"
+
 log = logging.getLogger("red.audio")
 log.setLevel(logging.DEBUG)
 
@@ -729,7 +732,7 @@ class Audio:
             await self.bot.say("Player toggled. You're now using ffmpeg.")
         self.save_settings()
 
-    @audioset.command(pass_context=True, name="volume")
+    @audioset.command(pass_context=True, name="volume", no_pm=True)
     @checks.mod_or_permissions(manage_messages=True)
     async def audioset_volume(self, ctx, percent: int):
         """Sets the volume (0 - 100)"""
@@ -743,7 +746,7 @@ class Audio:
         else:
             await self.bot.say("Volume must be between 0 and 100.")
 
-    @audioset.command(pass_context=True, name="vote")
+    @audioset.command(pass_context=True, name="vote", no_pm=True)
     @checks.mod_or_permissions(manage_messages=True)
     async def audioset_vote(self, ctx, percent: int):
         """Percentage needed for the masses to skip songs."""
@@ -760,6 +763,29 @@ class Audio:
         self.save_settings()
 
     @commands.group(pass_context=True)
+    async def audiostat(self, ctx):
+        """General stats on audio stuff."""
+        if ctx.invoked_subcommand is None:
+            await send_cmd_help(ctx)
+            return
+
+    @audiostat.command(name="servers")
+    async def audiostat_servers(self):
+        """Number of servers currently playing."""
+        count = 0
+        queue = copy.deepcopy(self.queue)
+        for server in queue:
+            vc = self.voice_client(server)
+            try:
+                if vc.audio_player.is_playing():
+                    count += 1
+            except:
+                pass
+
+        await self.bot.say("Currently playing music in {} servers.".format(
+            count))
+
+    @commands.group(pass_context=True)
     async def cache(self, ctx):
         """Cache management tools."""
         if ctx.invoked_subcommand is None:
@@ -772,6 +798,12 @@ class Audio:
         """Dumps the cache."""
         dumped = self._dump_cache()
         await self.bot.say("Dumped {:.3f} MB of audio files.".format(dumped))
+
+    @cache.command(name="minimum")
+    async def cache_minimum(self):
+        """Current minimum cache size, based on server count."""
+        await self.bot.say("The cache will be at least {:.3f} MB".format(
+            self._cache_min()))
 
     @cache.command(name="size")
     async def cache_size(self):

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -1247,7 +1247,7 @@ def check_folders():
 
 
 def check_files():
-    default = {"VOLUME": 0.5, "MAX_LENGTH": 3700, "QUEUE_MODE": True,
+    default = {"VOLUME": 50, "MAX_LENGTH": 3700, "QUEUE_MODE": True,
                "MAX_CACHE": 0, "SOUNDCLOUD_CLIENT_ID": None,
                "TITLE_STATUS": True, "AVCONV": False, "VOTE_THRESHOLD": 50,
                "SERVERS": {}}

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -466,8 +466,14 @@ class Audio:
             await asyncio.sleep(0.5)
 
         for entry in d.song.entries:
-            song_url = "https://www.youtube.com/watch?v={}".format(entry['id'])
-            playlist.append(song_url)
+            try:
+                song_url = "https://www.youtube.com/watch?v={}".format(
+                    entry['id'])
+                playlist.append(song_url)
+            except AttributeError:
+                pass
+            except TypeError:
+                pass
 
         log.debug("song list:\n\t{}".format(playlist))
 

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -1108,7 +1108,7 @@ class Audio:
         except:
             sid = server
 
-        if sid in self.settings["SERVERS"]:
+        if sid not in self.settings["SERVERS"]:
             self.settings["SERVERS"][sid] = {}
         ret = self.settings["SERVERS"][sid]
 

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -1249,7 +1249,7 @@ def check_folders():
 def check_files():
     default = {"VOLUME": 0.5, "MAX_LENGTH": 3700, "QUEUE_MODE": True,
                "MAX_CACHE": 0, "SOUNDCLOUD_CLIENT_ID": None,
-               "TITLE_STATUS": True, "AVCONV": False,
+               "TITLE_STATUS": True, "AVCONV": False, "VOTE_THRESHOLD": 50,
                "SERVERS": {}}
     settings_path = "data/audio/settings.json"
 

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -2,17 +2,11 @@ import discord
 from discord.ext import commands
 import threading
 import os
-from random import choice as rndchoice
 from random import shuffle
 from cogs.utils.dataIO import fileIO
 from cogs.utils import checks
 from __main__ import send_cmd_help
-from __main__ import settings as bot_settings
-import glob
 import re
-import aiohttp
-import json
-import time
 import logging
 import collections
 import copy
@@ -291,7 +285,7 @@ class Audio:
 
         song_filename = os.path.join(self.cache_path, filename)
         use_avconv = self.settings["AVCONV"]
-        volume = self.settings["VOLUME"]
+        volume = self.get_server_settings(server)["VOLUME"] / 100
         options = '-filter "volume=volume={}"'.format(volume)
 
         log.debug("making player on sid {}".format(server.id))
@@ -304,6 +298,16 @@ class Audio:
     # TODO: _current_playlist
 
     # TODO: _current_song
+
+    def _delete_playlist(self, server, name):
+        if not name.endswith('.txt'):
+            name = name + ".txt"
+        try:
+            os.remove(os.path.join('data/audio/playlists', server.id, name))
+        except OSError:
+            pass
+        except WindowsError:
+            pass
 
     # TODO: _disable_controls()
 

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -5,8 +5,8 @@ import threading
 import os
 from random import choice as rndchoice
 from random import shuffle
-from .utils.dataIO import fileIO
-from .utils import checks
+from cogs.utils.dataIO import fileIO
+from cogs.utils import checks
 from __main__ import send_cmd_help
 from __main__ import settings as bot_settings
 import glob
@@ -14,6 +14,9 @@ import re
 import aiohttp
 import json
 import time
+import logging
+
+log = logging.getLogger("red.audio")
 
 try:
     import youtube_dl
@@ -23,9 +26,9 @@ except:
 try:
     if not discord.opus.is_loaded():
         discord.opus.load_opus('libopus-0.dll')
-except OSError: # Incorrect bitness
+except OSError:  # Incorrect bitness
     opus = False
-except: # Missing opus
+except:  # Missing opus
     opus = None
 else:
     opus = True
@@ -41,901 +44,27 @@ youtube_dl_options = {
     'quiet': True,
     'no_warnings': True,
     'outtmpl': "data/audio/cache/%(id)s",
-    'default_search' : 'auto'}
+    'default_search': 'auto'
+}
 
-class Audio:
-    """Music streaming."""
 
-    def __init__(self, bot):
-        self.bot = bot
-        self.music_player = EmptyPlayer()
-        self.sfx_player = EmptyPlayer()
-        self.settings = fileIO("data/audio/settings.json", "load")
-        self.queue_mode = False
-        self.queue = []
-        self.playlist = []
-        self.current = -1 #current track index in self.playlist
-        self.downloader = {"DONE" : False, "TITLE" : False, "ID" : False, "URL" : False, "DURATION" : False, "DOWNLOADING" : False}
-        self.skip_votes = []
-        self.cleanup_timer = int(time.perf_counter())
-        self.past_titles = [] # This is to prevent the audio module from setting the status to None if a status other than a track's title gets set
+class MaximumLength(Exception):
+    def __init__(self, m):
+        self.message = m
 
-        self.sing =  ["https://www.youtube.com/watch?v=zGTkAVsrfg8", "https://www.youtube.com/watch?v=cGMWL8cOeAU",
-                     "https://www.youtube.com/watch?v=vFrjMq4aL-g", "https://www.youtube.com/watch?v=WROI5WYBU_A",
-                     "https://www.youtube.com/watch?v=41tIUr_ex3g", "https://www.youtube.com/watch?v=f9O2Rjn1azc"]
+    def __str__(self):
+        return self.message
 
-    @commands.command(pass_context=True, no_pm=True)
-    async def play(self, ctx, *link : str):
-        """Plays videos (links/search terms)
-        """
-        if self.downloader["DOWNLOADING"]:
-            await self.bot.say("I'm already downloading a track.")
-            return
-        msg = ctx.message
-        if await self.check_voice(msg.author, msg):
-            if link != ():
-                link = " ".join(link)
-                if "http" not in link and "www." not in link:
-                    link = "[SEARCH:]" + link
-                else:
-                    if not self.is_playlist_valid([link]):
-                        await self.bot.say("Invalid link.")
-                        return
-                if await self.is_alone_or_admin(msg):
-                    self.queue = []
-                    self.current = -1
-                    self.playlist = []
-                    self.queue.append(link)
-                    self.music_player.paused = False
-                    if not self.sfx_player.is_done(): self.sfx_player.stop()
-                    if not self.music_player.is_done(): self.music_player.stop()
-                    await self.bot.say("Playing requested link...")
-                else:
-                    self.playlist = []
-                    self.current = -1
-                    if not self.queue: await self.bot.say("The link has been put into queue.")
-                    self.queue.append(link)
-            else:
-                await self.bot.say("You need to add a link or search terms.")
 
-    @commands.command(aliases=["title"])
-    async def song(self):
-        """Shows song title
-        """
-        if self.downloader["TITLE"] and "localtracks" not in self.downloader["TITLE"]:
-            url = ""
-            if self.downloader["URL"]: url = 'Link : "' + self.downloader["URL"] + '"'
-            await self.bot.say(self.downloader["TITLE"] + "\n" + url)
-        else:
-            await self.bot.say("No title available.")
+class NotConnected(Exception):
+    pass
 
-    @commands.command(name="playlist", pass_context=True, no_pm=True)
-    async def _playlist(self, ctx, name : str): #some checks here
-        """Plays saved playlist
-        """
-        await self.start_playlist(ctx, name, random=False)
 
-    @commands.command(pass_context=True, no_pm=True)
-    async def mix(self, ctx, name : str): #some checks here
-        """Plays saved playlist (shuffled)
-        """
-        await self.start_playlist(ctx, name, random=True)
+class AuthorNotConnected(NotConnected):
+    pass
 
-    async def start_playlist(self, ctx, name, random=None):
-        if self.downloader["DOWNLOADING"]:
-            await self.bot.say("I'm already downloading a track.")
-            return
-        msg = ctx.message
-        name += ".txt"
-        if await self.check_voice(msg.author, msg):
-            if os.path.isfile("data/audio/playlists/" + name):
-                self.queue = []
-                self.current = -1
-                self.playlist = fileIO("data/audio/playlists/" + name, "load")["playlist"]
-                if random: shuffle(self.playlist)
-                self.music_player.paused = False
-                if self.music_player.is_playing(): self.music_player.stop()
-            else:
-                await self.bot.say("There's no playlist with that name.")
 
-    @commands.command(pass_context=True, aliases=["next"], no_pm=True)
-    async def skip(self, ctx):
-        """Skips song
-        """
-        msg = ctx.message
-        if self.music_player.is_playing():
-            if await self.is_alone_or_admin(msg):
-                self.music_player.paused = False
-                self.music_player.stop()
-            else:
-                await self.vote_skip(msg)
-        elif self.sfx_player.is_playing():
-            self.sfx_player.stop()
-
-    async def vote_skip(self, msg):
-        v_channel = msg.server.me.voice_channel
-        if msg.author.voice_channel.id == v_channel.id:
-            if msg.author.id in self.skip_votes:
-                await self.bot.say("You already voted.")
-                return
-            self.skip_votes.append(msg.author.id)
-            if msg.server.me.id not in self.skip_votes: self.skip_votes.append(msg.server.me.id)
-            current_users = []
-            for m in v_channel.voice_members:
-                current_users.append(m.id)
-
-            clean_skip_votes = [] #Removes votes of people no longer in the channel
-            for m_id in self.skip_votes:
-                if m_id in current_users:
-                    clean_skip_votes.append(m_id)
-            self.skip_votes = clean_skip_votes
-
-            votes_needed = (len(current_users)-1) // 2 + 1
-
-            if len(self.skip_votes)-1 >= votes_needed:
-                self.music_player.paused = False
-                if self.music_player.is_playing(): self.music_player.stop()
-                self.skip_votes = []
-                return
-            await self.bot.say("You voted to skip. Votes: [{0}/{1}]".format(str(len(self.skip_votes)-1), str(votes_needed)))
-
-
-    @commands.command(pass_context=True, no_pm=True)
-    async def local(self, ctx, name : str):
-        """Plays a local playlist
-
-        For bot's owner:
-        http://twentysix26.github.io/Red-Docs/red_audio/"""
-        help_link = "http://twentysix26.github.io/Red-Docs/red_audio/"
-        if self.downloader["DOWNLOADING"]:
-            await self.bot.say("I'm already downloading a track.")
-            return
-        msg = ctx.message
-        localplaylists = self.get_local_playlists()
-        if localplaylists and ("data/audio/localtracks/" not in name and "\\" not in name):
-            if name in localplaylists:
-                files = []
-                if glob.glob("data/audio/localtracks/" + name + "/*.mp3"):
-                    files.extend(glob.glob("data/audio/localtracks/" + name + "/*.mp3"))
-                if glob.glob("data/audio/localtracks/" + name + "/*.flac"):
-                    files.extend(glob.glob("data/audio/localtracks/" + name + "/*.flac"))
-                if await self.is_alone_or_admin(msg):
-                    if await self.check_voice(msg.author, ctx.message):
-                        self.queue = []
-                        self.current = -1
-                        self.playlist = files
-                        self.music_player.paused = False
-                        if self.music_player.is_playing(): self.music_player.stop()
-                else:
-                    await self.bot.say("I'm in queue mode. Controls are disabled if you're in a room with multiple people.")
-            else:
-                await self.bot.say("There is no local playlist with that name.")
-        else:
-            await self.bot.say("There are no valid playlists in the localtracks folder.\nIf you're the owner, see {}".format(help_link))
-
-    @commands.command(pass_context=True, no_pm=True)
-    async def sfx(self, ctx, *, name : str):
-        """Plays a local sound file
-
-        For bot's owner:
-        audio files must be placed in the data/audio/sfx folder.
-        Supported files are mp3, flac, wav"""
-        #sound effects default enabled
-        server = ctx.message.server
-        if server.id not in self.settings["SERVER_SFX_ON"]:
-            self.settings["SERVER_SFX_ON"][server.id] = True
-        if not self.settings["SERVER_SFX_ON"][server.id]:
-            await self.bot.say("Sound effects are not enabled on this server")
-            return
-
-        msg = ctx.message
-        localsfx = self.get_local_sfx()
-        if localsfx and ("data/audio/sfx/" not in name and "\\" not in name):
-            if name in localsfx.keys():
-                file = "data/audio/sfx/{}{}".format(name,localsfx[name])
-
-                if await self.check_voice(msg.author, ctx.message):
-                    try:
-                        if self.music_player.is_playing():
-                            self.music_player.paused = True
-                            self.music_player.pause()
-
-                        if self.sfx_player.is_playing():
-                            self.sfx_player.stop()
-
-                        self.sfx_player = self.bot.voice.create_ffmpeg_player(file, use_avconv=self.settings["AVCONV"],options='''-filter "volume=volume={}"'''.format(self.settings["VOLUME"]))
-                        self.sfx_player.start()
-                        while self.sfx_player.is_playing():
-                            await asyncio.sleep(.5)
-
-                        if not self.music_player.is_playing():
-                            self.music_player.paused = False
-                            self.music_player.resume()
-                    except AttributeError:
-                        #music_player not used yet. Still an EmptyPlayer.
-                        #better to ask for forgiveness?
-                        pass
-                    except Exception as e:
-                        print(e)
-
-            else:
-                await self.bot.say("There is no sound effect with that name.")
-        else:
-            await self.bot.say("There are no valid sound effects in the `data/audio/sfx` folder.")
-
-    def get_local_sfx(self):
-        filenames = {}
-        files = os.listdir("data/audio/sfx/")
-        #only reason why these are the only supported ext is cause I haven't tried any others
-        supported = [".mp3",".flac",".wav"]
-        for f in files:
-            item = os.path.splitext(f)
-            if item[1] in supported:
-                filenames[item[0]] = item[1]
-        if filenames != {}:
-            return filenames
-        else:
-            return False
-
-    @commands.command(pass_context=True, no_pm=True)
-    async def loop(self, ctx):
-        """Loops single song
-        """
-        msg = ctx.message
-        if self.music_player.is_playing():
-            if await self.is_alone_or_admin(msg):
-                self.current = -1
-                if self.downloader["URL"]:
-                    self.playlist = [self.downloader["URL"]]
-                else: # local
-                    self.playlist = [self.downloader["ID"]]
-                await self.bot.say("I will play this song on repeat.")
-            else:
-                await self.bot.say("I'm in queue mode. Controls are disabled if you're in a room with multiple people.")
-
-    @commands.command(pass_context=True, no_pm=True)
-    async def shuffle(self, ctx):
-        """Shuffle playlist
-        """
-        msg = ctx.message
-        if self.music_player.is_playing():
-            if await self.is_alone_or_admin(msg):
-                if self.playlist:
-                    shuffle(self.playlist)
-                    await self.bot.say("The order of this playlist has been mixed")
-            else:
-                await self.bot.say("I'm in queue mode. Controls are disabled if you're in a room with multiple people.")
-
-    @commands.command(pass_context=True, aliases=["previous"], no_pm=True) #TODO, PLAYLISTS
-    async def prev(self, ctx):
-        """Previous song
-        """
-        msg = ctx.message
-        if self.music_player.is_playing() and self.playlist:
-            if await self.is_alone_or_admin(msg):
-                self.current -= 2
-                if self.current == -1:
-                    self.current = len(self.playlist) -3
-                elif self.current == -2:
-                    self.current = len(self.playlist) -2
-                self.music_player.paused = False
-                self.music_player.stop()
-
-
-
-    @commands.command(pass_context=True, no_pm=True)
-    async def stop(self, ctx):
-        """Stops audio activity
-        """
-        msg = ctx.message
-        if self.music_player.is_playing() or self.sfx_player.is_playing():
-            if await self.is_alone_or_admin(msg):
-                await self.close_audio()
-            else:
-                await self.bot.say("You can't stop music when there are other people in the channel! Vote to skip instead.")
-        else:
-            await self.close_audio()
-
-    async def close_audio(self):
-        self.queue = []
-        self.playlist = []
-        self.current = -1
-        if not self.music_player.is_done(): self.music_player.stop()
-        if not self.sfx_player.is_done(): self.sfx_player.stop()
-        await asyncio.sleep(1)
-        if self.bot.voice: await self.bot.voice.disconnect()
-
-    @commands.command(name="queue", pass_context=True, no_pm=True) #check that author is in the same channel as the bot
-    async def _queue(self, ctx, *link : str):
-        """Add links or search terms to queue
-
-        Shows queue list if no links are provided.
-        """
-        if link == ():
-            queue_list = await self.queue_titles()
-            await self.bot.say("Videos in queue: \n" + queue_list + "\n\nType queue <link> to add a link or search terms to the queue.")
-        elif await self.check_voice(ctx.message.author, ctx.message):
-            if not self.playlist:
-                link = " ".join(link)
-                if "http" not in link or "." not in link:
-                    link = "[SEARCH:]" + link
-                else:
-                    if not self.is_playlist_valid([link]):
-                        await self.bot.say("Invalid link.")
-                        return
-                self.queue.append(link)
-                msg = ctx.message
-                result = await self.get_song_metadata(link)
-                try: # In case of invalid SOUNDCLOUD ID
-                    if result["title"] != []:
-                        await self.bot.say("{} has been put into the queue by {}.".format(result["title"], msg.author))
-                    else:
-                        await self.bot.say("The song has been put into the queue by {}, however it may error.".format(msg.author))
-                except:
-                    await self.bot.say("A song has been put into the queue by {}.".format(msg.author))
-
-            else:
-                await self.bot.say("I'm already playing a playlist.")
-
-    async def is_alone_or_admin(self, message): #Direct control. fix everything
-        author = message.author
-        server = message.server
-        if not self.settings["QUEUE_MODE"]:
-            return True
-        elif author.id == bot_settings.owner:
-            return True
-        elif discord.utils.get(author.roles, name=bot_settings.get_server_admin(server)) is not None:
-            return True
-        elif discord.utils.get(author.roles, name=bot_settings.get_server_mod(server)) is not None:
-            return True
-        elif len(author.voice_channel.voice_members) in (1, 2):
-            return True
-        else:
-            return False
-
-    @commands.command(name="sing", pass_context=True, no_pm=True)
-    async def _sing(self, ctx):
-        """Makes Red sing"""
-        if self.downloader["DOWNLOADING"]:
-            await self.bot.say("I'm already downloading a track.")
-            return
-        msg = ctx.message
-        if await self.check_voice(msg.author, msg):
-            if not self.music_player.is_playing():
-                    self.queue = []
-                    await self.play_video(rndchoice(self.sing))
-            else:
-                if await self.is_alone_or_admin(msg):
-                    self.queue = []
-                    await self.play_video(rndchoice(self.sing))
-                else:
-                    await self.bot.say("I'm already playing music for someone else at the moment.")
-
-    @commands.command()
-    async def pause(self):
-        """Pauses the current song"""
-        if self.music_player.is_playing():
-            self.music_player.paused = True
-            self.music_player.pause()
-            await self.bot.say("Song paused.")
-            
-    @commands.command()
-    async def resume(self):
-        """Resumes paused song."""
-        if self.sfx_player.is_playing():
-            self.sfx_player.stop()
-        elif not self.music_player.is_playing():
-            self.music_player.paused = False
-            self.music_player.resume()
-            await self.bot.say("Resuming song.")
-
-    @commands.group(name="list", pass_context=True)
-    async def _list(self, ctx):
-        """Lists playlists"""
-        if ctx.invoked_subcommand is None:
-            await send_cmd_help(ctx)
-
-    @_list.command(name="playlist", pass_context=True)
-    async def list_playlist(self, ctx):
-        msg = "Available playlists: \n\n```"
-        files = os.listdir("data/audio/playlists/")
-        if files:
-            for i, f in enumerate(files):
-                if f.endswith(".txt"):
-                    if i % 4 == 0 and i != 0:
-                        msg = msg + f.replace(".txt", "") + "\n"
-                    else:
-                        msg = msg + f.replace(".txt", "") + "\t"
-            msg += "```"
-            await self.bot.send_message(ctx.message.author, msg)
-        else:
-            await self.bot.say("There are no playlists.")
-
-    @_list.command(name="local", pass_context=True)
-    async def list_local(self, ctx):
-        msg = "Available local playlists: \n\n```"
-        dirs = self.get_local_playlists()
-        if dirs:
-            for i, d in enumerate(dirs):
-                if i % 4 == 0 and i != 0:
-                    msg = msg + d + "\n"
-                else:
-                    msg = msg + d + "\t"
-            msg += "```"
-            await self.bot.send_message(ctx.message.author, msg)
-        else:
-            await self.bot.say("There are no local playlists.")
-
-    @_list.command(name="sfx", pass_context=True)
-    async def list_sfx(self, ctx):
-        msgs = ["Available local sound effects: \n\n```\n"]
-        files = self.get_local_sfx()
-        m = 0
-        maxm = 1980
-        if files:
-            for i, d in enumerate(files.keys()):
-                if len(d) < maxm: #how did you get a filename this large?
-                    if len(msgs[m]) + len(d) > maxm:
-                        msgs[m] += "```"
-                        m += 1
-                        msgs.append("```\n")
-                    if i % 4 == 0 and i != 0:
-                        msgs[m] += d + "\n"
-                    else:
-                        msgs[m] += d + "\t"
-            msgs[m] += "```"
-            for msg in msgs:
-                await self.bot.send_message(ctx.message.author, msg)
-                await asyncio.sleep(1)
-        else:
-            await self.bot.say("There are no local sound effects.")
-
-    @_list.command(name="queue", pass_context=True)
-    async def list_queue(self, ctx):
-        queue_list = await self.queue_titles()
-        await self.bot.say("Videos in queue: \n" + queue_list)
-
-    async def queue_titles(self):
-        song_names = []
-        song_names.append(self.downloader["TITLE"])
-        if len(self.queue) > 0:
-            for song_url in self.queue:
-                try:
-                    result = await self.get_song_metadata(song_url)
-                    if result["title"] != []:
-                        song_names.append(result["title"])
-                    else:
-                        song_names.append("Could not get song title")
-                except:
-                    song_names.append("Could not get song title")
-            song_list = "\n".join(["{}: {}".format(str(i+1), s) for i, s in enumerate(song_names)])
-        elif self.music_player.is_playing():
-            song_list = "1: {}".format(song_names[0])
-        else:
-            song_list = "None"
-        return song_list
-
-    @commands.group(pass_context=True)
-    @checks.mod_or_permissions(manage_roles=True)
-    async def audioset(self, ctx):
-        """Changes audio module settings"""
-        if ctx.invoked_subcommand is None:
-            server = ctx.message.server
-            await send_cmd_help(ctx)
-            msg = "```"
-            for k, v in self.settings.items():
-                if type(v) is dict and server.id in v:
-                    msg += str(k) + ": " + str(v[server.id]) + "\n"
-                else:
-                    msg += str(k) + ": " + str(v) + "\n"
-            msg += "```"
-            await self.bot.say(msg)
-
-    @audioset.command(name="queue")
-    async def queueset(self):
-        """Enables/disables forced queue"""
-        self.settings["QUEUE_MODE"] = not self.settings["QUEUE_MODE"]
-        if self.settings["QUEUE_MODE"]:
-            await self.bot.say("Queue mode is now on.")
-        else:
-            await self.bot.say("Queue mode is now off.")
-        fileIO("data/audio/settings.json", "save", self.settings)
-
-    @audioset.command(name="status")
-    async def songstatus(self):
-        """Enables/disables songs' titles as status"""
-        self.settings["TITLE_STATUS"] = not self.settings["TITLE_STATUS"]
-        if self.settings["TITLE_STATUS"]:
-            await self.bot.say("Songs' titles will show up as status.")
-        else:
-            await self.bot.say("Songs' titles will no longer show up as status.")
-        fileIO("data/audio/settings.json", "save", self.settings)
-
-    @audioset.command()
-    async def maxlength(self, length : int):
-        """Maximum track length (seconds) for requested links"""
-        self.settings["MAX_LENGTH"] = length
-        await self.bot.say("Maximum length is now " + str(length) + " seconds.")
-        fileIO("data/audio/settings.json", "save", self.settings)
-
-    @audioset.command()
-    async def volume(self, level : float):
-        """Sets the volume (0-1)"""
-        if level >= 0 and level <= 1:
-            self.settings["VOLUME"] = level
-            await self.bot.say("Volume is now set at " + str(level) + ". It will take effect after the current track.")
-            fileIO("data/audio/settings.json", "save", self.settings)
-        else:
-            await self.bot.say("Volume must be between 0 and 1. Example: 0.40")
-
-    @audioset.command(name="sfx", pass_context=True, no_pm=True)
-    async def _sfx(self, ctx):
-        """Enables/Disables sound effects usage in the server"""
-        #default on.
-        server = ctx.message.server
-        if server.id not in self.settings["SERVER_SFX_ON"]:
-            self.settings["SERVER_SFX_ON"][server.id] = True
-        else:
-            self.settings["SERVER_SFX_ON"][server.id] = not self.settings["SERVER_SFX_ON"][server.id]
-        #for a toggle, settings should save here in case bot fails to send message
-        fileIO("data/audio/settings.json", "save", self.settings)
-        if self.settings["SERVER_SFX_ON"][server.id]:
-            await self.bot.say("Sound effects are now enabled on this server.")
-        else:
-            await self.bot.say("Sound effects are now disabled on this server.")
-
-    @audioset.command()
-    @checks.is_owner()
-    async def maxcache(self, size : int):
-        """Sets the maximum audio cache size (megabytes)
-
-        If set to 0, auto cleanup is disabled."""
-        self.settings["MAX_CACHE"] = size
-        fileIO("data/audio/settings.json", "save", self.settings)
-        if not size:
-            await self.bot.say("Auto audio cache cleanup disabled.")
-        else:
-            await self.bot.say("Maximum audio cache size has been set to " + str(size) + "MB.")
-
-    @audioset.command()
-    @checks.is_owner()
-    async def soundcloud(self, ID : str=None):
-        """Sets the SoundCloud Client ID
-        """
-        self.settings["SOUNDCLOUD_CLIENT_ID"] = ID
-        fileIO("data/audio/settings.json", "save", self.settings)
-        if not ID:
-            await self.bot.say("SoundCloud API intergration has been disabled")
-        else:
-            await self.bot.say("SoundCloud Client ID has been set")
-
-
-    @audioset.command(name="player")
-    @checks.is_owner()
-    async def player(self):
-        """Toggles between Ffmpeg and Avconv"""
-        self.settings["AVCONV"] = not self.settings["AVCONV"]
-        if self.settings["AVCONV"]:
-            await self.bot.say("Player toggled. You're now using Avconv")
-        else:
-            await self.bot.say("Player toggled. You're now using Ffmpeg")
-        fileIO("data/audio/settings.json", "save", self.settings)
-
-    @commands.group(pass_context=True)
-    @checks.is_owner()
-    async def cache(self, ctx):
-        """Audio cache management"""
-        if ctx.invoked_subcommand is None:
-            await self.bot.say("Current audio cache size: " + str(self.cache_size()) + "MB" )
-
-    @cache.command(name="empty")
-    async def cache_delete(self):
-        """Empties audio cache"""
-        self.empty_cache()
-        await self.bot.say("Cache emptied.")
-
-    def empty_cache(self):
-        files = os.listdir("data/audio/cache")
-        for f in files:
-            try:
-                os.unlink("data/audio/cache/" + f)
-            except PermissionError: # In case it tries to delete the file that it's currently playing
-                pass
-
-    def cache_size(self):
-        total = [os.path.getsize("data/audio/cache/" + f) for f in os.listdir("data/audio/cache")]
-        size = 0
-        for f in total:
-            size += f
-        return int(size / (1024*1024.0))
-
-    async def play_video(self, link):
-        self.downloader = {"DONE" : False, "TITLE" : False, "ID" : False, "URL": False, "DURATION" : False, "DOWNLOADING" : False}
-        if "https://" in link or "http://" in link or "[SEARCH:]" in link:
-            path = "data/audio/cache/"
-            t = threading.Thread(target=self.get_video, args=(link,self,))
-            t.start()
-        else: #local
-            path = ""
-            self.downloader = {"DONE" : True, "TITLE" : link, "ID" : link, "URL": False, "DURATION" : False, "DOWNLOADING" : False}
-        while not self.downloader["DONE"]:
-            await asyncio.sleep(1)
-        if self.downloader["ID"]:
-            try:
-                # sfx_player should only ever get stuck as much as music_player does
-                # when it happens to music_player, the reponsibility is put on the user to !stop
-                # so we'll do the same with sfx_player. a timeout could be placed here though.
-                while self.sfx_player.is_playing():
-                    await asyncio.sleep(.5)
-                if not self.music_player.is_done(): self.music_player.stop()
-                self.music_player = self.bot.voice.create_ffmpeg_player(path + self.downloader["ID"],use_avconv=self.settings["AVCONV"], options='''-filter "volume=volume={}"'''.format(self.settings["VOLUME"]))
-                self.music_player.paused = False
-                self.music_player.start()
-                if path != "" and self.settings["TITLE_STATUS"]:
-                    self.past_titles.append(self.downloader["TITLE"])
-                    await self.bot.change_status(discord.Game(name=self.downloader["TITLE"]))
-            except discord.errors.ClientException:
-                print("Error: I can't play music without ffmpeg. Install it.")
-                self.downloader = {"DONE" : False, "TITLE" : False, "ID" : False, "URL": False, "DURATION" : False, "DOWNLOADING" : False}
-                self.queue = []
-                self.playlist = []
-            except Exception as e:
-                print(e)
-        else:
-            pass
-
-
-    async def check_voice(self, author, message):
-        if self.bot.is_voice_connected():
-            v_channel = self.bot.voice.channel
-            if author.voice_channel == v_channel:
-                return True
-            elif len(v_channel.voice_members) == 1:
-                if author.voice_channel:
-                    if author.voice_channel.permissions_for(message.server.me).connect:
-                        wait = await self.close_audio()
-                        await self.bot.join_voice_channel(author.voice_channel)
-                        return True
-                    else:
-                        await self.bot.say("I need permissions to join that voice channel.")
-                        return False
-                else:
-                    await self.bot.say("You need to be in a voice channel.")
-                    return False
-            else:
-                if not self.playlist and not self.queue:
-                    return True
-                else:
-                    await self.bot.say("I'm already playing music for other people.")
-                    return False
-        elif author.voice_channel:
-            if author.voice_channel.permissions_for(message.server.me).connect:
-                await self.bot.join_voice_channel(author.voice_channel)
-                return True
-            else:
-                await self.bot.say("I need permissions to join that voice channel.")
-                return False
-        else:
-            await self.bot.say("You need to be in a voice channel.")
-            return False
-
-    async def queue_manager(self):
-        while self == self.bot.get_cog("Audio"):
-            if not self.music_player.paused:
-                if self.queue and not self.music_player.is_playing():
-                    new_link = self.queue[0]
-                    self.queue.pop(0)
-                    self.skip_votes = []
-                    await self.play_video(new_link)
-                elif self.playlist and not self.music_player.is_playing():
-                    if not self.current == len(self.playlist)-1:
-                        self.current += 1
-                    else:
-                        self.current = 0
-                    new_link = self.playlist[self.current]
-                    self.skip_votes = []
-                    await self.play_video(new_link)
-            await asyncio.sleep(1)
-
-    def get_video(self, url, audio):
-        try:
-            self.downloader["DOWNLOADING"] = True
-            yt = youtube_dl.YoutubeDL(youtube_dl_options)
-            if "[SEARCH:]" not in url:
-                v = yt.extract_info(url, download=False)
-            else:
-                url = url.replace("[SEARCH:]", "")
-                url = "https://youtube.com/watch?v=" + yt.extract_info(url, download=False)["entries"][0]["id"]
-                v = yt.extract_info(url, download=False)
-            if v["duration"] > self.settings["MAX_LENGTH"]: raise MaximumLength("Track exceeded maximum length. See help audioset maxlength")
-            if not os.path.isfile("data/audio/cache/" + v["id"]):
-                v = yt.extract_info(url, download=True)
-            audio.downloader = {"DONE" : True, "TITLE" : v["title"], "ID" : v["id"], "URL" : url, "DURATION" : v["duration"], "DOWNLOADING" : False} #Errors out here if invalid link
-        except Exception as e:
-            print(e) # TODO
-            audio.downloader = {"DONE" : True, "TITLE" : False, "ID" : False, "URL" : False, "DOWNLOADING" : False}
-
-    async def incoming_messages(self, msg):
-        if msg.author.id != self.bot.user.id:
-
-            if self.settings["MAX_CACHE"] != 0:
-                if abs(self.cleanup_timer - int(time.perf_counter())) >= 900: # checks cache's size every 15 minutes
-                    self.cleanup_timer = int(time.perf_counter())
-                    if self.cache_size() >= self.settings["MAX_CACHE"]:
-                        self.empty_cache()
-                        print("Cache emptied.")
-
-            if msg.channel.is_private and msg.attachments != []:
-                await self.transfer_playlist(msg)
-        if not msg.channel.is_private:
-            if not self.playlist and not self.queue and not self.music_player.is_playing() and str(msg.server.me.game) in self.past_titles:
-                self.past_titles = []
-                await self.bot.change_status(None)
-
-    def get_local_playlists(self):
-        dirs = []
-        files = os.listdir("data/audio/localtracks/")
-        for f in files:
-            if os.path.isdir("data/audio/localtracks/" + f) and " " not in f:
-                if glob.glob("data/audio/localtracks/" + f + "/*.mp3") != []:
-                    dirs.append(f)
-                elif glob.glob("data/audio/localtracks/" + f + "/*.flac") != []:
-                    dirs.append(f)
-        if dirs != []:
-            return dirs
-        else:
-            return False
-
-    @commands.command(pass_context=True, no_pm=True)
-    async def addplaylist(self, ctx, name : str, link : str): #CHANGE COMMAND NAME
-        """Adds tracks from youtube / soundcloud playlist link"""
-        if self.is_playlist_name_valid(name) and len(name) < 25:
-            if fileIO("playlists/" + name + ".txt", "check"):
-                await self.bot.say("`A playlist with that name already exists.`")
-                return False
-            if "youtube" in link.lower():
-                links = await self.parse_yt_playlist(link)
-            elif "soundcloud" in link.lower():
-                links = await self.parse_sc_playlist(link)
-            if links:
-                data = { "author"  : ctx.message.author.id,
-                         "playlist": links,
-                         "link"    : link}
-                fileIO("data/audio/playlists/" + name + ".txt", "save", data)
-                await self.bot.say("Playlist added. Name: {}, songs: {}".format(name, str(len(links))))
-            else:
-                await self.bot.say("Something went wrong. Either the link was incorrect or I was unable to retrieve the page.")
-        else:
-            await self.bot.say("Something is wrong with the playlist's link or its filename. Remember, the name must be with only numbers, letters and underscores.")
-
-    @commands.command(pass_context=True, no_pm=True)
-    async def delplaylist(self, ctx, name : str):
-        """Deletes playlist
-
-        Limited to owner, admins and author of the playlist."""
-        file_path = "data/audio/playlists/" + name + ".txt"
-        author = ctx.message.author
-        if fileIO(file_path, "check"):
-            playlist_author_id = fileIO(file_path, "load")["author"]
-            check = await self.admin_or_owner(ctx.message)
-            if check or author.id == playlist_author_id:
-                os.remove(file_path)
-                await self.bot.say("Playlist {} has been removed.".format(name))
-            else:
-                await self.bot.say("Only owner, admins and the author of the playlist can delete it.")
-        else:
-            await self.bot.say("There's no playlist with that name.")
-
-    async def admin_or_owner(self, message):
-        if message.author.id == bot_settings.owner:
-            return True
-        elif discord.utils.get(message.author.roles, name=bot_settings.get_server_admin(message.server)) is not None:
-            return True
-        else:
-            return False
-
-    async def transfer_playlist(self, message):
-        msg = message.attachments[0]
-        if msg["filename"].endswith(".txt"):
-            if not fileIO("data/audio/playlists/" + msg["filename"], "check"): #returns false if file already exists
-                r = await aiohttp.get(msg["url"])
-                r = await r.text()
-                data = r.replace("\r", "")
-                data = data.split()
-                if self.is_playlist_valid(data) and self.is_playlist_name_valid(msg["filename"].replace(".txt", "")):
-                    data = { "author" : message.author.id,
-                             "playlist": data,
-                             "link"    : False}
-                    fileIO("data/audio/playlists/" + msg["filename"], "save", data)
-                    await self.bot.send_message(message.channel, "Playlist added. Name: {}".format(msg["filename"].replace(".txt", "")))
-                else:
-                    await self.bot.send_message(message.channel, "Something is wrong with the playlist or its filename.") # Add formatting info
-            else:
-                await self.bot.send_message(message.channel, "A playlist with that name already exists. Change the filename and resubmit it.")
-
-    def is_playlist_valid(self, data):
-        data = [y for y in data if y != ""] # removes all empty elements
-        data = [y for y in data if y != "\n"]
-        pattern = "|".join(fileIO("data/audio/accepted_links.json", "load"))
-        for link in data:
-            rr = re.search(pattern, link, re.I | re.U)
-            if rr == None:
-                return False
-        return True
-
-    def is_playlist_link_valid(self, link):
-        pattern = "^https:\/\/www.youtube.com\/playlist\?list=(.[^:/]*)"
-        rr = re.search(pattern, link, re.I | re.U)
-        if not rr == None:
-            return rr.group(1)
-        else:
-            return False
-
-    def is_playlist_name_valid(self, name):
-        for l in name:
-            if l.isdigit() or l.isalpha() or l == "_":
-                pass
-            else:
-                return False
-        return True
-
-    async def parse_yt_playlist(self, url):
-        try:
-            if not "www.youtube.com/playlist?list=" in url:   
-                url = url.split("&")
-                url = "https://www.youtube.com/playlist?" + [x for x in url if "list=" in x][0]
-            playlist = []
-            yt = youtube_dl.YoutubeDL(youtube_dl_options)
-            for entry in yt.extract_info(url, download=False, process=False)["entries"]:
-                playlist.append("https://www.youtube.com/watch?v=" + entry["id"])
-            return playlist
-        except:
-            return False
-
-    async def parse_sc_playlist(self, link):
-        try:
-            playlist = []
-            yt = youtube_dl.YoutubeDL(youtube_dl_options)
-            for i in yt.extract_info(link, download=False, process=False)["entries"]:
-                playlist.append(i['url'][:4] + 's' + i['url'][4:])
-            return playlist
-        except:
-            return False
-
-    async def get_json(self, url):
-        """
-        Returns the JSON from an URL.
-        Expects the url to be valid and return a JSON object.
-        """
-        async with aiohttp.get(url) as r:
-            result = await r.json()
-        return result
-
-    async def get_song_metadata(self, song_url):
-        """
-        Returns JSON object containing metadata about the song.
-        Expects song_url to be valid url and in acepted_list
-        """
-
-        youtube_regex = (
-            r'(https?://)?(www\.)?'
-            '(youtube|youtu|youtube-nocookie)\.(com|be)/'
-            '(watch\?v=|embed/|v/|.+\?v=)?([^&=%\?]{11})')
-        soundcloud_regex = "^(https:\\/\\/soundcloud\\.com\\/.*)"
-        is_youtube_link = re.match(youtube_regex, song_url)
-        is_soundcloud_link = re.match(soundcloud_regex, song_url)
-
-        if is_youtube_link:
-            url = "http://www.youtube.com/oembed?url={0}&format=json".format(song_url)
-            result = await self.get_json(url)
-        elif is_soundcloud_link and (self.settings["SOUNDCLOUD_CLIENT_ID"] is not None):
-            url = "http://api.soundcloud.com/resolve.json?url={0}&client_id={1}".format(song_url, self.settings["SOUNDCLOUD_CLIENT_ID"])
-            result = await self.get_json(url)
-        else:
-            result = {"title": "A song "}
-        return result
-
-class EmptyPlayer(): #dummy player
+class EmptyPlayer:  # dummy player
     def __init__(self):
         self.paused = False
 
@@ -948,43 +77,156 @@ class EmptyPlayer(): #dummy player
     def is_done(self):
         return True
 
-class MaximumLength(Exception):
-    def __init__(self, m):
-        self.message = m
-    def __str__(self):
-        return self.message
+
+class Song:
+    def __init__(self, **kwargs):
+        self.title = kwargs.get('title')
+        self.id = kwargs.get('title')
+        self.url = kwargs.get('url')
+        self.duration = kwargs.get('duration')
+
+
+class Downloader(threading.Thread):
+    def __init__(self, url, max_duration):
+        self.url = url
+        self.max_duration = max_duration
+        self.done = False
+        self.song = None
+        self.failed = False
+
+    def run(self):
+        try:
+            self.download()
+        except:
+            self.done = True
+            self.failed = True
+        else:
+            self.done = True
+
+    def download(self):
+        yt = youtube_dl.YoutubeDL(youtube_dl_options)
+        if "[SEARCH:]" not in self.url:
+            video = yt.extract_info(self.url, download=False)
+        else:
+            self.url = "https://youtube.com/watch?v={}".format(
+                yt.extract_info(self.url, download=False)["entries"][0]["id"])
+            video = yt.extract_info(self.url, download=False)
+
+        self.song = Song(**video)
+
+        if video['duration'] > self.max_duration:
+            return
+
+        if not os.path.isfile('data/audio/cache' + self.song.id):
+            video = yt.extract_info(self.url)
+            self.song = Song(**video)
+
+
+class Audio:
+    """Music Streaming."""
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.downloaders = {}  # sid: object
+
+    @commands.command(pass_context=True)
+    async def play(self, ctx, url):
+        """Plays a song"""
+        server = ctx.message.server
+        author = ctx.message.author
+        voice_channel = author.voice_channel
+
+        if not self.voice_connected(server):
+            try:
+                can_connect = self.has_connect_perm(author, server)
+            except AuthorNotConnected:
+                await self.bot.say("You must join a voice channel before I can"
+                                   " play anything.")
+                return
+            if not can_connect:
+                await self.bot.say("I don't have permissions to join your"
+                                   " voice channel.")
+            else:
+                await self.bot.join_voice_channel(voice_channel)
+        else:  # We are connected but not to the right channel
+            if self.voice_client(server).channel != voice_channel:
+                pass  # TODO
+
+        if self.already_playing(server):
+            await self.bot.say("I'm already playing a song on this server!")
+
+        if server.id in self.downloaders:
+            if not self.downloaders[server.id].done:
+                await self.bot.say("I'm already downloading a song!")
+                return
+            else:
+                pass
+
+    def already_playing(self, server):
+        if not self.check_voice_connected(server):
+            return False
+        if self.voice_client(server) is None:
+            return False
+        if not hasattr(self.voice_client(server), 'player'):
+            return False
+        if not self.voice_client(server).player.is_playing():
+            return False
+        return True
+
+    def has_connect_perm(self, author, server):
+        channel = author.voice_channel
+        if channel is None:
+            raise AuthorNotConnected
+        if channel.permissions_for(server.me):
+            return True
+        return False
+
+    def voice_client(self, server):
+        return self.bot.voice_client_in(server)
+
+    def voice_connected(self, server):
+        if self.bot.is_voice_connected(server):
+            return True
+        return False
+
 
 def check_folders():
-    folders = ("data/audio", "data/audio/cache", "data/audio/playlists", "data/audio/localtracks", "data/audio/sfx")
+    folders = ("data/audio", "data/audio/cache", "data/audio/playlists",
+               "data/audio/localtracks", "data/audio/sfx")
     for folder in folders:
         if not os.path.exists(folder):
             print("Creating " + folder + " folder...")
             os.makedirs(folder)
 
-def check_files():
 
-    default = {"VOLUME" : 0.5, "MAX_LENGTH" : 3700, "QUEUE_MODE" : True, "MAX_CACHE" : 0, "SOUNDCLOUD_CLIENT_ID": None, "TITLE_STATUS" : True, "AVCONV" : False, "SERVER_SFX_ON" : {}}
+def check_files():
+    default = {"VOLUME": 0.5, "MAX_LENGTH": 3700, "QUEUE_MODE": True,
+               "MAX_CACHE": 0, "SOUNDCLOUD_CLIENT_ID": None,
+               "TITLE_STATUS": True, "AVCONV": False, "SERVER_SFX_ON": {}}
     settings_path = "data/audio/settings.json"
 
     if not os.path.isfile(settings_path):
         print("Creating default audio settings.json...")
         fileIO(settings_path, "save", default)
-    else: #consistency check
+    else:  # consistency check
         current = fileIO(settings_path, "load")
         if current.keys() != default.keys():
             for key in default.keys():
                 if key not in current.keys():
                     current[key] = default[key]
-                    print("Adding " + str(key) + " field to audio settings.json")
+                    print(
+                        "Adding " + str(key) + " field to audio settings.json")
             fileIO(settings_path, "save", current)
 
-
-    allowed = ["^(https:\/\/www\\.youtube\\.com\/watch\\?v=...........*)", "^(https:\/\/youtu.be\/...........*)",
-              "^(https:\/\/youtube\\.com\/watch\\?v=...........*)", "^(https:\/\/soundcloud\\.com\/.*)"]
+    allowed = ["^(https:\/\/www\\.youtube\\.com\/watch\\?v=...........*)",
+               "^(https:\/\/youtu.be\/...........*)",
+               "^(https:\/\/youtube\\.com\/watch\\?v=...........*)",
+               "^(https:\/\/soundcloud\\.com\/.*)"]
 
     if not os.path.isfile("data/audio/accepted_links.json"):
         print("Creating accepted_links.json...")
         fileIO("data/audio/accepted_links.json", "save", allowed)
+
 
 def setup(bot):
     check_folders()
@@ -993,13 +235,14 @@ def setup(bot):
         raise RuntimeError("You need to run `pip3 install youtube_dl`")
         return
     if opus is False:
-        raise RuntimeError("Your opus library's bitness must match your python installation's bitness. They both must be either 32bit or 64bit.")
+        raise RuntimeError(
+            "Your opus library's bitness must match your python installation's"
+            " bitness. They both must be either 32bit or 64bit.")
         return
     elif opus is None:
-        raise RuntimeError("You need to install ffmpeg and opus. See \"https://github.com/Twentysix26/Red-DiscordBot/wiki/Requirements\"")
+        raise RuntimeError(
+            "You need to install ffmpeg and opus. See \"https://github.com/"
+            "Twentysix26/Red-DiscordBot/wiki/Requirements\"")
         return
-    loop = asyncio.get_event_loop()
     n = Audio(bot)
-    loop.create_task(n.queue_manager())
-    bot.add_listener(n.incoming_messages, "on_message")
     bot.add_cog(n)

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -826,8 +826,8 @@ class Audio:
             await self.bot.say("I'm already downloading a file!")
             return
 
-        # TODO: URL validation
-        # TODO: song validity check
+        if not (self._match_sc_url(url) or self._match_yt_url(url)):
+            await self.bot.say("That's not a valid URL.")
         self._clear_queue(server)
         self._stop_player(server)
         self._add_to_queue(server, url)

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -1,6 +1,6 @@
 import discord
 from discord.ext import commands
-import multiprocessing
+import threading
 import os
 from random import choice as rndchoice
 from random import shuffle
@@ -19,6 +19,7 @@ import copy
 import asyncio
 
 log = logging.getLogger("red.audio")
+log.setLevel(logging.DEBUG)
 
 try:
     import youtube_dl
@@ -108,7 +109,7 @@ class Song:
         self.duration = kwargs.pop('duration', "")
 
 
-class Downloader(multiprocessing.Process):
+class Downloader(threading.Thread):
     def __init__(self, url, max_duration, download=False,
                  cache_path="data/audio/cache", *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -161,14 +162,25 @@ class Audio:
         self.queue = {}  # add deque's, repeat
         self.downloaders = {}  # sid: object
         self.settings = fileIO("data/audio/settings.json", 'load')
+        self.server_specific_setting_keys = ["VOLUME", "QUEUE_MODE",
+                                             "VOTE_THRESHOLD"]
         self.cache_path = "data/audio/cache"
 
     def _add_to_queue(self, server, url):
         if server.id not in self.queue:
-            self.queue[server.id] = {"REPEAT": False, "VOICE_CHANNEL_ID": None,
+            self.queue[server.id] = {"REPEAT": False, "PLAYLIST": False,
+                                     "VOICE_CHANNEL_ID": None,
                                      "QUEUE": deque(), "TEMP_QUEUE": deque(),
                                      "NOW_PLAYING": None}
         self.queue[server.id]["QUEUE"].append(url)
+
+    def _add_to_temp_queue(self, server, url):
+        if server.id not in self.queue:
+            self.queue[server.id] = {"REPEAT": False, "PLAYLIST": False,
+                                     "VOICE_CHANNEL_ID": None,
+                                     "QUEUE": deque(), "TEMP_QUEUE": deque(),
+                                     "NOW_PLAYING": None}
+        self.queue[server.id]["TEMP_QUEUE"].append(url)
 
     def _clear_queue(self, server):
         if server.id not in self.queue:
@@ -179,20 +191,26 @@ class Audio:
     def _create_ffmpeg_player(self, server, filename):
         """This function will guarantee we have a valid voice client,
             even if one doesn't exist previously."""
-        voice_client_id = self.queue[server.id]["VOICE_CHANNEL_ID"]
-        voice_client = self.bot.voice_client_in(server)
+        voice_channel_id = self.queue[server.id]["VOICE_CHANNEL_ID"]
+        voice_client = self.voice_client(server)
 
         if voice_client is None:
-            to_connect = self.bot.get_channel(voice_client_id)
+            log.debug("not connected when we should be in sid {}".format(
+                server.id))
+            to_connect = self.bot.get_channel(voice_channel_id)
             if to_connect is None:
                 raise VoiceNotConnected("Okay somehow we're not connected and"
                                         " we have no valid channel to"
                                         " reconnect to. In other words...LOL"
                                         " REKT.")
+            log.debug("valid reconnect channel for sid"
+                      " {}, reconnecting...".format(server.id))
             self.bot.join_voice_channel(to_connect)  # SHIT
-        elif voice_client.channel.id != voice_client_id:
+        elif voice_client.channel.id != voice_channel_id:
             # This was decided at 3:45 EST in #advanced-testing by 26
             self.queue[server.id]["VOICE_CHANNEL_ID"] = voice_client.channel.id
+            log.debug("reconnect chan id for sid {} is wrong, fixing".format(
+                server.id))
 
         # Okay if we reach here we definitively have a working voice_client
 
@@ -201,18 +219,42 @@ class Audio:
         volume = self.settings["VOLUME"]
         options = '-filter "volume=volume={}"'.format(volume)
 
+        log.debug("making player on sid {}".format(server.id))
+
         voice_client.audio_player = voice_client.create_ffmpeg_player(
             song_filename, use_avconv=use_avconv, options=options)
 
         return voice_client  # Just for ease of use, it's modified in-place
 
-    def _disconnect_from_voice(self, server):
+    def _disconnect_voice_client(self, server):
         if not self.voice_connected(server):
             return
 
-        voice_client = self.voice_client_in(server)
+        voice_client = self.voice_client(server)
 
-        voice_client.disconnect()
+        self.bot.loop.create_task(voice_client.disconnect())
+
+    async def _download_next(self, server, curr_dl, next_dl):
+        """Checks to see if we need to download the next, and does.
+
+        Both curr_dl and next_dl should already be started."""
+        if curr_dl.song is None:
+            # Only happens when the downloader thread hasn't initialized fully
+            #   There's no reason to wait if we can't compare
+            return
+
+        max_length = self.settings["MAX_LENGTH"]
+
+        while next_dl.is_alive():
+            await asyncio.sleep(0.5)
+
+        if curr_dl.song.id != next_dl.song.id:
+            log.debug("downloader ID's mismatch on sid {}".format(server.id) +
+                      " gonna start dl-ing the next thing on the queue"
+                      " id {}".format(next_dl.song.id))
+            self.downloaders[server.id] = Downloader(next_dl.url, max_length,
+                                                     download=True)
+            self.downloaders[server.id].start()
 
     async def _join_voice_channel(self, channel):
         server = channel.server
@@ -221,57 +263,82 @@ class Audio:
         await self.bot.join_voice_channel(channel)
 
     async def _play(self, sid, url):
+        """Returns the song object of what's playing"""
         if type(sid) is not discord.Server:
             server = self.bot.get_server(sid)
         else:
             server = sid
-        # We can assume by this point that there is definitely a player
+
+        assert type(server) is discord.Server
+        log.debug('starting to play on "{}"'.format(server.name))
+
         max_length = self.settings["MAX_LENGTH"]
         if server.id not in self.downloaders:  # We don't have a downloader
+            log.debug("sid {} not in downloaders, making one".format(
+                server.id))
             self.downloaders[server.id] = Downloader(url, max_length)
 
         if self.downloaders[server.id].url != url:  # Our downloader is old
             # I'm praying to Jeezus that we don't accidentally lose a running
             #   Downloader
+            log.debug("sid {} in downloaders but wrong url".format(server.id))
             self.downloaders[server.id] = Downloader(url, max_length)
 
-        # We're assuming we have the right thing in our downloader object
-        self.downloaders[server.id].start()
+        try:
+            # We're assuming we have the right thing in our downloader object
+            self.downloaders[server.id].start()
+            log.debug("starting our downloader for sid {}".format(server.id))
+        except RuntimeError:
+            # Queue manager already started it for us, isn't that nice?
+            pass
 
-        while not self.downloaders[server.id].done:  # Getting info w/o DL
+        while self.downloaders[server.id].is_alive():  # Getting info w/o DL
             await asyncio.sleep(0.5)
 
         song = self.downloaders[server.id].song
+        log.debug("sid {} wants to play songid {}".format(server.id, song.id))
 
         # Now we check to see if we have a cache hit
         cache_location = os.path.join(self.cache_path, song.id)
         if not os.path.exists(cache_location):
+            log.debug("cache miss on song id {}".format(song.id))
             self.downloaders[server.id] = Downloader(url, max_length,
                                                      download=True)
             self.downloaders[server.id].start()
 
-            while not self.downloaders[server.id].done:
+            while self.downloaders[server.id].is_alive():
                 await asyncio.sleep(0.5)
 
             song = self.downloaders[server.id].song
+        else:
+            log.debug("cache hit on song id {}".format(song.id))
 
         voice_client = self._create_ffmpeg_player(server, song.id)
         # That ^ creates the audio_player property
 
         voice_client.audio_player.start()
+        log.debug("starting player on sid {}".format(server.id))
 
         return song
+
+    def _remove_queue(self, server):
+        if server.id in self.queue:
+            del self.queue[server.id]
+
+    def _stop_and_disconnect(self, server):
+        self._clear_queue(server)
+        self._stop_downloader(server)
+        self._stop_player(server)
+        self._disconnect_voice_client(server)
 
     def _stop_downloader(self, server):
         if server.id not in self.downloaders:
             return
-        if self.downloaders[server.id].is_alive():
-            self.downloaders[server.id].terminate()
 
         del self.downloaders[server.id]
 
     def _stop_player(self, server):
-        if not self.voice_connected(server.id):
+        if not self.voice_connected(server):
             return
 
         voice_client = self.voice_client(server)
@@ -280,7 +347,39 @@ class Audio:
             voice_client.audio_player.stop()
             del voice_client.audio_player
 
-    @commands.command(pass_context=True)
+    @commands.command(hidden=True, pass_context=True)
+    @checks.is_owner()
+    async def joinvoice(self, ctx):
+        """Joins your voice channel"""
+        author = ctx.message.author
+        server = ctx.message.server
+        voice_channel = author.voice_channel
+
+        if voice_channel is not None:
+            self._stop_and_disconnect(server)
+
+        await self._join_voice_channel(voice_channel)
+
+    @commands.command(pass_context=True, no_pm=True)
+    async def pause(self, ctx):
+        """Pauses the current song, `!resume` to continue."""
+        server = ctx.message.server
+        if not self.voice_connected(server):
+            await self.bot.say("Not voice connected in this server.")
+            return
+
+        # We are connected somewhere
+        voice_client = self.voice_client(server)
+
+        if not hasattr(voice_client, 'audio_player'):
+            await self.bot.say("Nothing playing, nothing to pause.")
+        elif voice_client.audio_player.is_playing():
+            voice_client.audio_player.pause()
+            await self.bot.say("Paused.")
+        else:
+            await self.bot.say("Nothing playing, nothing to pause.")
+
+    @commands.command(pass_context=True, no_pm=True)
     async def play(self, ctx, url):
         """Plays a song"""
         server = ctx.message.server
@@ -307,7 +406,7 @@ class Audio:
 
         # Checking if playing in current server
 
-        if self.already_playing(server):
+        if self.is_playing(server):
             await self.bot.say("I'm already playing a song on this server!")
             return  # TODO Possibly execute queue?
 
@@ -318,7 +417,78 @@ class Audio:
             await self.bot.say("I'm already downloading a file!")
             return
 
+        # TODO
+        #   URL validation
+        #   song validity check
+        self._clear_queue(server)
+        self._stop_player(server)
         self._add_to_queue(server, url)
+
+    @commands.command(pass_context=True, no_pm=True, name="queue")
+    async def _queue(self, ctx, url):
+        """Queue's a song to play next. Extended functionality in `!help`
+
+        If you use `queue` when one song is playing, your new song will get
+            added to the song loop (if running). If you use `queue` when a
+            playlist is running, it will temporarily be played next and will
+            NOT stay in the playlist loop."""
+        server = ctx.message.server
+        if not self.voice_connected(server):
+            await self.bot.say("Not voice connected in this server.")
+            return
+
+        # We are connected somewhere
+        if not self.queue[server.id]:
+            log.debug("Something went wrong, we're connected but have no"
+                      " queue entry.")
+            raise VoiceNotConnected("Something went wrong, we have no internal"
+                                    " queue to modify. This should never"
+                                    " happen.")
+
+        # We have a queue to modify
+        if self.queue[server.id]["PLAYLIST"]:
+            log.debug("queueing to the temp_queue for sid {}".format(
+                server.id))
+            self._add_to_temp_queue(server, url)
+        else:
+            log.debug("queueing to the actual queue for sid {}".format(
+                server.id))
+            self._add_to_queue(server, url)
+        await self.bot.say("Queued.")
+
+    @commands.command(pass_context=True, no_pm=True)
+    async def resume(self, ctx):
+        """Resumes a paused song or playlist"""
+        server = ctx.message.server
+        if not self.voice_connected(server):
+            await self.bot.say("Not voice connected in this server.")
+            return
+
+        # We are connected somewhere
+        voice_client = self.voice_client(server)
+
+        if not hasattr(voice_client, 'audio_player'):
+            await self.bot.say("Nothing paused, nothing to resume.")
+        elif not voice_client.audio_player.is_done() and \
+                not voice_client.audio_player.is_playing():
+            voice_client.audio_player.resume()
+            await self.bot.say("Resuming.")
+        else:
+            await self.bot.say("Nothing paused, nothing to resume.")
+
+    @commands.command(pass_context=True, no_pm=True)
+    async def song(self, ctx):
+        """Info about the current song."""
+        server = ctx.message.server
+        if self.is_playing(server):
+            song = self.queue[server.id]["NOW_PLAYING"]
+            if song:
+                await self.bot.say("[{}] {}".format(song.creator,
+                                                    song.title))
+            else:
+                await self.bot.say("I don't know what this song is either.")
+        else:
+            await self.bot.say("I'm not playing anything on this server.")
 
     @commands.command(pass_context=True)
     async def stop(self, ctx):
@@ -327,19 +497,17 @@ class Audio:
         #   All those fun checks for permissions
         server = ctx.message.server
 
-        self._clear_queue(server)
-        self._stop_downloader(server)
-        self._stop_player(server)
-        self._disconnect_voice_client(server)
+        self._stop_and_disconnect(server)
+        self._remove_queue(server)
 
-    def already_playing(self, server):
+    def is_playing(self, server):
         if not self.voice_connected(server):
             return False
         if self.voice_client(server) is None:
             return False
         if not hasattr(self.voice_client(server), 'audio_player'):
             return False
-        if not self.voice_client(server).player.is_playing():
+        if not self.voice_client(server).audio_player.is_playing():
             return False
         return True
 
@@ -349,9 +517,28 @@ class Audio:
 
     def currently_downloading(self, server):
         if server.id in self.downloaders:
-            if not self.downloaders[server.id].done:
+            if self.downloaders[server.id].is_alive():
                 return True
         return False
+
+    def get_server_settings(self, server):
+        try:
+            sid = server.id
+        except:
+            sid = server
+
+        if sid in self.settings["SERVERS"]:
+            self.settings["SERVERS"][sid] = {}
+        ret = self.settings["SERVERS"][sid]
+
+        for setting in self.server_specific_setting_keys:
+            if setting not in ret:
+                # Add the default
+                ret[setting] = self.settings[setting]
+
+        self.save_settings()
+
+        return ret
 
     def has_connect_perm(self, author, server):
         channel = author.voice_channel
@@ -365,38 +552,66 @@ class Audio:
         """This function assumes that there's something in the queue for us to
             play"""
         server = self.bot.get_server(sid)
+        max_length = self.settings["MAX_LENGTH"]
 
         # This is a reference, or should be at least
         temp_queue = self.queue[server.id]["TEMP_QUEUE"]
         queue = self.queue[server.id]["QUEUE"]
         repeat = self.queue[server.id]["REPEAT"]
-        now_playing = self.queue[server.id]["NOW_PLAYING"]
 
         assert temp_queue is self.queue[server.id]["TEMP_QUEUE"]
         assert queue is self.queue[server.id]["QUEUE"]
-        assert repeat is self.queue[server.id]["REPEAT"]
-        assert now_playing is self.queue[server.id]["NOW_PLAYING"]
 
         # _play handles creating the voice_client and player for us
 
-        if len(temp_queue) > 0:  # Fake queue for irdumb's temp playlist songs
-            song = await self._play(temp_queue.popleft())
-            now_playing = song
-        else:  # We're in the normal queue
-            url = queue.popleft()
-            song = await self._play(sid, url)
-            now_playing = song
-            if repeat:
-                queue.appendleft(url)
+        if not self.is_playing(server):
+            log.debug("not playing anything on sid {}".format(server.id) +
+                      ", attempting to start a new song.")
+            if len(temp_queue) > 0:
+                # Fake queue for irdumb's temp playlist songs
+                log.debug("calling _play because temp_queue is non-empty")
+                song = await self._play(sid, temp_queue.popleft())
+            else:  # We're in the normal queue
+                url = queue.popleft()
+                log.debug("calling _play on the normal queue")
+                song = await self._play(sid, url)
+                if repeat:
+                    queue.appendleft(url)
+            self.queue[server.id]["NOW_PLAYING"] = song
+            log.debug("set now_playing for sid {}".format(server.id))
+        else:  # We're playing but we might be able to download a new song
+            curr_dl = self.downloaders[server.id]
+            if len(temp_queue) > 0:
+                next_dl = Downloader(temp_queue.peekleft(),
+                                     max_length)
+            elif len(queue) > 0:
+                next_dl = Downloader(queue.peekleft(), max_length)
+            else:
+                next_dl = None
+
+            if next_dl is not None:
+                # Download next song
+                next_dl.start()
+                await self._download_next(server, curr_dl, next_dl)
 
     async def queue_scheduler(self):
         while self == self.bot.get_cog('Audio'):
+            tasks = []
             for sid in self.queue:
                 if len(self.queue[sid]["QUEUE"]) == 0 and \
                         len(self.queue[sid]["TEMP_QUEUE"]) == 0:
                     continue
-                self.bot.loop.create_task(self.queue_manager(sid))
-            await asyncio.sleep(0.5)
+                # log.debug("scheduler found a non-empty queue"
+                #           " for sid: {}".format(sid))
+                tasks.append(
+                    self.bot.loop.create_task(self.queue_manager(sid)))
+                completed = [t.done() for t in tasks]
+                while not all(completed):
+                    await asyncio.sleep(0.5)
+            await asyncio.sleep(1)
+
+    def save_settings(self):
+        fileIO('data/audio/settings.json', 'save', self.settings)
 
     def voice_client(self, server):
         return self.bot.voice_client_in(server)
@@ -428,7 +643,8 @@ def check_folders():
 def check_files():
     default = {"VOLUME": 0.5, "MAX_LENGTH": 3700, "QUEUE_MODE": True,
                "MAX_CACHE": 0, "SOUNDCLOUD_CLIENT_ID": None,
-               "TITLE_STATUS": True, "AVCONV": False, "SERVER_SFX_ON": {}}
+               "TITLE_STATUS": True, "AVCONV": False,
+               "SERVERS": {}}
     settings_path = "data/audio/settings.json"
 
     if not os.path.isfile(settings_path):

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -277,7 +277,7 @@ class Audio:
                                         " REKT.")
             log.debug("valid reconnect channel for sid"
                       " {}, reconnecting...".format(server.id))
-            self.bot.join_voice_channel(to_connect)  # SHIT
+            await self._join_voice_channel(to_connect)  # SHIT
         elif voice_client.channel.id != voice_channel_id:
             # This was decided at 3:45 EST in #advanced-testing by 26
             self.queue[server.id]["VOICE_CHANNEL_ID"] = voice_client.channel.id

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -421,7 +421,7 @@ class Audio:
         except:
             pass
 
-        return Playlist(author=author, url=url, songlist=songlist)
+        return Playlist(author=author, url=url, playlist=songlist)
 
     def _match_sc_playlist(self, url):
         return self._match_sc_url(url)

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -1097,6 +1097,8 @@ class Audio:
         self._shuffle_queue(server)
         self._shuffle_temp_queue(server)
 
+        await self.bot.say("Queues shuffled.")
+
     @commands.command(pass_context=True, no_pm=True)
     async def skip(self, ctx):
         """Skips the currently playing song"""
@@ -1138,7 +1140,7 @@ class Audio:
             return False
         if not hasattr(self.voice_client(server), 'audio_player'):
             return False
-        if not self.voice_client(server).audio_player.is_playing():
+        if self.voice_client(server).audio_player.is_done():
             return False
         return True
 
@@ -1278,7 +1280,7 @@ class Audio:
         # Member is the bot
 
         if before.voice_channel != after.voice_channel:
-            self._set_queue_channel(after.channel.id)
+            self._set_queue_channel(after.voice_channel.id)
 
         if before.mute != after.mute:
             vc = self.voice_client(server)

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -836,7 +836,7 @@ class Audio:
             await self.bot.say("I'm already downloading a file!")
             return
 
-        if not (self._match_sc_url(url) or self._match_yt_url(url)):
+        if not self._valid_playable_url(url):
             await self.bot.say("That's not a valid URL.")
         self._clear_queue(server)
         self._stop_player(server)
@@ -858,7 +858,7 @@ class Audio:
                                " contain alpha-numeric characters or _.")
             return
 
-        if self._match_yt_playlist(url) or self._match_sc_playlist(url):
+        if self._valid_playable_url(url):
             try:
                 await self.bot.say("Enumerating song list...this could take"
                                    " a few moments.")
@@ -968,6 +968,10 @@ class Audio:
             raise VoiceNotConnected("Something went wrong, we have no internal"
                                     " queue to modify. This should never"
                                     " happen.")
+
+        if not self._valid_playable_url(url):
+            await self.bot.say("Invalid URL.")
+            return
 
         # We have a queue to modify
         if self.queue[server.id]["PLAYLIST"]:

--- a/cogs/utils/checks.py
+++ b/cogs/utils/checks.py
@@ -2,7 +2,7 @@ from discord.ext import commands
 import discord.utils
 from cogs.utils.settings import Settings
 from cogs.utils.dataIO import fileIO
-from __main__ import settings
+from red import settings
 
 #
 # This is a modified version of checks.py, originally made by Rapptz

--- a/cogs/utils/checks.py
+++ b/cogs/utils/checks.py
@@ -2,7 +2,7 @@ from discord.ext import commands
 import discord.utils
 from cogs.utils.settings import Settings
 from cogs.utils.dataIO import fileIO
-from red import settings
+from __main__ import settings
 
 #
 # This is a modified version of checks.py, originally made by Rapptz


### PR DESCRIPTION
Leaving this here so we can log discussion about multivoice audio design
## Todo:

**Priority:**
- [x] Downloading tracks
- [x] Play
- [x] Stop
- [x] Queue
- [x] Playlist functionality
- [x] Keep track of players by tacking them onto voice clients as `player` attributes
  - thanks Danny for not using `__slots__`!
- [x] Local files...

**Definite:**
- [ ] queue-playlist integration
  - [x] songs put in the queue will be played next after the current song finishes. once the queue is empty, playlist resumes.
  - [ ] when a queue is playing, adding a playlist puts it at the end of the current songs being played.  
- [x] playing on a repeating "current" playlist
- [ ] adding/removing songs to current
- [ ] adding/removing playlists to current
- [ ] playlist management
  - saving current songlist as playlist
  - adding/removing songs/playlists to x playlist
- [ ] queue management
  - removing x song from queue
  - moving songs around in the queue
- [ ] add sfx by link
- [x] disable loop without !stop
- [ ] When adding a song, don't just say "a song has been put in the queue" and don't just stick "a song" in the queue. Put in the search string, and then update it once the song name/url is found.
- [ ] Display current song duration/time till added song
  - 1:40 [███████...............] 3:21 <- updating every time !song is used
- [x] Fix the reload bug in #155 
- [x] Fix the bug in #153 
- [x] Really redo how audio handles multiple servers
- [ ] asyncio bug in #132
- [x] Make sure that mobile/desktop links work as in #80 
- [ ] Separate youtube search command #79 
- [ ] Make bot auto-disconnect after x seconds
- [ ] Make the bot display the file name of local tracks, instead of the path
  - In queue, and actually show in currently playing
- [ ] Settable skip percentage
  - settable % votes needed to exceed to skip. 50 == majority
- [ ] Make the bot display the file name of local tracks, instead of the path
  - In queue, and actually show in currently playing
- [x] Volume changes
  - `!audioset volume` by itself displays the current volume
  - range changed from 0-1 to 0-100

**Not so definite:**
- [x] Remove/rethink !play. Just have !queue functionality. give mods/admins/owner some way to override instead. maybe just through moving songs in queue
- [ ] Radio solutions
  - icecast/shoutcast/last.fm https://github.com/Twentysix26/Red-DiscordBot/issues/179
  - pandora/spotify
- [x] Discord.py dependent fixes
  - Join multiple voice channels (when discord.py supports)
  - remove song from status - stick into channel details?
- [ ] Features specified by #52 
- [ ] Features specified by #135 
- [ ] Features specified by #180 
- [x] Queue/Playlist integration.
  - adding a song to the queue doesn't remove the playlist.
  - once the current song finishes, the queue plays
  - the queue must finish before playlist resumes.
  - if a playlist is started while a queue is playing, the queue must finish before the playlist will start.
- [ ] Link resolving
  - `!queue willow` --> [SEARCH:]willow has been put into the queue by irdumb#1229
  - after giving it some time to resolve,
    - `!queue` --> Videos in queue: 1. Jasmine Thompson - Willow (Lyrics)
