### PR TITLE
[Dev V3] mockmsg command

### DIFF
--- a/core/dev_commands.py
+++ b/core/dev_commands.py
@@ -247,3 +247,21 @@ class Dev:
 
         ctx.message.author = old_author
         ctx.message.content = old_content
+
+    @commands.command(name="mockmsg")
+    @checks.is_owner()
+    async def mock_msg(self, ctx, user: discord.Member, *, content: str):
+        """Bot receives a message is if it were sent by a different user.
+
+        Only reads the raw content of the message. Attachments, embeds etc. are ignored."""
+        old_author = ctx.author
+        old_content = ctx.message.content
+        ctx.message.author = user
+        ctx.message.content = content
+
+        ctx.bot.dispatch("message", ctx.message)
+
+        await asyncio.sleep(2) # If we change the author and content back too quickly,
+                               #  the bot won't process the mocked message in time.
+        ctx.message.author = old_author
+        ctx.message.content = old_content


### PR DESCRIPTION
Since we already have a `mock` command which pretends a command was invoked by another user, another similar but equally useful feature is this `mockmsg` command, which pretends a message was sent by another user.

This would be really useful when developing cogs which interact with multiple users through `on_message` or `wait_for` events, such as Trivia.