### PR TITLE
Fix pagify bug

### DIFF
--- a/cogs/utils/chat_formatting.py
+++ b/cogs/utils/chat_formatting.py
@@ -40,8 +40,9 @@ def pagify(text, delims=["\n"], *, escape=True, shorten_by=8,
         shorten_by += num_mentions
     page_length -= shorten_by
     while len(in_text) > page_length:
-        closest_delim = max([in_text.rfind(d, len(d), page_length)
-                             for d in delims])
+        closest_delim = max([in_text.rfind(d, len(d) if in_text.startswith(d)
+                                           else 0, page_length)
+                            for d in delims])
         closest_delim = closest_delim if closest_delim != -1 else page_length
         if escape:
             to_send = escape_mass_mentions(in_text[:closest_delim])

--- a/cogs/utils/chat_formatting.py
+++ b/cogs/utils/chat_formatting.py
@@ -40,21 +40,22 @@ def pagify(text, delims=["\n"], *, escape=True, shorten_by=8,
         shorten_by += num_mentions
     page_length -= shorten_by
     while len(in_text) > page_length:
-        closest_delim = max([in_text.rfind(d, len(d) if in_text.startswith(d)
-                                           else 0, page_length)
-                            for d in delims])
-        closest_delim = closest_delim if closest_delim != -1 else page_length
+        closest_delim = max([in_text.rfind(d, 0, page_length)
+                             for d in delims])
+        closest_delim = closest_delim if closest_delim > 0 else page_length
         if escape:
             to_send = escape_mass_mentions(in_text[:closest_delim])
         else:
             to_send = in_text[:closest_delim]
-        yield to_send
+        if len(to_send.strip()) > 0:
+            yield to_send
         in_text = in_text[closest_delim:]
 
-    if escape:
-        yield escape_mass_mentions(in_text)
-    else:
-        yield in_text
+    if len(in_text.strip()) > 0:
+        if escape:
+            yield escape_mass_mentions(in_text)
+        else:
+            yield in_text
 
 
 def strikethrough(text):

--- a/cogs/utils/chat_formatting.py
+++ b/cogs/utils/chat_formatting.py
@@ -40,7 +40,7 @@ def pagify(text, delims=["\n"], *, escape=True, shorten_by=8,
         shorten_by += num_mentions
     page_length -= shorten_by
     while len(in_text) > page_length:
-        closest_delim = max([in_text.rfind(d, 0, page_length)
+        closest_delim = max([in_text.rfind(d, len(d), page_length)
                              for d in delims])
         closest_delim = closest_delim if closest_delim != -1 else page_length
         if escape:


### PR DESCRIPTION
Right now it seems pagify() will yield an empty string if it can't find a deliminator, and on looking at the code it looks like it's because it finds the deliminator at the start of the string if it's the second page or higher (since it was just cut off there for the previous page). By replacing the second `rfind` argument with `len(d)`, I think that'll fix that, and _limited_ testing shows that it does.