### PR TITLE
[Economy] Add setting for new account initial balance

### DIFF
--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -510,9 +510,10 @@ class Economy:
         server = ctx.message.server
         if credits >= 0:
             self.settings[server.id]["REGISTER_CREDITS"] = credits
-            await self.bot.say("Registering an account will now give " + str(credits) + " credits.")
         else:
             self.settings[server.id]["REGISTER_CREDITS"] = 0
+            credits = 0
+        await self.bot.say("Registering an account will now give {} credits.".format(credits))
         dataIO.save_json(self.file_path, self.settings)
 
     def display_time(self, seconds, granularity=2):  # What would I ever do without stackoverflow?

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -222,7 +222,7 @@ class Economy:
         user = ctx.message.author
         credits = 0
         if ctx.message.server.id in self.settings:
-            credits = self.settings[ctx.message.server.id]["REGISTER_CREDITS"]
+            credits = self.settings[ctx.message.server.id].get("REGISTER_CREDITS", 0)
         try:
             account = self.bank.create_account(user, initial_balance=credits)
             await self.bot.say("{} Account opened. Current balance: {}".format(user.mention,
@@ -508,11 +508,9 @@ class Economy:
     async def registercredits(self, ctx, credits : int):
         """Credits given on registering an account"""
         server = ctx.message.server
-        if credits >= 0:
-            self.settings[server.id]["REGISTER_CREDITS"] = credits
-        else:
-            self.settings[server.id]["REGISTER_CREDITS"] = 0
+        if credits < 0:
             credits = 0
+        self.settings[server.id]["REGISTER_CREDITS"] = credits
         await self.bot.say("Registering an account will now give {} credits.".format(credits))
         dataIO.save_json(self.file_path, self.settings)
 

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -224,7 +224,7 @@ class Economy:
         if ctx.message.server.id in self.settings:
             credits = self.settings[ctx.message.server.id]["REGISTER_CREDITS"]
         try:
-            account = self.bank.create_account(user, credits)
+            account = self.bank.create_account(user, initial_balance=credits)
             await self.bot.say("{} Account opened. Current balance: {}".format(user.mention,
                 account.balance))
         except AccountAlreadyExists:
@@ -508,8 +508,11 @@ class Economy:
     async def registercredits(self, ctx, credits : int):
         """Credits given on registering an account"""
         server = ctx.message.server
-        self.settings[server.id]["REGISTER_CREDITS"] = credits
-        await self.bot.say("Registering an account will now give " + str(credits) + " credits.")
+        if credits >= 0:
+            self.settings[server.id]["REGISTER_CREDITS"] = credits
+            await self.bot.say("Registering an account will now give " + str(credits) + " credits.")
+        else:
+            self.settings[server.id]["REGISTER_CREDITS"] = 0
         dataIO.save_json(self.file_path, self.settings)
 
     def display_time(self, seconds, granularity=2):  # What would I ever do without stackoverflow?

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -11,7 +11,7 @@ import os
 import time
 import logging
 
-default_settings = {"PAYDAY_TIME" : 300, "PAYDAY_CREDITS" : 120, "SLOT_MIN" : 5, "SLOT_MAX" : 100, "SLOT_TIME" : 0}
+default_settings = {"PAYDAY_TIME" : 300, "PAYDAY_CREDITS" : 120, "SLOT_MIN" : 5, "SLOT_MAX" : 100, "SLOT_TIME" : 0, "REGISTER_CREDITS" : 0}
 
 slot_payouts = """Slot machine payouts:
     :two: :two: :six: Bet * 5000
@@ -220,8 +220,11 @@ class Economy:
     async def register(self, ctx):
         """Registers an account at the Twentysix bank"""
         user = ctx.message.author
+        credits = 0
+        if ctx.message.server.id in self.settings:
+            credits = self.settings[ctx.message.server.id]["REGISTER_CREDITS"]
         try:
-            account = self.bank.create_account(user)
+            account = self.bank.create_account(user, credits)
             await self.bot.say("{} Account opened. Current balance: {}".format(user.mention,
                 account.balance))
         except AccountAlreadyExists:
@@ -499,6 +502,14 @@ class Economy:
         server = ctx.message.server
         self.settings[server.id]["PAYDAY_CREDITS"] = credits
         await self.bot.say("Every payday will now give " + str(credits) + " credits.")
+        dataIO.save_json(self.file_path, self.settings)
+
+    @economyset.command(pass_context=True)
+    async def registercredits(self, ctx, credits : int):
+        """Credits given on registering an account"""
+        server = ctx.message.server
+        self.settings[server.id]["REGISTER_CREDITS"] = credits
+        await self.bot.say("Registering an account will now give " + str(credits) + " credits.")
         dataIO.save_json(self.file_path, self.settings)
 
     def display_time(self, seconds, granularity=2):  # What would I ever do without stackoverflow?


### PR DESCRIPTION
Supersedes #367 as that PR is extremely out of date. This brings the changes into the current version of economy, thus using dataIO instead of fileIO. 