### PR TITLE
[mod] include trigger message in cleanup self if selfbot

### DIFF
--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -684,6 +684,10 @@ class Mod:
             return False
 
         to_delete = []
+        # Selfbot convenience, delete trigger message
+        if author == self.bot.user:
+            to_delete.append(ctx.message)
+            number += 1
 
         tries_left = 5
         tmp = ctx.message


### PR DESCRIPTION
It's no secret why I wrote `[p]cleanup self`. I just forgot to make it delete the trigger message if it's run in my use case.