### PR TITLE
[Launcher and Red.py] Red-DiscordBot-Sharded v1.0

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -575,7 +575,7 @@ def shardss_menu():
                 print("Enabled Sharding")
                 wait()
         elif choice == "2":
-            with open("data/data/shard/shard.json", "r+") as settings:
+            with open("data/shard/shard.json", "r+") as settings:
                 settings["SHARDS"] = "False"
                 f.seek(0)
                 f.write(json.dumps(settings, indent=4, sort_keys=True))

--- a/launcher.py
+++ b/launcher.py
@@ -572,7 +572,7 @@ def shardss_menu():
                 f.truncate()
                 print("Enabled Sharding")
         elif choice == "2":
-            with open("data/data/shard/shard.json", "r+") as settings:
+            with open("data/shard/shard.json", "r+") as settings:
                 settings["SHARDS"] = "False"
                 f.seek(0)
                 f.write(json.dumps(settings, indent=4, sort_keys=True))

--- a/launcher.py
+++ b/launcher.py
@@ -529,7 +529,7 @@ def main():
         print("3. Update")
         print("4. Install requirements")
         print("5. Maintenance (repair, reset...)")
-        print("6. Open Shard Menu (Back up Data, this is in Beta)")
+        print("6. Open Shard Menu v1.0 (Back up Data, There's a data issue)")
         print("\n0. Quit")
         choice = user_choice()
         if choice == "1":

--- a/launcher.py
+++ b/launcher.py
@@ -10,6 +10,7 @@ except ImportError:
 import platform
 import webbrowser
 import hashlib
+import json
 import argparse
 import shutil
 import stat
@@ -27,6 +28,10 @@ FFMPEG_BUILDS_URL = "https://ffmpeg.zeranoe.com/builds/"
 
 INTRO = ("==========================\n"
          "Red Discord Bot - Launcher\n"
+         "==========================\n")
+
+SHARD_INTRO = ("==========================\n"
+         "Red Discord Bot - Shard Menu\n"
          "==========================\n")
 
 IS_WINDOWS = os.name == "nt"
@@ -287,6 +292,7 @@ def update_menu():
         print("3. Update requirements")
         print("\nOthers:")
         print("4. Update pip (might require admin privileges)")
+        print("5. Disable Sharding")
         print("\n0. Go back")
         choice = user_choice()
         if choice == "1":
@@ -524,6 +530,7 @@ def main():
         print("3. Update")
         print("4. Install requirements")
         print("5. Maintenance (repair, reset...)")
+        print("6. Open Shard Menu (Back up Data, this is in Beta)")
         print("\n0. Quit")
         choice = user_choice()
         if choice == "1":
@@ -536,11 +543,45 @@ def main():
             requirements_menu()
         elif choice == "5":
             maintenance_menu()
+        elif choice == "6":
+            shardss_menu()
         elif choice == "0":
             break
         clear_screen()
 
 args = parse_cli_arguments()
+
+
+def shardss_menu():
+    clear_screen()
+    while True:
+        print(SHARD_INTRO)
+        print("Shard Menu:\n")
+        print("1. Enable Shards")
+        print("2. Disable Shards")
+        print("\n0. Go back")
+        choice = user_choice()
+        if choice == "1":
+            with open("data/red/settings.json", "r+") as f:
+                settings = json.load(f)
+                settings["SHARDS"] = "True"
+                settings["SHARD0"] = "0"
+                settings["SHARDC"] = "2"
+                f.seek(0)
+                f.write(json.dumps(settings, indent=4, sort_keys=True))
+                f.truncate()
+                print("Enabled Sharding")
+        elif choice == "2":
+            with open("data/red/settings.json", "r+") as settings:
+                settings["SHARDS"] = "False"
+                f.seek(0)
+                f.write(json.dumps(settings, indent=4, sort_keys=True))
+                f.truncate()
+                wait()
+                print("Disabled Sharding")
+        elif choice == "0":
+            break
+        clear_screen()
 
 if __name__ == '__main__':
     abspath = os.path.abspath(__file__)

--- a/launcher.py
+++ b/launcher.py
@@ -292,7 +292,6 @@ def update_menu():
         print("3. Update requirements")
         print("\nOthers:")
         print("4. Update pip (might require admin privileges)")
-        print("5. Disable Sharding")
         print("\n0. Go back")
         choice = user_choice()
         if choice == "1":

--- a/launcher.py
+++ b/launcher.py
@@ -292,6 +292,7 @@ def update_menu():
         print("3. Update requirements")
         print("\nOthers:")
         print("4. Update pip (might require admin privileges)")
+        print("5. Disable Sharding")
         print("\n0. Go back")
         choice = user_choice()
         if choice == "1":
@@ -561,7 +562,7 @@ def shardss_menu():
         print("\n0. Go back")
         choice = user_choice()
         if choice == "1":
-            with open("data/red/settings.json", "r+") as f:
+            with open("data/shard/shard.json", "r+") as f:
                 settings = json.load(f)
                 settings["SHARDS"] = "True"
                 settings["SHARD0"] = "0"
@@ -571,7 +572,7 @@ def shardss_menu():
                 f.truncate()
                 print("Enabled Sharding")
         elif choice == "2":
-            with open("data/red/settings.json", "r+") as settings:
+            with open("data/data/shard/shard.json", "r+") as settings:
                 settings["SHARDS"] = "False"
                 f.seek(0)
                 f.write(json.dumps(settings, indent=4, sort_keys=True))

--- a/launcher.py
+++ b/launcher.py
@@ -292,7 +292,6 @@ def update_menu():
         print("3. Update requirements")
         print("\nOthers:")
         print("4. Update pip (might require admin privileges)")
-        print("5. Disable Sharding")
         print("\n0. Go back")
         choice = user_choice()
         if choice == "1":
@@ -572,7 +571,7 @@ def shardss_menu():
                 f.truncate()
                 print("Enabled Sharding")
         elif choice == "2":
-            with open("data/shard/shard.json", "r+") as settings:
+            with open("data/data/shard/shard.json", "r+") as settings:
                 settings["SHARDS"] = "False"
                 f.seek(0)
                 f.write(json.dumps(settings, indent=4, sort_keys=True))

--- a/launcher.py
+++ b/launcher.py
@@ -558,26 +558,43 @@ def shardss_menu():
         print("Shard Menu:\n")
         print("1. Enable Shards")
         print("2. Disable Shards")
+        print("3. Add another shard Value")
         print("\n0. Go back")
         choice = user_choice()
         if choice == "1":
             with open("data/shard/shard.json", "r+") as f:
                 settings = json.load(f)
                 settings["SHARDS"] = "True"
-                settings["SHARD0"] = "0"
-                settings["SHARDC"] = "2"
+                shardidin = input("Please enter shard id here: ")
+                settings["SHARD0"] = shardidin
+                shardcountin = input("Please enter total shard count: ")
+                settings["SHARDC"] = shardcountin
                 f.seek(0)
                 f.write(json.dumps(settings, indent=4, sort_keys=True))
                 f.truncate()
                 print("Enabled Sharding")
+                wait()
         elif choice == "2":
             with open("data/data/shard/shard.json", "r+") as settings:
                 settings["SHARDS"] = "False"
                 f.seek(0)
                 f.write(json.dumps(settings, indent=4, sort_keys=True))
                 f.truncate()
-                wait()
                 print("Disabled Sharding")
+                wait()
+        elif choice == "3":
+            with open("data/shard/shard.json", "r+") as f:
+                shardname = input("Please enter value name (Something like SHARD0): ")
+                shardidout = input("Please enter shard id: ")
+                shardidcountout = input("Please enter total shard count: ")
+                settings = json.load(f)
+                settings[shardname] = shardidout
+                settings["SHARDC"] = shardidcountout
+                f.seek(0)
+                f.write(json.dumps(settings, indent=4, sort_keys=True))
+                f.truncate()
+                print("Added Value")
+                wait()
         elif choice == "0":
             break
         clear_screen()

--- a/red.py
+++ b/red.py
@@ -50,13 +50,13 @@ description = "Red - A multifunction Discord bot by Twentysix"
 shardpath = "data/shard/"
 if not os.path.exists(shardpath):
     os.makedirs(shardpath)
-
-# Firt Time Run Json, wont need it after
-with open(shardpath + "shard.json", "w") as f:
-    writeJ = '{"SHARDS": "False","SHARD0": "0","SHARD1": "1","SHARDC": "2"}'
-    parse = json.loads(writeJ)
-    f.write(json.dumps(parse, indent=4, sort_keys=True))
-    f.truncate()
+    with open(shardpath + "shard.json", "w") as f:
+        writeJ = '{"SHARDS": "False","SHARD0": "0","SHARD1": "1","SHARDC": "2"}'
+        parse = json.loads(writeJ)
+        f.write(json.dumps(parse, indent=4, sort_keys=True))
+        f.truncate()
+else:
+    print("Found Shard Path")
 
 with open("data/shard/shard.json") as f:
     config = json.load(f)

--- a/red.py
+++ b/red.py
@@ -7,6 +7,7 @@ import logging.handlers
 import traceback
 import datetime
 import subprocess
+import json
 
 try:
     assert sys.version_info >= (3, 5)
@@ -46,6 +47,23 @@ from io import TextIOWrapper
 
 description = "Red - A multifunction Discord bot by Twentysix"
 
+shardpath = "data/shard/"
+if not os.path.exists(shardpath):
+    os.makedirs(shardpath)
+
+# Firt Time Run Json, wont need it after
+with open(shardpath + "shard.json", "w") as f:
+    writeJ = '{"SHARDS": "False","SHARD0": "0","SHARD1": "1","SHARDC": "2"}'
+    parse = json.loads(writeJ)
+    f.write(json.dumps(parse, indent=4, sort_keys=True))
+    f.truncate()
+
+with open("data/shard/shard.json") as f:
+    config = json.load(f)
+
+shard_check = config["SHARDS"]
+shardzero = config["SHARD0"]
+shardc = config["SHARDC"]
 
 class Bot(commands.Bot):
     def __init__(self, *args, **kwargs):
@@ -245,7 +263,11 @@ class Formatter(commands.HelpFormatter):
 def initialize(bot_class=Bot, formatter_class=Formatter):
     formatter = formatter_class(show_check_failure=False)
 
-    bot = bot_class(formatter=formatter, description=description, pm_help=None)
+    #Basic Shard info. Create this file as many as the shards have.
+    if shard_check == "True":
+        bot = bot_class(formatter=formatter, description=description, pm_help=None, shard_id=int(shardzero), shard_count=int(shardc))
+    if shard_check == "False":
+        bot = bot_class(formatter=formatter, description=description, pm_help=None)
 
     import __main__
     __main__.send_cmd_help = bot.send_cmd_help  # Backwards
@@ -315,6 +337,10 @@ def initialize(bot_class=Bot, formatter_class=Formatter):
         print("\nConnected to:")
         print("{} servers".format(servers))
         print("{} channels".format(channels))
+        try:
+            print("Shard #{0} out of {1} Shards".format(bot.shard_id,bot.shard_count)) # Displays shard count and ID
+        except Exception as e:
+            print("No shards defind")
         print("{} users\n".format(users))
         prefix_label = 'Prefix'
         if len(bot.settings.prefixes) > 1:


### PR DESCRIPTION
![intro](https://catch-me-outside.how-about-th.at/71a85a.png)
## Red-DiscordBot-Sharded v1.0 - Maxie

### PR closed. (I made a mistake with disabling shards, go to the repo for the update. "will you finish v2.0?" eh.

# To-do
* Change file system to a database (or change file system that is shard friendly)
## Description
This is just Red-DiscordBot that can be sharded for the users that have big bots using the base.

## Why did you make this?
Since it seemed that others didn't take sharding as a priority, i whipped up something that allows you to shard with a red base.

## Setting up

If you modified your `red.py` you'll need to copy and paste the code i added.

Same with the launcher. Note, when using `Update Red` in the launcher, the new update may overwrite my code, so you'll need to repaste what i added.

### Setting up your first instance

make sure your shards.json file looks something like
```
{
    "SHARD0": "0",
    "SHARD1": "1",
    "SHARDC": "2",
    "SHARDS": "False"
}
```
SHARDC is for the shard count, so thats the amount of shards you have. 

the shard counting system starts from 0, so if SHARDC (shard count) is set to 2, the two shards would be `0,1`

defaultly, `red.py` is set up to run with shards disabled. You can turn them on in the launcher. When enabling, it'll ask you for a shard ID, you need to type 0, this is `SHARD0`.

![example](https://catch-me-outside.how-about-th.at/35bae2.gif)

Both `SHARD0` and `SHARD1` have been defined, but enabling will make you set `SHARD0` to a value, which I'll change, my main goal was to make the the user get a hang of the `Add Value` button which I'll be going over.

next you can run the first instance.

### Setting up your second instance

Setting up the second instance is easy. Go to line 65, and change `SHARD0` to `SHARD1`.

![Example2](https://catch-me-outside.how-about-th.at/f4eea8.gif)

now run the second instance. that was easy right??

### Now here's the fun stuff.

you might be asking, "how do i add a third one??".

you'll need to add a new value to `shard.json`. open the launcher, and open the shards menu.
select `Add new shard Value` and go through the steps of making a value. Since we started at 0, the third shard will be `2`

![Example3](https://catch-me-outside.how-about-th.at/06dd45.gif)

Now redo what i did for the second instance, but instead of `SHARD1` it would be `SHARD2`


## FAQ

1. Why don't all my servers show up??
A. Sharding makes your bot login to only a certain amount of servers, so the other shards fill in the rest.

2. Why didnt my prefix update?
~~A. You need to reload/restart your other shards, its like turning off one stove but leaving the other on, you need to turn the other off also.~~ Data corruption

3. What happened to my custom commands?
A. As for v1.0 of this, there is data corruption. My idea for fixing it is either to wait for a different type of database or to make separate shard files. Idea would be the bot would read both files, but only write to the specific shard file, thus loading cc's from another shard, but not over writing it. "is this possible?" I'll have to look into it more, this is all based off of ideas at the moment. 