### PR TITLE
[V3 Core] Fix reload of core cogs

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -115,7 +115,7 @@ class Core:
     def cleanup_and_refresh_modules(self, module_name: str):
         """Interally reloads modules so that changes are detected"""
         splitted = module_name.split('.')
-        
+
         def maybe_reload(new_name):
             try:
                 lib = sys.modules[new_name]


### PR DESCRIPTION
This solves the issue of core cogs not being found when doing `reload`