### PR TITLE
[Downloader] Fix error on branch cog update

### DIFF
--- a/cogs/downloader.py
+++ b/cogs/downloader.py
@@ -581,14 +581,14 @@ class Downloader:
             else:
                 rpcmd = ["git", "-C", dd + name, "rev-parse", "HEAD"]
                 p = run(["git", "-C", dd + name, "reset", "--hard",
-                        "origin/HEAD", "-q"])
+                        "HEAD", "-q"])
                 if p.returncode != 0:
-                    raise UpdateError("Error resetting to origin/HEAD")
+                    raise UpdateError("Error resetting to HEAD")
                 p = run(rpcmd, stdout=PIPE)
                 if p.returncode != 0:
                     raise UpdateError("Unable to determine old commit hash")
                 oldhash = p.stdout.decode().strip()
-                p = run(["git", "-C", dd + name, "pull", "-q", "--ff-only"])
+                p = run(["git", "-C", dd + name, "pull", "-q"])
                 if p.returncode != 0:
                     raise UpdateError("Error pulling updates")
                 p = run(rpcmd, stdout=PIPE)


### PR DESCRIPTION
Branches get a "<repo name that is a branch>: Error Pulling Updates" when trying to do cog update. This is due to two things:
1. branches can't ff-only if they are not merged. Merging fixes this but point 2 is still valid.
2. reset --hard origin/HEAD reverts it to the point where it split up from the master branch. So even if the error regarding ff is fixed, it will keep redownloading the latest files since it's being reverted to the split point all the time.