### PR TITLE
Fix gitignore to include playlists properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 *.json
 *.pyc
 __pycache__
-data
-!data/trivia/*
-!data/audio/playlists/*
+data/*
+!data/trivia/
+!data/audio/
+data/audio/*
+!data/audio/playlists/
 *.exe
 *.dll


### PR DESCRIPTION
Edit on Dec 5: Make `git status` show untracked trivia and playlists.