### PR TITLE
[Downloader V3] Find a cog from a command

### DIFF
--- a/core/core_commands.py
+++ b/core/core_commands.py
@@ -55,6 +55,10 @@ class Core:
     @checks.is_owner()
     async def _reload(self, ctx, *, cog_name: str):
         """Reloads a package"""
+        if cog_name == "downloader":
+            await ctx.send("DONT RELOAD DOWNLOADER.")
+            return
+
         if not cog_name.startswith("cogs."):
             cog_name = "cogs." + cog_name
 


### PR DESCRIPTION
For the record, we can't reload downloader right now because the module refresher tries to import every single cog in every repo downloader has cloned. This should be fixed in #853 