### PR TITLE
make is_owner actually check the owner setting

### DIFF
--- a/core/bot.py
+++ b/core/bot.py
@@ -51,7 +51,7 @@ class Red(commands.Bot):
         super().__init__(**kwargs)
 
     async def is_owner(self, user):
-        if user.id in self.db.coowners():
+        if user.id in self.db.coowners() or user.id == self.db.owner():
             return True
         return await super().is_owner(user)
 


### PR DESCRIPTION
As it stands now, our `is_owner` function simply checks if the user is a coowner and failing that, calls d.py's `is_owner` function (which checks if the user is the application's owner). Thus it looks to me as if our owner setting is completely ignored in this check (hence the PR fixing that)