### PR TITLE
[customcom, alias] Selfbot compatibility v2

### DIFF
--- a/cogs/alias.py
+++ b/cogs/alias.py
@@ -108,8 +108,7 @@ class Alias:
                 await self.bot.say("There are no aliases on this server.")
 
     async def check_aliases(self, message):
-        if message.author == self.bot.user or \
-                len(message.content) < 2 or message.channel.is_private:
+        if len(message.content) < 2 or message.channel.is_private:
             return
 
         msg = message.content

--- a/cogs/customcom.py
+++ b/cogs/customcom.py
@@ -106,8 +106,7 @@ class CustomCommands:
             await self.bot.say("There are no custom commands in this server. Use addcom [command] [text]")
 
     async def checkCC(self, message):
-        if message.author == self.bot.user or\
-                len(message.content) < 2 or message.channel.is_private:
+        if len(message.content) < 2 or message.channel.is_private:
             return
 
         msg = message.content

--- a/red.py
+++ b/red.py
@@ -141,11 +141,11 @@ def user_allowed(message):
 
     author = message.author
 
-    mod = bot.get_cog('Mod')
-
-    if author.bot:
+    if author.bot or author == bot.user:
         return False
 
+    mod = bot.get_cog('Mod')
+ 
     if mod is not None:
         if settings.owner == author.id:
             return True


### PR DESCRIPTION
* Customcom:
  - Don't ignore self directly, use `user_allowed()` from main
* Alias:
  - Same as customcom

Moving the `message.author==user.bot` check to user_allowed() allows all cogs that use it to avoid self-triggering now, as well as being triggered by another bot. This only applies to userbots, since bot accounts are matched by the existing `author.bot` check.

The purpose of moving it into red.py is to allow `user_allowed()` to be redefined centrally.