### PR TITLE
[Sentry/Security] Cleared out websocket breadcrumbs

### DIFF
--- a/core/sentry_setup.py
+++ b/core/sentry_setup.py
@@ -1,4 +1,4 @@
-from raven import Client
+from raven import Client, breadcrumbs
 from raven.versioning import fetch_git_sha
 from raven.conf import setup_logging
 from raven.handlers.logging import SentryHandler
@@ -35,6 +35,8 @@ def init_sentry_logging(logger):
         release=fetch_git_sha(str(Path.cwd()))
     )
 
+    breadcrumbs.ignore_logger("websockets")
+    breadcrumbs.ignore_logger("websockets.protocol")
     handler = SentryHandler(client)
     logger.addHandler(handler)
 


### PR DESCRIPTION
Sending these websockets over causes some security issues, because it sends sensitive information such as the Token used for the bot under some conditions. This PR addresses that issue by not sending the websocket information at all, we will still have access to the same information provided since it gets echo'd by ``discord.gateway``. Any sensitive data that found was mine and has been purged off the Sentry server.