### PR TITLE
[Owner] Lock [p]set owner to owner only.

### DIFF
--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -239,6 +239,7 @@ class Owner:
             return
 
     @_set.command(pass_context=True)
+    @checks.is_owner()
     async def owner(self, ctx):
         """Sets owner"""
         if self.setowner_lock:


### PR DESCRIPTION
Why was it not set to owner only in the first place.