### PR TITLE
Fixes an issue with patch notes not showing

### DIFF
--- a/cogs/downloader.py
+++ b/cogs/downloader.py
@@ -519,8 +519,24 @@ class Downloader:
         return bool(find_spec(name))
 
     def _do_first_run(self):
-        invalid = []
         save = False
+        repos_copy = deepcopy(self.repos)
+
+        # Issue 725
+        for repo in repos_copy:
+            for cog in repos_copy[repo]:
+                cog_data = repos_copy[repo][cog]
+                if isinstance(cog_data, str):  # ... url field
+                    continue
+                for k, v in cog_data.items():
+                    if k in ("file", "folder"):
+                        repos_copy[repo][cog][k] = os.path.normpath(cog_data[k])
+
+        if self.repos != repos_copy:
+            self.repos = repos_copy
+            save = True
+
+        invalid = []
 
         for repo in self.repos:
             broken = 'url' in self.repos[repo] and len(self.repos[repo]) == 1

--- a/cogs/downloader.py
+++ b/cogs/downloader.py
@@ -13,6 +13,7 @@ from functools import partial
 from concurrent.futures import ThreadPoolExecutor
 from time import time
 from importlib.util import find_spec
+from copy import deepcopy
 
 NUM_THREADS = 4
 REPO_NONEX = 0x1

--- a/cogs/downloader.py
+++ b/cogs/downloader.py
@@ -344,9 +344,8 @@ class Downloader:
 
     def patch_notes_handler(self, repo_cog_hash_pairs):
         for repo, cog, oldhash in repo_cog_hash_pairs:
-            pathsplit = self.repos[repo][cog]['file'].split('/')
-            repo_path = os.path.join(*pathsplit[:-2])
-            cogfile = os.path.join(*pathsplit[-2:])
+            repo_path = os.path.join('data', 'downloader', repo)
+            cogfile = os.path.join(cog, cog + ".py")
             cmd = ["git", "-C", repo_path, "log", "--relative-date",
                    "--reverse", oldhash + '..', cogfile
                    ]


### PR DESCRIPTION
There was a discovery that the way repos are being added could lead to
multiple path separators being used within the "file" and "folder"
strings. This was brought about by "/" being used statically in some
locations of the downloader and the use of "os.path.join" in others.
However, it while the windows operating system, can handle this, the git
program installed cannot.
Until one path delimiters method is settled on and applied, I've
temporarily resolved the patch note issue by recreating the repo
location, and the cogfile within it using "os.path.join" so git now get
the correct values.

Resolves issue Twentysix26/Red-DiscordBot#725