### PR TITLE
Pagify - shorten on the last page + when no delims

### DIFF
--- a/cogs/utils/chat_formatting.py
+++ b/cogs/utils/chat_formatting.py
@@ -34,8 +34,9 @@ def italics(text):
 def pagify(text, delims=[], escape=True, shorten_by=8, page_length=2000):
     """DOES NOT RESPECT MARKDOWN BOXES OR INLINE CODE"""
     in_text = text
+    page_length -= shorten_by
     while len(in_text) > page_length:
-        closest_delim = max([in_text.rfind(d, 0, page_length - shorten_by)
+        closest_delim = max([in_text.rfind(d, 0, page_length)
                              for d in delims])
         closest_delim = closest_delim if closest_delim != -1 else page_length
         if escape:


### PR DESCRIPTION
iirc, `shorten_by` was used so that you could do something like
```py
pg_fmt = "```py\n{}```"
for page in pagify(data, ['\n', ' '], shorten_by=len(pg_fmt.format(''))):
    await self.bot.say(pg_fmt.format(page))
```
so that the additional formatting would not exceed `page_length`.

iind, pages could exceed that length when no delims are found or on the last page