### PR TITLE
[Core] Move __main__.settings into bot

### DIFF
--- a/cogs/utils/settings.py
+++ b/cogs/utils/settings.py
@@ -4,11 +4,17 @@ import os
 
 default_path = "data/red/settings.json"
 
+
 class Settings:
-    def __init__(self,path=default_path):
+
+    def __init__(self, path=default_path):
         self.path = path
         self.check_folders()
-        self.default_settings = {"EMAIL" : "EmailHere", "PASSWORD" : "", "OWNER" : "id_here", "PREFIXES" : [], "default":{"ADMIN_ROLE" : "Transistor", "MOD_ROLE" : "Process"}, "LOGIN_TYPE" : "email"}
+        self.default_settings = {
+            "EMAIL": "EmailHere", "PASSWORD": "", "OWNER": "id_here",
+            "PREFIXES": [],
+            "default": {"ADMIN_ROLE": "Transistor", "MOD_ROLE": "Process"},
+            "LOGIN_TYPE": "email"}
         if not dataIO.is_valid_json(self.path):
             self.bot_settings = self.default_settings
             self.save_settings()
@@ -18,7 +24,8 @@ class Settings:
                 for key in self.default_settings.keys():
                     if key not in current.keys():
                         current[key] = self.default_settings[key]
-                        print("Adding " + str(key) + " field to red settings.json")
+                        print("Adding " + str(key) +
+                              " field to red settings.json")
                 dataIO.save_json(self.path, current)
             self.bot_settings = dataIO.load_json(self.path)
         if "default" not in self.bot_settings:
@@ -32,14 +39,14 @@ class Settings:
                 os.makedirs(folder)
 
     def save_settings(self):
-        dataIO.save_json(self.path,self.bot_settings)
+        dataIO.save_json(self.path, self.bot_settings)
 
     def update_old_settings(self):
         mod = self.bot_settings["MOD_ROLE"]
         admin = self.bot_settings["ADMIN_ROLE"]
         del self.bot_settings["MOD_ROLE"]
         del self.bot_settings["ADMIN_ROLE"]
-        self.bot_settings["default"] = {"MOD_ROLE":mod,"ADMIN_ROLE":admin}
+        self.bot_settings["default"] = {"MOD_ROLE": mod, "ADMIN_ROLE": admin}
         self.save_settings()
 
     @property
@@ -47,7 +54,7 @@ class Settings:
         return self.bot_settings["OWNER"]
 
     @owner.setter
-    def owner(self,value):
+    def owner(self, value):
         self.bot_settings["OWNER"] = value
         self.save_settings()
 
@@ -56,7 +63,7 @@ class Settings:
         return self.bot_settings["EMAIL"]
 
     @email.setter
-    def email(self,value):
+    def email(self, value):
         self.bot_settings["EMAIL"] = value
         self.save_settings()
 
@@ -65,7 +72,7 @@ class Settings:
         return self.bot_settings["PASSWORD"]
 
     @password.setter
-    def password(self,value):
+    def password(self, value):
         self.bot_settings["PASSWORD"] = value
         self.save_settings()
 
@@ -74,8 +81,8 @@ class Settings:
         return self.bot_settings["PREFIXES"]
 
     @prefixes.setter
-    def prefixes(self,value):
-        assert isinstance(value,list)
+    def prefixes(self, value):
+        assert isinstance(value, list)
         self.bot_settings["PREFIXES"] = value
         self.save_settings()
 
@@ -83,10 +90,10 @@ class Settings:
     def default_admin(self):
         if "default" not in self.bot_settings:
             self.update_old_settings()
-        return self.bot_settings["default"].get("ADMIN_ROLE","")
+        return self.bot_settings["default"].get("ADMIN_ROLE", "")
 
     @default_admin.setter
-    def default_admin(self,value):
+    def default_admin(self, value):
         if "default" not in self.bot_settings:
             self.update_old_settings()
         self.bot_settings["default"]["ADMIN_ROLE"] = value
@@ -96,10 +103,10 @@ class Settings:
     def default_mod(self):
         if "default" not in self.bot_settings:
             self.update_old_settings()
-        return self.bot_settings["default"].get("MOD_ROLE","")
+        return self.bot_settings["default"].get("MOD_ROLE", "")
 
     @default_mod.setter
-    def default_mod(self,value):
+    def default_mod(self, value):
         if "default" not in self.bot_settings:
             self.update_old_settings()
         self.bot_settings["default"]["MOD_ROLE"] = value
@@ -108,60 +115,62 @@ class Settings:
     @property
     def servers(self):
         ret = {}
-        server_ids = list(filter(lambda x: str(x).isdigit(),self.bot_settings))
+        server_ids = list(
+            filter(lambda x: str(x).isdigit(), self.bot_settings))
         for server in server_ids:
-            ret.update({server:self.bot_settings[server]})
+            ret.update({server: self.bot_settings[server]})
         return ret
 
     @property
     def login_type(self):
-                return self.bot_settings["LOGIN_TYPE"]
+        return self.bot_settings["LOGIN_TYPE"]
 
     @login_type.setter
-    def login_type(self,value):
-                self.bot_settings["LOGIN_TYPE"] = value
-                self.save_settings()
+    def login_type(self, value):
+        self.bot_settings["LOGIN_TYPE"] = value
+        self.save_settings()
 
-    def get_server(self,server):
+    def get_server(self, server):
         if server is None:
             return self.bot_settings["default"].copy()
-        assert isinstance(server,discord.Server)
-        return self.bot_settings.get(server.id,self.bot_settings["default"]).copy()
+        assert isinstance(server, discord.Server)
+        return self.bot_settings.get(server.id,
+                                     self.bot_settings["default"]).copy()
 
-    def get_server_admin(self,server):
+    def get_server_admin(self, server):
         if server is None:
             return self.default_admin
-        assert isinstance(server,discord.Server)
+        assert isinstance(server, discord.Server)
         if server.id not in self.bot_settings:
             return self.default_admin
-        return self.bot_settings[server.id].get("ADMIN_ROLE","")
+        return self.bot_settings[server.id].get("ADMIN_ROLE", "")
 
-    def set_server_admin(self,server,value):
+    def set_server_admin(self, server, value):
         if server is None:
             return
-        assert isinstance(server,discord.Server)
+        assert isinstance(server, discord.Server)
         if server.id not in self.bot_settings:
             self.add_server(server.id)
         self.bot_settings[server.id]["ADMIN_ROLE"] = value
         self.save_settings()
 
-    def get_server_mod(self,server):
+    def get_server_mod(self, server):
         if server is None:
             return self.default_mod
-        assert isinstance(server,discord.Server)
+        assert isinstance(server, discord.Server)
         if server.id not in self.bot_settings:
             return self.default_mod
-        return self.bot_settings[server.id].get("MOD_ROLE","")
+        return self.bot_settings[server.id].get("MOD_ROLE", "")
 
-    def set_server_mod(self,server,value):
+    def set_server_mod(self, server, value):
         if server is None:
             return
-        assert isinstance(server,discord.Server)
+        assert isinstance(server, discord.Server)
         if server.id not in self.bot_settings:
             self.add_server(server.id)
         self.bot_settings[server.id]["MOD_ROLE"] = value
         self.save_settings()
 
-    def add_server(self,sid):
+    def add_server(self, sid):
         self.bot_settings[sid] = self.bot_settings["default"].copy()
         self.save_settings()

--- a/red.py
+++ b/red.py
@@ -47,6 +47,7 @@ class Bot(commands.Bot):
         self.counter = Counter()
         self.uptime = datetime.datetime.now()
         self._message_modifiers = []
+        self.settings = Settings()
         super().__init__(*args, **kwargs)
 
     async def send_message(self, *args, **kwargs):
@@ -174,7 +175,7 @@ bot = Bot(command_prefix=["_"], formatter=formatter,
 send_cmd_help = bot.send_cmd_help  # Backwards
 user_allowed = bot.user_allowed    # compatibility
 
-settings = Settings()
+settings = bot.settings
 
 
 @bot.event

--- a/red.py
+++ b/red.py
@@ -32,15 +32,15 @@ from collections import Counter
 
 #
 # Red, a Discord bot by Twentysix, based on discord.py and its command
-#   extension.
+#                             extension.
 #
-#   https://github.com/Twentysix26/
+#                   https://github.com/Twentysix26/
 #
 #
 # red.py and cogs/utils/checks.py both contain some modified functions
-#   originally made by Rapptz.
+#                     originally made by Rapptz.
 #
-#   https://github.com/Rapptz/RoboDanny/tree/async
+#                 https://github.com/Rapptz/RoboDanny/
 #
 
 description = "Red - A multifunction Discord bot by Twentysix"

--- a/red.py
+++ b/red.py
@@ -31,12 +31,16 @@ from cogs.utils.chat_formatting import inline
 from collections import Counter
 
 #
-#  Red, a Discord bot by Twentysix, based on discord.py and its command extension
-#                   https://github.com/Twentysix26/
+# Red, a Discord bot by Twentysix, based on discord.py and its command
+#   extension.
+#
+#   https://github.com/Twentysix26/
 #
 #
-# red.py and cogs/utils/checks.py both contain some modified functions originally made by Rapptz
-#             https://github.com/Rapptz/RoboDanny/tree/async
+# red.py and cogs/utils/checks.py both contain some modified functions
+#   originally made by Rapptz.
+#
+#   https://github.com/Rapptz/RoboDanny/tree/async
 #
 
 description = "Red - A multifunction Discord bot by Twentysix"
@@ -246,12 +250,14 @@ async def on_command_error(error, ctx):
     else:
         logger.exception(type(error).__name__, exc_info=error)
 
+
 async def get_oauth_url():
     try:
         data = await bot.application_info()
     except Exception as e:
         return "Couldn't retrieve invite link.Error: {}".format(e)
     return discord.utils.oauth_url(data.id)
+
 
 async def set_bot_owner():
     try:
@@ -295,8 +301,8 @@ def check_configs():
                   "process.")
             exit(1)
 
-        print("\nChoose a prefix. A prefix is what you type before a command.\n"
-              "A typical prefix would be the exclamation mark.\n"
+        print("\nChoose a prefix. A prefix is what you type before a command."
+              "\nA typical prefix would be the exclamation mark.\n"
               "Can be multiple characters. You will be able to change it "
               "later and add more of them.\nChoose your prefix:")
         confirmation = False
@@ -304,47 +310,51 @@ def check_configs():
             new_prefix = ensure_reply("\nPrefix> ").strip()
             print("\nAre you sure you want {0} as your prefix?\nYou "
                   "will be able to issue commands like this: {0}help"
-                  "\nType yes to confirm or no to change it".format(new_prefix))
+                  "\nType yes to confirm or no to change it".format(
+                      new_prefix))
             confirmation = get_answer()
 
         settings.prefixes = [new_prefix]
         if settings.login_type == "email":
-            print("\nOnce you're done with the configuration, you will have to type "
-                  "'{}set owner' *in Discord's chat*\nto set yourself as owner.\n"
-                  "Press enter to continue".format(new_prefix))
-            settings.owner = input("") # Shh, they will never know it's here
+            print("\nOnce you're done with the configuration, you will have to"
+                  " type '{}set owner' *in Discord's chat*\nto set yourself as"
+                  " owner.\nPress enter to continue".format(new_prefix))
+            settings.owner = input("")  # Shh, they will never know it's here
             if settings.owner == "":
                 settings.owner = "id_here"
             if not settings.owner.isdigit() or len(settings.owner) < 17:
                 if settings.owner != "id_here":
                     print("\nERROR: What you entered is not a valid ID. Set "
-                          "yourself as owner later with {}set owner".format(new_prefix))
+                          "yourself as owner later with {}set owner".format(
+                              new_prefix))
                 settings.owner = "id_here"
         else:
             settings.owner = "id_here"
 
-        print("\nInput the admin role's name. Anyone with this role in Discord will be "
-              "able to use the bot's admin commands")
+        print("\nInput the admin role's name. Anyone with this role in Discord"
+              " will be able to use the bot's admin commands")
         print("Leave blank for default name (Transistor)")
         settings.default_admin = input("\nAdmin role> ")
         if settings.default_admin == "":
             settings.default_admin = "Transistor"
 
-        print("\nInput the moderator role's name. Anyone with this role in Discord will "
-              "be able to use the bot's mod commands")
+        print("\nInput the moderator role's name. Anyone with this role in"
+              " Discord will be able to use the bot's mod commands")
         print("Leave blank for default name (Process)")
         settings.default_mod = input("\nModerator role> ")
         if settings.default_mod == "":
             settings.default_mod = "Process"
 
-        print("\nThe configuration is done. Leave this window always open to keep "
-              "Red online.\nAll commands will have to be issued through Discord's "
-              "chat, *this window will now be read only*.\nPress enter to continue")
+        print("\nThe configuration is done. Leave this window always open to"
+              " keep Red online.\nAll commands will have to be issued through"
+              " Discord's chat, *this window will now be read only*.\nPress"
+              " enter to continue")
         input("\n")
 
     if not os.path.isfile("data/red/cogs.json"):
         print("Creating new cogs.json...")
         dataIO.save_json("data/red/cogs.json", {})
+
 
 def set_logger():
     global logger
@@ -378,11 +388,13 @@ def set_logger():
     logger.addHandler(fhandler)
     logger.addHandler(stdout_handler)
 
+
 def ensure_reply(msg):
     choice = ""
     while choice == "":
         choice = input(msg)
     return choice
+
 
 def get_answer():
     choices = ("yes", "y", "no", "n")
@@ -394,10 +406,12 @@ def get_answer():
     else:
         return False
 
+
 def set_cog(cog, value):
     data = dataIO.load_json("data/red/cogs.json")
     data[cog] = value
     dataIO.save_json("data/red/cogs.json", data)
+
 
 def load_cogs():
     no_prompt = "--no-prompt" in sys.argv[1:]
@@ -501,11 +515,11 @@ if __name__ == '__main__':
         error = True
         logger.error(traceback.format_exc())
         choice = input("Invalid login credentials. "
-            "If they worked before Discord might be having temporary "
-            "technical issues.\nIn this case, press enter and "
-            "try again later.\nOtherwise you can type 'reset' to "
-            "delete the current configuration and redo the setup process "
-            "again the next start.\n> ")
+                       "If they worked before Discord might be having temporary "
+                       "technical issues.\nIn this case, press enter and "
+                       "try again later.\nOtherwise you can type 'reset' to "
+                       "delete the current configuration and redo the setup process "
+                       "again the next start.\n> ")
         if choice.strip() == "reset":
             shutil.copy('data/red/settings.json',
                         'data/red/settings-{}.bak'.format(int(time.time())))


### PR DESCRIPTION
The core bot settings are now available as `bot.settings`. This does maintain backwards compatibility so all your `from __main__ import settings` uses still work though you all should begin to move away from that.

PEP8