### PR TITLE
Added a class to chat utils to help make strings plural

### DIFF
--- a/cogs/utils/chat_formatting.py
+++ b/cogs/utils/chat_formatting.py
@@ -1,3 +1,16 @@
+
+class PluralDict(dict):
+    def __missing__(self, key):
+        if '(' in key and key.endswith(')'):
+            key, rest = key.split('(', 1)
+            value = super().__getitem__(key)
+            suffix = rest.rstrip(')').split(',')
+            if len(suffix) == 1:
+                suffix.insert(0, '')
+            return suffix[0] if value <= 1 else suffix[1]
+        raise KeyError(key)
+
+
 def error(text):
     return "\N{NO ENTRY SIGN} {}".format(text)
 


### PR DESCRIPTION
This is a cool way to make strings plural in your output. This could be a niche thing, but I have found it useful. Below is a small cog showing two examples.

```Python
from discord.ext import commands
from cogs.utils.chat_formatting import PluralDict


class Test:
    def __init__(self, bot):
        self.bot = bot

    @commands.command(pass_context=True, no_pm=True)
    async def test1(self, ctx, seconds: int):
        remaining = self.time_test(seconds)
        await self.bot.say(remaining)

    @commands.command(pass_context=True, no_pm=True)
    async def test2(self, ctx):
        loot = self.loot_calculator()
        await self.bot.say(loot)

    def time_test(self, seconds):
        m, s = divmod(seconds, 60)
        h, m = divmod(m, 60)
        data = PluralDict({'hour': h, 'minute': m, 'second': s})
        fmt = ("{hour} hour{hour(s)}, {minute} minute{minute(s)}, "
               "and {second} second{second(s)}")
        msg = fmt.format_map(data)
        return msg

    def loot_calculator(self):
        loot_table = PluralDict({'scarf': 2, "staff": 2, "sword": 1})
        fmt = ("You recieved: {scarf} scar{scarf(f,ves)}, {staff} sta{staff(ff,ves)}, "
               "and {sword} sword{sword(s)}")
        msg = fmt.format_map(loot_table)
        return msg


def setup(bot):
    n = Test(bot)
    bot.add_cog(n)
```
**Test1**
[p]test1 4000
\>>> 1 hour, 6 minutes, and 40 seconds

**Test2**
[p]test2
\>>> You recieved: 2 scarves, 2 staves, and 1 sword