### PR TITLE
utils/chat_formatting: pagify: Add option for page length

### DIFF
--- a/cogs/utils/chat_formatting.py
+++ b/cogs/utils/chat_formatting.py
@@ -15,13 +15,13 @@ def italics(text):
     return "*{}*".format(text)
 
 
-def pagify(text, delims=[], escape=True, shorten_by=8):
+def pagify(text, delims=[], escape=True, shorten_by=8, page_length=2000):
     """DOES NOT RESPECT MARKDOWN BOXES OR INLINE CODE"""
     in_text = text
-    while len(in_text) > 2000:
-        closest_delim = max([in_text.rfind(d, 0, 2000 - shorten_by)
+    while len(in_text) > page_length:
+        closest_delim = max([in_text.rfind(d, 0, page_length - shorten_by)
                              for d in delims])
-        closest_delim = closest_delim if closest_delim != -1 else 2000
+        closest_delim = closest_delim if closest_delim != -1 else page_length
         if escape:
             to_send = escape_mass_mentions(in_text[:closest_delim])
         else:


### PR DESCRIPTION
When adding the pager to the repl cog, I ran into a problem where the `box`'d output of a page would be over the 2000 char message limit. Since `box()` adds 8-10 characters to the message, that needs to be accounted for in the pager's character limit.

This PR adds an optional kwarg to `pagify()` to change the limit, which defaults 2000.
