### PR TITLE
[Streams] add list of streamalerts for specified channel

### DIFF
--- a/cogs/streams.py
+++ b/cogs/streams.py
@@ -113,18 +113,22 @@ class Streams:
            (defaults to the current channel)"""
         if not channel:
             channel = ctx.message.channel
-        msg = "Twitch Streams: \n"
-        for stream in self.twitch_streams:
-            if channel.id in stream["CHANNELS"]:
-                msg += stream["NAME"] + " is " + ("online" if stream["ALREADY_ONLINE"] else "offline") + "\n"
-        msg += "\nBeam Streams: \n"
-        for stream in self.beam_streams:
-            if channel.id in stream["CHANNELS"]:
-                msg += stream["NAME"] + " is " + ("online" if stream["ALREADY_ONLINE"] else "offline") + "\n"
-        msg += "\nHitbox Streams: \n"
-        for stream in self.hitbox_streams:
-            if channel.id in stream["CHANNELS"]:
-                msg += stream["NAME"] + " is " + ("online" if stream["ALREADY_ONLINE"] else "offline") + "\n"
+        msg = "Stream alerts for the current channel: "
+        if len([s for s in self.twitch_streams if channel.id in s["CHANNELS"]]) > 0:
+            msg += "\nTwitch Streams: \n"
+            for stream in self.twitch_streams:
+                if channel.id in stream["CHANNELS"]:
+                    msg += stream["NAME"] + " is " + ("online" if stream["ALREADY_ONLINE"] else "offline") + "\n"
+        if len([s for s in self.beam_streams if channel.id in s["CHANNELS"]]) > 0:
+            msg += "\nBeam Streams: \n"
+            for stream in self.beam_streams:
+                if channel.id in stream["CHANNELS"]:
+                    msg += stream["NAME"] + " is " + ("online" if stream["ALREADY_ONLINE"] else "offline") + "\n"
+        if len([s for s in self.hitbox_streams if channel.id in s["CHANNELS"]]) > 0:
+            msg += "\nHitbox Streams: \n"
+            for stream in self.hitbox_streams:
+                if channel.id in stream["CHANNELS"]:
+                    msg += stream["NAME"] + " is " + ("online" if stream["ALREADY_ONLINE"] else "offline") + "\n"
         await self.bot.say(msg)
 
     @streamalert.command(name="twitch", pass_context=True)

--- a/cogs/streams.py
+++ b/cogs/streams.py
@@ -80,13 +80,33 @@ class Streams:
             await self.bot.say("Error.")
 
     @commands.group(pass_context=True, no_pm=True)
-    @checks.mod_or_permissions(manage_server=True)
     async def streamalert(self, ctx):
         """Adds/removes stream alerts from the current channel"""
         if ctx.invoked_subcommand is None:
             await send_cmd_help(ctx)
 
+    @streamalert.command(name="list", pass_context=True)
+    async def streamalert_list(self, ctx, channel: discord.Channel=None):
+        """Lists all streamalerts for the specified channel
+           (defaults to the current channel)"""
+        if not channel:
+            channel = ctx.message.channel
+        msg = "Twitch Streams: \n"
+        for stream in self.twitch_streams:
+            if channel.id in stream["CHANNELS"]:
+                msg += stream["NAME"] + " is " + ("online" if stream["ALREADY_ONLINE"] else "offline") + "\n"
+        msg += "\nBeam Streams: \n"
+        for stream in self.beam_streams:
+            if channel.id in stream["CHANNELS"]:
+                msg += stream["NAME"] + " is " + ("online" if stream["ALREADY_ONLINE"] else "offline") + "\n"
+        msg += "\nHitbox Streams: \n"
+        for stream in self.hitbox_streams:
+            if channel.id in stream["CHANNELS"]:
+                msg += stream["NAME"] + " is " + ("online" if stream["ALREADY_ONLINE"] else "offline") + "\n"
+        await self.bot.say(msg)
+
     @streamalert.command(name="twitch", pass_context=True)
+    @checks.mod_or_permissions(manage_server=True)
     async def twitch_alert(self, ctx, stream: str):
         """Adds/removes twitch alerts from the current channel"""
         stream = escape_mass_mentions(stream)
@@ -138,6 +158,7 @@ class Streams:
         dataIO.save_json("data/streams/twitch.json", self.twitch_streams)
 
     @streamalert.command(name="hitbox", pass_context=True)
+    @checks.mod_or_permissions(manage_server=True)
     async def hitbox_alert(self, ctx, stream: str):
         """Adds/removes hitbox alerts from the current channel"""
         stream = escape_mass_mentions(stream)
@@ -184,6 +205,7 @@ class Streams:
         dataIO.save_json("data/streams/hitbox.json", self.hitbox_streams)
 
     @streamalert.command(name="beam", pass_context=True)
+    @checks.mod_or_permissions(manage_server=True)
     async def beam_alert(self, ctx, stream: str):
         """Adds/removes beam alerts from the current channel"""
         stream = escape_mass_mentions(stream)
@@ -230,6 +252,7 @@ class Streams:
         dataIO.save_json("data/streams/beam.json", self.beam_streams)
 
     @streamalert.command(name="stop", pass_context=True)
+    @checks.mod_or_permissions(manage_server=True)
     async def stop_alert(self, ctx):
         """Stops all streams alerts in the current channel"""
         channel = ctx.message.channel


### PR DESCRIPTION
Adds in a simple list of streamalerts for a specified channel (defaulting to the channel the command is run in). This command is accessible to everyone and so the checks that were originally on the base streamalert command have been moved to the subcommands that need to be protected. Shoutouts to ZeroContrast#7382 in Discord for the idea