### PR TITLE
[core, launcher] Workaround for Debian pip quirk

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -83,6 +83,12 @@ def install_reqs(audio):
         "-r", txt
     ]
 
+    # Debian-patched pip defaults to --user, which conflicts with --target.
+    # They also add a --system option to force it not to install to user path.
+    ic = pip.commands.InstallCommand()
+    if ic.cmd_opts.has_option('--system'):
+        args.append('--system')
+
     if IS_MAC: # --target is a problem on Homebrew. See PR #552
         args.remove("--target")
         args.remove(REQS_DIR)

--- a/red.py
+++ b/red.py
@@ -210,6 +210,12 @@ class Bot(commands.Bot):
             args.remove("--target")
             args.remove("lib")
 
+        # Debian-patched pip defaults to --user, which conflicts with --target.
+        # They also add a --system option to force it not to install to user path.
+        ic = pip.commands.InstallCommand()
+        if ic.cmd_opts.has_option('--system'):
+            args.append('--system')
+
         def install():
             code = subprocess.call(args)
             sys.path_importer_cache = {}


### PR DESCRIPTION
Checks if the --system parameter exists; if so, use it.
See https://github.com/pypa/pip/issues/3826#issuecomment-232115009