### PR TITLE
[Core V3] Add setup instructions for external data and cog paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 # Core
 core/config.py              @tekulvw
 core/cog_manager.py         @tekulvw
+core/data_manager.py        @tekulvw
 core/drivers/*              @tekulvw
 core/sentry_setup.py        @Kowlin @tekulvw
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,7 @@
 
 # Core
 core/config.py              @tekulvw
+core/cog_manager.py         @tekulvw
 core/drivers/*              @tekulvw
 core/sentry_setup.py        @Kowlin @tekulvw
 

--- a/cogs/downloader/downloader.py
+++ b/cogs/downloader/downloader.py
@@ -21,12 +21,6 @@ from .checks import install_agreement
 
 
 class Downloader:
-
-    COG_PATH = Path.cwd() / "cogs"
-    LIB_PATH = Path.cwd() / "lib"
-    SHAREDLIB_PATH = LIB_PATH / "cog_shared"
-    SHAREDLIB_INIT = SHAREDLIB_PATH / "__init__.py"
-
     def __init__(self, bot: Red):
         self.bot = bot
 
@@ -39,6 +33,11 @@ class Downloader:
         )
 
         self.already_agreed = False
+
+        self.COG_PATH = self.bot.cog_mgr.install_path
+        self.LIB_PATH = self.bot.main_dir / "lib"
+        self.SHAREDLIB_PATH = self.LIB_PATH / "cog_shared"
+        self.SHAREDLIB_INIT = self.SHAREDLIB_PATH / "__init__.py"
 
         self.LIB_PATH.mkdir(parents=True, exist_ok=True)
         self.SHAREDLIB_PATH.mkdir(parents=True, exist_ok=True)

--- a/cogs/downloader/downloader.py
+++ b/cogs/downloader/downloader.py
@@ -34,7 +34,6 @@ class Downloader:
 
         self.already_agreed = False
 
-        self.COG_PATH = self.bot.cog_mgr.install_path
         self.LIB_PATH = self.bot.main_dir / "lib"
         self.SHAREDLIB_PATH = self.LIB_PATH / "cog_shared"
         self.SHAREDLIB_INIT = self.SHAREDLIB_PATH / "__init__.py"
@@ -49,6 +48,14 @@ class Downloader:
             syspath.insert(1, str(self.LIB_PATH))
 
         self._repo_manager = RepoManager(self.conf)
+
+    @property
+    def cog_install_path(self):
+        """
+        Returns the current cog install path.
+        :return:
+        """
+        return self.bot.cog_mgr.install_path
 
     @property
     def installed_cogs(self) -> Tuple[Installable]:
@@ -95,7 +102,7 @@ class Downloader:
         """
         failed = []
         for cog in cogs:
-            if not await cog.copy_to(self.COG_PATH):
+            if not await cog.copy_to(self.cog_install_path):
                 failed.append(cog)
 
         # noinspection PyTypeChecker
@@ -242,7 +249,7 @@ class Downloader:
                            " `{}`: `{}`".format(cog.name, cog.requirements))
             return
 
-        await repo_name.install_cog(cog, self.COG_PATH)
+        await repo_name.install_cog(cog, self.cog_install_path)
 
         await self._add_to_installed(cog)
 
@@ -259,7 +266,7 @@ class Downloader:
         # noinspection PyUnresolvedReferences,PyProtectedMember
         real_name = cog_name.name
 
-        poss_installed_path = self.COG_PATH / real_name
+        poss_installed_path = self.cog_install_path / real_name
         if poss_installed_path.exists():
             await self._delete_cog(poss_installed_path)
             # noinspection PyTypeChecker

--- a/cogs/downloader/repo_manager.py
+++ b/cogs/downloader/repo_manager.py
@@ -13,6 +13,7 @@ import functools
 from discord.ext import commands
 
 from core import Config
+from core import data_manager
 from .errors import *
 from .installable import Installable, InstallableType
 from .log import log
@@ -428,9 +429,12 @@ class RepoManager:
     def __init__(self, downloader_config: Config):
         self.downloader_config = downloader_config
 
-        self.repos_folder = Path(__file__).parent / 'repos'
-
         self._repos = self._load_repos()  # str_name: Repo
+
+    @property
+    def repos_folder(self) -> Path:
+        data_folder = data_manager.cog_data_path(self)
+        return data_folder / 'repos'
 
     def does_repo_exist(self, name: str) -> bool:
         return name in self._repos

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,6 +1,7 @@
 from core.config import Config
 from subprocess import run, PIPE
 from collections import namedtuple
+from core.cli import determine_main_folder
 
 __all__ = ["Config", "__version__"]
 version_info = namedtuple("VersionInfo", "major minor patch")
@@ -10,8 +11,11 @@ BASE_VERSION = version_info(3, 0, 0)
 
 def get_latest_version():
     try:
+        cmd = "cd {} && git describe --abbrev=0 --tags".format(
+            determine_main_folder()
+        )
         p = run(
-            "git describe --abbrev=0 --tags".split(),
+            cmd.split(),
             stdout=PIPE
         )
     except FileNotFoundError:

--- a/core/bot.py
+++ b/core/bot.py
@@ -63,7 +63,8 @@ class Red(commands.Bot):
 
         self.main_dir = bot_dir
 
-        self.cog_mgr = CogManager(paths=(str(self.main_dir),))
+        self.cog_mgr = CogManager(paths=(str(self.main_dir),),
+                                  bot_dir=self.main_dir)
 
         super().__init__(**kwargs)
 

--- a/core/bot.py
+++ b/core/bot.py
@@ -6,6 +6,7 @@ from discord.ext import commands
 from collections import Counter
 
 from discord.ext.commands import GroupMixin
+from pathlib import Path
 
 from core import Config
 from enum import Enum
@@ -15,7 +16,7 @@ from core.cog_manager import CogManager
 
 
 class Red(commands.Bot):
-    def __init__(self, cli_flags, **kwargs):
+    def __init__(self, cli_flags, bot_dir: Path=Path.cwd(), **kwargs):
         self._shutdown_mode = ExitCodes.CRITICAL
         self.db = Config.get_core_conf(force_registration=True)
         self._co_owners = cli_flags.co_owner
@@ -60,8 +61,9 @@ class Red(commands.Bot):
         self.counter = Counter()
         self.uptime = None
 
-        # This needs to be optional at some point.
-        self.cog_mgr = CogManager(paths=('cogs',))
+        self.main_dir = bot_dir
+
+        self.cog_mgr = CogManager(paths=(str(self.main_dir),))
 
         super().__init__(**kwargs)
 

--- a/core/bot.py
+++ b/core/bot.py
@@ -99,15 +99,19 @@ class Red(commands.Bot):
         """Lists packages present in the cogs the folder"""
         return os.listdir("cogs")
 
-    async def save_packages_status(self):
-        # TODO: This is going to have to change.
-        """
-        loaded = []
-        for package in self.extensions:
-            if package.startswith("cogs."):
-                loaded.append(package)
-        await self.db.packages.set(loaded)
-        """
+    async def save_packages_status(self, packages):
+        await self.db.packages.set(packages)
+
+    async def add_loaded_package(self, pkg_name: str):
+        curr_pkgs = self.db.packages()
+        if pkg_name not in curr_pkgs:
+            curr_pkgs.append(pkg_name)
+            await self.save_packages_status(curr_pkgs)
+
+    async def remove_loaded_package(self, pkg_name: str):
+        curr_pkgs = self.db.packages()
+        if pkg_name in curr_pkgs:
+            await self.save_packages_status([p for p in curr_pkgs if p != pkg_name])
 
     def load_extension(self, spec: ModuleSpec):
         name = spec.name.split('.')[-1]

--- a/core/bot.py
+++ b/core/bot.py
@@ -63,7 +63,7 @@ class Red(commands.Bot):
 
         self.main_dir = bot_dir
 
-        self.cog_mgr = CogManager(paths=(str(self.main_dir),),
+        self.cog_mgr = CogManager(paths=(str(self.main_dir / 'cogs'),),
                                   bot_dir=self.main_dir)
 
         super().__init__(**kwargs)

--- a/core/cli.py
+++ b/core/cli.py
@@ -198,8 +198,27 @@ def setup_cog_install_location(red: Red):
           " it please press [ENTER] otherwise enter your desired"
           " cog install path.\n\n")
 
-    data_path = core_data_path() / "installed_cogs"
-    print("Default: {}".format(data_path))
+    data_path = core_data_path().parent / "installed_cogs"
+    print("Default: {}\n".format(data_path))
+
+    new_path = input('> ')
+
+    if new_path != '':
+        new_path = Path(new_path)
+        data_path = new_path
+
+    if not data_path.exists():
+        try:
+            data_path.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            print("We were unable to create your chosen directory."
+                  " You may need to restart this process with admin"
+                  " privileges.\n\nFor now we'll be using the built-in"
+                  " 'cogs' folder as your install folder.")
+            data_path = determine_main_folder() / 'cogs'
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(red.cog_mgr.set_install_path(data_path))
 
 
 def setup(cli_flags, bot_dir: Path) -> Tuple[Red, str, logging.Logger, logging.Logger]:

--- a/core/cli.py
+++ b/core/cli.py
@@ -219,6 +219,7 @@ def setup_cog_install_location(red: Red):
 
     loop = asyncio.get_event_loop()
     loop.run_until_complete(red.cog_mgr.set_install_path(data_path))
+    loop.run_until_complete(red.cog_mgr.conf.install_path_set.set(True))
 
 
 def setup(cli_flags, bot_dir: Path) -> Tuple[Red, str, logging.Logger, logging.Logger]:
@@ -250,7 +251,8 @@ def setup(cli_flags, bot_dir: Path) -> Tuple[Red, str, logging.Logger, logging.L
 
     sentry_setup(red, sentry_log)
 
-    setup_cog_install_location(red)
+    if not red.cog_mgr.conf.install_path_set():
+        setup_cog_install_location(red)
     return red, token, log, sentry_log
 
 

--- a/core/cli.py
+++ b/core/cli.py
@@ -102,6 +102,9 @@ def parse_cli_flags():
     parser.add_argument("--dev",
                         action="store_true",
                         help="Enables developer mode")
+    parser.add_argument("config",
+                        nargs='?',
+                        help="Path to config generated on initial setup.")
 
     args = parser.parse_args()
 

--- a/core/cli.py
+++ b/core/cli.py
@@ -1,7 +1,24 @@
 import argparse
 import asyncio
+import logging.handlers
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Tuple
+from copy import deepcopy
 
+from core.global_checks import init_global_checks
+from core.events import init_events
+from core.core_commands import Core
+from core.dev_commands import Dev
+from core.cog_manager import CogManagerUI
+from core.data_manager import basic_config_default, load_basic_configuration, core_data_path
+from core.json_io import JsonIO
 from core.bot import Red
+from core.sentry_setup import init_sentry_logging
+
+import appdirs
 
 
 def confirm(m=""):
@@ -114,3 +131,143 @@ def parse_cli_flags():
         args.prefix = []
 
     return args
+
+
+def init_loggers(cli_flags):
+    # d.py stuff
+    dpy_logger = logging.getLogger("discord")
+    dpy_logger.setLevel(logging.WARNING)
+    console = logging.StreamHandler()
+    console.setLevel(logging.WARNING)
+    dpy_logger.addHandler(console)
+
+    # Red stuff
+
+    logger = logging.getLogger("red")
+
+    red_format = logging.Formatter(
+        '%(asctime)s %(levelname)s %(module)s %(funcName)s %(lineno)d: '
+        '%(message)s',
+        datefmt="[%d/%m/%Y %H:%M]")
+
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(red_format)
+
+    if cli_flags.debug:
+        os.environ['PYTHONASYNCIODEBUG'] = '1'
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.WARNING)
+
+    logfile_path = core_data_path() / 'red.log'
+    fhandler = logging.handlers.RotatingFileHandler(
+        filename=str(logfile_path), encoding='utf-8', mode='a',
+        maxBytes=10**7, backupCount=5)
+    fhandler.setFormatter(red_format)
+
+    logger.addHandler(fhandler)
+    logger.addHandler(stdout_handler)
+
+    # Sentry stuff
+    sentry_logger = logging.getLogger("red.sentry")
+    sentry_logger.setLevel(logging.WARNING)
+
+    return logger, sentry_logger
+
+
+def sentry_setup(red: Red, sentry_log: logging.Logger):
+    if red.db.enable_sentry() is None:
+        ask_sentry(red)
+
+    if red.db.enable_sentry():
+        init_sentry_logging(red, sentry_log)
+
+
+def determine_main_folder() -> Path:
+    return Path(os.path.dirname(__file__)).resolve().parent
+
+
+def setup(cli_flags, bot_dir: Path) -> Tuple[Red, str, logging.Logger, logging.Logger]:
+    log, sentry_log = init_loggers(cli_flags)
+    description = "Red v3 - Alpha"
+    red = Red(cli_flags, description=description, pm_help=None,
+              bot_dir=bot_dir)
+    init_global_checks(red)
+    init_events(red, cli_flags)
+
+    red.add_cog(Core())
+    red.add_cog(CogManagerUI())
+
+    if cli_flags.dev:
+        red.add_cog(Dev())
+
+    token = os.environ.get("RED_TOKEN", red.db.token())
+    prefix = cli_flags.prefix or red.db.prefix()
+
+    if token is None or not prefix:
+        if cli_flags.no_prompt is False:
+            new_token = interactive_config(red, token_set=bool(token),
+                                           prefix_set=bool(prefix))
+            if new_token:
+                token = new_token
+        else:
+            log.critical("Token and prefix must be set in order to login.")
+            sys.exit(1)
+
+    sentry_setup(red, sentry_log)
+    return red, token, log, sentry_log
+
+
+def basic_setup():
+    """
+    Creates the data storage folder.
+    :return:
+    """
+    proj_name = "Red-DiscordBot"
+    author = "Twentysix26 et al."
+
+    default_data_dir = Path(appdirs.user_data_dir(proj_name, author))
+
+    print("Hello! Before we begin the full configuration process we need to"
+          " gather some initial information about where you'd like us"
+          " to store your bot's data. We've attempted to figure out a"
+          " sane default data location which is printed below. If you don't"
+          " want to change this default please press [ENTER], otherwise"
+          " input your desired data location.")
+    print()
+    print("Default: {}".format(default_data_dir))
+
+    new_path = input('> ')
+
+    if new_path != '':
+        new_path = Path(new_path)
+        default_data_dir = new_path
+
+    if not default_data_dir.exists():
+        try:
+            default_data_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            print("We were unable to create your chosen directory."
+                  " You may need to restart this process with admin"
+                  " privileges.")
+            sys.exit(1)
+
+    print("You have chosen {} to be your data directory."
+          "".format(default_data_dir))
+
+    default_dirs = deepcopy(basic_config_default)
+    default_dirs['DATA_PATH'] = str(default_data_dir.resolve())
+
+    conf_path = Path.cwd() / 'config.json'
+    saver = JsonIO(conf_path)
+
+    saver._save_json(default_dirs)
+
+    print("Your configuration file has been saved to this directory:"
+          "\n\n{}\n\nFrom here on out you must run Red with the"
+          " configuration file as a positional argument. You may"
+          " move the configuration file wherever you wish.".format(
+              conf_path
+          ))
+
+    load_basic_configuration(conf_path)

--- a/core/cli.py
+++ b/core/cli.py
@@ -187,6 +187,10 @@ def determine_main_folder() -> Path:
     return Path(os.path.dirname(__file__)).resolve().parent
 
 
+def setup_cog_install_location(red: Red):
+    pass
+
+
 def setup(cli_flags, bot_dir: Path) -> Tuple[Red, str, logging.Logger, logging.Logger]:
     log, sentry_log = init_loggers(cli_flags)
     description = "Red v3 - Alpha"
@@ -215,6 +219,8 @@ def setup(cli_flags, bot_dir: Path) -> Tuple[Red, str, logging.Logger, logging.L
             sys.exit(1)
 
     sentry_setup(red, sentry_log)
+
+    setup_cog_install_location(red)
     return red, token, log, sentry_log
 
 
@@ -254,6 +260,9 @@ def basic_setup():
 
     print("You have chosen {} to be your data directory."
           "".format(default_data_dir))
+    if not confirm("Please confirm (y/n):"):
+        print("Please start the process over.")
+        sys.exit(0)
 
     default_dirs = deepcopy(basic_config_default)
     default_dirs['DATA_PATH'] = str(default_data_dir.resolve())

--- a/core/cli.py
+++ b/core/cli.py
@@ -20,6 +20,9 @@ from core.sentry_setup import init_sentry_logging
 
 import appdirs
 
+_proj_name = "Red-DiscordBot"
+_author = "Twentysix26 et al."
+
 
 def confirm(m=""):
     return input(m).lower().strip() in ("y", "yes")
@@ -188,7 +191,15 @@ def determine_main_folder() -> Path:
 
 
 def setup_cog_install_location(red: Red):
-    pass
+    print("\nWe're now giving you the opportunity to choose your"
+          " cog install directory. This is the directory that our"
+          " Downloader cog will install 3rd party cogs to. We've tried"
+          " to provide a sane default below, if you don't want to change"
+          " it please press [ENTER] otherwise enter your desired"
+          " cog install path.\n\n")
+
+    data_path = core_data_path() / "installed_cogs"
+    print("Default: {}".format(data_path))
 
 
 def setup(cli_flags, bot_dir: Path) -> Tuple[Red, str, logging.Logger, logging.Logger]:
@@ -229,10 +240,8 @@ def basic_setup():
     Creates the data storage folder.
     :return:
     """
-    proj_name = "Red-DiscordBot"
-    author = "Twentysix26 et al."
 
-    default_data_dir = Path(appdirs.user_data_dir(proj_name, author))
+    default_data_dir = Path(appdirs.user_data_dir(_proj_name, _author))
 
     print("Hello! Before we begin the full configuration process we need to"
           " gather some initial information about where you'd like us"
@@ -275,7 +284,7 @@ def basic_setup():
     print("Your configuration file has been saved to this directory:"
           "\n\n{}\n\nFrom here on out you must run Red with the"
           " configuration file as a positional argument. You may"
-          " move the configuration file wherever you wish.".format(
+          " move the configuration file wherever you wish.\n".format(
               conf_path
           ))
 

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -26,7 +26,7 @@ class CogManager:
             paths=()
         )
 
-        self._paths = set(self.conf.paths() + paths)
+        self._paths = set(self.conf.paths() + list(paths))
 
     @property
     def paths(self) -> Tuple[Path, ...]:

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -39,7 +39,9 @@ class CogManager:
         This will return all currently valid path directories.
         :return:
         """
-        paths = [Path(p) for p in self._paths] + [self.install_path]
+        paths = [Path(p) for p in self._paths]
+        if self.install_path not in paths:
+            paths.append(self.install_path)
         return tuple(p.resolve() for p in paths if p.is_dir())
 
     @property

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from discord.ext import commands
 
+from core import checks
 from core.config import Config
 from core.utils.chat_formatting import box
 
@@ -155,6 +156,7 @@ class CogManager:
 
 class CogManagerUI:
     @commands.command()
+    @checks.is_owner()
     async def paths(self, ctx: commands.Context):
         """
         Lists current cog paths in order of priority.
@@ -168,6 +170,7 @@ class CogManagerUI:
         await ctx.send(box(msg))
 
     @commands.command()
+    @checks.is_owner()
     async def addpath(self, ctx: commands.Context, path: Path):
         """
         Add a path to the list of available cog paths.
@@ -181,6 +184,7 @@ class CogManagerUI:
         await ctx.send("Path successfully added.")
 
     @commands.command()
+    @checks.is_owner()
     async def removepath(self, ctx: commands.Context, path_number: int):
         """
         Removes a path from the available cog paths given the path_number
@@ -197,6 +201,7 @@ class CogManagerUI:
         await ctx.send("Path successfully removed.")
 
     @commands.command()
+    @checks.is_owner()
     async def reorderpath(self, ctx: commands.Context, from_: int, to: int):
         """
         Reorders paths internally to allow discovery of different cogs.
@@ -221,3 +226,23 @@ class CogManagerUI:
         await ctx.bot.cog_mgr.set_paths(all_paths)
         await ctx.send("Paths reordered.")
 
+    @commands.command()
+    @checks.is_owner()
+    async def installpath(self, ctx: commands.Context, path: Path=None):
+        """
+        Returns the current install path or sets it if one is provided.
+            The provided path must be absolute or relative to the bot's
+            directory and it must already exist.
+
+        No installed cogs will be transferred in the process.
+        """
+        if path:
+            try:
+                await ctx.bot.cog_mgr.set_install_path(path)
+            except ValueError:
+                await ctx.send("That path does not exist.")
+                return
+
+        install_path = ctx.bot.cog_mgr.install_path
+        await ctx.send("The bot will install new cogs to the `{}`"
+                       " directory.".format(install_path))

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -39,7 +39,7 @@ class CogManager:
         This will return all currently valid path directories.
         :return:
         """
-        paths = [Path(p) for p in self._paths]
+        paths = [Path(p) for p in self._paths] + [self.install_path]
         return tuple(p.resolve() for p in paths if p.is_dir())
 
     @property
@@ -48,7 +48,7 @@ class CogManager:
         Returns the install path for 3rd party cogs.
         :return:
         """
-        p = self.conf.install_path()
+        p = Path(self.conf.install_path())
         return p.resolve()
 
     async def set_install_path(self, path: Path) -> Path:
@@ -61,7 +61,7 @@ class CogManager:
         if not path.is_dir():
             raise ValueError("The install path must be an existing directory.")
         resolved = path.resolve()
-        await self.conf.install_path.set(resolved)
+        await self.conf.install_path.set(str(resolved))
         return resolved
 
     @staticmethod

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -28,7 +28,8 @@ class CogManager:
         self.conf = Config.get_conf(self, 2938473984732, True)
         self.conf.register_global(
             paths=(),
-            install_path=str(bot_dir.resolve() / "cogs")
+            install_path=str(bot_dir.resolve() / "cogs"),
+            install_path_set=False
         )
 
         self._paths = set(list(self.conf.paths()) + list(paths))

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -24,11 +24,11 @@ class NoModuleFound(CogManagerException):
 
 
 class CogManager:
-    def __init__(self, paths: Tuple[str]=()):
+    def __init__(self, paths: Tuple[str]=(), bot_dir: Path=Path.cwd()):
         self.conf = Config.get_conf(self, 2938473984732, True)
         self.conf.register_global(
             paths=(),
-            install_path="cogs"
+            install_path=str(bot_dir.resolve() / "cogs")
         )
 
         self._paths = set(list(self.conf.paths()) + list(paths))

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -52,7 +52,8 @@ class CogManager:
 
     async def set_install_path(self, path: Path) -> Path:
         """
-        Install path setter.
+        Install path setter, will return the absolute path to
+            the given path.
         :param path:
         :return:
         """

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -26,7 +26,7 @@ class CogManager:
             paths=()
         )
 
-        self._paths = set(self.conf.paths() + list(paths))
+        self._paths = set(list(self.conf.paths()) + list(paths))
 
     @property
     def paths(self) -> Tuple[Path, ...]:

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -1,0 +1,115 @@
+from importlib import invalidate_caches
+from importlib.util import spec_from_file_location
+from importlib.machinery import ModuleSpec
+from typing import Tuple, Union
+from pathlib import Path
+
+from core.config import Config
+
+
+class CogManagerException(Exception):
+    pass
+
+
+class InvalidPath(CogManagerException):
+    pass
+
+
+class NoModuleFound(CogManagerException):
+    pass
+
+
+class CogManager:
+    def __init__(self, paths=()):
+        self.conf = Config.get_conf(self, 2938473984732, True)
+        self.conf.register_global(
+            paths=()
+        )
+
+        self._paths = set(self.conf.paths() + paths)
+
+    @property
+    def paths(self) -> Tuple[Path, ...]:
+        """
+        This will return all currently valid path directories.
+        :return:
+        """
+        paths = [Path(p) for p in self._paths]
+        return tuple(p for p in paths if p.is_dir())
+
+    @staticmethod
+    def _ensure_path_obj(path: Union[Path, str]) -> Path:
+        """
+        Guarantees an object will be a path object.
+        :param path:
+        :return:
+        """
+        try:
+            path.exists()
+        except AttributeError:
+            path = Path(path)
+        return path
+
+    async def add_path(self, path: Union[Path, str]):
+        """
+        Adds a cog path to current list, will ignore duplicates. Does have
+            a side effect of removing all invalid paths from the saved path
+            list.
+
+        Will raise InvalidPath if given anything that does not resolve to
+            a directory.
+        :param path:
+        :return:
+        """
+        path = self._ensure_path_obj(path)
+
+        # This makes the path absolute, will break if a bot install
+        # changes OS/Computer?
+        path = path.resolve()
+
+        if not path.is_dir():
+            raise InvalidPath("'{}' is not a valid directory.".format(path))
+
+        all_paths = set(self.paths + (path, ))
+        to_save = [str(p) for p in all_paths]
+        await self.conf.set("paths", to_save)
+
+    async def remove_path(self, path: Union[Path, str]) -> Tuple[Path, ...]:
+        """
+        Removes a path from the current paths list.
+        :param path:
+        :return:
+        """
+        path = self._ensure_path_obj(path)
+        all_paths = list(self.paths)
+        if path in all_paths:
+            all_paths.remove(path)  # Modifies in place
+            await self.conf.set("paths", all_paths)
+        return tuple(all_paths)
+
+    def find_cog(self, name: str) -> ModuleSpec:
+        """
+        Finds a cog in the list of available path.
+
+        Raises NoModuleFound if unavailable.
+        :param name:
+        :return:
+        """
+        for path in self.paths:
+            spec = spec_from_file_location(name, path)
+            if spec:
+                return spec
+
+        raise NoModuleFound("No module by the name of '{}' was found"
+                            " in any available path.".format(name))
+
+    @staticmethod
+    def invalidate_caches():
+        """
+        This is an alias for an importlib internal and should be called
+            any time that a new module has been installed to a cog directory.
+
+            *I think.*
+        :return:
+        """
+        invalidate_caches()

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -99,6 +99,9 @@ class CogManager:
         if not path.is_dir():
             raise InvalidPath("'{}' is not a valid directory.".format(path))
 
+        if path == self.install_path:
+            raise ValueError("Cannot add the install path as an additional path.")
+
         all_paths = set(self.paths + (path, ))
         # noinspection PyTypeChecker
         await self.set_paths(all_paths)
@@ -165,7 +168,7 @@ class CogManagerUI:
         """
         install_path = ctx.bot.cog_mgr.install_path
         cog_paths = ctx.bot.cog_mgr.paths
-        cog_paths = cog_paths[1:]  # Install path is always first
+        cog_paths = [p for p in cog_paths if p != install_path]
 
         msg = "Install Path: {}\n\n".format(install_path)
 
@@ -187,8 +190,12 @@ class CogManagerUI:
                            " point to a valid directory.")
             return
 
-        await ctx.bot.cog_mgr.add_path(path)
-        await ctx.send("Path successfully added.")
+        try:
+            await ctx.bot.cog_mgr.add_path(path)
+        except ValueError as e:
+            await ctx.send(str(e))
+        else:
+            await ctx.send("Path successfully added.")
 
     @commands.command()
     @checks.is_owner()

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -41,7 +41,7 @@ class CogManager:
         """
         paths = [Path(p) for p in self._paths]
         if self.install_path not in paths:
-            paths.append(self.install_path)
+            paths.insert(0, self.install_path)
         return tuple(p.resolve() for p in paths if p.is_dir())
 
     @property
@@ -163,12 +163,17 @@ class CogManagerUI:
         """
         Lists current cog paths in order of priority.
         """
+        install_path = ctx.bot.cog_mgr.install_path
         cog_paths = ctx.bot.cog_mgr.paths
-        msg = []
-        for i, p in enumerate(cog_paths, start=1):
-            msg.append("{}. {}".format(i, p))
+        cog_paths = cog_paths[1:]  # Install path is always first
 
-        msg = "\n".join(msg)
+        msg = "Install Path: {}\n\n".format(install_path)
+
+        partial = []
+        for i, p in enumerate(cog_paths, start=1):
+            partial.append("{}. {}".format(i, p))
+
+        msg += "\n".join(partial)
         await ctx.send(box(msg))
 
     @commands.command()

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -1,5 +1,5 @@
+import pkgutil
 from importlib import invalidate_caches
-from importlib.util import spec_from_file_location
 from importlib.machinery import ModuleSpec
 from typing import Tuple, Union
 from pathlib import Path
@@ -20,7 +20,7 @@ class NoModuleFound(CogManagerException):
 
 
 class CogManager:
-    def __init__(self, paths=()):
+    def __init__(self, paths: Tuple[str]=()):
         self.conf = Config.get_conf(self, 2938473984732, True)
         self.conf.register_global(
             paths=()
@@ -95,10 +95,12 @@ class CogManager:
         :param name:
         :return:
         """
-        for path in self.paths:
-            spec = spec_from_file_location(name, path)
-            if spec:
-                return spec
+        resolved_paths = [str(p.resolve()) for p in self.paths]
+        for finder, module_name, _ in pkgutil.iter_modules(resolved_paths):
+            if name == module_name:
+                spec = finder.find_spec(name)
+                if spec:
+                    return spec
 
         raise NoModuleFound("No module by the name of '{}' was found"
                             " in any available path.".format(name))

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -251,6 +251,8 @@ class CogManagerUI:
         No installed cogs will be transferred in the process.
         """
         if path:
+            if not path.is_absolute():
+                path = (ctx.bot.main_dir / path).resolve()
             try:
                 await ctx.bot.cog_mgr.set_install_path(path)
             except ValueError:

--- a/core/cog_manager.py
+++ b/core/cog_manager.py
@@ -26,7 +26,8 @@ class CogManager:
     def __init__(self, paths: Tuple[str]=()):
         self.conf = Config.get_conf(self, 2938473984732, True)
         self.conf.register_global(
-            paths=()
+            paths=(),
+            install_path="cogs"
         )
 
         self._paths = set(list(self.conf.paths()) + list(paths))
@@ -39,6 +40,27 @@ class CogManager:
         """
         paths = [Path(p) for p in self._paths]
         return tuple(p.resolve() for p in paths if p.is_dir())
+
+    @property
+    def install_path(self) -> Path:
+        """
+        Returns the install path for 3rd party cogs.
+        :return:
+        """
+        p = self.conf.install_path()
+        return p.resolve()
+
+    async def set_install_path(self, path: Path) -> Path:
+        """
+        Install path setter.
+        :param path:
+        :return:
+        """
+        if not path.is_dir():
+            raise ValueError("The install path must be an existing directory.")
+        resolved = path.resolve()
+        await self.conf.install_path.set(resolved)
+        return resolved
 
     @staticmethod
     def _ensure_path_obj(path: Union[Path, str]) -> Path:
@@ -98,7 +120,7 @@ class CogManager:
         """
         self._paths = paths_
         str_paths = [str(p) for p in paths_]
-        await self.conf.set("paths", str_paths)
+        await self.conf.paths.set(str_paths)
 
     def find_cog(self, name: str) -> ModuleSpec:
         """

--- a/core/config.py
+++ b/core/config.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 from pathlib import Path
 
 from .drivers.red_json import JSON as JSONDriver
+from core.data_manager import cog_data_path, core_data_path
 
 log = logging.getLogger("red.config")
 
@@ -210,6 +211,7 @@ class MemberGroup(Group):
         # noinspection PyTypeChecker
         return self._guild_group()
 
+
 class Config:
     GLOBAL = "GLOBAL"
     GUILD = "GUILD"
@@ -242,18 +244,18 @@ class Config:
             of data keys before allowing you to get/set values?
         :return:
         """
-        cog_name = cog_instance.__class__.__name__
+        cog_path_override = cog_data_path(cog_instance)
+        cog_name = cog_path_override.stem
         uuid = str(hash(identifier))
 
-        spawner = JSONDriver(cog_name)
+        spawner = JSONDriver(cog_name, data_path_override=cog_path_override)
         return cls(cog_name=cog_name, unique_identifier=uuid,
                    force_registration=force_registration,
                    driver_spawn=spawner)
 
     @classmethod
     def get_core_conf(cls, force_registration: bool=False):
-        core_data_path = Path.cwd() / 'core' / '.data'
-        driver_spawn = JSONDriver("Core", data_path_override=core_data_path)
+        driver_spawn = JSONDriver("Core", data_path_override=core_data_path())
         return cls(cog_name="Core", driver_spawn=driver_spawn,
                    unique_identifier='0',
                    force_registration=force_registration)

--- a/core/core_commands.py
+++ b/core/core_commands.py
@@ -69,7 +69,7 @@ class Core:
             await ctx.send("Failed to reload package. Check your console or "
                            "logs for details.")
         else:
-            await ctx.bot.save_packages_status()
+            await ctx.bot.remove_loaded_package(cog_name)
             await ctx.send("Done.")
 
     def cleanup_and_refresh_modules(self, module_name: str):

--- a/core/core_commands.py
+++ b/core/core_commands.py
@@ -41,7 +41,7 @@ class Core:
             await ctx.send("Failed to load package. Check your console or "
                            "logs for details.")
         else:
-            await ctx.bot.save_packages_status()
+            await ctx.bot.add_loaded_package(cog_name)
             await ctx.send("Done.")
 
     @commands.group()
@@ -50,7 +50,7 @@ class Core:
         """Unloads a package"""
         if cog_name in ctx.bot.extensions:
             ctx.bot.unload_extension(cog_name)
-            await ctx.bot.save_packages_status()
+            await ctx.bot.remove_loaded_package(cog_name)
             await ctx.send("Done.")
         else:
             await ctx.send("That extension is not loaded.")

--- a/core/data_manager.py
+++ b/core/data_manager.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+from core.json_io import JsonIO
+
+jsonio = None
+basic_config = None
+
+basic_config_default = {
+    "DATA_PATH": None,
+    "COG_PATH_APPEND": "cogs",
+    "CORE_PATH_APPEND": "core"
+}
+
+
+def load_basic_configuration(path: Path):
+    global jsonio
+    global basic_config
+
+    jsonio = JsonIO(path)
+    basic_config = jsonio._load_json()
+
+
+def _base_data_path() -> Path:
+    if basic_config is None:
+        raise RuntimeError("You must load the basic config before you"
+                           " can get the base data path.")
+    path = basic_config['DATA_PATH']
+    return Path(path).resolve()
+
+
+def cog_data_path(cog_instance=None) -> Path:
+    """
+    Gets the base cog data path. If you want to get the folder with
+        which to store your own cog's data please pass in an instance
+        of your cog class.
+    :param cog_instance:
+    :return:
+    """
+    try:
+        base_data_path = Path(_base_data_path())
+    except RuntimeError as e:
+        raise RuntimeError("You must load the basic config before you"
+                           " can get the cog data path.") from e
+    cog_path = base_data_path / basic_config['COG_PATH_APPEND']
+    if cog_instance:
+        cog_path = cog_path / cog_instance.__class__.__name__
+    cog_path.mkdir(exist_ok=True, parents=True)
+
+    return cog_path.resolve()
+
+
+def core_data_path() -> Path:
+    try:
+        base_data_path = Path(_base_data_path())
+    except RuntimeError as e:
+        raise RuntimeError("You must load the basic config before you"
+                           " can get the core data path.") from e
+    core_path = base_data_path / basic_config['CORE_PATH_APPEND']
+    core_path.mkdir(exist_ok=True, parents=True)
+
+    return core_path.resolve()

--- a/core/events.py
+++ b/core/events.py
@@ -38,7 +38,8 @@ def init_events(bot, cli_flags):
 
             for package in packages:
                 try:
-                    bot.load_extension(package)
+                    spec = bot.cog_mgr.find_cog(package)
+                    bot.load_extension(spec)
                 except Exception as e:
                     log.exception("Failed to load package {}".format(package),
                                   exc_info=e)

--- a/core/events.py
+++ b/core/events.py
@@ -43,10 +43,7 @@ def init_events(bot, cli_flags):
                 except Exception as e:
                     log.exception("Failed to load package {}".format(package),
                                   exc_info=e)
-                    failed.append(package)
-
-            if failed:
-                await bot.save_packages_status()
+                    await bot.remove_loaded_package(package)
             if packages:
                 print("Loaded packages: " + ", ".join(packages))
 

--- a/core/sentry_setup.py
+++ b/core/sentry_setup.py
@@ -1,9 +1,6 @@
 from raven import Client, breadcrumbs
 from raven.versioning import fetch_git_sha
-from raven.conf import setup_logging
 from raven.handlers.logging import SentryHandler
-
-from pathlib import Path
 
 __all__ = ("init_sentry_logging", "should_log")
 

--- a/core/sentry_setup.py
+++ b/core/sentry_setup.py
@@ -27,12 +27,12 @@ include_paths = (
 client = None
 
 
-def init_sentry_logging(logger):
+def init_sentry_logging(bot, logger):
     global client
     client = Client(
         dsn=("https://27f3915ba0144725a53ea5a99c9ae6f3:87913fb5d0894251821dcf06e5e9cfe6@"
              "sentry.telemetry.red/19?verify_ssl=0"),
-        release=fetch_git_sha(str(Path.cwd()))
+        release=fetch_git_sha(str(bot.main_dir))
     )
 
     breadcrumbs.ignore_logger("websockets")

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from core.bot import Red, ExitCodes
 from core.cog_manager import CogManagerUI
 from core.global_checks import init_global_checks
@@ -67,11 +69,17 @@ def init_loggers(cli_flags):
     return logger, sentry_logger
 
 
+def determine_main_folder() -> Path:
+    return Path(os.path.dirname(__file__)).resolve()
+
+
 if __name__ == '__main__':
     cli_flags = parse_cli_flags()
     log, sentry_log = init_loggers(cli_flags)
     description = "Red v3 - Alpha"
-    red = Red(cli_flags, description=description, pm_help=None)
+    bot_dir = determine_main_folder()
+    red = Red(cli_flags, description=description, pm_help=None,
+              bot_dir=bot_dir)
     init_global_checks(red)
     init_events(red, cli_flags)
 

--- a/main.py
+++ b/main.py
@@ -55,8 +55,10 @@ def init_loggers(cli_flags):
     else:
         logger.setLevel(logging.WARNING)
 
+    from core.data_manager import core_data_path
+    logfile_path = core_data_path() / 'red.log'
     fhandler = logging.handlers.RotatingFileHandler(
-        filename='red.log', encoding='utf-8', mode='a',
+        filename=str(logfile_path), encoding='utf-8', mode='a',
         maxBytes=10**7, backupCount=5)
     fhandler.setFormatter(red_format)
 

--- a/main.py
+++ b/main.py
@@ -115,7 +115,7 @@ if __name__ == '__main__':
         ask_sentry(red)
 
     if red.db.enable_sentry():
-        init_sentry_logging(sentry_log)
+        init_sentry_logging(red, sentry_log)
 
     loop = asyncio.get_event_loop()
     cleanup_tasks = True

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from core.bot import Red, ExitCodes
 from core.cog_manager import CogManagerUI
+from core.data_manager import load_basic_configuration
 from core.global_checks import init_global_checks
 from core.events import init_events
 from core.sentry_setup import init_sentry_logging
@@ -75,6 +76,14 @@ def determine_main_folder() -> Path:
 
 if __name__ == '__main__':
     cli_flags = parse_cli_flags()
+
+    if cli_flags.config:
+        load_basic_configuration(Path(cli_flags.config).resolve())
+    else:
+        raise RuntimeError("You need to create a basic configuration file,"
+                           " this error will disappear when the launcher has"
+                           " been rewritten.")
+
     log, sentry_log = init_loggers(cli_flags)
     description = "Red v3 - Alpha"
     bot_dir = determine_main_folder()

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 from core.bot import Red, ExitCodes
+from core.cog_manager import CogManagerUI
 from core.global_checks import init_global_checks
 from core.events import init_events
 from core.sentry_setup import init_sentry_logging
@@ -75,6 +76,7 @@ if __name__ == '__main__':
     init_events(red, cli_flags)
 
     red.add_cog(Core())
+    red.add_cog(CogManagerUI())
 
     if cli_flags.dev:
         red.add_cog(Dev())

--- a/main.py
+++ b/main.py
@@ -1,19 +1,10 @@
 from pathlib import Path
 
-from core.bot import Red, ExitCodes
-from core.cog_manager import CogManagerUI
+from core.bot import ExitCodes
 from core.data_manager import load_basic_configuration
-from core.global_checks import init_global_checks
-from core.events import init_events
-from core.sentry_setup import init_sentry_logging
-from core.cli import interactive_config, confirm, parse_cli_flags, ask_sentry
-from core.core_commands import Core
-from core.dev_commands import Dev
+from core.cli import confirm, parse_cli_flags, setup, basic_setup, determine_main_folder
 import asyncio
 import discord
-import logging.handlers
-import logging
-import os
 import sys
 
 #
@@ -29,95 +20,15 @@ if discord.version_info.major < 1:
     sys.exit(1)
 
 
-def init_loggers(cli_flags):
-    # d.py stuff
-    dpy_logger = logging.getLogger("discord")
-    dpy_logger.setLevel(logging.WARNING)
-    console = logging.StreamHandler()
-    console.setLevel(logging.WARNING)
-    dpy_logger.addHandler(console)
-
-    # Red stuff
-
-    logger = logging.getLogger("red")
-
-    red_format = logging.Formatter(
-        '%(asctime)s %(levelname)s %(module)s %(funcName)s %(lineno)d: '
-        '%(message)s',
-        datefmt="[%d/%m/%Y %H:%M]")
-
-    stdout_handler = logging.StreamHandler(sys.stdout)
-    stdout_handler.setFormatter(red_format)
-
-    if cli_flags.debug:
-        os.environ['PYTHONASYNCIODEBUG'] = '1'
-        logger.setLevel(logging.DEBUG)
-    else:
-        logger.setLevel(logging.WARNING)
-
-    from core.data_manager import core_data_path
-    logfile_path = core_data_path() / 'red.log'
-    fhandler = logging.handlers.RotatingFileHandler(
-        filename=str(logfile_path), encoding='utf-8', mode='a',
-        maxBytes=10**7, backupCount=5)
-    fhandler.setFormatter(red_format)
-
-    logger.addHandler(fhandler)
-    logger.addHandler(stdout_handler)
-
-    # Sentry stuff
-    sentry_logger = logging.getLogger("red.sentry")
-    sentry_logger.setLevel(logging.WARNING)
-
-    return logger, sentry_logger
-
-
-def determine_main_folder() -> Path:
-    return Path(os.path.dirname(__file__)).resolve()
-
-
 if __name__ == '__main__':
     cli_flags = parse_cli_flags()
 
     if cli_flags.config:
         load_basic_configuration(Path(cli_flags.config).resolve())
     else:
-        raise RuntimeError("You need to create a basic configuration file,"
-                           " this error will disappear when the launcher has"
-                           " been rewritten.")
+        basic_setup()
 
-    log, sentry_log = init_loggers(cli_flags)
-    description = "Red v3 - Alpha"
-    bot_dir = determine_main_folder()
-    red = Red(cli_flags, description=description, pm_help=None,
-              bot_dir=bot_dir)
-    init_global_checks(red)
-    init_events(red, cli_flags)
-
-    red.add_cog(Core())
-    red.add_cog(CogManagerUI())
-
-    if cli_flags.dev:
-        red.add_cog(Dev())
-
-    token = os.environ.get("RED_TOKEN", red.db.token())
-    prefix = cli_flags.prefix or red.db.prefix()
-
-    if token is None or not prefix:
-        if cli_flags.no_prompt is False:
-            new_token = interactive_config(red, token_set=bool(token),
-                                           prefix_set=bool(prefix))
-            if new_token:
-                token = new_token
-        else:
-            log.critical("Token and prefix must be set in order to login.")
-            sys.exit(1)
-
-    if red.db.enable_sentry() is None:
-        ask_sentry(red)
-
-    if red.db.enable_sentry():
-        init_sentry_logging(red, sentry_log)
+    red, token, log, sentry_log = setup(cli_flags, determine_main_folder())
 
     loop = asyncio.get_event_loop()
     cleanup_tasks = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytest
 git+https://github.com/pytest-dev/pytest-asyncio
 pymongo
 git+https://github.com/getsentry/raven-python
+appdirs

--- a/tests/cogs/downloader/test_downloader.py
+++ b/tests/cogs/downloader/test_downloader.py
@@ -31,7 +31,7 @@ def patch_relative_to(monkeysession):
 def repo_manager(tmpdir_factory, config):
     config.register_global(repos={})
     rm = RepoManager(config)
-    rm.repos_folder = Path(str(tmpdir_factory.getbasetemp())) / 'repos'
+    # rm.repos_folder = Path(str(tmpdir_factory.getbasetemp())) / 'repos'
     return rm
 
 

--- a/tests/cogs/downloader/test_installable.py
+++ b/tests/cogs/downloader/test_installable.py
@@ -5,7 +5,7 @@ from cogs.downloader.installable import Installable, InstallableType
 from pathlib import Path
 
 INFO_JSON = {
-    "author": (
+    "_author": (
         "tekulvw",
     ),
     "bot_version": (3, 0, 0),

--- a/tests/cogs/downloader/test_installable.py
+++ b/tests/cogs/downloader/test_installable.py
@@ -5,7 +5,7 @@ from cogs.downloader.installable import Installable, InstallableType
 from pathlib import Path
 
 INFO_JSON = {
-    "_author": (
+    "author": (
         "tekulvw",
     ),
     "bot_version": (3, 0, 0),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,13 @@ def monkeysession(request):
     mpatch.undo()
 
 
+@pytest.fixture(autouse=True)
+def override_data_path(tmpdir):
+    from core import data_manager
+    data_manager.basic_config = data_manager.basic_config_default
+    data_manager.basic_config['DATA_PATH'] = str(tmpdir)
+
+
 @pytest.fixture()
 def json_driver(tmpdir_factory):
     import uuid

--- a/tests/core/test_sentry.py
+++ b/tests/core/test_sentry.py
@@ -2,9 +2,9 @@ from core import sentry_setup
 import logging
 
 
-def test_sentry_capture():
+def test_sentry_capture(red):
     log = logging.getLogger(__name__)
-    sentry_setup.init_sentry_logging(log)
+    sentry_setup.init_sentry_logging(red, log)
 
     assert sentry_setup.client is not None
 


### PR DESCRIPTION
One more step towards pip installability.

### New Features
- Refactored initial setup
- Add components to initial setup to ask for data path and cog install path for Downloader
- Setup creates a `config.json` file that's now required to start the bot as it contains the data path

### What does this mean?
*We're no longer depended on current working directory.*

### How do I use this?
1. Update your requirements: `pip install -U -r requirements.txt`
2. `python /path/to/main.py`
3. The bot will then generate a file named `config.json` to the current working directory.
4. From now on run the bot using `python /path/to/main.py /path/to/config.json`

### Dependencies
- ~~#853~~
- #879 