### PR TITLE
[Core V3] Fix pagify bug

### DIFF
--- a/core/utils/chat_formatting.py
+++ b/core/utils/chat_formatting.py
@@ -52,7 +52,7 @@ def pagify(text, delims=["\n"], *, escape_mass_mentions=True, shorten_by=8,
             yield to_send
         in_text = in_text[closest_delim:]
 
-    if len(in_text.strip()) > 0
+    if len(in_text.strip()) > 0:
         if escape_mass_mentions:
             yield escape(in_text, mass_mentions=True)
         else:

--- a/core/utils/chat_formatting.py
+++ b/core/utils/chat_formatting.py
@@ -35,25 +35,28 @@ def pagify(text, delims=["\n"], *, escape_mass_mentions=True, shorten_by=8,
            page_length=2000):
     """DOES NOT RESPECT MARKDOWN BOXES OR INLINE CODE"""
     in_text = text
-    if escape_mass_mentions:
-        num_mentions = text.count("@here") + text.count("@everyone")
-        shorten_by += num_mentions
     page_length -= shorten_by
     while len(in_text) > page_length:
-        closest_delim = max([in_text.rfind(d, 0, page_length)
+        this_page_len = page_length
+        if escape_mass_mentions:
+            this_page_len -= (in_text.count("@here", 0, page_length) +
+                              in_text.count("@everyone", 0, page_length))
+        closest_delim = max([in_text.rfind(d, 1, this_page_len)
                              for d in delims])
-        closest_delim = closest_delim if closest_delim != -1 else page_length
+        closest_delim = closest_delim if closest_delim != -1 else this_page_length
         if escape_mass_mentions:
             to_send = escape(in_text[:closest_delim], mass_mentions=True)
         else:
             to_send = in_text[:closest_delim]
-        yield to_send
+        if len(to_send.strip()) > 0:
+            yield to_send
         in_text = in_text[closest_delim:]
 
-    if escape_mass_mentions:
-        yield escape(in_text, mass_mentions=True)
-    else:
-        yield in_text
+    if len(in_text.strip()) > 0
+        if escape_mass_mentions:
+            yield escape(in_text, mass_mentions=True)
+        else:
+            yield in_text
 
 
 def strikethrough(text):


### PR DESCRIPTION
Yes, I'm bringing this up again, since development has moved on from my original PR at #646.

This one also implements the fix in PR #543 by @Chovin. While that issue has been *addressed*, the fix is... lacking, since it counts mass mentions in the entire text and removes that count from each page. Chovin's fix (counting only in the specific page, not in the entire text) should be better, since the page length will be more regular and there won't be any strange bugs of trying to post low-length messages in the rare case that there's a lot of mentions.

For commentary on my fix, which altogether prevents sending 0-length / whitespace-only messages, please see the original PR. (#646)

This has not yet been thoroughly tested, though it did fix the original issue that I had that spawned this PR in the first place.