### PR TITLE
[Audio] Fix 'Nonetype has no attribute "server"' issues

### DIFF
--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -575,7 +575,12 @@ class Audio:
         return self.queue[server.id]["PLAYLIST"]
 
     async def _join_voice_channel(self, channel):
-        server = channel.server
+        try:
+            server = channel.server
+        except AttributeError:
+            await self.bot.say("You must join a voice channel before I can"
+                               " play anything.")
+            return
         if server.id in self.queue:
             self.queue[server.id]["VOICE_CHANNEL_ID"] = channel.id
         try:


### PR DESCRIPTION
Fixes 2nd part of issue [#425]

Caused by queuing a song using [p]play when the bot is in the voice channel, but the queuer isn't.