### PR TITLE
[Streams] Twitch API v5

### DIFF
--- a/cogs/streams.py
+++ b/cogs/streams.py
@@ -71,7 +71,7 @@ class Streams:
         regex = r'^(https?\:\/\/)?(www\.)?(twitch\.tv\/)'
         stream = re.sub(regex, '', stream)
         try:
-            data = await self.fetch_twitch_id(stream, raise_if_none=True)
+            data = await self.fetch_twitch_ids(stream, raise_if_none=True)
             embed = await self.twitch_online(data[0]["_id"])
         except OfflineStream:
             await self.bot.say(stream + " is offline.")
@@ -118,7 +118,7 @@ class Streams:
         stream = re.sub(regex, '', stream)
         channel = ctx.message.channel
         try:
-            data = await self.fetch_twitch_id(stream, raise_if_none=True)
+            data = await self.fetch_twitch_ids(stream, raise_if_none=True)
         except StreamNotFound:
             await self.bot.say("That stream doesn't exist.")
             return
@@ -298,8 +298,7 @@ class Streams:
         elif data["livestream"][0]["media_is_live"] == "0":
             raise OfflineStream()
         elif data["livestream"][0]["media_is_live"] == "1":
-            data = self.hitbox_embed(data)
-            return data
+            return self.hitbox_embed(data)
 
         raise APIError()
 
@@ -317,8 +316,7 @@ class Streams:
         if r.status == 200:
             if data["stream"] is None:
                 raise OfflineStream()
-            embed = self.twitch_embed(data)
-            return embed
+            return self.twitch_embed(data)
         elif r.status == 400:
             raise InvalidCredentials()
         elif r.status == 404:
@@ -333,8 +331,7 @@ class Streams:
             data = await r.json(encoding='utf-8')
         if r.status == 200:
             if data["online"] is True:
-                data = self.beam_embed(data)
-                return data
+                return self.beam_embed(data)
             else:
                 raise OfflineStream()
         elif r.status == 404:
@@ -342,7 +339,7 @@ class Streams:
         else:
             raise APIError()
 
-    async def fetch_twitch_id(self, *streams, raise_if_none=False):
+    async def fetch_twitch_ids(self, *streams, raise_if_none=False):
         def chunks(l):
             for i in range(0, len(l), 100):
                 yield l[i:i + 100]
@@ -546,7 +543,7 @@ class Streams:
         if not to_convert:
             return
 
-        results = await self.fetch_twitch_id(*to_convert)
+        results = await self.fetch_twitch_ids(*to_convert)
 
         for stream in self.twitch_streams:
             for result in results:

--- a/cogs/streams.py
+++ b/cogs/streams.py
@@ -550,6 +550,9 @@ class Streams:
                 if stream["NAME"].lower() == result["name"].lower():
                     stream["ID"] = result["_id"]
 
+        # We might as well delete the invalid / renamed ones
+        self.twitch_streams = [s for s in self.twitch_streams if "ID" in s]
+
         dataIO.save_json("data/streams/twitch.json", self.twitch_streams)
 
 

--- a/cogs/streams.py
+++ b/cogs/streams.py
@@ -458,7 +458,14 @@ class Streams:
     async def stream_checker(self):
         CHECK_DELAY = 60
 
-        await self._convert_twitch_usernames_to_ids()
+        try:
+            await self._migration_twitch_v5()
+        except InvalidCredentials:
+            print("Error during convertion of twitch usernames to IDs: "
+                  "invalid token")
+        except Exception as e:
+            print("Error during convertion of twitch usernames to IDs: "
+                  "{}".format(e))
 
         while self == self.bot.get_cog("Streams"):
             save = False
@@ -529,8 +536,8 @@ class Streams:
         """Avoids Discord's caching"""
         return "?rnd=" + "".join([choice(ascii_letters) for i in range(6)])
 
-    async def _convert_twitch_usernames_to_ids(self):
-        # Migration to Twitch API v5
+    async def _migration_twitch_v5(self):
+        #  Migration of old twitch streams to API v5
         to_convert = []
         for stream in self.twitch_streams:
             if "ID" not in stream:

--- a/cogs/streams.py
+++ b/cogs/streams.py
@@ -480,10 +480,10 @@ class Streams:
                 else:
                     _type = "NAME"
                 for stream in streams_list:
+                    if _type not in stream:
+                        continue
                     key = (parser, stream[_type])
                     try:
-                        if _type not in stream:
-                            continue
                         embed = await parser(stream[_type])
                     except OfflineStream:
                         if stream["ALREADY_ONLINE"]:


### PR DESCRIPTION
This PR implements Twitch's api v5, which makes use of IDs instead of names.
Since names is all we used to store, this attempts to fetch and save all the missing stream IDs on loading (with a single request if they're inferior to 100).
Some testing would be appreciated, especially the migration part.