### PR TITLE
[Core] [WIP] V3 Delayed cog loading

### DIFF
--- a/core/bot.py
+++ b/core/bot.py
@@ -115,8 +115,11 @@ class Red(commands.Bot):
                 return False
         return True
 
-    def handle_load_extension(self, _: str):
+    def handle_load_extension(self, name_: str):
         to_remove = []
+        if "cogs." + name_ in self.extensions:
+            return
+
         for name, deps in self.delayed_load_info.items():
             if self.can_load_delayed(deps):
                 self.load_extension("cogs." + name)

--- a/core/bot.py
+++ b/core/bot.py
@@ -118,12 +118,9 @@ class Red(commands.Bot):
     def can_load_delayed(self, info: MutableMapping[str, Any]) -> bool:
         meets_ready = (not info["wait_ready"]) or self.is_ready()
 
-        def get_loaded_extensions():
-            for ext in self.extensions:
-                yield ext.split('.')[-1]
+        loaded_exts = [ext.split('.')[-1] for ext in self.extensions.keys()]
 
-        meets_deps = all(c in list(get_loaded_extensions()) for c in
-                         info["cog_deps"])
+        meets_deps = all(c in loaded_exts for c in info["cog_deps"])
 
         return meets_ready and meets_deps
 

--- a/core/bot.py
+++ b/core/bot.py
@@ -1,5 +1,4 @@
 from typing import Tuple, MutableMapping, Any
-
 from discord.ext import commands
 from collections import Counter
 
@@ -91,8 +90,9 @@ class Red(commands.Bot):
                 loaded.append(package)
         await self.db.set("packages", loaded)
 
-    def delayed_load_extension(self, name: str, wait_until_ready: bool=False,
-                               cog_dependencies: Tuple[str]=()):
+    def delayed_load_extension(
+            self, name: str, wait_until_ready: bool=False,
+            cog_dependencies: Tuple[str]=()):
         """
         This function allows you to delay loading of your cog until the bot
             has issued an `on_ready` event and/or until other cog
@@ -124,7 +124,7 @@ class Red(commands.Bot):
 
         return meets_ready and meets_deps
 
-    async def on_load_extension(self, _: str):
+    def handle_load_extension(self, _: str):
         to_remove = []
         for name, info in self.delayed_load_info.items():
             if self.can_load_delayed(info):
@@ -141,6 +141,14 @@ class Red(commands.Bot):
             raise
         else:
             self.dispatch('load_extension', name)
+
+    def unload_extension(self, name):
+        try:
+            super().unload_extension(name)
+        except:
+            raise
+        else:
+            self.dispatch('unload_extension', name)
 
 
 class ExitCodes(Enum):

--- a/core/bot.py
+++ b/core/bot.py
@@ -110,9 +110,10 @@ class Red(commands.Bot):
     def can_load_delayed(self, dependencies: Tuple[str]) -> bool:
         loaded_exts = [ext.split('.')[-1] for ext in self.extensions.keys()]
 
-        meets_deps = all(c in loaded_exts for c in dependencies)
-
-        return meets_deps
+        for dep in dependencies:
+            if not any(ext.endswith(dep) for ext in loaded_exts):
+                return False
+        return True
 
     def handle_load_extension(self, _: str):
         to_remove = []

--- a/core/bot.py
+++ b/core/bot.py
@@ -1,4 +1,9 @@
+import importlib
 from typing import Tuple, MutableMapping, Any
+
+import sys
+
+import discord
 from discord.ext import commands
 from collections import Counter
 
@@ -103,7 +108,7 @@ class Red(commands.Bot):
         """
 
         if self.can_load_delayed(cog_dependencies):
-            self.load_extension("cogs." + name)
+            self.load_extension("cogs." + name, from_delayed=True)
         else:
             self.delayed_load_info[name] = cog_dependencies
 
@@ -126,18 +131,28 @@ class Red(commands.Bot):
 
         for name, deps in self.delayed_load_info.items():
             if self.can_load_delayed(deps):
-                self.load_extension("cogs." + name)
+                self.load_extension("cogs." + name, from_delayed=True)
                 to_remove.append(name)
 
         for name in to_remove:
             del self.delayed_load_info[name]
 
-    def load_extension(self, name: str):
+    def load_extension(self, name: str, from_delayed: bool=False):
+        if name in self.extensions:
+            return
+
+        lib = importlib.import_module(name)
+        if not hasattr(lib, 'setup'):
+            del lib
+            del sys.modules[name]
+            raise discord.ClientException('extension does not have a setup function')
+
         try:
-            super().load_extension(name)
-        except:
-            raise
+            lib.setup(self, from_delayed)
+        except TypeError:
+            lib.setup(self)
         else:
+            self.extensions[name] = lib
             self.dispatch('load_extension', name)
 
     def unload_extension(self, name):

--- a/core/bot.py
+++ b/core/bot.py
@@ -117,7 +117,11 @@ class Red(commands.Bot):
 
     def handle_load_extension(self, name_: str):
         to_remove = []
-        if "cogs." + name_ in self.extensions:
+
+        # Preventing stack overflow here
+        if not name_.startswith("cogs."):
+            name_ = "cogs." + name_
+        if name_ in self.extensions:
             return
 
         for name, deps in self.delayed_load_info.items():

--- a/core/bot.py
+++ b/core/bot.py
@@ -103,7 +103,7 @@ class Red(commands.Bot):
         """
 
         if self.can_load_delayed(cog_dependencies):
-            self.load_extension(name)
+            self.load_extension("cogs." + name)
         else:
             self.delayed_load_info[name] = cog_dependencies
 
@@ -119,7 +119,7 @@ class Red(commands.Bot):
         to_remove = []
         for name, deps in self.delayed_load_info.items():
             if self.can_load_delayed(deps):
-                self.load_extension(name)
+                self.load_extension("cogs." + name)
                 to_remove.append(name)
 
         for name in to_remove:


### PR DESCRIPTION
After speaking with @palmtree5 (and experiencing this problem myself) it seems to make sense to have a single, centralized way of delaying cog loading until either the bot is ready or some other cog dependency has loaded first.