### PR TITLE
[Core] Universal config: MongoDB and JSON backend

### DIFF
--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -227,7 +227,10 @@ class Owner:
         if not ctx.message.channel.is_private:
             censor = (self.bot.settings.email,
                       self.bot.settings.password,
-                      self.bot.settings.token)
+                      self.bot.settings.token,
+                      self.bot.settings.mongo_url,
+                      self.bot.settings.mongo_user,
+                      self.bot.settings.mongo_password)
             r = "[EXPUNGED]"
             for w in censor:
                 if w is None or w == "":

--- a/cogs/utils/config.py
+++ b/cogs/utils/config.py
@@ -140,6 +140,18 @@ class BaseConfig:
 
 
 class Config(BaseConfig):
+    """
+    Config object created by `Bot.get_conf()`
+
+    Use the `set()` function to save data at a certain level
+        e.g.:
+            Global level: `conf.set("key1", "value1")`
+            Server level: `conf.server(server_id).set("key2", "value2")
+
+    Misc data is special, use `conf.get_misc()` and `conf.set_misc(value)`
+        respectively.
+    """
+
     def __getattr__(self, key):
         try:
             default = self.defaults[self.collection][key]

--- a/cogs/utils/config.py
+++ b/cogs/utils/config.py
@@ -53,6 +53,18 @@ class BaseConfig:
             `self.collection` and `self.collection_uuid`."""
         raise NotImplemented
 
+    def __setattr__(self, key, value):
+        if 'defaults' in self.__dict__:  # Necessary to let the cog load
+            restricted = list(self.defaults[self.collection].keys()) + \
+                list(self.restricted_keys)
+            if key in restricted:
+                raise ValueError("Not allowed to dynamically set attributes of"
+                                 " restricted_keys: {}".format(restricted))
+            else:
+                self.__dict__[key] = value
+        else:
+            self.__dict__[key] = value
+
     def clear(self):
         """Clears all values in the current context ONLY."""
         raise NotImplemented

--- a/cogs/utils/config.py
+++ b/cogs/utils/config.py
@@ -1,6 +1,3 @@
-from .drivers.red_mongo import MissingCollection
-
-
 class BaseConfig:
     def __init__(self, cog_name, unique_identifier, driver_spawn,
                  hash_uuid=True, collection="GLOBAL", collection_uuid=None,
@@ -172,9 +169,6 @@ class Config(BaseConfig):
         elif self.collection == "USER":
             self.driver.set_user(self.cog_name, self.uuid,
                                  self.collection_uuid, key, value)
-        else:
-            raise MissingCollection("Can't find collection: {}".format(
-                self.collection))
 
     def clear(self):
         self.driver_setmap[self.collection](

--- a/cogs/utils/config.py
+++ b/cogs/utils/config.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from .red_mongo import MissingCollection
 
 

--- a/cogs/utils/config.py
+++ b/cogs/utils/config.py
@@ -44,9 +44,12 @@ class BaseConfig:
     @property
     def driver(self):
         if self._driver is None:
-            return self.driver_spawn()
-        else:
-            return self._driver
+            try:
+                self._driver = self.driver_spawn()
+            except TypeError:
+                return self.driver_spawn
+
+        return self._driver
 
     def __getattr__(self, key):
         """This should be used to return config key data as determined by

--- a/cogs/utils/config.py
+++ b/cogs/utils/config.py
@@ -1,0 +1,169 @@
+from copy import deepcopy
+from .red_mongo import MissingCollection
+
+
+class BaseConfig:
+    def __init__(self, cog_name, unique_identifier, driver, hash_uuid=True,
+                 collection="GLOBAL", collection_uuid=None, defaults={}):
+        self.cog_name = cog_name
+        if hash_uuid:
+            self.uuid = hash(unique_identifier)
+        else:
+            self.uuid = unique_identifier
+        self.driver = driver
+        self.collection = collection
+        self.collection_uuid = collection_uuid
+
+        self.curr_key = None
+
+        self.defaults = defaults if defaults else {
+            "GLOBAL": {}, "SERVER": {}, "CHANNEL": {}, "ROLE": {},
+            "MEMBER": {}, "USER": {}}
+
+    def __getattr__(self, key):
+        """This should be used to return config key data as determined by
+            `self.collection` and `self.collection_uuid`."""
+        raise NotImplemented
+
+    def clear(self):
+        """Clears all values in the current context ONLY."""
+        raise NotImplemented
+
+    def set(self, value):
+        """This should set config key with value `value` in the
+            corresponding collection as defined by `self.collection` and
+            `self.collection_uuid`."""
+        raise NotImplemented
+
+    def server(self, server):
+        """This should return a `BaseConfig` instance with the corresponding
+            `collection` and `collection_uuid`."""
+        raise NotImplemented
+
+    def channel(self, channel):
+        """This should return a `BaseConfig` instance with the corresponding
+            `collection` and `collection_uuid`."""
+        raise NotImplemented
+
+    def role(self, role):
+        """This should return a `BaseConfig` instance with the corresponding
+            `collection` and `collection_uuid`."""
+        raise NotImplemented
+
+    def member(self, member):
+        """This should return a `BaseConfig` instance with the corresponding
+            `collection` and `collection_uuid`."""
+        raise NotImplemented
+
+    def user(self, user):
+        """This should return a `BaseConfig` instance with the corresponding
+            `collection` and `collection_uuid`."""
+        raise NotImplemented
+
+    def registerGlobal(self, key, default=None):
+        """Registers a global config key `key`"""
+        self.defaults["GLOBAL"][key] = default
+
+    def registerServer(self, key, default=None):
+        """Registers a server config key `key`"""
+        self.defaults["SERVER"][key] = default
+
+    def registerChannel(self, key, default=None):
+        """Registers a channel config key `key`"""
+        self.defaults["CHANNEL"][key] = default
+
+    def registerRole(self, key, default=None):
+        """Registers a role config key `key`"""
+        self.defaults["ROLE"][key] = default
+
+    def registerMember(self, key, default=None):
+        """Registers a member config key `key`"""
+        self.defaults["MEMBER"][key] = default
+
+    def registerUser(self, key, default=None):
+        """Registers a user config key `key`"""
+        self.defaults["USER"][key] = default
+
+
+class MongoConfig(BaseConfig):
+
+    __slots__ = ("collection", "collection_uuid", "curr_key")
+
+    def __getattr__(self, key):
+        try:
+            default = self.defaults[self.collection][key]
+        except KeyError as e:
+            raise AttributeError("Key '{}' not registered!".format(key)) from e
+
+        self.curr_key = key
+
+        collections = {
+            "GLOBAL": self.driver.get_global,
+            "SERVER": self.driver.get_server,
+            "CHANNEL": self.driver.get_channel,
+            "ROLE": self.driver.get_role,
+            "USER": self.driver.get_user
+        }
+
+        if self.collection != "MEMBER":
+            collections[self.collection](self.cog_name, self.uuid,
+                                         self.collection_uuid, key,
+                                         default=default)
+        else:
+            mid, sid = self.collection_uuid
+            self.driver.get_member(self.cog_name, self.uuid,
+                                   mid, sid, key, default=default)
+
+    def set(self, value):
+        if self.collection == "GLOBAL":
+            self.driver.set_global(self.cog_name, self.uuid, self.curr_key,
+                                   value)
+        elif self.collection == "SERVER":
+            self.driver.set_server(self.cog_name, self.uuid,
+                                   self.collection_uuid, self.curr_key, value)
+        elif self.collection == "CHANNEL":
+            self.driver.set_channel(self.cog_name, self.uuid,
+                                    self.collection_uuid, self.curr_key, value)
+        elif self.collection == "ROLE":
+            self.driver.set_channel(self.cog_name, self.uuid,
+                                    self.collection_uuid, self.curr_key, value)
+        elif self.collection == "MEMBER":
+            mid, sid = self.collection_uuid
+            self.driver.set_member(self.cog_name, self.uuid, mid, sid,
+                                   self.curr_key, value)
+        elif self.collection == "USER":
+            self.driver.set_user(self.cog_name, self.uuid,
+                                 self.collection_uuid, self.curr_key, value)
+        else:
+            raise MissingCollection("Can't find collection: {}".format(
+                self.collection))
+
+    def server(self, server):
+        new = deepcopy(self)
+        new.collection = "SERVER"
+        new.collection_uuid = server.id
+        return new
+
+    def channel(self, channel):
+        new = deepcopy(self)
+        new.collection = "CHANNEL"
+        new.collection_uuid = channel.id
+        return new
+
+    def role(self, role):
+        new = deepcopy(self)
+        new.collection = "ROLE"
+        new.collection_uuid = role.id
+        return new
+
+    def member(self, member):
+        new = deepcopy(self)
+        new.collection = "MEMBER"
+        new.collection_uuid = (member.id, server.id)
+        return new
+
+    def user(self, user):
+        new = deepcopy(self)
+        new.collection = "USER"
+        new.collection_uuid = user.id
+        return new

--- a/cogs/utils/config.py
+++ b/cogs/utils/config.py
@@ -148,7 +148,7 @@ class Config(BaseConfig):
             Global level: `conf.set("key1", "value1")`
             Server level: `conf.server(server_id).set("key2", "value2")
 
-    Misc data is special, use `conf.get_misc()` and `conf.set_misc(value)`
+    Misc data is special, use `conf.misc()` and `conf.set_misc(value)`
         respectively.
     """
 

--- a/cogs/utils/config.py
+++ b/cogs/utils/config.py
@@ -150,25 +150,13 @@ class Config(BaseConfig):
         if key not in self.defaults[self.collection]:
             raise AttributeError("Key '{}' not registered!".format(key))
 
-        if self.collection == "GLOBAL":
-            self.driver.set_global(self.cog_name, self.uuid, key,
-                                   value)
-        elif self.collection == "SERVER":
-            self.driver.set_server(self.cog_name, self.uuid,
-                                   self.collection_uuid, key, value)
-        elif self.collection == "CHANNEL":
-            self.driver.set_channel(self.cog_name, self.uuid,
-                                    self.collection_uuid, key, value)
-        elif self.collection == "ROLE":
-            self.driver.set_role(self.cog_name, self.uuid,
-                                 self.collection_uuid, key, value)
+        if self.collection in self.driver_setmap:
+            func = self.driver_setmap[self.collection]
+            func(self.cog_name, self.uuid, self.collection_uuid, key, value)
         elif self.collection == "MEMBER":
             mid, sid = self.collection_uuid
             self.driver.set_member(self.cog_name, self.uuid, mid, sid,
                                    key, value)
-        elif self.collection == "USER":
-            self.driver.set_user(self.cog_name, self.uuid,
-                                 self.collection_uuid, key, value)
 
     def clear(self):
         self.driver_setmap[self.collection](

--- a/cogs/utils/config.py
+++ b/cogs/utils/config.py
@@ -1,4 +1,4 @@
-from .red_mongo import MissingCollection
+from .drivers.red_mongo import MissingCollection
 
 
 class BaseConfig:

--- a/cogs/utils/config.py
+++ b/cogs/utils/config.py
@@ -31,6 +31,10 @@ class BaseConfig:
 
         self.curr_key = None
 
+        self.restricted_keys = ("cog_name", "cog_identifier", "_id",
+                                "server_id", "channel_id", "role_id",
+                                "user_id")
+
         self.defaults = defaults if defaults else {
             "GLOBAL": {}, "SERVER": {}, "CHANNEL": {}, "ROLE": {},
             "MEMBER": {}, "USER": {}}
@@ -77,26 +81,38 @@ class BaseConfig:
 
     def registerGlobal(self, key, default=None):
         """Registers a global config key `key`"""
+        if key in self.restricted_keys:
+            raise KeyError("Attempt to use restricted key: '{}'".format(key))
         self.defaults["GLOBAL"][key] = default
 
     def registerServer(self, key, default=None):
         """Registers a server config key `key`"""
+        if key in self.restricted_keys:
+            raise KeyError("Attempt to use restricted key: '{}'".format(key))
         self.defaults["SERVER"][key] = default
 
     def registerChannel(self, key, default=None):
         """Registers a channel config key `key`"""
+        if key in self.restricted_keys:
+            raise KeyError("Attempt to use restricted key: '{}'".format(key))
         self.defaults["CHANNEL"][key] = default
 
     def registerRole(self, key, default=None):
         """Registers a role config key `key`"""
+        if key in self.restricted_keys:
+            raise KeyError("Attempt to use restricted key: '{}'".format(key))
         self.defaults["ROLE"][key] = default
 
     def registerMember(self, key, default=None):
         """Registers a member config key `key`"""
+        if key in self.restricted_keys:
+            raise KeyError("Attempt to use restricted key: '{}'".format(key))
         self.defaults["MEMBER"][key] = default
 
     def registerUser(self, key, default=None):
         """Registers a user config key `key`"""
+        if key in self.restricted_keys:
+            raise KeyError("Attempt to use restricted key: '{}'".format(key))
         self.defaults["USER"][key] = default
 
 

--- a/cogs/utils/config.py
+++ b/cogs/utils/config.py
@@ -177,7 +177,8 @@ class Config(BaseConfig):
         new.collection_uuid = role.id
         return new
 
-    def member(self, member, server):
+    def member(self, member):
+        server = member.server
         new = type(self)(self.cog_name, self.uuid, self.driver,
                          hash_uuid=False, defaults=self.defaults)
         new.collection = "MEMBER"

--- a/cogs/utils/config.py
+++ b/cogs/utils/config.py
@@ -160,8 +160,8 @@ class Config(BaseConfig):
             self.driver.set_channel(self.cog_name, self.uuid,
                                     self.collection_uuid, key, value)
         elif self.collection == "ROLE":
-            self.driver.set_channel(self.cog_name, self.uuid,
-                                    self.collection_uuid, key, value)
+            self.driver.set_role(self.cog_name, self.uuid,
+                                 self.collection_uuid, key, value)
         elif self.collection == "MEMBER":
             mid, sid = self.collection_uuid
             self.driver.set_member(self.cog_name, self.uuid, mid, sid,

--- a/cogs/utils/config.py
+++ b/cogs/utils/config.py
@@ -106,64 +106,75 @@ class MongoConfig(BaseConfig):
         }
 
         if self.collection != "MEMBER":
-            collections[self.collection](self.cog_name, self.uuid,
-                                         self.collection_uuid, key,
-                                         default=default)
+            ret = collections[self.collection](
+                self.cog_name, self.uuid, self.collection_uuid, key,
+                default=default)
         else:
             mid, sid = self.collection_uuid
-            self.driver.get_member(self.cog_name, self.uuid,
-                                   mid, sid, key, default=default)
+            ret = self.driver.get_member(
+                self.cog_name, self.uuid, mid, sid, key,
+                default=default)
 
-    def set(self, value):
+        return ret
+
+    def set(self, key, value):
+        if key not in self.defaults[self.collection]:
+            raise AttributeError("Key '{}' not registered!".format(key))
+
         if self.collection == "GLOBAL":
-            self.driver.set_global(self.cog_name, self.uuid, self.curr_key,
+            self.driver.set_global(self.cog_name, self.uuid, key,
                                    value)
         elif self.collection == "SERVER":
             self.driver.set_server(self.cog_name, self.uuid,
-                                   self.collection_uuid, self.curr_key, value)
+                                   self.collection_uuid, key, value)
         elif self.collection == "CHANNEL":
             self.driver.set_channel(self.cog_name, self.uuid,
-                                    self.collection_uuid, self.curr_key, value)
+                                    self.collection_uuid, key, value)
         elif self.collection == "ROLE":
             self.driver.set_channel(self.cog_name, self.uuid,
-                                    self.collection_uuid, self.curr_key, value)
+                                    self.collection_uuid, key, value)
         elif self.collection == "MEMBER":
             mid, sid = self.collection_uuid
             self.driver.set_member(self.cog_name, self.uuid, mid, sid,
-                                   self.curr_key, value)
+                                   key, value)
         elif self.collection == "USER":
             self.driver.set_user(self.cog_name, self.uuid,
-                                 self.collection_uuid, self.curr_key, value)
+                                 self.collection_uuid, key, value)
         else:
             raise MissingCollection("Can't find collection: {}".format(
                 self.collection))
 
     def server(self, server):
-        new = deepcopy(self)
+        new = type(self)(self.cog_name, self.uuid, self.driver,
+                         hash_uuid=False, defaults=self.defaults)
         new.collection = "SERVER"
         new.collection_uuid = server.id
         return new
 
     def channel(self, channel):
-        new = deepcopy(self)
+        new = type(self)(self.cog_name, self.uuid, self.driver,
+                         hash_uuid=False, defaults=self.defaults)
         new.collection = "CHANNEL"
         new.collection_uuid = channel.id
         return new
 
     def role(self, role):
-        new = deepcopy(self)
+        new = type(self)(self.cog_name, self.uuid, self.driver,
+                         hash_uuid=False, defaults=self.defaults)
         new.collection = "ROLE"
         new.collection_uuid = role.id
         return new
 
-    def member(self, member):
-        new = deepcopy(self)
+    def member(self, member, server):
+        new = type(self)(self.cog_name, self.uuid, self.driver,
+                         hash_uuid=False, defaults=self.defaults)
         new.collection = "MEMBER"
         new.collection_uuid = (member.id, server.id)
         return new
 
     def user(self, user):
-        new = deepcopy(self)
+        new = type(self)(self.cog_name, self.uuid, self.driver,
+                         hash_uuid=False, defaults=self.defaults)
         new.collection = "USER"
         new.collection_uuid = user.id
         return new

--- a/cogs/utils/config.py
+++ b/cogs/utils/config.py
@@ -2,14 +2,16 @@ from .red_mongo import MissingCollection
 
 
 class BaseConfig:
-    def __init__(self, cog_name, unique_identifier, driver, hash_uuid=True,
-                 collection="GLOBAL", collection_uuid=None, defaults={}):
+    def __init__(self, cog_name, unique_identifier, driver_spawn,
+                 hash_uuid=True, collection="GLOBAL", collection_uuid=None,
+                 defaults={}):
         self.cog_name = cog_name
         if hash_uuid:
             self.uuid = hash(unique_identifier)
         else:
             self.uuid = unique_identifier
-        self.driver = driver
+        self.driver_spawn = driver_spawn
+        self._driver = None
         self.collection = collection
         self.collection_uuid = collection_uuid
 
@@ -38,6 +40,13 @@ class BaseConfig:
         self.defaults = defaults if defaults else {
             "GLOBAL": {}, "SERVER": {}, "CHANNEL": {}, "ROLE": {},
             "MEMBER": {}, "USER": {}}
+
+    @property
+    def driver(self):
+        if self._driver is None:
+            return self.driver_spawn()
+        else:
+            return self._driver
 
     def __getattr__(self, key):
         """This should be used to return config key data as determined by
@@ -117,9 +126,6 @@ class BaseConfig:
 
 
 class Config(BaseConfig):
-
-    __slots__ = ("collection", "collection_uuid", "curr_key")
-
     def __getattr__(self, key):
         try:
             default = self.defaults[self.collection][key]
@@ -177,6 +183,7 @@ class Config(BaseConfig):
                          hash_uuid=False, defaults=self.defaults)
         new.collection = "SERVER"
         new.collection_uuid = server.id
+        new._driver = None
         return new
 
     def channel(self, channel):
@@ -184,6 +191,7 @@ class Config(BaseConfig):
                          hash_uuid=False, defaults=self.defaults)
         new.collection = "CHANNEL"
         new.collection_uuid = channel.id
+        new._driver = None
         return new
 
     def role(self, role):
@@ -191,6 +199,7 @@ class Config(BaseConfig):
                          hash_uuid=False, defaults=self.defaults)
         new.collection = "ROLE"
         new.collection_uuid = role.id
+        new._driver = None
         return new
 
     def member(self, member):
@@ -199,6 +208,7 @@ class Config(BaseConfig):
                          hash_uuid=False, defaults=self.defaults)
         new.collection = "MEMBER"
         new.collection_uuid = (member.id, server.id)
+        new._driver = None
         return new
 
     def user(self, user):
@@ -206,4 +216,5 @@ class Config(BaseConfig):
                          hash_uuid=False, defaults=self.defaults)
         new.collection = "USER"
         new.collection_uuid = user.id
+        new._driver = None
         return new

--- a/cogs/utils/config.py
+++ b/cogs/utils/config.py
@@ -88,37 +88,37 @@ class BaseConfig:
             `collection` and `collection_uuid`."""
         raise NotImplemented
 
-    def registerGlobal(self, key, default=None):
+    def register_global(self, key, default=None):
         """Registers a global config key `key`"""
         if key in self.restricted_keys:
             raise KeyError("Attempt to use restricted key: '{}'".format(key))
         self.defaults["GLOBAL"][key] = default
 
-    def registerServer(self, key, default=None):
+    def register_server(self, key, default=None):
         """Registers a server config key `key`"""
         if key in self.restricted_keys:
             raise KeyError("Attempt to use restricted key: '{}'".format(key))
         self.defaults["SERVER"][key] = default
 
-    def registerChannel(self, key, default=None):
+    def register_channel(self, key, default=None):
         """Registers a channel config key `key`"""
         if key in self.restricted_keys:
             raise KeyError("Attempt to use restricted key: '{}'".format(key))
         self.defaults["CHANNEL"][key] = default
 
-    def registerRole(self, key, default=None):
+    def register_role(self, key, default=None):
         """Registers a role config key `key`"""
         if key in self.restricted_keys:
             raise KeyError("Attempt to use restricted key: '{}'".format(key))
         self.defaults["ROLE"][key] = default
 
-    def registerMember(self, key, default=None):
+    def register_member(self, key, default=None):
         """Registers a member config key `key`"""
         if key in self.restricted_keys:
             raise KeyError("Attempt to use restricted key: '{}'".format(key))
         self.defaults["MEMBER"][key] = default
 
-    def registerUser(self, key, default=None):
+    def register_user(self, key, default=None):
         """Registers a user config key `key`"""
         if key in self.restricted_keys:
             raise KeyError("Attempt to use restricted key: '{}'".format(key))

--- a/cogs/utils/drivers/red_base.py
+++ b/cogs/utils/drivers/red_base.py
@@ -1,39 +1,45 @@
 class BaseDriver:
     def get_global(self, cog_name, ident, collection_id, key, *, default=None):
-        raise NotImplemented
+        raise NotImplementedError()
 
     def get_server(self, cog_name, ident, server_id, key, *, default=None):
-        raise NotImplemented
+        raise NotImplementedError()
 
     def get_channel(self, cog_name, ident, channel_id, key, *, default=None):
-        raise NotImplemented
+        raise NotImplementedError()
 
     def get_role(self, cog_name, ident, role_id, key, *, default=None):
-        raise NotImplemented
+        raise NotImplementedError()
 
     def get_member(self, cog_name, ident, user_id, server_id, key, *,
                    default=None):
-        raise NotImplemented
+        raise NotImplementedError()
 
     def get_user(self, cog_name, ident, user_id, key, *, default=None):
-        raise NotImplemented
+        raise NotImplementedError()
+
+    def get_misc(self, cog_name, ident, *, default=None):
+        raise NotImplementedError()
 
     def set_global(self, cog_name, ident, key, value, clear=False):
-        raise NotImplemented
+        raise NotImplementedError()
 
     def set_server(self, cog_name, ident, server_id, key, value, clear=False):
-        raise NotImplemented
+        raise NotImplementedError()
 
     def set_channel(self, cog_name, ident, channel_id, key, value,
                     clear=False):
-        raise NotImplemented
+        raise NotImplementedError()
 
     def set_role(self, cog_name, ident, role_id, key, value, clear=False):
-        raise NotImplemented
+        raise NotImplementedError()
 
     def set_member(self, cog_name, ident, user_id, server_id, key, value,
                    clear=False):
-        raise NotImplemented
+        raise NotImplementedError()
 
     def set_user(self, cog_name, ident, user_id, key, value, clear=False):
-        raise NotImplemented
+        raise NotImplementedError()
+
+    def set_misc(self, cog_name, ident, value, clear=False):
+        raise NotImplementedError()

--- a/cogs/utils/drivers/red_base.py
+++ b/cogs/utils/drivers/red_base.py
@@ -1,0 +1,39 @@
+class BaseDriver:
+    def get_global(self, cog_name, ident, collection_id, key, *, default=None):
+        raise NotImplemented
+
+    def get_server(self, cog_name, ident, server_id, key, *, default=None):
+        raise NotImplemented
+
+    def get_channel(self, cog_name, ident, channel_id, key, *, default=None):
+        raise NotImplemented
+
+    def get_role(self, cog_name, ident, role_id, key, *, default=None):
+        raise NotImplemented
+
+    def get_member(self, cog_name, ident, user_id, server_id, key, *,
+                   default=None):
+        raise NotImplemented
+
+    def get_user(self, cog_name, ident, user_id, key, *, default=None):
+        raise NotImplemented
+
+    def set_global(self, cog_name, ident, key, value, clear=False):
+        raise NotImplemented
+
+    def set_server(self, cog_name, ident, server_id, key, value, clear=False):
+        raise NotImplemented
+
+    def set_channel(self, cog_name, ident, channel_id, key, value,
+                    clear=False):
+        raise NotImplemented
+
+    def set_role(self, cog_name, ident, role_id, key, value, clear=False):
+        raise NotImplemented
+
+    def set_member(self, cog_name, ident, user_id, server_id, key, value,
+                   clear=False):
+        raise NotImplemented
+
+    def set_user(self, cog_name, ident, user_id, key, value, clear=False):
+        raise NotImplemented

--- a/cogs/utils/drivers/red_json.py
+++ b/cogs/utils/drivers/red_json.py
@@ -47,14 +47,15 @@ class JSON(BaseDriver):
         userdata = self.data["USER"].get(str(user_id), {})
         return userdata.get(key, default)
 
-    def set_global(self, cog_name, ident, key, value, clear=False):
+    def set_global(self, cog_name, ident, _, key, value, *, clear=False):
         if clear:
             self.data["GLOBAL"] = {}
         else:
             self.data["GLOBAL"][key] = value
         dataIO.save_json(self.data_path, self.data)
 
-    def set_server(self, cog_name, ident, server_id, key, value, clear=False):
+    def set_server(self, cog_name, ident, server_id, key, value, *,
+                   clear=False):
         server_id = str(server_id)
         if clear:
             self.data["SERVER"][server_id] = {}
@@ -66,7 +67,7 @@ class JSON(BaseDriver):
                 self.data["SERVER"][server_id][key] = value
         dataIO.save_json(self.data_path, self.data)
 
-    def set_channel(self, cog_name, ident, channel_id, key, value,
+    def set_channel(self, cog_name, ident, channel_id, key, value, *,
                     clear=False):
         channel_id = str(channel_id)
         if clear:
@@ -79,7 +80,7 @@ class JSON(BaseDriver):
                 self.data["CHANNEL"][channel_id][key] = value
         dataIO.save_json(self.data_path, self.data)
 
-    def set_role(self, cog_name, ident, role_id, key, value, clear=False):
+    def set_role(self, cog_name, ident, role_id, key, value, *, clear=False):
         role_id = str(role_id)
         if clear:
             self.data["ROLE"][role_id] = {}
@@ -91,7 +92,7 @@ class JSON(BaseDriver):
                 self.data["ROLE"][role_id][key] = value
         dataIO.save_json(self.data_path, self.data)
 
-    def set_member(self, cog_name, ident, user_id, server_id, key, value,
+    def set_member(self, cog_name, ident, user_id, server_id, key, value, *,
                    clear=False):
         user_id = str(user_id)
         server_id = str(server_id)
@@ -109,7 +110,7 @@ class JSON(BaseDriver):
                 self.data["MEMBER"][user_id][server_id][key] = value
         dataIO.save_json(self.data_path, self.data)
 
-    def set_user(self, cog_name, ident, user_id, key, value, clear=False):
+    def set_user(self, cog_name, ident, user_id, key, value, *, clear=False):
         user_id = str(user_id)
         if clear:
             self.data["USER"][user_id] = {}

--- a/cogs/utils/drivers/red_json.py
+++ b/cogs/utils/drivers/red_json.py
@@ -52,15 +52,14 @@ class JSON(BaseDriver):
         miscdata = self.data["MISC"]
         return miscdata.get("MISC", default)
 
-    def set_global(self, cog_name, ident, _, key, value, *, clear=False):
+    def set_global(self, cog_name, ident, key, value, clear=False):
         if clear:
             self.data["GLOBAL"] = {}
         else:
             self.data["GLOBAL"][key] = value
         dataIO.save_json(self.data_path, self.data)
 
-    def set_server(self, cog_name, ident, server_id, key, value, *,
-                   clear=False):
+    def set_server(self, cog_name, ident, server_id, key, value, clear=False):
         server_id = str(server_id)
         if clear:
             self.data["SERVER"][server_id] = {}
@@ -72,8 +71,7 @@ class JSON(BaseDriver):
                 self.data["SERVER"][server_id][key] = value
         dataIO.save_json(self.data_path, self.data)
 
-    def set_channel(self, cog_name, ident, channel_id, key, value, *,
-                    clear=False):
+    def set_channel(self, cog_name, ident, channel_id, key, value, clear=False):
         channel_id = str(channel_id)
         if clear:
             self.data["CHANNEL"][channel_id] = {}
@@ -85,7 +83,7 @@ class JSON(BaseDriver):
                 self.data["CHANNEL"][channel_id][key] = value
         dataIO.save_json(self.data_path, self.data)
 
-    def set_role(self, cog_name, ident, role_id, key, value, *, clear=False):
+    def set_role(self, cog_name, ident, role_id, key, value, clear=False):
         role_id = str(role_id)
         if clear:
             self.data["ROLE"][role_id] = {}
@@ -97,8 +95,7 @@ class JSON(BaseDriver):
                 self.data["ROLE"][role_id][key] = value
         dataIO.save_json(self.data_path, self.data)
 
-    def set_member(self, cog_name, ident, user_id, server_id, key, value, *,
-                   clear=False):
+    def set_member(self, cog_name, ident, user_id, server_id, key, value, clear=False):
         user_id = str(user_id)
         server_id = str(server_id)
         if clear:
@@ -115,7 +112,7 @@ class JSON(BaseDriver):
                 self.data["MEMBER"][user_id][server_id][key] = value
         dataIO.save_json(self.data_path, self.data)
 
-    def set_user(self, cog_name, ident, user_id, key, value, *, clear=False):
+    def set_user(self, cog_name, ident, user_id, key, value, clear=False):
         user_id = str(user_id)
         if clear:
             self.data["USER"][user_id] = {}

--- a/cogs/utils/drivers/red_json.py
+++ b/cogs/utils/drivers/red_json.py
@@ -13,7 +13,8 @@ class JSON(BaseDriver):
         except FileNotFoundError:
             self.data = {}
 
-        for k in ("GLOBAL", "SERVER", "CHANNEL", "ROLE", "MEMBER", "USER"):
+        for k in ("GLOBAL", "SERVER", "CHANNEL", "ROLE", "MEMBER", "USER",
+                  "MISC"):
             if k not in self.data:
                 self.data[k] = {}
         try:
@@ -46,6 +47,10 @@ class JSON(BaseDriver):
     def get_user(self, cog_name, ident, user_id, key, *, default=None):
         userdata = self.data["USER"].get(str(user_id), {})
         return userdata.get(key, default)
+
+    def get_misc(self, cog_name, ident, *, default=None):
+        miscdata = self.data["MISC"]
+        return miscdata.get("MISC", default)
 
     def set_global(self, cog_name, ident, _, key, value, *, clear=False):
         if clear:
@@ -120,4 +125,11 @@ class JSON(BaseDriver):
             except KeyError:
                 self.data["USER"][user_id] = {}
                 self.data["USER"][user_id][key] = value
+        dataIO.save_json(self.data_path, self.data)
+
+    def set_misc(self, cog_name, ident, value, clear=False):
+        if clear:
+            self.data["MISC"] = {}
+        else:
+            self.data["MISC"]["MISC"] = value
         dataIO.save_json(self.data_path, self.data)

--- a/cogs/utils/drivers/red_json.py
+++ b/cogs/utils/drivers/red_json.py
@@ -1,8 +1,9 @@
-from .dataIO import dataIO
+from ..dataIO import dataIO
 import os
+from .red_base import BaseDriver
 
 
-class JSON:
+class JSON(BaseDriver):
     def __init__(self, cog_name, *args, **kwargs):
         self.cog_name = cog_name
         self.data_path = "data/{}/settings.json".format(self.cog_name)

--- a/cogs/utils/drivers/red_mongo.py
+++ b/cogs/utils/drivers/red_mongo.py
@@ -1,4 +1,5 @@
 import pymongo as m
+from .red_base import BaseDriver
 
 
 class RedMongoException(Exception):
@@ -17,7 +18,7 @@ class MissingCollection(RedMongoException):
     pass
 
 
-class Mongo:
+class Mongo(BaseDriver):
     def __init__(self, host, port=27017, admin_user=None, admin_pass=None,
                  **kwargs):
         self.conn = m.MongoClient(host=host, port=port, **kwargs)

--- a/cogs/utils/drivers/red_mongo.py
+++ b/cogs/utils/drivers/red_mongo.py
@@ -38,7 +38,7 @@ class Mongo(BaseDriver):
         self._user = self._db.USER
         self._misc = self._db.MISC
 
-    def get_global(self, cog_name, cog_identifier, key, *, default=None):
+    def get_global(self, cog_name, cog_identifier, _, key, *, default=None):
         doc = self._global.find(
             {"cog_name": cog_name, "cog_identifier": cog_identifier},
             projection=[key, ], batch_size=2)

--- a/cogs/utils/red_json.py
+++ b/cogs/utils/red_json.py
@@ -1,4 +1,5 @@
 from .dataIO import dataIO
+import os
 
 
 class JSON:
@@ -14,7 +15,11 @@ class JSON:
         for k in ("GLOBAL", "SERVER", "CHANNEL", "ROLE", "MEMBER", "USER"):
             if k not in self.data:
                 self.data[k] = {}
-        dataIO.save_json(self.data_path, self.data)
+        try:
+            dataIO.save_json(self.data_path, self.data)
+        except FileNotFoundError:
+            os.makedirs("data/{}".format(self.cog_name))
+            dataIO.save_json(self.data_path, self.data)
 
     def get_global(self, cog_name, ident, key, *, default=None):
         return self.data["GLOBAL"].get(key, default)

--- a/cogs/utils/red_json.py
+++ b/cogs/utils/red_json.py
@@ -21,7 +21,7 @@ class JSON:
             os.makedirs("data/{}".format(self.cog_name))
             dataIO.save_json(self.data_path, self.data)
 
-    def get_global(self, cog_name, ident, key, *, default=None):
+    def get_global(self, cog_name, ident, _, key, *, default=None):
         return self.data["GLOBAL"].get(key, default)
 
     def get_server(self, cog_name, ident, server_id, key, *, default=None):

--- a/cogs/utils/red_json.py
+++ b/cogs/utils/red_json.py
@@ -1,0 +1,116 @@
+from .dataIO import dataIO
+
+
+class JSON:
+    def __init__(self, cog_name, *args, **kwargs):
+        self.cog_name = cog_name
+        self.data_path = "data/{}/settings.json".format(self.cog_name)
+
+        try:
+            self.data = dataIO.load_json(self.data_path)
+        except FileNotFoundError:
+            self.data = {}
+
+        for k in ("GLOBAL", "SERVER", "CHANNEL", "ROLE", "MEMBER", "USER"):
+            if k not in self.data:
+                self.data[k] = {}
+        dataIO.save_json(self.data_path, self.data)
+
+    def get_global(self, cog_name, ident, key, *, default=None):
+        return self.data["GLOBAL"].get(key, default)
+
+    def get_server(self, cog_name, ident, server_id, key, *, default=None):
+        serverdata = self.data["SERVER"].get(str(server_id), {})
+        return serverdata.get(key, default)
+
+    def get_channel(self, cog_name, ident, channel_id, key, *, default=None):
+        channeldata = self.data["CHANNEL"].get(str(channel_id), {})
+        return channeldata.get(key, default)
+
+    def get_role(self, cog_name, ident, role_id, key, *, default=None):
+        roledata = self.data["ROLE"].get(str(role_id), {})
+        return roledata.get(key, default)
+
+    def get_member(self, cog_name, ident, user_id, server_id, key, *,
+                   default=None):
+        userdata = self.data["MEMBER"].get(str(user_id), {})
+        serverdata = userdata.get(str(server_id), {})
+        return serverdata.get(key, default)
+
+    def get_user(self, cog_name, ident, user_id, key, *, default=None):
+        userdata = self.data["USER"].get(str(user_id), {})
+        return userdata.get(key, default)
+
+    def set_global(self, cog_name, ident, key, value, clear=False):
+        if clear:
+            self.data["GLOBAL"] = {}
+        else:
+            self.data["GLOBAL"][key] = value
+        dataIO.save_json(self.data_path, self.data)
+
+    def set_server(self, cog_name, ident, server_id, key, value, clear=False):
+        server_id = str(server_id)
+        if clear:
+            self.data["SERVER"][server_id] = {}
+        else:
+            try:
+                self.data["SERVER"][server_id][key] = value
+            except KeyError:
+                self.data["SERVER"][server_id] = {}
+                self.data["SERVER"][server_id][key] = value
+        dataIO.save_json(self.data_path, self.data)
+
+    def set_channel(self, cog_name, ident, channel_id, key, value,
+                    clear=False):
+        channel_id = str(channel_id)
+        if clear:
+            self.data["CHANNEL"][channel_id] = {}
+        else:
+            try:
+                self.data["CHANNEL"][channel_id][key] = value
+            except KeyError:
+                self.data["CHANNEL"][channel_id] = {}
+                self.data["CHANNEL"][channel_id][key] = value
+        dataIO.save_json(self.data_path, self.data)
+
+    def set_role(self, cog_name, ident, role_id, key, value, clear=False):
+        role_id = str(role_id)
+        if clear:
+            self.data["ROLE"][role_id] = {}
+        else:
+            try:
+                self.data["ROLE"][role_id][key] = value
+            except KeyError:
+                self.data["ROLE"][role_id] = {}
+                self.data["ROLE"][role_id][key] = value
+        dataIO.save_json(self.data_path, self.data)
+
+    def set_member(self, cog_name, ident, user_id, server_id, key, value,
+                   clear=False):
+        user_id = str(user_id)
+        server_id = str(server_id)
+        if clear:
+            self.data["MEMBER"][user_id] = {}
+        else:
+            try:
+                self.data["MEMBER"][user_id][server_id][key] = value
+            except KeyError:
+                if user_id not in self.data["MEMBER"]:
+                    self.data["MEMBER"][user_id] = {}
+                if server_id not in self.data["MEMBER"][user_id]:
+                    self.data["MEMBER"][user_id][server_id] = {}
+
+                self.data["MEMBER"][user_id][server_id][key] = value
+        dataIO.save_json(self.data_path, self.data)
+
+    def set_user(self, cog_name, ident, user_id, key, value, clear=False):
+        user_id = str(user_id)
+        if clear:
+            self.data["USER"][user_id] = {}
+        else:
+            try:
+                self.data["USER"][user_id][key] = value
+            except KeyError:
+                self.data["USER"][user_id] = {}
+                self.data["USER"][user_id][key] = value
+        dataIO.save_json(self.data_path, self.data)

--- a/cogs/utils/red_mongo.py
+++ b/cogs/utils/red_mongo.py
@@ -18,10 +18,17 @@ class MissingCollection(RedMongoException):
 
 
 class Mongo:
-    def __init__(self, host, port=27017, **kwargs):
+    def __init__(self, host, port=27017, admin_user=None, admin_pass=None,
+                 **kwargs):
         self.conn = m.MongoClient(host=host, port=port, **kwargs)
 
+        self.admin_user = admin_user
+        self.admin_pass = admin_pass
+
         self._db = self.conn.red
+        if self.admin_user is not None and self.admin_pass is not None:
+            self._db.authenticate(self.admin_user, self.admin_pass)
+
         self._global = self._db.GLOBAL
         self._server = self._db.SERVER
         self._channel = self._db.CHANNEL

--- a/cogs/utils/red_mongo.py
+++ b/cogs/utils/red_mongo.py
@@ -1,0 +1,180 @@
+import pymongo as m
+
+
+class RedMongoException(Exception):
+    """Base Red Mongo Exception class"""
+    pass
+
+
+class MultipleMatches(RedMongoException):
+    """Raised when multiple documents match a single cog_name and
+        cog_identifier pair."""
+    pass
+
+
+class MissingCollection(RedMongoException):
+    """Raised when a collection is missing from the mongo db"""
+    pass
+
+
+class Mongo:
+    def __init__(self, host, port=27017, **kwargs):
+        self.conn = m.MongoClient(host=host, port=port, **kwargs)
+
+        self._db = self.conn.red
+        self._global = self._db.GLOBAL
+        self._server = self._db.SERVER
+        self._channel = self._db.CHANNEL
+        self._role = self._db.ROLE
+        self._member = self._db.MEMBER
+        self._user = self._db.USER
+
+    def get_global(self, cog_name, cog_identifier, key, *, default=None):
+        doc = self._global.find(
+            {"cog_name": cog_name, "cog_identifier": cog_identifier},
+            projection=[key, ], batch_size=2)
+        if len(doc) == 2:
+            raise MultipleMatches("Too many matching documents at the GLOBAL"
+                                  " level: ({}, {})".format(cog_name,
+                                                            cog_identifier))
+        elif len(doc) == 1:
+            return doc[0].get(key, default)
+        return default
+
+    def get_server(self, cog_name, cog_identifier, server_id, key, *,
+                   default=None):
+        doc = self._server.find(
+            {"cog_name": cog_name, "cog_identifier": cog_identifier,
+             "server_id": server_id},
+            projection=[key, ], batch_size=2)
+        if len(doc) == 2:
+            raise MultipleMatches("Too many matching documents at the SERVER"
+                                  " level: ({}, {}, {})".format(
+                                      cog_name, cog_identifier, server_id))
+        elif len(doc) == 1:
+            return doc[0].get(key, default)
+        return default
+
+    def get_channel(self, cog_name, cog_identifier, channel_id, key, *,
+                    default=None):
+        doc = self._channel.find(
+            {"cog_name": cog_name, "cog_identifier": cog_identifier,
+             "channel_id": channel_id},
+            projection=[key, ], batch_size=2)
+        if len(doc) == 2:
+            raise MultipleMatches("Too many matching documents at the CHANNEL"
+                                  " level: ({}, {}, {})".format(
+                                      cog_name, cog_identifier, channel_id))
+        elif len(doc) == 1:
+            return doc[0].get(key, default)
+        return default
+
+    def get_role(self, cog_name, cog_identifier, role_id, key, *,
+                 default=None):
+        doc = self._role.find(
+            {"cog_name": cog_name, "cog_identifier": cog_identifier,
+             "role_id": role_id},
+            projection=[key, ], batch_size=2)
+        if len(doc) == 2:
+            raise MultipleMatches("Too many matching documents at the SERVER"
+                                  " level: ({}, {}, {})".format(
+                                      cog_name, cog_identifier, role_id))
+        elif len(doc) == 1:
+            return doc[0].get(key, default)
+        return default
+
+    def get_member(self, cog_name, cog_identifier, user_id, server_id, key, *,
+                   default=None):
+        doc = self._member.find(
+            {"cog_name": cog_name, "cog_identifier": cog_identifier,
+             "user_id": user_id, "server_id": server_id},
+            projection=[key, ], batch_size=2)
+        if len(doc) == 2:
+            raise MultipleMatches("Too many matching documents at the SERVER"
+                                  " level: ({}, {}, mid {}, sid {})".format(
+                                      cog_name, cog_identifier, user_id,
+                                      server_id))
+        elif len(doc) == 1:
+            return doc[0].get(key, default)
+        return default
+
+    def get_user(self, cog_name, cog_identifier, user_id, key, *,
+                 default=None):
+        doc = self._global.find(
+            {"cog_name": cog_name, "cog_identifier": cog_identifier,
+             "user_id": user_id},
+            projection=[key, ], batch_size=2)
+        if len(doc) == 2:
+            raise MultipleMatches("Too many matching documents at the SERVER"
+                                  " level: ({}, {}, mid {})".format(
+                                      cog_name, cog_identifier, user_id))
+        elif len(doc) == 1:
+            return doc[0].get(key, default)
+        return default
+
+    def set_global(self, cog_name, cog_identifier, key, value):
+        filter = {"cog_name": cog_name, "cog_identifier": cog_identifier}
+        data = {key: value}
+        if self._global.count(filter) > 1:
+            raise MultipleMatches("Too many matching documents at the GLOBAL"
+                                  " level: ({}, {})".format(cog_name,
+                                                            cog_identifier))
+        else:
+            self._global.update_one(filter, data, upsert=True)
+
+    def set_server(self, cog_name, cog_identifier, server_id, key, value):
+        filter = {"cog_name": cog_name, "cog_identifier": cog_identifier,
+                  "server_id": server_id}
+        data = {key: value}
+        if self._server.count(filter) > 1:
+            raise MultipleMatches("Too many matching documents at the SERVER"
+                                  " level: ({}, {}, {})".format(
+                                      cog_name, cog_identifier, server_id))
+        else:
+            self._server.update_one(filter, data, upsert=True)
+
+    def set_channel(self, cog_name, cog_identifier, channel_id, key, value):
+        filter = {"cog_name": cog_name, "cog_identifier": cog_identifier,
+                  "channel_id": channel_id}
+        data = {key: value}
+        if self._channel.count(filter) > 1:
+            raise MultipleMatches("Too many matching documents at the CHANNEL"
+                                  " level: ({}, {}, {})".format(
+                                      cog_name, cog_identifier, channel_id))
+        else:
+            self._channel.update_one(filter, data, upsert=True)
+
+    def set_role(self, cog_name, cog_identifier, role_id, key, value):
+        filter = {"cog_name": cog_name, "cog_identifier": cog_identifier,
+                  "role_id": role_id}
+        data = {key: value}
+        if self._role.count(filter) > 1:
+            raise MultipleMatches("Too many matching documents at the ROLE"
+                                  " level: ({}, {}, {})".format(
+                                      cog_name, cog_identifier, role_id))
+        else:
+            self._role.update_one(filter, data, upsert=True)
+
+    def set_member(self, cog_name, cog_identifier, user_id, server_id, key,
+                   value):
+        filter = {"cog_name": cog_name, "cog_identifier": cog_identifier,
+                  "server_id": server_id, "user_id": user_id}
+        data = {key: value}
+        if self._member.count(filter) > 1:
+            raise MultipleMatches("Too many matching documents at the SERVER"
+                                  " level: ({}, {}, mid {}, sid {})".format(
+                                      cog_name, cog_identifier, user_id,
+                                      server_id))
+        else:
+            self._member.update_one(filter, data, upsert=True)
+
+    def set_user(self, cog_name, cog_identifier, user_id, key, value):
+        filter = {"cog_name": cog_name, "cog_identifier": cog_identifier,
+                  "user_id": user_id}
+        data = {key: value}
+        if self._user.count(filter) > 1:
+            raise MultipleMatches("Too many matching documents at the SERVER"
+                                  " level: ({}, {}, mid {})".format(
+                                      cog_name, cog_identifier, user_id))
+        else:
+            self._user.update_one(filter, data, upsert=True)

--- a/cogs/utils/red_mongo.py
+++ b/cogs/utils/red_mongo.py
@@ -33,11 +33,11 @@ class Mongo:
         doc = self._global.find(
             {"cog_name": cog_name, "cog_identifier": cog_identifier},
             projection=[key, ], batch_size=2)
-        if len(doc) == 2:
+        if doc.count() == 2:
             raise MultipleMatches("Too many matching documents at the GLOBAL"
                                   " level: ({}, {})".format(cog_name,
                                                             cog_identifier))
-        elif len(doc) == 1:
+        elif doc.count() == 1:
             return doc[0].get(key, default)
         return default
 
@@ -47,11 +47,11 @@ class Mongo:
             {"cog_name": cog_name, "cog_identifier": cog_identifier,
              "server_id": server_id},
             projection=[key, ], batch_size=2)
-        if len(doc) == 2:
+        if doc.count() == 2:
             raise MultipleMatches("Too many matching documents at the SERVER"
                                   " level: ({}, {}, {})".format(
                                       cog_name, cog_identifier, server_id))
-        elif len(doc) == 1:
+        elif doc.count() == 1:
             return doc[0].get(key, default)
         return default
 
@@ -61,11 +61,11 @@ class Mongo:
             {"cog_name": cog_name, "cog_identifier": cog_identifier,
              "channel_id": channel_id},
             projection=[key, ], batch_size=2)
-        if len(doc) == 2:
+        if doc.count() == 2:
             raise MultipleMatches("Too many matching documents at the CHANNEL"
                                   " level: ({}, {}, {})".format(
                                       cog_name, cog_identifier, channel_id))
-        elif len(doc) == 1:
+        elif doc.count() == 1:
             return doc[0].get(key, default)
         return default
 
@@ -75,11 +75,11 @@ class Mongo:
             {"cog_name": cog_name, "cog_identifier": cog_identifier,
              "role_id": role_id},
             projection=[key, ], batch_size=2)
-        if len(doc) == 2:
+        if doc.count() == 2:
             raise MultipleMatches("Too many matching documents at the SERVER"
                                   " level: ({}, {}, {})".format(
                                       cog_name, cog_identifier, role_id))
-        elif len(doc) == 1:
+        elif doc.count() == 1:
             return doc[0].get(key, default)
         return default
 
@@ -89,32 +89,33 @@ class Mongo:
             {"cog_name": cog_name, "cog_identifier": cog_identifier,
              "user_id": user_id, "server_id": server_id},
             projection=[key, ], batch_size=2)
-        if len(doc) == 2:
+        if doc.count() == 2:
             raise MultipleMatches("Too many matching documents at the SERVER"
                                   " level: ({}, {}, mid {}, sid {})".format(
                                       cog_name, cog_identifier, user_id,
                                       server_id))
-        elif len(doc) == 1:
+        elif doc.count() == 1:
             return doc[0].get(key, default)
         return default
 
     def get_user(self, cog_name, cog_identifier, user_id, key, *,
                  default=None):
-        doc = self._global.find(
+        doc = self._user.find(
             {"cog_name": cog_name, "cog_identifier": cog_identifier,
              "user_id": user_id},
             projection=[key, ], batch_size=2)
-        if len(doc) == 2:
+        if doc.count() == 2:
             raise MultipleMatches("Too many matching documents at the SERVER"
                                   " level: ({}, {}, mid {})".format(
                                       cog_name, cog_identifier, user_id))
-        elif len(doc) == 1:
+        elif doc.count() == 1:
             return doc[0].get(key, default)
-        return default
+        else:
+            return default
 
     def set_global(self, cog_name, cog_identifier, key, value):
         filter = {"cog_name": cog_name, "cog_identifier": cog_identifier}
-        data = {key: value}
+        data = {"$set": {key: value}}
         if self._global.count(filter) > 1:
             raise MultipleMatches("Too many matching documents at the GLOBAL"
                                   " level: ({}, {})".format(cog_name,
@@ -125,7 +126,7 @@ class Mongo:
     def set_server(self, cog_name, cog_identifier, server_id, key, value):
         filter = {"cog_name": cog_name, "cog_identifier": cog_identifier,
                   "server_id": server_id}
-        data = {key: value}
+        data = {"$set": {key: value}}
         if self._server.count(filter) > 1:
             raise MultipleMatches("Too many matching documents at the SERVER"
                                   " level: ({}, {}, {})".format(
@@ -136,7 +137,7 @@ class Mongo:
     def set_channel(self, cog_name, cog_identifier, channel_id, key, value):
         filter = {"cog_name": cog_name, "cog_identifier": cog_identifier,
                   "channel_id": channel_id}
-        data = {key: value}
+        data = {"$set": {key: value}}
         if self._channel.count(filter) > 1:
             raise MultipleMatches("Too many matching documents at the CHANNEL"
                                   " level: ({}, {}, {})".format(
@@ -147,7 +148,7 @@ class Mongo:
     def set_role(self, cog_name, cog_identifier, role_id, key, value):
         filter = {"cog_name": cog_name, "cog_identifier": cog_identifier,
                   "role_id": role_id}
-        data = {key: value}
+        data = {"$set": {key: value}}
         if self._role.count(filter) > 1:
             raise MultipleMatches("Too many matching documents at the ROLE"
                                   " level: ({}, {}, {})".format(
@@ -159,7 +160,7 @@ class Mongo:
                    value):
         filter = {"cog_name": cog_name, "cog_identifier": cog_identifier,
                   "server_id": server_id, "user_id": user_id}
-        data = {key: value}
+        data = {"$set": {key: value}}
         if self._member.count(filter) > 1:
             raise MultipleMatches("Too many matching documents at the SERVER"
                                   " level: ({}, {}, mid {}, sid {})".format(
@@ -171,7 +172,7 @@ class Mongo:
     def set_user(self, cog_name, cog_identifier, user_id, key, value):
         filter = {"cog_name": cog_name, "cog_identifier": cog_identifier,
                   "user_id": user_id}
-        data = {key: value}
+        data = {"$set": {key: value}}
         if self._user.count(filter) > 1:
             raise MultipleMatches("Too many matching documents at the SERVER"
                                   " level: ({}, {}, mid {})".format(

--- a/cogs/utils/red_mongo.py
+++ b/cogs/utils/red_mongo.py
@@ -113,7 +113,7 @@ class Mongo:
         else:
             return default
 
-    def set_global(self, cog_name, cog_identifier, key, value):
+    def set_global(self, cog_name, cog_identifier, key, value, clear=False):
         filter = {"cog_name": cog_name, "cog_identifier": cog_identifier}
         data = {"$set": {key: value}}
         if self._global.count(filter) > 1:
@@ -121,9 +121,13 @@ class Mongo:
                                   " level: ({}, {})".format(cog_name,
                                                             cog_identifier))
         else:
-            self._global.update_one(filter, data, upsert=True)
+            if clear:
+                self._global.delete_one(filter)
+            else:
+                self._global.update_one(filter, data, upsert=True)
 
-    def set_server(self, cog_name, cog_identifier, server_id, key, value):
+    def set_server(self, cog_name, cog_identifier, server_id, key, value,
+                   clear=False):
         filter = {"cog_name": cog_name, "cog_identifier": cog_identifier,
                   "server_id": server_id}
         data = {"$set": {key: value}}
@@ -132,9 +136,13 @@ class Mongo:
                                   " level: ({}, {}, {})".format(
                                       cog_name, cog_identifier, server_id))
         else:
-            self._server.update_one(filter, data, upsert=True)
+            if clear:
+                self._server.delete_one(filter)
+            else:
+                self._server.update_one(filter, data, upsert=True)
 
-    def set_channel(self, cog_name, cog_identifier, channel_id, key, value):
+    def set_channel(self, cog_name, cog_identifier, channel_id, key, value,
+                    clear=False):
         filter = {"cog_name": cog_name, "cog_identifier": cog_identifier,
                   "channel_id": channel_id}
         data = {"$set": {key: value}}
@@ -143,9 +151,13 @@ class Mongo:
                                   " level: ({}, {}, {})".format(
                                       cog_name, cog_identifier, channel_id))
         else:
-            self._channel.update_one(filter, data, upsert=True)
+            if clear:
+                self._channel.delete_one(filter)
+            else:
+                self._channel.update_one(filter, data, upsert=True)
 
-    def set_role(self, cog_name, cog_identifier, role_id, key, value):
+    def set_role(self, cog_name, cog_identifier, role_id, key, value,
+                 clear=False):
         filter = {"cog_name": cog_name, "cog_identifier": cog_identifier,
                   "role_id": role_id}
         data = {"$set": {key: value}}
@@ -154,10 +166,13 @@ class Mongo:
                                   " level: ({}, {}, {})".format(
                                       cog_name, cog_identifier, role_id))
         else:
-            self._role.update_one(filter, data, upsert=True)
+            if clear:
+                self._role.delete_one(filter)
+            else:
+                self._role.update_one(filter, data, upsert=True)
 
     def set_member(self, cog_name, cog_identifier, user_id, server_id, key,
-                   value):
+                   value, clear=False):
         filter = {"cog_name": cog_name, "cog_identifier": cog_identifier,
                   "server_id": server_id, "user_id": user_id}
         data = {"$set": {key: value}}
@@ -167,9 +182,13 @@ class Mongo:
                                       cog_name, cog_identifier, user_id,
                                       server_id))
         else:
-            self._member.update_one(filter, data, upsert=True)
+            if clear:
+                self._member.delete_one(filter)
+            else:
+                self._member.update_one(filter, data, upsert=True)
 
-    def set_user(self, cog_name, cog_identifier, user_id, key, value):
+    def set_user(self, cog_name, cog_identifier, user_id, key, value,
+                 clear=False):
         filter = {"cog_name": cog_name, "cog_identifier": cog_identifier,
                   "user_id": user_id}
         data = {"$set": {key: value}}
@@ -178,4 +197,7 @@ class Mongo:
                                   " level: ({}, {}, mid {})".format(
                                       cog_name, cog_identifier, user_id))
         else:
-            self._user.update_one(filter, data, upsert=True)
+            if clear:
+                self._user.delete_one(filter)
+            else:
+                self._user.update_one(filter, data, upsert=True)

--- a/cogs/utils/settings.py
+++ b/cogs/utils/settings.py
@@ -262,6 +262,15 @@ class Settings:
         self.bot_settings['MONGO_PASSWORD'] = value
         self.save_settings()
 
+    @property
+    def backend(self):
+        return self.bot_settings.get("BACKEND", "json")
+
+    @backend.setter
+    def backend(self, value):
+        self.bot_settings["BACKEND"] = value
+        self.save_settings()
+
     def get_server(self, server):
         if server is None:
             return self.bot_settings["default"].copy()

--- a/cogs/utils/settings.py
+++ b/cogs/utils/settings.py
@@ -22,8 +22,8 @@ class Settings:
             "default": {"ADMIN_ROLE": "Transistor",
                         "MOD_ROLE": "Process",
                         "PREFIXES": []}
-                        }
-        self._memory_only = False
+        }
+        self.memory_only = False
 
         if not dataIO.is_valid_json(self.path):
             self.bot_settings = deepcopy(self.default_settings)
@@ -225,6 +225,24 @@ class Settings:
         for server in server_ids:
             ret.update({server: self.bot_settings[server]})
         return ret
+
+    @property
+    def rethink_url(self):
+        return self.bot_settings.get("RETHINK_URL", 'localhost')
+
+    @rethink_url.setter
+    def rethink_url(self, value):
+        self.bot_settings["RETHINK_URL"] = value
+        self.save_settings()
+
+    @property
+    def rethink_port(self):
+        return self.bot_settings.get("RETHINK_PORT", 28015)
+
+    @rethink_port.setter
+    def rethink_port(self, value):
+        self.bot_settings["RETHINK_PORT"] = value
+        self.save_settings
 
     def get_server(self, server):
         if server is None:

--- a/cogs/utils/settings.py
+++ b/cogs/utils/settings.py
@@ -228,21 +228,39 @@ class Settings:
 
     @property
     def mongo_url(self):
-        return self.bot_settings.get("mongo_URL", 'localhost')
+        return self.bot_settings.get("MONGO_URL", 'localhost')
 
     @mongo_url.setter
     def mongo_url(self, value):
-        self.bot_settings["mongo_URL"] = value
+        self.bot_settings["MONGO_URL"] = value
         self.save_settings()
 
     @property
     def mongo_port(self):
-        return self.bot_settings.get("mongo_PORT", 28015)
+        return self.bot_settings.get("MONGO_PORT", 27017)
 
     @mongo_port.setter
     def mongo_port(self, value):
-        self.bot_settings["mongo_PORT"] = value
+        self.bot_settings["MONGO_PORT"] = value
         self.save_settings
+
+    @property
+    def mongo_user(self):
+        return self.bot_settings.get("MONGO_USER", "")
+
+    @mongo_user.setter
+    def mongo_port(self, value):
+        self.bot_settings["MONGO_USER"] = value
+        self.save_settings()
+
+    @property
+    def mongo_password(self):
+        return self.bot_settings.get("MONGO_PASSWORD", "")
+
+    @mongo_password.setter
+    def mongo_password(self, value):
+        self.bot_settings['MONGO_PASSWORD'] = value
+        self.save_settings()
 
     def get_server(self, server):
         if server is None:

--- a/cogs/utils/settings.py
+++ b/cogs/utils/settings.py
@@ -227,21 +227,21 @@ class Settings:
         return ret
 
     @property
-    def rethink_url(self):
-        return self.bot_settings.get("RETHINK_URL", 'localhost')
+    def mongo_url(self):
+        return self.bot_settings.get("mongo_URL", 'localhost')
 
-    @rethink_url.setter
-    def rethink_url(self, value):
-        self.bot_settings["RETHINK_URL"] = value
+    @mongo_url.setter
+    def mongo_url(self, value):
+        self.bot_settings["mongo_URL"] = value
         self.save_settings()
 
     @property
-    def rethink_port(self):
-        return self.bot_settings.get("RETHINK_PORT", 28015)
+    def mongo_port(self):
+        return self.bot_settings.get("mongo_PORT", 28015)
 
-    @rethink_port.setter
-    def rethink_port(self, value):
-        self.bot_settings["RETHINK_PORT"] = value
+    @mongo_port.setter
+    def mongo_port(self, value):
+        self.bot_settings["mongo_PORT"] = value
         self.save_settings
 
     def get_server(self, server):

--- a/cogs/utils/settings.py
+++ b/cogs/utils/settings.py
@@ -249,7 +249,7 @@ class Settings:
         return self.bot_settings.get("MONGO_USER", "")
 
     @mongo_user.setter
-    def mongo_port(self, value):
+    def mongo_user(self, value):
         self.bot_settings["MONGO_USER"] = value
         self.save_settings()
 

--- a/cogs/utils/settings.py
+++ b/cogs/utils/settings.py
@@ -23,7 +23,7 @@ class Settings:
                         "MOD_ROLE": "Process",
                         "PREFIXES": []}
         }
-        self.memory_only = False
+        self._memory_only = False
 
         if not dataIO.is_valid_json(self.path):
             self.bot_settings = deepcopy(self.default_settings)

--- a/red.py
+++ b/red.py
@@ -227,8 +227,11 @@ class Bot(commands.Bot):
     def get_mongo_conf(self, cog_name, unique_identifier):
         url = self.settings.mongo_url
         port = self.settings.mongo_port
-        driver = Mongo(url, port)
-        return CogConfig(cog_name, unique_identifier, driver)
+
+        def spawn_driver():
+            return Mongo(url, port)
+
+        return CogConfig(cog_name, unique_identifier, spawn_driver)
 
 
 class Formatter(commands.HelpFormatter):

--- a/red.py
+++ b/red.py
@@ -226,6 +226,19 @@ class Bot(commands.Bot):
         return await asyncio.wait_for(response, timeout=timeout)
 
     def get_conf(self, cog_name, unique_identifier):
+        """
+        Gets a config object that cog's can use to safely store data. The
+            backend to this is totally modular and can easily switch between
+            JSON and a DB. However, when changed, all data will likely be lost
+            unless cogs write some converters for their data.
+
+        Positional Arguments:
+        cog_name - String representation of your cog name, normally something
+            like `self.__class__.__name__`
+        unique_identifier - a random integer or string that is used to
+            differentiate your cog from any other named the same. This way we
+            can safely store data for multiple cogs that are named the same.
+        """
         url = self.settings.mongo_url
         port = self.settings.mongo_port
 

--- a/red.py
+++ b/red.py
@@ -28,6 +28,8 @@ except AssertionError:
 from cogs.utils.settings import Settings
 from cogs.utils.dataIO import dataIO
 from cogs.utils.chat_formatting import inline
+from cogs.utils.red_mongo import Mongo
+from cogs.utils.config import Config as CogConfig
 from collections import Counter
 from io import TextIOWrapper
 
@@ -221,6 +223,12 @@ class Bot(commands.Bot):
 
         response = self.loop.run_in_executor(None, install)
         return await asyncio.wait_for(response, timeout=timeout)
+
+    def get_mongo_conf(self, cog_name, unique_identifier):
+        url = self.settings.mongo_url
+        port = self.settings.mongo_port
+        driver = Mongo(url, port)
+        return CogConfig(cog_name, unique_identifier, driver)
 
 
 class Formatter(commands.HelpFormatter):

--- a/red.py
+++ b/red.py
@@ -225,7 +225,7 @@ class Bot(commands.Bot):
         response = self.loop.run_in_executor(None, install)
         return await asyncio.wait_for(response, timeout=timeout)
 
-    def get_mongo_conf(self, cog_name, unique_identifier):
+    def get_conf(self, cog_name, unique_identifier):
         url = self.settings.mongo_url
         port = self.settings.mongo_port
 

--- a/red.py
+++ b/red.py
@@ -28,8 +28,8 @@ except AssertionError:
 from cogs.utils.settings import Settings
 from cogs.utils.dataIO import dataIO
 from cogs.utils.chat_formatting import inline
-from cogs.utils.red_mongo import Mongo
-from cogs.utils.red_json import JSON as JSONDriver
+from cogs.utils.drivers.red_mongo import Mongo
+from cogs.utils.drivers.red_json import JSON as JSONDriver
 from cogs.utils.config import Config as CogConfig
 from collections import Counter
 from io import TextIOWrapper

--- a/red.py
+++ b/red.py
@@ -29,6 +29,7 @@ from cogs.utils.settings import Settings
 from cogs.utils.dataIO import dataIO
 from cogs.utils.chat_formatting import inline
 from cogs.utils.red_mongo import Mongo
+from cogs.utils.red_json import JSON as JSONDriver
 from cogs.utils.config import Config as CogConfig
 from collections import Counter
 from io import TextIOWrapper
@@ -228,8 +229,13 @@ class Bot(commands.Bot):
         url = self.settings.mongo_url
         port = self.settings.mongo_port
 
-        def spawn_driver():
+        def spawn_mongo_driver():
             return Mongo(url, port)
+
+        if self.settings.backend == "json":
+            spawn_driver = JSONDriver(cog_name)
+        elif self.settings.backend == "mongo":
+            spawn_driver = spawn_mongo_driver
 
         return CogConfig(cog_name, unique_identifier, spawn_driver)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pip
 git+git://github.com/Rapptz/discord.py.git#egg=discord.py[voice]
 youtube_dl
 imgurpython
+pymongo


### PR DESCRIPTION
Lot's o shit changed, we know have:
 * Defined global/server/channel/role/member/user specific CONFIG variables accessed through a config interface
 * Adds `MONGO_URL` and `MONGO_PORT` keys to red.json WHICH MUST BE SET BEFORE USE
 * Use `bot.get_conf(cogname, some_random_unique_number_or_string_that_SHOULD_NEVER_CHANGE)` to get your global conf object

Quick Example:
```py
conf = bot.get_conf("Test", 12980234578923458902345)

conf.register_global("keyname")
conf.register_server("keyname")
conf.register_channel("keyname")
conf.register_role("keyname")
conf.register_member("keyname")
conf.register_user("keyname")

conf.keyname
conf.set("keyname", value)
conf.set_misc({"test1": "hello"})

conf.server(server_obj).keyname
conf.server(server_obj).set("keyname", value)

conf.channel(channel_obj).keyname

conf.role(role_obj).keyname

conf.member(member_obj).keyname

conf.user(user_obj).keyname

conf.misc()
```

[Example cog](https://github.com/tekulvw/Squid-Plugins/blob/master/example518/example518.py)