### PR TITLE
[Core] Added on_error logging

### DIFF
--- a/red.py
+++ b/red.py
@@ -375,6 +375,10 @@ def initialize(bot_class=Bot, formatter_class=Formatter):
         else:
             bot.logger.exception(type(error).__name__, exc_info=error)
 
+    @bot.event
+    async def on_error(error, ctx):
+        bot.logger.exception(type(error).__name__, exc_info=error)
+
     return bot
 
 

--- a/red.py
+++ b/red.py
@@ -376,8 +376,8 @@ def initialize(bot_class=Bot, formatter_class=Formatter):
             bot.logger.exception(type(error).__name__, exc_info=error)
 
     @bot.event
-    async def on_error(error, ctx):
-        bot.logger.exception(type(error).__name__, exc_info=error)
+    async def on_error(error_event, *args, **kwargs):
+        bot.logger.error("Error in event: {}".format(event_name), exc_info=sys.exc_info())
 
     return bot
 

--- a/red.py
+++ b/red.py
@@ -377,7 +377,7 @@ def initialize(bot_class=Bot, formatter_class=Formatter):
 
     @bot.event
     async def on_error(error_event, *args, **kwargs):
-        bot.logger.error("Error in event: {}".format(event_name), exc_info=sys.exc_info())
+        bot.logger.error("Error in event: {}".format(error_event), exc_info=sys.exc_info())
 
     return bot
 


### PR DESCRIPTION
Added on_error logging to handle errors that don't occur in commands. What this does is logging them to the logging module, that redirects them to the handlers (By default ``data/red/red.log`` and stdout)

One thing that I'm not very clear on is the ``ctx`` argument in the ``on_error`` function though. Could not find any information on it.