### PR TITLE
[Core] CLI flags, initial selfbot support, revamped setup / main screen, etc

### DIFF
--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -1378,7 +1378,7 @@ def setup(bot):
     global logger
     check_folders()
     check_files()
-    logger = logging.getLogger("mod")
+    logger = logging.getLogger("red.mod")
     # Prevents the logger from being loaded again in case of module reload
     if logger.level == 0:
         logger.setLevel(logging.INFO)

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -483,9 +483,7 @@ class Owner:
         if len(token) < 50:
             await self.bot.say("Invalid token.")
         else:
-            self.bot.settings.login_type = "token"
-            self.bot.settings.email = token
-            self.bot.settings.password = None
+            self.bot.settings.token = token
             self.bot.settings.save_settings()
             await self.bot.say("Token set. Restart me.")
             log.debug("Token changed.")

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -225,13 +225,16 @@ class Owner:
         result = str(result)
 
         if not ctx.message.channel.is_private:
-            censor = (self.bot.settings.email, self.bot.settings.password)
+            censor = (self.bot.settings.email,
+                      self.bot.settings.password,
+                      self.bot.settings.token)
             r = "[EXPUNGED]"
             for w in censor:
-                if w != "":
-                    result = result.replace(w, r)
-                    result = result.replace(w.lower(), r)
-                    result = result.replace(w.upper(), r)
+                if w is None or w == "":
+                    continue
+                result = result.replace(w, r)
+                result = result.replace(w.lower(), r)
+                result = result.replace(w.upper(), r)
 
         result = list(pagify(result, shorten_by=16))
 
@@ -263,11 +266,16 @@ class Owner:
     @_set.command(pass_context=True)
     async def owner(self, ctx):
         """Sets owner"""
+        if self.bot.settings.no_prompt is True:
+            await self.bot.say("Console interaction is disabled. Start Red "
+                               "without the `--no-prompt` flag to use this "
+                               "command.")
+            return
         if self.setowner_lock:
             await self.bot.say("A set owner command is already pending.")
             return
 
-        if self.bot.settings.owner != "id_here":
+        if self.bot.settings.owner is not None:
             await self.bot.say(
             "The owner is already set. Remember that setting the owner "
             "to someone else other than who hosts the bot has security "
@@ -294,6 +302,7 @@ class Owner:
             return
 
         self.bot.settings.prefixes = sorted(prefixes, reverse=True)
+        self.bot.settings.save_settings()
         log.debug("Setting global prefixes to:\n\t{}"
                   "".format(self.bot.settings.prefixes))
 
@@ -315,6 +324,7 @@ class Owner:
 
         if prefixes == ():
             self.bot.settings.set_server_prefixes(server, [])
+            self.bot.settings.save_settings()
             current_p = ", ".join(self.bot.settings.prefixes)
             await self.bot.say("Server prefixes reset. Current prefixes: "
                                "`{}`".format(current_p))
@@ -322,6 +332,7 @@ class Owner:
 
         prefixes = sorted(prefixes, reverse=True)
         self.bot.settings.set_server_prefixes(server, prefixes)
+        self.bot.settings.save_settings()
         log.debug("Setting server's {} prefixes to:\n\t{}"
                   "".format(server.id, self.bot.settings.prefixes))
 
@@ -474,7 +485,8 @@ class Owner:
         else:
             self.bot.settings.login_type = "token"
             self.bot.settings.email = token
-            self.bot.settings.password = ""
+            self.bot.settings.password = None
+            self.bot.settings.save_settings()
             await self.bot.say("Token set. Restart me.")
             log.debug("Token changed.")
 
@@ -645,7 +657,7 @@ class Owner:
     @commands.command(pass_context=True)
     async def contact(self, ctx, *, message : str):
         """Sends message to the owner"""
-        if self.bot.settings.owner == "id_here":
+        if self.bot.settings.owner is None:
             await self.bot.say("I have no owner set.")
             return
         owner = discord.utils.get(self.bot.get_all_members(),
@@ -684,7 +696,7 @@ class Owner:
         py_version = "[{}.{}.{}]({})".format(*os.sys.version_info[:3],
                                              python_url)
 
-        owner_set = self.bot.settings.owner != "id_here"
+        owner_set = self.bot.settings.owner is not None
         owner = self.bot.settings.owner if owner_set else None
         if owner:
             owner = discord.utils.get(self.bot.get_all_members(), id=owner)
@@ -782,6 +794,7 @@ class Owner:
 
         if choice == "yes":
             self.bot.settings.owner = author.id
+            self.bot.settings.save_settings()
             print(author.name + " has been set as owner.")
             self.setowner_lock = False
             self.owner.hidden = True

--- a/cogs/utils/settings.py
+++ b/cogs/utils/settings.py
@@ -52,14 +52,20 @@ class Settings:
 
     def parse_cmd_arguments(self):
         parser = argparse.ArgumentParser(description="Red - Discord Bot")
-        parser.add_argument("--email")
-        parser.add_argument("--password")
-        parser.add_argument("--token")
-        parser.add_argument("--owner", help="ID of the owner")
+        parser.add_argument("--email", help="Email login. Must provide a "
+                                            "password too. Not using a bot "
+                                            "account with a token is "
+                                            "discouraged")
+        parser.add_argument("--password", help="Password of the email login")
+        parser.add_argument("--token", help="Login token")
+        parser.add_argument("--owner", help="ID of the owner. Only who hosts "
+                                            "Red should be owner, this has "
+                                            "security implications")
         parser.add_argument("--prefix", "-p", action="append",
-                            help="Global prefix. Can be multiple.")
-        parser.add_argument("--admin-role")
-        parser.add_argument("--mod-role")
+                            help="Global prefix. Can be multiple")
+        parser.add_argument("--admin-role", help="Role seen as admin role by "
+                                                 "Red")
+        parser.add_argument("--mod-role", help="Role seen as mod role by Red")
         parser.add_argument("--no-prompt",
                             action="store_true",
                             help="Disables console inputs. Features requiring "
@@ -77,26 +83,25 @@ class Settings:
                             help="Enables debug mode")
 
         args = parser.parse_args()
-        args_items = vars(args)
 
-        for arg in args_items:
-            if args_items[arg] is None:
-                continue
-            if arg == "token":
-                self.token = args.token
-                self.login_type = "token"
-            elif arg == "email":
-                self.email = args.email
-                self.password = args.password
-                self.login_type = "email"
-            elif arg == "owner":
-                self.owner = args.owner
-            elif arg == "prefix":
-                self.prefixes = sorted(args.prefix, reverse=True)
-            elif arg == "admin_role":
-                self.default_admin = args.admin_role
-            elif arg == "mod_role":
-                self.default_mod = args.mod_role
+        if args.email and args.password:
+            self.email = args.email
+            self.password = args.password
+            self.token = None
+            self.login_type = "email"
+        if args.token:
+            self.token = args.token
+            self.email = None
+            self.password = None
+            self.login_type = "token"
+        if args.owner:
+            self.owner = args.owner
+        if args.prefix:
+            self.prefixes = sorted(args.prefix, reverse=True)
+        if args.admin_role:
+            self.default_admin = args.admin_role
+        if args.mod_role:
+            self.default_mod = args.mod_role
 
         self.no_prompt = args.no_prompt
         self.self_bot = args.self_bot

--- a/cogs/utils/settings.py
+++ b/cogs/utils/settings.py
@@ -61,7 +61,7 @@ class Settings:
         parser.add_argument("--admin-role")
         parser.add_argument("--mod-role")
         parser.add_argument("--no-prompt",
-                            action='store_true',
+                            action="store_true",
                             help="Disables console inputs. Features requiring "
                                  "console interaction could be disabled as a "
                                  "result")
@@ -69,9 +69,12 @@ class Settings:
                             action='store_true',
                             help="Specifies if Red should log in as selfbot")
         parser.add_argument("--memory-only",
-                            action='store_true',
+                            action="store_true",
                             help="Arguments passed and future edits to the "
                                  "settings will not be saved to disk")
+        parser.add_argument("--debug",
+                            action="store_true",
+                            help="Enables debug mode")
 
         args = parser.parse_args()
         args_items = vars(args)
@@ -98,6 +101,7 @@ class Settings:
         self.no_prompt = args.no_prompt
         self.self_bot = args.self_bot
         self.memory_only = args.memory_only
+        self.debug = args.debug
 
         self.save_settings()
 

--- a/red.py
+++ b/red.py
@@ -231,7 +231,7 @@ async def on_ready():
         len(bot.cogs), total_cogs, len(bot.commands)))
     print("-----------------")
 
-    if settings.login_type == "token" and not settings.self_bot:
+    if settings.token and not settings.self_bot:
         print("\nUse this url to bring your bot to a server:")
         url = await get_oauth_url()
         bot.oauth_url = url
@@ -346,15 +346,13 @@ def interactive_setup():
               "#creating-a-new-bot-account")
         print("and obtain your bot's token like described.")
 
-    if settings.token is None and settings.email is None:
+    if not settings.login_credentials:
         print("\nInsert your bot's token:")
         while settings.token is None and settings.email is None:
             choice = input("> ")
             if "@" not in choice and len(choice) >= 50:  # Assuming token
-                settings.login_type = "token"
                 settings.token = choice
             elif "@" in choice:
-                settings.login_type = "email"
                 settings.email = choice
                 settings.password = input("\nPassword> ")
             else:
@@ -520,10 +518,12 @@ def main():
 
     print("Logging into Discord...")
 
-    if settings.login_type == "token":
-        yield from bot.login(settings.token, bot=not settings.self_bot)
+    if settings.login_credentials:
+        yield from bot.login(*settings.login_credentials,
+                             bot=not settings.self_bot)
     else:
-        yield from bot.login(settings.email, settings.password, bot=not settings.self_bot)
+        print("No credentials available to login.")
+        raise RuntimeError()
     yield from bot.connect()
 
 if __name__ == '__main__':

--- a/red.py
+++ b/red.py
@@ -356,15 +356,6 @@ def interactive_setup():
 
 def set_logger():
     global logger
-    logger = logging.getLogger("discord")
-    logger.setLevel(logging.WARNING)
-    handler = logging.FileHandler(
-        filename='data/red/discord.log', encoding='utf-8', mode='a')
-    handler.setFormatter(logging.Formatter(
-        '%(asctime)s %(levelname)s %(module)s %(funcName)s %(lineno)d: '
-        '%(message)s',
-        datefmt="[%d/%m/%Y %H:%M]"))
-    logger.addHandler(handler)
 
     logger = logging.getLogger("red")
     logger.setLevel(logging.INFO)
@@ -376,7 +367,12 @@ def set_logger():
 
     stdout_handler = logging.StreamHandler(sys.stdout)
     stdout_handler.setFormatter(red_format)
-    stdout_handler.setLevel(logging.INFO)
+    if settings.debug:
+        stdout_handler.setLevel(logging.DEBUG)
+        logger.setLevel(logging.DEBUG)
+    else:
+        stdout_handler.setLevel(logging.INFO)
+        logger.setLevel(logging.INFO)
 
     fhandler = logging.handlers.RotatingFileHandler(
         filename='data/red/red.log', encoding='utf-8', mode='a',
@@ -386,6 +382,18 @@ def set_logger():
     logger.addHandler(fhandler)
     logger.addHandler(stdout_handler)
 
+    logger = logging.getLogger("discord")
+    if settings.debug:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.WARNING)
+    handler = logging.FileHandler(
+        filename='data/red/discord.log', encoding='utf-8', mode='a')
+    handler.setFormatter(logging.Formatter(
+        '%(asctime)s %(levelname)s %(module)s %(funcName)s %(lineno)d: '
+        '%(message)s',
+        datefmt="[%d/%m/%Y %H:%M]"))
+    logger.addHandler(handler)
 
 def ensure_reply(msg):
     choice = ""

--- a/red.py
+++ b/red.py
@@ -133,8 +133,8 @@ class Bot(commands.Bot):
         if author.bot:
             return False
 
-        if author == self.user and not self.settings.self_bot:
-            return False
+        if author == self.user:
+            return self.settings.self_bot
 
         mod = self.get_cog('Mod')
 

--- a/red.py
+++ b/red.py
@@ -60,7 +60,7 @@ class Bot(commands.Bot):
             return bot.settings.get_prefixes(message.server)
 
         self.counter = Counter()
-        self.uptime = datetime.datetime.now()
+        self.uptime = datetime.datetime.now() #  Will be refreshed before login
         self._message_modifiers = []
         self.settings = Settings()
         self._intro_displayed = False
@@ -251,6 +251,11 @@ async def on_ready():
 
 
 @bot.event
+async def on_resumed():
+    bot.counter["session_resumed"] += 1
+
+
+@bot.event
 async def on_command(command, ctx):
     bot.counter["processed_commands"] += 1
 
@@ -429,18 +434,18 @@ def set_logger():
     logger.addHandler(fhandler)
     logger.addHandler(stdout_handler)
 
-    logger = logging.getLogger("discord")
+    dpy_logger = logging.getLogger("discord")
     if settings.debug:
-        logger.setLevel(logging.DEBUG)
+        dpy_logger.setLevel(logging.DEBUG)
     else:
-        logger.setLevel(logging.WARNING)
+        dpy_logger.setLevel(logging.WARNING)
     handler = logging.FileHandler(
         filename='data/red/discord.log', encoding='utf-8', mode='a')
     handler.setFormatter(logging.Formatter(
         '%(asctime)s %(levelname)s %(module)s %(funcName)s %(lineno)d: '
         '%(message)s',
         datefmt="[%d/%m/%Y %H:%M]"))
-    logger.addHandler(handler)
+    dpy_logger.addHandler(handler)
 
 
 def ensure_reply(msg):
@@ -517,6 +522,7 @@ def main():
     set_logger()
 
     print("Logging into Discord...")
+    bot.uptime = datetime.datetime.now()
 
     if settings.login_credentials:
         yield from bot.login(*settings.login_credentials,

--- a/red.py
+++ b/red.py
@@ -27,6 +27,7 @@ from cogs.utils.settings import Settings
 from cogs.utils.dataIO import dataIO
 from cogs.utils.chat_formatting import inline
 from collections import Counter
+from io import TextIOWrapper
 
 #
 # Red, a Discord bot by Twentysix, based on discord.py and its command
@@ -526,6 +527,10 @@ def main():
     yield from bot.connect()
 
 if __name__ == '__main__':
+    sys.stdout = TextIOWrapper(sys.stdout.detach(),
+                               encoding=sys.stdout.encoding,
+                               errors="replace",
+                               line_buffering=True)
     error = False
     loop = asyncio.get_event_loop()
     try:

--- a/red.py
+++ b/red.py
@@ -129,7 +129,10 @@ class Bot(commands.Bot):
     def user_allowed(self, message):
         author = message.author
 
-        if author.bot or author == self.user:
+        if author.bot:
+            return False
+
+        if author == self.user and not self.settings.self_bot:
             return False
 
         mod = self.get_cog('Mod')
@@ -212,7 +215,7 @@ async def on_ready():
         len(bot.cogs), total_cogs, len(bot.commands)))
     prefix_label = "Prefixes:" if len(settings.prefixes) > 1 else "Prefix:"
     print("{} {}\n".format(prefix_label, " ".join(settings.prefixes)))
-    if settings.login_type == "token":
+    if settings.login_type == "token" and not settings.self_bot:
         print("------")
         print("Use this url to bring your bot to a server:")
         url = await get_oauth_url()

--- a/red.py
+++ b/red.py
@@ -519,7 +519,6 @@ def main():
     if not settings.no_prompt:
         interactive_setup()
     load_cogs()
-    set_logger()
 
     print("Logging into Discord...")
     bot.uptime = datetime.datetime.now()
@@ -537,6 +536,7 @@ if __name__ == '__main__':
                                encoding=sys.stdout.encoding,
                                errors="replace",
                                line_buffering=True)
+    set_logger()
     error = False
     loop = asyncio.get_event_loop()
     try:


### PR DESCRIPTION
**Changes:**
Startup flags: can be started and configured without ever doing the interactive setup
Changed default settings format so that all unset values are None
Removed new cogs prompt
Removed `LOGIN_TYPE` from settings.json. It now defaults to token and fallbacks to email/password
Smarter initial setup: only asks for the settings that are actually missing
Startup flag that allows settings to be memory-only
Initial selfbot support
Only reset login credentials (on confirmation) instead of deleting the whole file in case of login failure
Revamped main screen
Made sure that nothing blows up when you run Red on Windows without `chcp 65001`
Possibility of setting credentials in the environment variables `RED_TOKEN` / `RED_EMAIL` `RED_PASSWORD` 

**Possible breaking changes:**
Cogs that make use of bot.email and expect a token (I don't think there are any, but still)
Cogs that set settings and expect them to save automatically. This is now disabled to allow memory-only settings.
`Settings.login_type` is no longer a thing

**Warning:** Testing this PR will change the format of your settings.json. It won't work anymore if you try to use it again in the current build.