### PR TITLE
[Owner] display availble update count in [p]version

### DIFF
--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -4,7 +4,6 @@ from cogs.utils import checks
 from __main__ import set_cog
 from .utils.dataIO import dataIO
 from .utils.chat_formatting import pagify, box
-from requests.compat import json as complexjson
 
 import importlib
 import traceback
@@ -15,7 +14,6 @@ import datetime
 import glob
 import os
 import aiohttp
-import json
 
 log = logging.getLogger("red.owner")
 


### PR DESCRIPTION
This will pull the commit log for the repo from github's api and return an int representing the number of available updates (aka commits that have not yet been pulled) which is then added into the embed that [p]version posts or return None if there is some sort of failure in that check (for example if the repo url is somehow not valid)