### PR TITLE
[V3] Multiple cog paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,7 @@
 
 # Core
 core/config.py              @tekulvw
+core/cog_manager.py         @tekulvw
 core/drivers/*              @tekulvw
 core/sentry_setup.py        @Kowlin @tekulvw
 

--- a/cogs/downloader/downloader.py
+++ b/cogs/downloader/downloader.py
@@ -21,12 +21,6 @@ from .checks import install_agreement
 
 
 class Downloader:
-
-    COG_PATH = Path.cwd() / "cogs"
-    LIB_PATH = Path.cwd() / "lib"
-    SHAREDLIB_PATH = LIB_PATH / "cog_shared"
-    SHAREDLIB_INIT = SHAREDLIB_PATH / "__init__.py"
-
     def __init__(self, bot: Red):
         self.bot = bot
 
@@ -39,6 +33,11 @@ class Downloader:
         )
 
         self.already_agreed = False
+
+        self.COG_PATH = self.bot.cog_mgr.install_path
+        self.LIB_PATH = self.bot.main_dir / "lib"
+        self.SHAREDLIB_PATH = self.LIB_PATH / "cog_shared"
+        self.SHAREDLIB_INIT = self.SHAREDLIB_PATH / "__init__.py"
 
         self.LIB_PATH.mkdir(parents=True, exist_ok=True)
         self.SHAREDLIB_PATH.mkdir(parents=True, exist_ok=True)

--- a/cogs/downloader/downloader.py
+++ b/cogs/downloader/downloader.py
@@ -34,7 +34,6 @@ class Downloader:
 
         self.already_agreed = False
 
-        self.COG_PATH = self.bot.cog_mgr.install_path
         self.LIB_PATH = self.bot.main_dir / "lib"
         self.SHAREDLIB_PATH = self.LIB_PATH / "cog_shared"
         self.SHAREDLIB_INIT = self.SHAREDLIB_PATH / "__init__.py"
@@ -49,6 +48,14 @@ class Downloader:
             syspath.insert(1, str(self.LIB_PATH))
 
         self._repo_manager = RepoManager(self.conf)
+
+    @property
+    def cog_install_path(self):
+        """
+        Returns the current cog install path.
+        :return:
+        """
+        return self.bot.cog_mgr.install_path
 
     @property
     def installed_cogs(self) -> Tuple[Installable]:
@@ -95,7 +102,7 @@ class Downloader:
         """
         failed = []
         for cog in cogs:
-            if not await cog.copy_to(self.COG_PATH):
+            if not await cog.copy_to(self.cog_install_path):
                 failed.append(cog)
 
         # noinspection PyTypeChecker
@@ -242,7 +249,7 @@ class Downloader:
                            " `{}`: `{}`".format(cog.name, cog.requirements))
             return
 
-        await repo_name.install_cog(cog, self.COG_PATH)
+        await repo_name.install_cog(cog, self.cog_install_path)
 
         await self._add_to_installed(cog)
 
@@ -259,7 +266,7 @@ class Downloader:
         # noinspection PyUnresolvedReferences,PyProtectedMember
         real_name = cog_name.name
 
-        poss_installed_path = self.COG_PATH / real_name
+        poss_installed_path = self.cog_install_path / real_name
         if poss_installed_path.exists():
             await self._delete_cog(poss_installed_path)
             # noinspection PyTypeChecker

--- a/core/bot.py
+++ b/core/bot.py
@@ -63,7 +63,8 @@ class Red(commands.Bot):
 
         self.main_dir = bot_dir
 
-        self.cog_mgr = CogManager(paths=(str(self.main_dir),))
+        self.cog_mgr = CogManager(paths=(str(self.main_dir),),
+                                  bot_dir=self.main_dir)
 
         super().__init__(**kwargs)
 

--- a/core/bot.py
+++ b/core/bot.py
@@ -6,6 +6,7 @@ from discord.ext import commands
 from collections import Counter
 
 from discord.ext.commands import GroupMixin
+from pathlib import Path
 
 from core import Config
 from enum import Enum
@@ -15,7 +16,7 @@ from core.cog_manager import CogManager
 
 
 class Red(commands.Bot):
-    def __init__(self, cli_flags, **kwargs):
+    def __init__(self, cli_flags, bot_dir: Path=Path.cwd(), **kwargs):
         self._shutdown_mode = ExitCodes.CRITICAL
         self.db = Config.get_core_conf(force_registration=True)
         self._co_owners = cli_flags.co_owner
@@ -60,8 +61,9 @@ class Red(commands.Bot):
         self.counter = Counter()
         self.uptime = None
 
-        # This needs to be optional at some point.
-        self.cog_mgr = CogManager(paths=('cogs',))
+        self.main_dir = bot_dir
+
+        self.cog_mgr = CogManager(paths=(str(self.main_dir),))
 
         super().__init__(**kwargs)
 

--- a/core/bot.py
+++ b/core/bot.py
@@ -99,15 +99,19 @@ class Red(commands.Bot):
         """Lists packages present in the cogs the folder"""
         return os.listdir("cogs")
 
-    async def save_packages_status(self):
-        # TODO: This is going to have to change.
-        """
-        loaded = []
-        for package in self.extensions:
-            if package.startswith("cogs."):
-                loaded.append(package)
-        await self.db.packages.set(loaded)
-        """
+    async def save_packages_status(self, packages):
+        await self.db.packages.set(packages)
+
+    async def add_loaded_package(self, pkg_name: str):
+        curr_pkgs = self.db.packages()
+        if pkg_name not in curr_pkgs:
+            curr_pkgs.append(pkg_name)
+            await self.save_packages_status(curr_pkgs)
+
+    async def remove_loaded_package(self, pkg_name: str):
+        curr_pkgs = self.db.packages()
+        if pkg_name in curr_pkgs:
+            await self.save_packages_status([p for p in curr_pkgs if p != pkg_name])
 
     def load_extension(self, spec: ModuleSpec):
         name = spec.name.split('.')[-1]

--- a/core/bot.py
+++ b/core/bot.py
@@ -63,7 +63,7 @@ class Red(commands.Bot):
 
         self.main_dir = bot_dir
 
-        self.cog_mgr = CogManager(paths=(str(self.main_dir),),
+        self.cog_mgr = CogManager(paths=(str(self.main_dir / 'cogs'),),
                                   bot_dir=self.main_dir)
 
         super().__init__(**kwargs)

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -26,7 +26,7 @@ class CogManager:
             paths=()
         )
 
-        self._paths = set(self.conf.paths() + paths)
+        self._paths = set(self.conf.paths() + list(paths))
 
     @property
     def paths(self) -> Tuple[Path, ...]:

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -39,7 +39,9 @@ class CogManager:
         This will return all currently valid path directories.
         :return:
         """
-        paths = [Path(p) for p in self._paths] + [self.install_path]
+        paths = [Path(p) for p in self._paths]
+        if self.install_path not in paths:
+            paths.append(self.install_path)
         return tuple(p.resolve() for p in paths if p.is_dir())
 
     @property

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from discord.ext import commands
 
+from core import checks
 from core.config import Config
 from core.utils.chat_formatting import box
 
@@ -155,6 +156,7 @@ class CogManager:
 
 class CogManagerUI:
     @commands.command()
+    @checks.is_owner()
     async def paths(self, ctx: commands.Context):
         """
         Lists current cog paths in order of priority.
@@ -168,6 +170,7 @@ class CogManagerUI:
         await ctx.send(box(msg))
 
     @commands.command()
+    @checks.is_owner()
     async def addpath(self, ctx: commands.Context, path: Path):
         """
         Add a path to the list of available cog paths.
@@ -181,6 +184,7 @@ class CogManagerUI:
         await ctx.send("Path successfully added.")
 
     @commands.command()
+    @checks.is_owner()
     async def removepath(self, ctx: commands.Context, path_number: int):
         """
         Removes a path from the available cog paths given the path_number
@@ -197,6 +201,7 @@ class CogManagerUI:
         await ctx.send("Path successfully removed.")
 
     @commands.command()
+    @checks.is_owner()
     async def reorderpath(self, ctx: commands.Context, from_: int, to: int):
         """
         Reorders paths internally to allow discovery of different cogs.
@@ -221,3 +226,23 @@ class CogManagerUI:
         await ctx.bot.cog_mgr.set_paths(all_paths)
         await ctx.send("Paths reordered.")
 
+    @commands.command()
+    @checks.is_owner()
+    async def installpath(self, ctx: commands.Context, path: Path=None):
+        """
+        Returns the current install path or sets it if one is provided.
+            The provided path must be absolute or relative to the bot's
+            directory and it must already exist.
+
+        No installed cogs will be transferred in the process.
+        """
+        if path:
+            try:
+                await ctx.bot.cog_mgr.set_install_path(path)
+            except ValueError:
+                await ctx.send("That path does not exist.")
+                return
+
+        install_path = ctx.bot.cog_mgr.install_path
+        await ctx.send("The bot will install new cogs to the `{}`"
+                       " directory.".format(install_path))

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -39,7 +39,7 @@ class CogManager:
         This will return all currently valid path directories.
         :return:
         """
-        paths = [Path(p) for p in self._paths]
+        paths = [Path(p) for p in self._paths] + [self.install_path]
         return tuple(p.resolve() for p in paths if p.is_dir())
 
     @property
@@ -48,7 +48,7 @@ class CogManager:
         Returns the install path for 3rd party cogs.
         :return:
         """
-        p = self.conf.install_path()
+        p = Path(self.conf.install_path())
         return p.resolve()
 
     async def set_install_path(self, path: Path) -> Path:
@@ -61,7 +61,7 @@ class CogManager:
         if not path.is_dir():
             raise ValueError("The install path must be an existing directory.")
         resolved = path.resolve()
-        await self.conf.install_path.set(resolved)
+        await self.conf.install_path.set(str(resolved))
         return resolved
 
     @staticmethod

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -24,11 +24,11 @@ class NoModuleFound(CogManagerException):
 
 
 class CogManager:
-    def __init__(self, paths: Tuple[str]=()):
+    def __init__(self, paths: Tuple[str]=(), bot_dir: Path=Path.cwd()):
         self.conf = Config.get_conf(self, 2938473984732, True)
         self.conf.register_global(
             paths=(),
-            install_path="cogs"
+            install_path=str(bot_dir.resolve() / "cogs")
         )
 
         self._paths = set(list(self.conf.paths()) + list(paths))

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -52,7 +52,8 @@ class CogManager:
 
     async def set_install_path(self, path: Path) -> Path:
         """
-        Install path setter.
+        Install path setter, will return the absolute path to
+            the given path.
         :param path:
         :return:
         """

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -26,7 +26,7 @@ class CogManager:
             paths=()
         )
 
-        self._paths = set(self.conf.paths() + list(paths))
+        self._paths = set(list(self.conf.paths()) + list(paths))
 
     @property
     def paths(self) -> Tuple[Path, ...]:

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -1,0 +1,115 @@
+from importlib import invalidate_caches
+from importlib.util import spec_from_file_location
+from importlib.machinery import ModuleSpec
+from typing import Tuple, Union
+from pathlib import Path
+
+from core.config import Config
+
+
+class CogManagerException(Exception):
+    pass
+
+
+class InvalidPath(CogManagerException):
+    pass
+
+
+class NoModuleFound(CogManagerException):
+    pass
+
+
+class CogManager:
+    def __init__(self, paths=()):
+        self.conf = Config.get_conf(self, 2938473984732, True)
+        self.conf.register_global(
+            paths=()
+        )
+
+        self._paths = set(self.conf.paths() + paths)
+
+    @property
+    def paths(self) -> Tuple[Path, ...]:
+        """
+        This will return all currently valid path directories.
+        :return:
+        """
+        paths = [Path(p) for p in self._paths]
+        return tuple(p for p in paths if p.is_dir())
+
+    @staticmethod
+    def _ensure_path_obj(path: Union[Path, str]) -> Path:
+        """
+        Guarantees an object will be a path object.
+        :param path:
+        :return:
+        """
+        try:
+            path.exists()
+        except AttributeError:
+            path = Path(path)
+        return path
+
+    async def add_path(self, path: Union[Path, str]):
+        """
+        Adds a cog path to current list, will ignore duplicates. Does have
+            a side effect of removing all invalid paths from the saved path
+            list.
+
+        Will raise InvalidPath if given anything that does not resolve to
+            a directory.
+        :param path:
+        :return:
+        """
+        path = self._ensure_path_obj(path)
+
+        # This makes the path absolute, will break if a bot install
+        # changes OS/Computer?
+        path = path.resolve()
+
+        if not path.is_dir():
+            raise InvalidPath("'{}' is not a valid directory.".format(path))
+
+        all_paths = set(self.paths + (path, ))
+        to_save = [str(p) for p in all_paths]
+        await self.conf.set("paths", to_save)
+
+    async def remove_path(self, path: Union[Path, str]) -> Tuple[Path, ...]:
+        """
+        Removes a path from the current paths list.
+        :param path:
+        :return:
+        """
+        path = self._ensure_path_obj(path)
+        all_paths = list(self.paths)
+        if path in all_paths:
+            all_paths.remove(path)  # Modifies in place
+            await self.conf.set("paths", all_paths)
+        return tuple(all_paths)
+
+    def find_cog(self, name: str) -> ModuleSpec:
+        """
+        Finds a cog in the list of available path.
+
+        Raises NoModuleFound if unavailable.
+        :param name:
+        :return:
+        """
+        for path in self.paths:
+            spec = spec_from_file_location(name, path)
+            if spec:
+                return spec
+
+        raise NoModuleFound("No module by the name of '{}' was found"
+                            " in any available path.".format(name))
+
+    @staticmethod
+    def invalidate_caches():
+        """
+        This is an alias for an importlib internal and should be called
+            any time that a new module has been installed to a cog directory.
+
+            *I think.*
+        :return:
+        """
+        invalidate_caches()

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -99,6 +99,9 @@ class CogManager:
         if not path.is_dir():
             raise InvalidPath("'{}' is not a valid directory.".format(path))
 
+        if path == self.install_path:
+            raise ValueError("Cannot add the install path as an additional path.")
+
         all_paths = set(self.paths + (path, ))
         # noinspection PyTypeChecker
         await self.set_paths(all_paths)
@@ -165,7 +168,7 @@ class CogManagerUI:
         """
         install_path = ctx.bot.cog_mgr.install_path
         cog_paths = ctx.bot.cog_mgr.paths
-        cog_paths = cog_paths[1:]  # Install path is always first
+        cog_paths = [p for p in cog_paths if p != install_path]
 
         msg = "Install Path: {}\n\n".format(install_path)
 
@@ -187,8 +190,12 @@ class CogManagerUI:
                            " point to a valid directory.")
             return
 
-        await ctx.bot.cog_mgr.add_path(path)
-        await ctx.send("Path successfully added.")
+        try:
+            await ctx.bot.cog_mgr.add_path(path)
+        except ValueError as e:
+            await ctx.send(str(e))
+        else:
+            await ctx.send("Path successfully added.")
 
     @commands.command()
     @checks.is_owner()

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -41,7 +41,7 @@ class CogManager:
         """
         paths = [Path(p) for p in self._paths]
         if self.install_path not in paths:
-            paths.append(self.install_path)
+            paths.insert(0, self.install_path)
         return tuple(p.resolve() for p in paths if p.is_dir())
 
     @property
@@ -163,12 +163,17 @@ class CogManagerUI:
         """
         Lists current cog paths in order of priority.
         """
+        install_path = ctx.bot.cog_mgr.install_path
         cog_paths = ctx.bot.cog_mgr.paths
-        msg = []
-        for i, p in enumerate(cog_paths, start=1):
-            msg.append("{}. {}".format(i, p))
+        cog_paths = cog_paths[1:]  # Install path is always first
 
-        msg = "\n".join(msg)
+        msg = "Install Path: {}\n\n".format(install_path)
+
+        partial = []
+        for i, p in enumerate(cog_paths, start=1):
+            partial.append("{}. {}".format(i, p))
+
+        msg += "\n".join(partial)
         await ctx.send(box(msg))
 
     @commands.command()

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -1,5 +1,5 @@
+import pkgutil
 from importlib import invalidate_caches
-from importlib.util import spec_from_file_location
 from importlib.machinery import ModuleSpec
 from typing import Tuple, Union
 from pathlib import Path
@@ -20,7 +20,7 @@ class NoModuleFound(CogManagerException):
 
 
 class CogManager:
-    def __init__(self, paths=()):
+    def __init__(self, paths: Tuple[str]=()):
         self.conf = Config.get_conf(self, 2938473984732, True)
         self.conf.register_global(
             paths=()
@@ -95,10 +95,12 @@ class CogManager:
         :param name:
         :return:
         """
-        for path in self.paths:
-            spec = spec_from_file_location(name, path)
-            if spec:
-                return spec
+        resolved_paths = [str(p.resolve()) for p in self.paths]
+        for finder, module_name, _ in pkgutil.iter_modules(resolved_paths):
+            if name == module_name:
+                spec = finder.find_spec(name)
+                if spec:
+                    return spec
 
         raise NoModuleFound("No module by the name of '{}' was found"
                             " in any available path.".format(name))

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -26,7 +26,8 @@ class CogManager:
     def __init__(self, paths: Tuple[str]=()):
         self.conf = Config.get_conf(self, 2938473984732, True)
         self.conf.register_global(
-            paths=()
+            paths=(),
+            install_path="cogs"
         )
 
         self._paths = set(list(self.conf.paths()) + list(paths))
@@ -39,6 +40,27 @@ class CogManager:
         """
         paths = [Path(p) for p in self._paths]
         return tuple(p.resolve() for p in paths if p.is_dir())
+
+    @property
+    def install_path(self) -> Path:
+        """
+        Returns the install path for 3rd party cogs.
+        :return:
+        """
+        p = self.conf.install_path()
+        return p.resolve()
+
+    async def set_install_path(self, path: Path) -> Path:
+        """
+        Install path setter.
+        :param path:
+        :return:
+        """
+        if not path.is_dir():
+            raise ValueError("The install path must be an existing directory.")
+        resolved = path.resolve()
+        await self.conf.install_path.set(resolved)
+        return resolved
 
     @staticmethod
     def _ensure_path_obj(path: Union[Path, str]) -> Path:
@@ -98,7 +120,7 @@ class CogManager:
         """
         self._paths = paths_
         str_paths = [str(p) for p in paths_]
-        await self.conf.set("paths", str_paths)
+        await self.conf.paths.set(str_paths)
 
     def find_cog(self, name: str) -> ModuleSpec:
         """

--- a/core/core_commands.py
+++ b/core/core_commands.py
@@ -41,7 +41,7 @@ class Core:
             await ctx.send("Failed to load package. Check your console or "
                            "logs for details.")
         else:
-            await ctx.bot.save_packages_status()
+            await ctx.bot.add_loaded_package(cog_name)
             await ctx.send("Done.")
 
     @commands.group()
@@ -50,7 +50,7 @@ class Core:
         """Unloads a package"""
         if cog_name in ctx.bot.extensions:
             ctx.bot.unload_extension(cog_name)
-            await ctx.bot.save_packages_status()
+            await ctx.bot.remove_loaded_package(cog_name)
             await ctx.send("Done.")
         else:
             await ctx.send("That extension is not loaded.")

--- a/core/events.py
+++ b/core/events.py
@@ -38,7 +38,8 @@ def init_events(bot, cli_flags):
 
             for package in packages:
                 try:
-                    bot.load_extension(package)
+                    spec = bot.cog_mgr.find_cog(package)
+                    bot.load_extension(spec)
                 except Exception as e:
                     log.exception("Failed to load package {}".format(package),
                                   exc_info=e)

--- a/core/events.py
+++ b/core/events.py
@@ -43,10 +43,7 @@ def init_events(bot, cli_flags):
                 except Exception as e:
                     log.exception("Failed to load package {}".format(package),
                                   exc_info=e)
-                    failed.append(package)
-
-            if failed:
-                await bot.save_packages_status()
+                    await bot.remove_loaded_package(package)
             if packages:
                 print("Loaded packages: " + ", ".join(packages))
 

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from core.bot import Red, ExitCodes
 from core.cog_manager import CogManagerUI
 from core.global_checks import init_global_checks
@@ -67,11 +69,17 @@ def init_loggers(cli_flags):
     return logger, sentry_logger
 
 
+def determine_main_folder() -> Path:
+    return Path(os.path.dirname(__file__)).resolve()
+
+
 if __name__ == '__main__':
     cli_flags = parse_cli_flags()
     log, sentry_log = init_loggers(cli_flags)
     description = "Red v3 - Alpha"
-    red = Red(cli_flags, description=description, pm_help=None)
+    bot_dir = determine_main_folder()
+    red = Red(cli_flags, description=description, pm_help=None,
+              bot_dir=bot_dir)
     init_global_checks(red)
     init_events(red, cli_flags)
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 from core.bot import Red, ExitCodes
+from core.cog_manager import CogManagerUI
 from core.global_checks import init_global_checks
 from core.events import init_events
 from core.sentry_setup import init_sentry_logging
@@ -75,6 +76,7 @@ if __name__ == '__main__':
     init_events(red, cli_flags)
 
     red.add_cog(Core())
+    red.add_cog(CogManagerUI())
 
     if cli_flags.dev:
         red.add_cog(Dev())

--- a/tests/core/test_cog_manager.py
+++ b/tests/core/test_cog_manager.py
@@ -44,8 +44,14 @@ async def test_add_path(cog_mgr, tmpdir):
 @pytest.mark.asyncio
 async def test_add_path_already_install_path(cog_mgr, tmpdir):
     path = Path(str(tmpdir))
-
     await cog_mgr.set_install_path(path)
-
     with pytest.raises(ValueError):
         await cog_mgr.add_path(path)
+
+
+@pytest.mark.asyncio
+async def test_remove_path(cog_mgr, tmpdir):
+    path = Path(str(tmpdir))
+    await cog_mgr.add_path(path)
+    await cog_mgr.remove_path(path)
+    assert path not in cog_mgr.paths

--- a/tests/core/test_cog_manager.py
+++ b/tests/core/test_cog_manager.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import pytest
+from core import cog_manager
+
+
+@pytest.fixture()
+def cog_mgr(red):
+    return red.cog_mgr
+
+
+@pytest.fixture()
+def default_dir(red):
+    return red.main_dir
+
+
+def test_ensure_cogs_in_paths(cog_mgr, default_dir):
+    cogs_dir = default_dir / 'cogs'
+    assert cogs_dir in cog_mgr.paths
+
+
+@pytest.mark.asyncio
+async def test_install_path_set(cog_mgr: cog_manager.CogManager, tmpdir):
+    path = Path(str(tmpdir))
+    await cog_mgr.set_install_path(path)
+    assert cog_mgr.install_path == path
+
+
+@pytest.mark.asyncio
+async def test_install_path_set_bad(cog_mgr):
+    path = Path('something')
+
+    with pytest.raises(ValueError):
+        await cog_mgr.set_install_path(path)
+
+
+@pytest.mark.asyncio
+async def test_add_path(cog_mgr, tmpdir):
+    path = Path(str(tmpdir))
+    await cog_mgr.add_path(path)
+    assert path in cog_mgr.paths
+
+
+@pytest.mark.asyncio
+async def test_add_path_already_install_path(cog_mgr, tmpdir):
+    path = Path(str(tmpdir))
+
+    await cog_mgr.set_install_path(path)
+
+    with pytest.raises(ValueError):
+        await cog_mgr.add_path(path)


### PR DESCRIPTION
## Warning
This exists as a proof of concept, this PR is currently missing major UI stuff so it's not applicable to anyone but developers at the moment. This PR **does not** modify `sys.path` but it does make use of some `importlib` internals and overrides d.py's `load_extension` and `unload_extension` so we may run into some issues down the line when Danny overhauls his loading system (this is OK and expected).

## How to use
1. Let the bot boot up once and close it
2. Go to cogs/.data/CogManager/settings.py and edit the GLOBAL section
3. You need to add `paths: []` to the GLOBAL section containing any path you wish to access cogs from
4. Use load/unload/reload as normal

Things to add:
- [x] Adding paths command
- [x] Removing paths command
- [x] Re-ordering paths command
- [x] ~~Cogs local path needs to be added at install, not at runtime~~ see comment below
- [x] Add an install path
- [x] tests

### ~~This PR depends on #869~~