### PR TITLE
Add commands for setting default mod/admin roles for the bot

### DIFF
--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -297,7 +297,7 @@ class Owner:
            This is used if a server-specific role is not set"""
         self.bot.settings.default_mod = role_name
         self.bot.settings.save_settings()
-        await self.bot.say("Set the default mod role")
+        await self.bot.say("The default mod role name has been set.")
 
     @_set.command()
     @checks.is_owner()
@@ -307,7 +307,7 @@ class Owner:
            This is used if a server-specific role is not set"""
         self.bot.settings.default_admin = role_name
         self.bot.settings.save_settings()
-        await self.bot.say("Set the default admin role")
+        await self.bot.say("The default admin role name has been set.")
 
     @_set.command(pass_context=True)
     @checks.is_owner()

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -291,6 +291,28 @@ class Owner:
 
     @_set.command(pass_context=True)
     @checks.is_owner()
+    async def defaultmodrole(self, ctx, role_name: str):
+        """Sets the default mod role_name
+           (which is used if a server-specific
+           one is not set)
+        """
+        self.bot.settings.default_mod = role_name
+        self.bot.settings.save_settings()
+        await self.bot.say("Set the default mod role")
+
+    @_set.command(pass_context=True)
+    @checks.is_owner()
+    async def defaultadminrole(self, ctx, role_name: str):
+        """Sets the default admin role_name
+           (which is used if a server-specific
+           one is not set)
+        """
+        self.bot.settings.default_admin = role_name
+        self.bot.settings.save_settings()
+        await self.bot.say("Set the default admin role")
+
+    @_set.command(pass_context=True)
+    @checks.is_owner()
     async def prefix(self, ctx, *prefixes):
         """Sets Red's global prefixes
 

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -289,24 +289,22 @@ class Owner:
                              args=(ctx.message.author,))
         t.start()
 
-    @_set.command(pass_context=True)
+    @_set.command()
     @checks.is_owner()
-    async def defaultmodrole(self, ctx, role_name: str):
-        """Sets the default mod role_name
-           (which is used if a server-specific
-           one is not set)
-        """
+    async def defaultmodrole(self, *, role_name: str):
+        """Sets the default mod role name
+
+           This is used if a server-specific role is not set"""
         self.bot.settings.default_mod = role_name
         self.bot.settings.save_settings()
         await self.bot.say("Set the default mod role")
 
-    @_set.command(pass_context=True)
+    @_set.command()
     @checks.is_owner()
-    async def defaultadminrole(self, ctx, role_name: str):
-        """Sets the default admin role_name
-           (which is used if a server-specific
-           one is not set)
-        """
+    async def defaultadminrole(self, *, role_name: str):
+        """Sets the default admin role name
+
+           This is used if a server-specific role is not set"""
         self.bot.settings.default_admin = role_name
         self.bot.settings.save_settings()
         await self.bot.say("Set the default admin role")


### PR DESCRIPTION
Pretty self explanatory. Currently there isn't a way to set the default mod and admin roles short of redoing setup or manually editing the json but this adds the commands to do it inside discord