### PR TITLE
Fix for AttributeError in queue command

### DIFF
--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -412,7 +412,7 @@ class Audio:
         while any([d.is_alive() for d in downloaders]):
             await asyncio.sleep(0.1)
 
-        songs = [d.song for d in downloaders]
+        songs = [d.song for d in downloaders if d.song is not None]
         return songs
 
     async def _download_next(self, server, curr_dl, next_dl):


### PR DESCRIPTION
Happens when a video is not available.

```ERROR: SuM_jSENSrc: YouTube said: This video is not available.
[06/11/2016 21:49] ERROR red on_command_error 88: Exception in command 'queue'
Traceback (most recent call last):
  File "C:\Users\fox\Desktop\Red-DiscordBot\cogs\audio.py", line 1591, in _queue
_list
    song_info.append("{}. {.title}".format(num, song))
AttributeError: 'NoneType' object has no attribute 'title'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\fox\AppData\Local\Programs\Python\Python35-32\lib\site-packages
\discord\ext\commands\core.py", line 50, in wrapped
    ret = yield from coro(*args, **kwargs)
  File "C:\Users\fox\Desktop\Red-DiscordBot\cogs\audio.py", line 1520, in _queue

    return await self._queue_list(ctx)
  File "C:\Users\fox\Desktop\Red-DiscordBot\cogs\audio.py", line 1593, in _queue
_list
    song_info.append("{}. {.webpage_url}".format(num, song))
AttributeError: 'NoneType' object has no attribute 'webpage_url'