### PR TITLE
[Mod] APIify modlogs

### DIFF
--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -151,11 +151,18 @@ class ModLog:
 
         dataIO.save_json("data/mod/modlog.json", self.cases)
 
-        msg = await self.bot.get_message(channel, case["message"])
-        if msg:
-            await self.bot.edit_message(msg, case_msg)
-        else:
+        if case["message"] is None:
             raise CaseMessageNotFound()
+
+        try:
+            msg = await self.bot.get_message(channel, case["message"])
+        except discord.NotFound:
+            raise CaseMessageNotFound()
+        except discord.Forbidden:
+            raise NoModLogAccess()
+        else:
+            await self.bot.edit_message(msg, case_msg)
+
 
     def format_case_msg(self, case, server):
         tmp = case.copy()


### PR DESCRIPTION
This will allow for easier usage of mod logs by third party cogs by allowing them to be able to register new case types. The mod log can be accessed by other cogs by doing something like `self.modlog = self.bot.get_cog("Mod").modlog`. Then from there, they can use `register_casetype` to add a new case type and then use `new_case` for adding new cases. This does not reset cases at all, but settings related to the modlog feature (i.e. modlog channel and case type settings) would need to be redone by the user after updating if this were merged as is