### PR TITLE
[Mod] move ignore/unignore of servers and channels to Owner

### DIFF
--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -1582,10 +1582,8 @@ def check_folders():
 
 
 def check_files():
-    ignore_list = {"SERVERS": [], "CHANNELS": []}
 
     files = {
-        "ignorelist.json"     : ignore_list,
         "filter.json"         : {},
         "past_names.json"     : {},
         "past_nicknames.json" : {},

--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -94,7 +94,6 @@ class Mod:
 
     def __init__(self, bot):
         self.bot = bot
-        self.ignore_list = dataIO.load_json("data/mod/ignorelist.json")
         self.filter = dataIO.load_json("data/mod/filter.json")
         self.past_names = dataIO.load_json("data/mod/past_names.json")
         self.past_nicknames = dataIO.load_json("data/mod/past_nicknames.json")
@@ -1041,92 +1040,6 @@ class Mod:
                                "channel (or its message history)")
         else:
             await self.bot.say("Case #{} updated.".format(case))
-
-    @commands.group(pass_context=True, no_pm=True)
-    @checks.admin_or_permissions(manage_channels=True)
-    async def ignore(self, ctx):
-        """Adds servers/channels to ignorelist"""
-        if ctx.invoked_subcommand is None:
-            await send_cmd_help(ctx)
-            await self.bot.say(self.count_ignored())
-
-    @ignore.command(name="channel", pass_context=True)
-    async def ignore_channel(self, ctx, channel: discord.Channel=None):
-        """Ignores channel
-
-        Defaults to current one"""
-        current_ch = ctx.message.channel
-        if not channel:
-            if current_ch.id not in self.ignore_list["CHANNELS"]:
-                self.ignore_list["CHANNELS"].append(current_ch.id)
-                dataIO.save_json("data/mod/ignorelist.json", self.ignore_list)
-                await self.bot.say("Channel added to ignore list.")
-            else:
-                await self.bot.say("Channel already in ignore list.")
-        else:
-            if channel.id not in self.ignore_list["CHANNELS"]:
-                self.ignore_list["CHANNELS"].append(channel.id)
-                dataIO.save_json("data/mod/ignorelist.json", self.ignore_list)
-                await self.bot.say("Channel added to ignore list.")
-            else:
-                await self.bot.say("Channel already in ignore list.")
-
-    @ignore.command(name="server", pass_context=True)
-    async def ignore_server(self, ctx):
-        """Ignores current server"""
-        server = ctx.message.server
-        if server.id not in self.ignore_list["SERVERS"]:
-            self.ignore_list["SERVERS"].append(server.id)
-            dataIO.save_json("data/mod/ignorelist.json", self.ignore_list)
-            await self.bot.say("This server has been added to the ignore list.")
-        else:
-            await self.bot.say("This server is already being ignored.")
-
-    @commands.group(pass_context=True, no_pm=True)
-    @checks.admin_or_permissions(manage_channels=True)
-    async def unignore(self, ctx):
-        """Removes servers/channels from ignorelist"""
-        if ctx.invoked_subcommand is None:
-            await send_cmd_help(ctx)
-            await self.bot.say(self.count_ignored())
-
-    @unignore.command(name="channel", pass_context=True)
-    async def unignore_channel(self, ctx, channel: discord.Channel=None):
-        """Removes channel from ignore list
-
-        Defaults to current one"""
-        current_ch = ctx.message.channel
-        if not channel:
-            if current_ch.id in self.ignore_list["CHANNELS"]:
-                self.ignore_list["CHANNELS"].remove(current_ch.id)
-                dataIO.save_json("data/mod/ignorelist.json", self.ignore_list)
-                await self.bot.say("This channel has been removed from the ignore list.")
-            else:
-                await self.bot.say("This channel is not in the ignore list.")
-        else:
-            if channel.id in self.ignore_list["CHANNELS"]:
-                self.ignore_list["CHANNELS"].remove(channel.id)
-                dataIO.save_json("data/mod/ignorelist.json", self.ignore_list)
-                await self.bot.say("Channel removed from ignore list.")
-            else:
-                await self.bot.say("That channel is not in the ignore list.")
-
-    @unignore.command(name="server", pass_context=True)
-    async def unignore_server(self, ctx):
-        """Removes current server from ignore list"""
-        server = ctx.message.server
-        if server.id in self.ignore_list["SERVERS"]:
-            self.ignore_list["SERVERS"].remove(server.id)
-            dataIO.save_json("data/mod/ignorelist.json", self.ignore_list)
-            await self.bot.say("This server has been removed from the ignore list.")
-        else:
-            await self.bot.say("This server is not in the ignore list.")
-
-    def count_ignored(self):
-        msg = "```Currently ignoring:\n"
-        msg += str(len(self.ignore_list["CHANNELS"])) + " channels\n"
-        msg += str(len(self.ignore_list["SERVERS"])) + " servers\n```\n"
-        return msg
 
     @commands.group(name="filter", pass_context=True, no_pm=True)
     @checks.mod_or_permissions(manage_messages=True)

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -46,6 +46,7 @@ class Owner:
         self.setowner_lock = False
         self.disabled_commands = dataIO.load_json("data/red/disabled_commands.json")
         self.global_ignores = dataIO.load_json("data/red/global_ignores.json")
+        self.ignore_list = dataIO.load_json("data/mod/ignorelist.json")
         self.session = aiohttp.ClientSession(loop=self.bot.loop)
 
     def __unload(self):
@@ -252,6 +253,92 @@ class Owner:
                     finally:
                         break
             await self.bot.say(box(page, lang="py"))
+
+    @commands.group(pass_context=True, no_pm=True)
+    @checks.admin_or_permissions(manage_channels=True)
+    async def ignore(self, ctx):
+        """Adds servers/channels to ignorelist"""
+        if ctx.invoked_subcommand is None:
+            await self.bot.send_cmd_help(ctx)
+            await self.bot.say(self.count_ignored())
+
+    @ignore.command(name="channel", pass_context=True)
+    async def ignore_channel(self, ctx, channel: discord.Channel=None):
+        """Ignores channel
+
+        Defaults to current one"""
+        current_ch = ctx.message.channel
+        if not channel:
+            if current_ch.id not in self.ignore_list["CHANNELS"]:
+                self.ignore_list["CHANNELS"].append(current_ch.id)
+                dataIO.save_json("data/mod/ignorelist.json", self.ignore_list)
+                await self.bot.say("Channel added to ignore list.")
+            else:
+                await self.bot.say("Channel already in ignore list.")
+        else:
+            if channel.id not in self.ignore_list["CHANNELS"]:
+                self.ignore_list["CHANNELS"].append(channel.id)
+                dataIO.save_json("data/mod/ignorelist.json", self.ignore_list)
+                await self.bot.say("Channel added to ignore list.")
+            else:
+                await self.bot.say("Channel already in ignore list.")
+
+    @ignore.command(name="server", pass_context=True)
+    async def ignore_server(self, ctx):
+        """Ignores current server"""
+        server = ctx.message.server
+        if server.id not in self.ignore_list["SERVERS"]:
+            self.ignore_list["SERVERS"].append(server.id)
+            dataIO.save_json("data/mod/ignorelist.json", self.ignore_list)
+            await self.bot.say("This server has been added to the ignore list.")
+        else:
+            await self.bot.say("This server is already being ignored.")
+
+    @commands.group(pass_context=True, no_pm=True)
+    @checks.admin_or_permissions(manage_channels=True)
+    async def unignore(self, ctx):
+        """Removes servers/channels from ignorelist"""
+        if ctx.invoked_subcommand is None:
+            await self.bot.send_cmd_help(ctx)
+            await self.bot.say(self.count_ignored())
+
+    @unignore.command(name="channel", pass_context=True)
+    async def unignore_channel(self, ctx, channel: discord.Channel=None):
+        """Removes channel from ignore list
+
+        Defaults to current one"""
+        current_ch = ctx.message.channel
+        if not channel:
+            if current_ch.id in self.ignore_list["CHANNELS"]:
+                self.ignore_list["CHANNELS"].remove(current_ch.id)
+                dataIO.save_json("data/mod/ignorelist.json", self.ignore_list)
+                await self.bot.say("This channel has been removed from the ignore list.")
+            else:
+                await self.bot.say("This channel is not in the ignore list.")
+        else:
+            if channel.id in self.ignore_list["CHANNELS"]:
+                self.ignore_list["CHANNELS"].remove(channel.id)
+                dataIO.save_json("data/mod/ignorelist.json", self.ignore_list)
+                await self.bot.say("Channel removed from ignore list.")
+            else:
+                await self.bot.say("That channel is not in the ignore list.")
+
+    @unignore.command(name="server", pass_context=True)
+    async def unignore_server(self, ctx):
+        """Removes current server from ignore list"""
+        server = ctx.message.server
+        if server.id in self.ignore_list["SERVERS"]:
+            self.ignore_list["SERVERS"].remove(server.id)
+            dataIO.save_json("data/mod/ignorelist.json", self.ignore_list)
+            await self.bot.say("This server has been removed from the ignore list.")
+        else:
+            await self.bot.say("This server is not in the ignore list.")
+
+    def count_ignored(self):
+        msg = "```Currently ignoring:\n"
+        msg += str(len(self.ignore_list["CHANNELS"])) + " channels\n"
+        msg += str(len(self.ignore_list["SERVERS"])) + " servers\n```\n"
+        return msg
 
     @commands.group(name="set", pass_context=True)
     async def _set(self, ctx):

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -46,7 +46,7 @@ class Owner:
         self.setowner_lock = False
         self.disabled_commands = dataIO.load_json("data/red/disabled_commands.json")
         self.global_ignores = dataIO.load_json("data/red/global_ignores.json")
-        self.ignore_list = dataIO.load_json("data/mod/ignorelist.json")
+        self.ignore_list = dataIO.load_json("data/red/ignorelist.json")
         self.session = aiohttp.ClientSession(loop=self.bot.loop)
 
     def __unload(self):
@@ -1158,12 +1158,26 @@ def _import_old_data(data):
 
     return data
 
+def _import_old_ignorelist(data):
+    """Import ignorelist.json from mod.py"""
+    try:
+        data["ignorelist"] = dataIO.load_json("data/mod/ignorelist.json")
+    except FileNotFoundError:
+        pass
+    return data
 
 def check_files():
     if not os.path.isfile("data/red/disabled_commands.json"):
         print("Creating empty disabled_commands.json...")
         dataIO.save_json("data/red/disabled_commands.json", [])
-
+    if not os.path.isfile("data/red/ignorelist.json"):
+        print("Creating empty ignorelist.json...")
+        data = {"SERVERS": [], "CHANNELS": []}
+        try:
+            data = _import_old_ignorelist(data)
+        except Exception as e:
+            log.error("Failed to migrate ignore list data from mod.py: {}".format(e))
+        dataIO.save_json("data/red/ignorelist.json", data)
     if not os.path.isfile("data/red/global_ignores.json"):
         print("Creating empty global_ignores.json...")
         data = {"blacklist": [], "whitelist": []}

--- a/red.py
+++ b/red.py
@@ -156,7 +156,7 @@ class Bot(commands.Bot):
         if author == self.user:
             return self.settings.self_bot
 
-        mod_cog = self.get_cog('Mod')
+        local_ignores = self.get_cog("Owner").ignore_list
         global_ignores = self.get_cog('Owner').global_ignores
 
         if self.settings.owner == author.id:
@@ -180,13 +180,12 @@ class Bot(commands.Bot):
                 if r is not None:
                     return True
 
-        if mod_cog is not None:
-            if not message.channel.is_private:
-                if message.server.id in mod_cog.ignore_list["SERVERS"]:
-                    return False
+        if not message.channel.is_private:
+            if message.server.id in local_ignores.ignore_list["SERVERS"]:
+                return False
 
-                if message.channel.id in mod_cog.ignore_list["CHANNELS"]:
-                    return False
+            if message.channel.id in local_ignores.ignore_list["CHANNELS"]:
+                return False
 
         return True
 


### PR DESCRIPTION
Moves the ignore and unignore commands to the owner cog. They don't really belong in mod IMO as they target ignoring channels/servers and aren't really related to moderating users so much as granular control over where the bot works. Related to #700