### PR TITLE
[Core] Add shutdown command

### DIFF
--- a/core/core_commands.py
+++ b/core/core_commands.py
@@ -71,6 +71,19 @@ class Core:
             await ctx.bot.save_packages_status()
             await ctx.send("Done.")
 
+    @commands.command(name="shutdown")
+    @checks.is_owner()
+    async def _shutdown(self, ctx, silently: bool=False):
+        """Shuts down the bot"""
+        wave = "\N{WAVING HAND SIGN}"
+        skin = "\N{EMOJI MODIFIER FITZPATRICK TYPE-3}"
+        try:  # We don't want missing perms to stop our shutdown
+            if not silently:
+                await ctx.send("Shutting down... " + wave + skin)
+        except:
+            pass
+        await ctx.bot.shutdown()
+
     def cleanup_and_refresh_modules(self, module_name: str):
         """Interally reloads modules so that changes are detected"""
         splitted = module_name.split('.')


### PR DESCRIPTION
Adds a shutdown command to the core commands so we don't have to keep doing `[p]debug bot.shutdown` or causing a `KeyboardInterrupt` to shutdown the bot