### PR TITLE
[mod] Add cleanup bot command, remove slow deletion delay

### DIFF
--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -402,11 +402,7 @@ class Mod:
     @commands.group(pass_context=True)
     @checks.mod_or_permissions(manage_messages=True)
     async def cleanup(self, ctx):
-        """Deletes messages.
-
-        cleanup messages [number]
-        cleanup user [name/mention] [number]
-        cleanup text \"Text here\" [number]"""
+        """Deletes messages."""
         if ctx.invoked_subcommand is None:
             await send_cmd_help(ctx)
 


### PR DESCRIPTION
also make `[p]cleanup after` bot-only, since it uses an API endpoint only available to bots.

The purpose of `[p]cleanup bot` is so mods and above can clean up bot messages in general, or ones that fit a pattern like payday or leveler.

As for removing the delay, there's no need for it since discord.py handles rate limits and the limit is only for deletions. In the worst case, deletion in other channels might be a few seconds slow.