### PR TITLE
[V3][Docs] add install guides to the documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,17 @@ Welcome to Red - Discord Bot's documentation!
 =============================================
 
 .. toctree::
+    :maxdepth: 1
+    :caption: Installation Guides:
+
+    install_windows
+    install_mac
+    install_ubuntu
+    install_debian
+    install_centos
+    install_raspbian
+
+.. toctree::
     :maxdepth: 2
     :caption: Cog Reference:
 

--- a/docs/install_centos.rst
+++ b/docs/install_centos.rst
@@ -8,10 +8,12 @@ Installing Red on CentOS 7
 Installing pre-requirements
 ---------------------------
 
-:code:`yum -y groupinstall development`
-:code:`yum -y install https://centos7.iuscommunity.org/ius-release.rpm`
-:code:`yum -y install yum-utils wget which python35u python35u-pip python35u-devel openssl-devel libffi-devel git opus-devel`
-:code:`sh -c "$(wget https://gist.githubusercontent.com/mustafaturan/7053900/raw/27f4c8bad3ee2bb0027a1a52dc8501bf1e53b270/latest-ffmpeg-centos6.sh -O -)"`
+.. code-block:: none
+
+    yum -y groupinstall development
+    yum -y install https://centos7.iuscommunity.org/ius-release.rpm
+    yum -y install yum-utils wget which python35u python35u-pip python35u-devel openssl-devel libffi-devel git opus-devel
+    sh -c "$(wget https://gist.githubusercontent.com/mustafaturan/7053900/raw/27f4c8bad3ee2bb0027a1a52dc8501bf1e53b270/latest-ffmpeg-centos6.sh -O -)"
 
 --------------
 Installing Red

--- a/docs/install_centos.rst
+++ b/docs/install_centos.rst
@@ -1,0 +1,38 @@
+.. centos install guide
+
+==========================
+Installing Red on CentOS 7
+==========================
+
+---------------------------
+Installing pre-requirements
+---------------------------
+
+:code:`yum -y groupinstall development`
+:code:`yum -y install https://centos7.iuscommunity.org/ius-release.rpm`
+:code:`yum -y install yum-utils wget which python35u python35u-pip python35u-devel openssl-devel libffi-devel git opus-devel`
+:code:`sh -c "$(wget https://gist.githubusercontent.com/mustafaturan/7053900/raw/27f4c8bad3ee2bb0027a1a52dc8501bf1e53b270/latest-ffmpeg-centos6.sh -O -)"`
+
+--------------
+Installing Red
+--------------
+
+:code:`pip3 install red-discordbot[voice]`
+
+----------------------
+Setting up an instance
+----------------------
+
+Run :code:`redbot-setup` and follow the prompts. It will ask first for where you want to
+store the data (the default is :code:`~/.local/share/Red-DiscordBot`) and will then ask
+for confirmation of that selection. Next, it will ask you to choose your storage backend
+(the default here is JSON). It will then ask for a name for your instance. This can be
+anything as long as it does not contain spaces; however, keep in mind that this is the
+name you will use to run your bot, and so it should be something you can remember.
+
+-----------
+Running Red
+-----------
+
+Run :code:`redbot <your instance name>` and run through the initial setup. This will ask for
+your token and a prefix.

--- a/docs/install_debian.rst
+++ b/docs/install_debian.rst
@@ -1,0 +1,45 @@
+.. debian install guide
+
+================================
+Installing Red on Debian Stretch
+================================
+
+.. warning:: For safety reasons, DO NOT install Red with a root user. Instead, make a new one.
+
+---------------------------
+Installing pre-requirements
+---------------------------
+
+:code:`echo "deb http://httpredir.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list`
+:code:`apt-get update`
+:code:`apt-get install python3.5-dev python3-pip build-essential libssl-dev libffi-dev git ffmpeg libopus-dev unzip -y`
+
+------------------
+Installing the bot
+------------------
+
+To install without audio:
+
+:code:`pip3 install red-discordbot`
+
+To install with audio:
+
+:code:`pip3 install red-discordbot[voice]`
+
+------------------------
+Setting up your instance
+------------------------
+
+Run :code:`redbot-setup` and follow the prompts. It will ask first for where you want to
+store the data (the default is :code:`~/.local/share/Red-DiscordBot`) and will then ask
+for confirmation of that selection. Next, it will ask you to choose your storage backend
+(the default here is JSON). It will then ask for a name for your instance. This can be
+anything as long as it does not contain spaces; however, keep in mind that this is the
+name you will use to run your bot, and so it should be something you can remember.
+
+-----------
+Running Red
+-----------
+
+Run :code:`redbot <your instance name>` and run through the initial setup. This will ask for
+your token and a prefix.

--- a/docs/install_debian.rst
+++ b/docs/install_debian.rst
@@ -10,9 +10,11 @@ Installing Red on Debian Stretch
 Installing pre-requirements
 ---------------------------
 
-:code:`echo "deb http://httpredir.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list`
-:code:`apt-get update`
-:code:`apt-get install python3.5-dev python3-pip build-essential libssl-dev libffi-dev git ffmpeg libopus-dev unzip -y`
+.. code-block:: none
+
+    echo "deb http://httpredir.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list
+    apt-get update
+    apt-get install python3.5-dev python3-pip build-essential libssl-dev libffi-dev git ffmpeg libopus-dev unzip -y
 
 ------------------
 Installing the bot

--- a/docs/install_mac.rst
+++ b/docs/install_mac.rst
@@ -9,14 +9,14 @@ Installing pre-requirements
 ---------------------------
 
 * Install Brew
-  * In Finder or Spotlight, search for and open terminal. In the window that will open, paste this:
-    :code:`/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
-    and press enter.
+    * In Finder or Spotlight, search for and open terminal. In the window that will open, paste this:
+      :code:`/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
+      and press enter.
 * After the installation, install the required packages by pasting the commands and pressing enter, one-by-one:
-  * :code:`brew install python3 --with-brewed-openssl`
-  * :code:`brew install git`
-  * :code:`brew install ffmpeg --with-ffplay`
-  * :code:`brew install opus`
+    * :code:`brew install python3 --with-brewed-openssl`
+    * :code:`brew install git`
+    * :code:`brew install ffmpeg --with-ffplay`
+    * :code:`brew install opus`
 
 --------------
 Installing Red

--- a/docs/install_mac.rst
+++ b/docs/install_mac.rst
@@ -1,0 +1,39 @@
+.. mac install guide
+
+=====================
+Installing Red on Mac
+=====================
+
+---------------------------
+Installing pre-requirements
+---------------------------
+
+* Install Brew
+  * In Finder or Spotlight, search for and open terminal. In the window that will open, paste this:
+    :code:`/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
+    and press enter.
+* After the installation, install the required packages by pasting the commands and pressing enter, one-by-one:
+  * :code:`brew install python3 --with-brewed-openssl`
+  * :code:`brew install git`
+  * :code:`brew install ffmpeg --with-ffplay`
+  * :code:`brew install opus`
+
+--------------
+Installing Red
+--------------
+
+To install Red, run :code:`pip3 install red-discordbot[voice]`
+
+----------------------
+Setting up an instance
+----------------------
+
+To set up an instance, run :code:`redbot-setup` and follow the steps there, providing the requested information
+or accepting the defaults. Keep in mind that the instance name will be the one you use when running the bot, so
+make it something you can remember
+
+-----------
+Running Red
+-----------
+
+Run :code:`redbot <your instance name>` and go through the initial setup (it will ask for the token and a prefix).

--- a/docs/install_raspbian.rst
+++ b/docs/install_raspbian.rst
@@ -8,7 +8,9 @@ Installing Red on Raspbian Stretch
 Installing pre-requirements
 ---------------------------
 
-:code:`sudo apt-get install python3.5-dev python3-pip build-essential libssl-dev libffi-dev git libav-tools libopus-dev unzip -y`
+.. code-block:: none
+
+    sudo apt-get install python3.5-dev python3-pip build-essential libssl-dev libffi-dev git libav-tools libopus-dev unzip -y
 
 --------------
 Installing Red

--- a/docs/install_raspbian.rst
+++ b/docs/install_raspbian.rst
@@ -1,0 +1,37 @@
+.. raspbian install guide
+
+==================================
+Installing Red on Raspbian Stretch
+==================================
+
+---------------------------
+Installing pre-requirements
+---------------------------
+
+:code:`sudo apt-get install python3.5-dev python3-pip build-essential libssl-dev libffi-dev git libav-tools libopus-dev unzip -y`
+
+--------------
+Installing Red
+--------------
+
+:code:`pip3 install red-discordbot[voice]`
+
+----------------------
+Setting up an instance
+----------------------
+
+Run :code:`redbot-setup` and follow the prompts. It will ask first for where you want to
+store the data (the default is :code:`~/.local/share/Red-DiscordBot`) and will then ask
+for confirmation of that selection. Next, it will ask you to choose your storage backend
+(the default here is JSON). It will then ask for a name for your instance. This can be
+anything as long as it does not contain spaces; however, keep in mind that this is the
+name you will use to run your bot, and so it should be something you can remember.
+
+-----------
+Running Red
+-----------
+
+Run :code:`redbot <your instance name>` and run through the initial setup. This will ask for
+your token and a prefix.
+
+.. warning:: Audio will not work on Raspberry Pi's **below** 2B. This is a CPU problem and *cannot* be fixed.

--- a/docs/install_ubuntu.rst
+++ b/docs/install_ubuntu.rst
@@ -10,7 +10,9 @@ Installing Red on Ubuntu 16.04
 Installing the pre-requirements
 -------------------------------
 
-:code:`apt-get install python3.5-dev python3-pip build-essential libssl-dev libffi-dev git ffmpeg libopus-dev unzip -y`
+.. code-block:: none
+
+    sudo apt install python3.5-dev python3-pip build-essential libssl-dev libffi-dev git ffmpeg libopus-dev unzip -y
 
 ------------------
 Installing the bot

--- a/docs/install_ubuntu.rst
+++ b/docs/install_ubuntu.rst
@@ -1,0 +1,43 @@
+.. ubuntu install guide
+
+==============================
+Installing Red on Ubuntu 16.04
+==============================
+
+.. warning:: For safety reasons, DO NOT install Red with a root user. Instead, make a new one.
+
+-------------------------------
+Installing the pre-requirements
+-------------------------------
+
+:code:`apt-get install python3.5-dev python3-pip build-essential libssl-dev libffi-dev git ffmpeg libopus-dev unzip -y`
+
+------------------
+Installing the bot
+------------------
+
+To install without audio:
+
+:code:`pip3 install red-discordbot`
+
+To install with audio:
+
+:code:`pip3 install red-discordbot[voice]`
+
+------------------------
+Setting up your instance
+------------------------
+
+Run :code:`redbot-setup` and follow the prompts. It will ask first for where you want to
+store the data (the default is :code:`~/.local/share/Red-DiscordBot`) and will then ask
+for confirmation of that selection. Next, it will ask you to choose your storage backend
+(the default here is JSON). It will then ask for a name for your instance. This can be
+anything as long as it does not contain spaces; however, keep in mind that this is the
+name you will use to run your bot, and so it should be something you can remember.
+
+-----------
+Running Red
+-----------
+
+Run :code:`redbot <your instance name>` and run through the initial setup. This will ask for
+your token and a prefix.

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -1,0 +1,37 @@
+.. windows installation docs
+
+=========================
+Installing Red on Windows
+=========================
+
+---------------
+Needed Software
+---------------
+
+* `Python <https://python.org/downloads/>`_ - Red needs at least Python 3.5
+
+.. attention:: Please note that 3.6 has issues on some versions of Windows.
+               If you try using Red with 3.6 and experience issues, uninstall
+               Python 3.6 and install the latest version of Python 3.5
+
+.. note:: Please make sure that the box to add Python to PATH is CHECKED, otherwise
+          you may run into issues when trying to run Red
+
+* `Git <https://git-scm.com/download/win>`_
+
+.. attention:: Please choose the option to "Run Git from the Windows Command Prompt" in Git's setup
+
+--------------
+Installing Red
+--------------
+
+1. Open a command prompt (open Start, search for "command prompt", then click it)
+2. Run the appropriate command, depending on if you want audio or not
+  * No audio: :code:`python -m pip install Red-DiscordBot`
+  * Audio: :code:`python -m pip install Red-DiscordBot[voice]`
+3. Once that has completed, run :code:`redbot-setup` to set up your instance
+  * This will set the location where data will be stored, as well as your
+    storage backend and the name of the instance (which will be used for
+    running the bot)
+4. Once done setting up the instance, run :code:`redbot <your instance name>` to run Red.
+   It will walk through the initial setup, asking for your token and a prefix


### PR DESCRIPTION
This adds install guides for the following operating systems:
- Windows
- OSX
- Ubuntu 16.04
- Debian Stretch
- CentOS 7
- Raspbian Stretch

One note: The Windows and Ubuntu pages seem to be causing issues with the sidebar for a reason that isn't immediately apparent to me