### PR TITLE
Send notification to channel when song changes

### DIFF
--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -1175,6 +1175,7 @@ class Audio:
         server = ctx.message.server
         author = ctx.message.author
         voice_channel = author.voice_channel
+        self.playing_text_channel = ctx.message.channel
 
         # Checking already connected, will join if not
 
@@ -1486,6 +1487,7 @@ class Audio:
         server = ctx.message.server
         author = ctx.message.author
         voice_channel = ctx.message.author.voice_channel
+        self.playing_text_channel = ctx.message.channel
 
         caller = inspect.currentframe().f_back.f_code.co_name
 

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -954,8 +954,11 @@ class Audio:
             if len(active_servers) == 1:
                 server = active_servers[0].server
                 song = self.queue[server.id]["NOW_PLAYING"]
-            if song:
-                await self.bot.say("Now playing: " + song.title)
+                if song:
+                    message = "Now playing: {}.".format(song.title)
+                    await self.bot.send_message(self.playing_text_channel, message)
+                else:
+                    await self.bot.send_message(self.playing_text_channel, "I'm not playing anything right now")
 
     def _valid_playlist_name(self, name):
         for l in name:
@@ -1010,7 +1013,7 @@ class Audio:
     @checks.is_owner()
     async def audioset_notify(self):
         """Maximum track length (seconds) for requested links"""
-        self.settings["NOTIFY"] = not self.settings.get("NOTIFY", False)
+        self.settings["NOTIFY"] = not self.settings.get["NOTIFY"]
         if self.settings["NOTIFY"]:
             await self.bot.say("Now notifying when a new track plays.")
         else:
@@ -1257,6 +1260,7 @@ class Audio:
         server = ctx.message.server
         author = ctx.message.author
         voice_channel = author.voice_channel
+        self.playing_text_channel = ctx.message.channel
 
         # Checking if playing in current server
 
@@ -1936,8 +1940,8 @@ class Audio:
                 song = None
             self.queue[server.id]["NOW_PLAYING"] = song
             log.debug("set now_playing for sid {}".format(server.id))
-            self.bot.loop.create_task(self._update_bot_status())
             self.bot.loop.create_task(self._notify_song_name())
+            self.bot.loop.create_task(self._update_bot_status())
 
         elif server.id in self.downloaders:
             # We're playing but we might be able to download a new song

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -1013,7 +1013,7 @@ class Audio:
     @checks.is_owner()
     async def audioset_notify(self):
         """Maximum track length (seconds) for requested links"""
-        self.settings["NOTIFY"] = not self.settings.get["NOTIFY"]
+        self.settings["NOTIFY"] = not self.settings["NOTIFY"]
         if self.settings["NOTIFY"]:
             await self.bot.say("Now notifying when a new track plays.")
         else:

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -1012,7 +1012,7 @@ class Audio:
     @audioset.command(name="notify")
     @checks.is_owner()
     async def audioset_notify(self):
-        """Maximum track length (seconds) for requested links"""
+        """Send notifications to the channel when the songs changes"""
         self.settings["NOTIFY"] = not self.settings["NOTIFY"]
         if self.settings["NOTIFY"]:
             await self.bot.say("Now notifying when a new track plays.")


### PR DESCRIPTION
This is in response to #284 and similar to the change proposed in #325. However, this change should work no matter what channel the bot is in.

This uses an !audioset option, "notify", to determine whether or not to send the message. By default, this notify option is set to False.

It required storing the text channel that the play commands are initiated so that the bot can send the message to the right channel.
