### PR TITLE
stop playing on empty channel after 5 minutes

### DIFF
--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -1842,12 +1842,10 @@ class Audio:
                     stop_times[server] = int(time.time())
 
                 if hasattr(vc, 'audio_player'):
-                    if (vc.audio_player.is_done() or len(vc.channel.voice_members) == 1) and \
-                            (server not in stop_times or
-                             stop_times[server] is None):
-                        log.debug("putting sid {} in stop loop".format(
-                            server.id))
-                        stop_times[server] = int(time.time())
+                    if (vc.audio_player.is_done() or len(vc.channel.voice_members) == 1):
+                        if server not in stop_times or stop_times[server] is None:
+                            log.debug("putting sid {} in stop loop".format(server.id))
+                            stop_times[server] = int(time.time())
                     elif vc.audio_player.is_playing():
                         stop_times[server] = None
 

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -1842,7 +1842,7 @@ class Audio:
                     stop_times[server] = int(time.time())
 
                 if hasattr(vc, 'audio_player'):
-                    if vc.audio_player.is_done() and \
+                    if (vc.audio_player.is_done() or len(vc.channel.voice_members) == 1) and \
                             (server not in stop_times or
                              stop_times[server] is None):
                         log.debug("putting sid {} in stop loop".format(
@@ -1856,7 +1856,8 @@ class Audio:
                         int(time.time()) - stop_times[server] > 300:
                     # 5 min not playing to d/c
                     log.debug("dcing from sid {} after 300s".format(server.id))
-                    await self._disconnect_voice_client(server)
+                    self._clear_queue(server)
+                    await self._stop_and_disconnect(server)
                     stop_times[server] = None
             await asyncio.sleep(5)
 


### PR DESCRIPTION

I removed the elif and changed the statement to an "or" comparison, you'll see below. This way if you disconnect reconnect due to network or accident you don't dump your whole queue. Also then moved the clear queue to the section where it preforms the disconnect. So basically if the bot is done playing or no one is in the channel for 5 minutes, its clears queue, stops, disconnects.