### PR TITLE
[utils] checks: properly handle empty permissions, add simple decorators

### DIFF
--- a/cogs/utils/checks.py
+++ b/cogs/utils/checks.py
@@ -28,6 +28,8 @@ def is_owner():
 def check_permissions(ctx, perms):
     if is_owner_check(ctx):
         return True
+    elif not perms:
+        return False
 
     ch = ctx.message.channel
     author = ctx.message.author
@@ -75,3 +77,12 @@ def serverowner_or_permissions(**perms):
 
         return check_permissions(ctx,perms)
     return commands.check(predicate)
+
+def serverowner():
+    return serverowner_or_permissions()
+
+def admin():
+    return admin_or_permissions()
+
+def mod():
+    return mod_or_permissions()


### PR DESCRIPTION
`@checks.admin_or_permissions()` will always return true, because `any([]) = True`.

This commit fixes that (returns `False` for empty kwargs) and adds:  
- `@checks.admin()`: allows if user has server admin role (or is bot's owner)
- `@checks.mod()`: allows if user has server mod role (or is bot's owner)
- `@checks.serverowner()`: allows if user is server owner (or is bot's owner)

These new decorators are basically wrappers for their `or_permissions` counterparts, but take no arguments.
