### PR TITLE
[Docs] Setup intersphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,4 +185,6 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3.5', None),
+                       'dpy': ('https://discordpy.readthedocs.io/en/rewrite/', None),
+                       'motor': ('https://motor.readthedocs.io/en/stable/', None)}


### PR DESCRIPTION
This allows us to cross reference with links to other projects' documentation (dpy).

For example:
![image](https://user-images.githubusercontent.com/3731082/29237519-ce574738-7eed-11e7-961f-a5f8904dc9b4.png)
