### PR TITLE
[general] fix poll question slice when length of prefix > 1

### DIFF
--- a/cogs/general.py
+++ b/cogs/general.py
@@ -339,7 +339,7 @@ class General:
             if "@everyone" in check or "@here" in check:
                 await self.bot.say("Nice try.")
                 return
-            p = NewPoll(message, self)
+            p = NewPoll(message, " ".join(text), self)
             if p.valid:
                 self.poll_sessions.append(p)
                 await p.start()
@@ -377,13 +377,12 @@ class General:
             return user.joined_at
 
 class NewPoll():
-    def __init__(self, message, main):
+    def __init__(self, message, text, main):
         self.channel = message.channel
         self.author = message.author.id
         self.client = main.bot
         self.poll_sessions = main.poll_sessions
-        msg = message.content[6:]
-        msg = msg.split(";")
+        msg = [ans.strip() for ans in text.split(";")]
         if len(msg) < 2: # Needs at least one question and 2 choices
             self.valid = False
             return None


### PR DESCRIPTION
Currently, questions/answers are extracted with a hard-coded slice of the message content:
`msg = message.content[6:]`

Polls invoked with a prefix longer than 1 character have unwanted characters bleeding into the question. This PR fixes that, and also happens to fix a related problem I found, where italics markdown would break if answers contained whitespace at the beginning or end.

This is in reference to issue #684 .