### PR TITLE
[V3] Launcher

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -26,8 +26,8 @@ IS_MAC = sys.platform == "darwin"
 
 def parse_cli_args():
     parser = argparse.ArgumentParser(description="Red - Discord Bot's launcher (V3)")
-    with open(config_file, "r") as fin:
-            instances = json.loads(fin.read())
+    with config_file.open("r") as fin:
+        instances = json.loads(fin.read())
     parser.add_argument("instancename", metavar="instancename", type=str,
                         nargs="?", help="The instance to run", choices=list(instances.keys()))
     parser.add_argument("--start", "-s",
@@ -102,7 +102,7 @@ def run_red(selected_instance, autorestart=False):
 
 
 def instance_menu():
-    with open(config_file, "r") as fin:
+    with config_file.open("r") as fin:
         instances = json.loads(fin.read())
     if not instances:
         print("No instances found!")

--- a/launcher.py
+++ b/launcher.py
@@ -1,46 +1,142 @@
-from redbot.core.bot import ExitCodes
-from redbot.core.data_manager import config_file
+# pylint: disable=missing-docstring
+from __future__ import print_function
+
+import getpass
+import json
+import os
+import platform
 import subprocess
 import sys
-import json
+
+import pkg_resources
+from redbot.core.data_manager import config_file
+from redbot.setup import basic_setup
+
+PYTHON_OK = sys.version_info >= (3, 5)
+
+INTRO = ("==========================\n"
+         "Red Discord Bot - Launcher\n"
+         "==========================\n")
+
+IS_WINDOWS = os.name == "nt"
+IS_MAC = sys.platform == "darwin"
 
 
 def update_red():
-    pass
+    interpreter = sys.executable
+    print("Updating Red...")
+    code = subprocess.call([
+        interpreter, "-m",
+        "pip", "install", "-U",
+        "Red-DiscordBot"
+    ])
+    print("Red has been updated")
 
 
 def run_red(autorestart=False):
-
-    if interpreter is None:  # This should never happen, but what if
-        raise RuntimeError("Couldn't find Python's interpreter")
-    
     with open(config_file, "r") as fin:
         instances = json.loads(fin.read())
-    
+    selected_instance = instance_menu(instances)
+    if not selected_instance:
+        return None
+    while True:
+        print("Starting {}...".format(selected_instance))
+        status = subprocess.call(["redbot", selected_instance])
+        if (not autorestart) or (autorestart and status != 26):
+            break
+
 
 def instance_menu(instances):
     if not instances:
-        raise RuntimeError(
-            "No instances configured! Configure an instance with "
-            "redbot-setup and retry!"
-        )
-    counter = 1
+        print("No instances found!")
+        return None
+    counter = 0
     print("Red instance menu\n")
-    print("Please select one of the following:\n\n")
-    namenummap = {}
+   
+    name_num_map = {}
     for name in list(instances.keys()):
-        print("{}. {}\n".format(counter, name))
-        namenummap[str(counter)] = name
+        print("{}. {}\n".format(counter+1, name))
+        name_num_map[str(counter+1)] = name
         counter += 1
-    selection = input("Enter your selection: ")
+    selection = user_choice()
     try:
         selection = int(selection)
     except ValueError:
         print("Invalid input! Try again.")
         return instance_menu(instances)
     else:
-        if selection not in list(range(1, counter)):
+        if selection not in list(range(1, counter+1)):
             print("Invalid selection! Please try again")
             return instance_menu(instances)
         else:
-            return namenummap[str(counter)]
+            return name_num_map[str(selection)]
+
+
+def clear_screen():
+    if IS_WINDOWS:
+        os.system("cls")
+    else:
+        os.system("clear")
+
+
+def user_choice():
+    return input("> ").lower().strip()
+
+
+def debug_info():
+    pyver = sys.version
+    redver = pkg_resources.get_distribution("Red-DiscordBot").version
+    osver = ""
+    if IS_WINDOWS:
+        os_info = platform.uname()
+        osver = "{} {} (version {}) {}".format(
+            os_info.system, os_info.release, os_info.version, os_info.machine
+        )
+    elif IS_MAC:
+        os_info = platform.mac_ver()
+        osver = "Mac OSX {} {}".format(os_info[0], os_info[2])
+    else:
+        os_info = platform.linux_distribution()  # pylint: disable=deprecated-method
+        osver = "{} {} {}".format(os_info[0], os_info[1], platform.machine())
+    user_who_ran = getpass.getuser()
+    info = "Debug Info for Red\n\n" +\
+        "Python version: {}\n".format(pyver) +\
+        "Red version: {}\n".format(redver) +\
+        "OS version: {}\n".format(osver) +\
+        "User: {}\n".format(user_who_ran)
+    print(info)
+    exit(0)
+
+
+def main():
+    while True:
+        print(INTRO)
+        print("1. Run Red w/ autorestart in case of issues")
+        print("2. Run Red")
+        print("3. Update Red")
+        print("4. Create Instance")
+        print("5. Debug information (use this if having issues with the launcher or bot)")
+        print("0. Exit")
+        choice = user_choice()
+        if choice == "1":
+            run_red(autorestart=True)
+        elif choice == "2":
+            run_red(autorestart=False)
+        elif choice == "3":
+            update_red()
+        elif choice == "4":
+            basic_setup()
+        elif choice == "5":
+            debug_info()
+        elif choice == "0":
+            break
+        clear_screen()
+
+
+if __name__ == "__main__":
+    if not PYTHON_OK:
+        raise RuntimeError(
+            "Red requires Python 3.5 or greater. "
+            "Please install the correct version!"
+        )
+    main()

--- a/launcher.py
+++ b/launcher.py
@@ -12,7 +12,7 @@ import appdirs
 from pathlib import Path
 
 import pkg_resources
-# from redbot.setup import basic_setup
+from redbot.setup import basic_setup
 
 config_dir = Path(appdirs.AppDirs("Red-DiscordBot").user_config_dir)
 config_file = config_dir / 'config.json'
@@ -196,7 +196,10 @@ def main():
                 run_red(instance, autorestart=False)
             wait()
         elif choice == "3":
-            update_red()
+            update_red(dev=True, voice=True)
+            wait()
+        elif choice == "4":
+            basic_setup()
             wait()
         elif choice == "5":
             debug_info()

--- a/launcher.py
+++ b/launcher.py
@@ -8,11 +8,14 @@ import platform
 import subprocess
 import sys
 import argparse
-import time
+import appdirs
+from pathlib import Path
 
 import pkg_resources
-from redbot.core.data_manager import config_file
-from redbot.setup import basic_setup
+# from redbot.setup import basic_setup
+
+config_dir = Path(appdirs.AppDirs("Red-DiscordBot").user_config_dir)
+config_file = config_dir / 'config.json'
 
 PYTHON_OK = sys.version_info >= (3, 5)
 INTERACTIVE_MODE = not len(sys.argv) > 1  # CLI flags = non-interactive
@@ -58,7 +61,7 @@ def parse_cli_args():
                         help="Prints basic debug info that would be useful for support",
                         action="store_true")
     return parser.parse_args()
-    
+
 
 def update_red(dev=False, voice=False, mongo=False, docs=False, test=False):
     interpreter = sys.executable
@@ -178,7 +181,7 @@ def main():
         print("1. Run Red w/ autorestart in case of issues")
         print("2. Run Red")
         print("3. Update Red")
-        print("4. Create Instance")
+        # print("4. Create Instance")
         print("5. Debug information (use this if having issues with the launcher or bot)")
         print("0. Exit")
         choice = user_choice()
@@ -194,9 +197,6 @@ def main():
             wait()
         elif choice == "3":
             update_red()
-            wait()
-        elif choice == "4":
-            basic_setup()
             wait()
         elif choice == "5":
             debug_info()

--- a/launcher.py
+++ b/launcher.py
@@ -1,0 +1,46 @@
+from redbot.core.bot import ExitCodes
+from redbot.core.data_manager import config_file
+import subprocess
+import sys
+import json
+
+
+def update_red():
+    pass
+
+
+def run_red(autorestart=False):
+
+    if interpreter is None:  # This should never happen, but what if
+        raise RuntimeError("Couldn't find Python's interpreter")
+    
+    with open(config_file, "r") as fin:
+        instances = json.loads(fin.read())
+    
+
+def instance_menu(instances):
+    if not instances:
+        raise RuntimeError(
+            "No instances configured! Configure an instance with "
+            "redbot-setup and retry!"
+        )
+    counter = 1
+    print("Red instance menu\n")
+    print("Please select one of the following:\n\n")
+    namenummap = {}
+    for name in list(instances.keys()):
+        print("{}. {}\n".format(counter, name))
+        namenummap[str(counter)] = name
+        counter += 1
+    selection = input("Enter your selection: ")
+    try:
+        selection = int(selection)
+    except ValueError:
+        print("Invalid input! Try again.")
+        return instance_menu(instances)
+    else:
+        if selection not in list(range(1, counter)):
+            print("Invalid selection! Please try again")
+            return instance_menu(instances)
+        else:
+            return namenummap[str(counter)]

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -1,7 +1,9 @@
 import argparse
 import asyncio
+import typing
 
-from redbot.core.bot import Red
+if typing.TYPE_CHECKING:
+    from redbot.core.bot import Red
 
 
 def confirm(m=""):
@@ -46,7 +48,7 @@ def interactive_config(red, token_set, prefix_set):
     return token
 
 
-def ask_sentry(red: Red):
+def ask_sentry(red: "Red"):
     loop = asyncio.get_event_loop()
     print("\nThank you for installing Red V3 alpha! The current version\n"
           " is not suited for production use and is aimed at testing\n"

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -686,7 +686,7 @@ class Config:
         """
         return self._get_base_group(self.USER, user.id)
 
-    def member(self, member: "discord.Member") -> MemberGroup:
+    def member(self, member: "discord.Member") -> Group:
         """Returns a `Group` for the given member.
 
         Parameters

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -1,8 +1,9 @@
 import logging
 from copy import deepcopy
-from typing import Callable, Union, Tuple
+from typing import Callable, Union, Tuple, TYPE_CHECKING
 
-import discord
+if TYPE_CHECKING:
+    import discord
 
 from .data_manager import cog_data_path, core_data_path
 from .drivers.red_json import JSON as JSONDriver
@@ -606,7 +607,7 @@ class Config:
             force_registration=self.force_registration
         )
 
-    def guild(self, guild: discord.Guild) -> Group:
+    def guild(self, guild: "discord.Guild") -> Group:
         """
         Returns a :py:class:`.Group` for the given guild.
 
@@ -614,7 +615,7 @@ class Config:
         """
         return self._get_base_group(self.GUILD, guild.id)
 
-    def channel(self, channel: discord.TextChannel) -> Group:
+    def channel(self, channel: "discord.TextChannel") -> Group:
         """
         Returns a :py:class:`.Group` for the given channel. This does not currently support differences between
         text and voice channels.
@@ -623,7 +624,7 @@ class Config:
         """
         return self._get_base_group(self.CHANNEL, channel.id)
 
-    def role(self, role: discord.Role) -> Group:
+    def role(self, role: "discord.Role") -> Group:
         """
         Returns a :py:class:`.Group` for the given role.
 
@@ -631,7 +632,7 @@ class Config:
         """
         return self._get_base_group(self.ROLE, role.id)
 
-    def user(self, user: discord.User) -> Group:
+    def user(self, user: "discord.User") -> Group:
         """
         Returns a :py:class:`.Group` for the given user.
 
@@ -639,7 +640,7 @@ class Config:
         """
         return self._get_base_group(self.USER, user.id)
 
-    def member(self, member: discord.Member) -> MemberGroup:
+    def member(self, member: "discord.Member") -> MemberGroup:
         """
         Returns a :py:class:`.MemberGroup` for the given member.
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -111,6 +111,19 @@ class Core:
         except:
             pass
         await ctx.bot.shutdown()
+    
+    @commands.command(name="restart")
+    @checks.is_owner()
+    async def _restart(self, ctx, silently: bool=False):
+        """Restarts the bot"""
+        wave = "\N{WAVING HAND SIGN}"
+        skin = "\N{EMOJI MODIFIER FITZPATRICK TYPE-3}"
+        try:  # We don't want missing perms to stop our shutdown
+            if not silently:
+                await ctx.send(_("Restarting... ") + wave + skin)
+        except:
+            pass
+        await ctx.bot.shutdown(restart=True)
 
     def cleanup_and_refresh_modules(self, module_name: str):
         """Interally reloads modules so that changes are detected"""

--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -89,7 +89,7 @@ def update_red(dev=False, voice=False, mongo=False, docs=False, test=False):
     if test:
         egg_l.append("test")
     if dev:
-        package = "git+https://github.com/palmtree5/Red-DiscordBot@V3/launcher"
+        package = "git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop"
         if egg_l:
             package += "#egg=Red-DiscordBot[{}]".format(", ".join(egg_l))
     else:

--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -173,7 +173,7 @@ def debug_info():
     exit(0)
 
 
-def main():
+def main_menu():
     if IS_WINDOWS:
         os.system("TITLE Red - Discord Bot V3 Launcher")
     while True:
@@ -181,7 +181,7 @@ def main():
         print("1. Run Red w/ autorestart in case of issues")
         print("2. Run Red")
         print("3. Update Red")
-        # print("4. Create Instance")
+        print("4. Create Instance")
         print("5. Debug information (use this if having issues with the launcher or bot)")
         print("0. Exit")
         choice = user_choice()
@@ -207,9 +207,7 @@ def main():
             break
         clear_screen()
 
-args = parse_cli_args()
-
-if __name__ == "__main__":
+def main():
     if not PYTHON_OK:
         raise RuntimeError(
             "Red requires Python 3.5 or greater. "
@@ -235,7 +233,13 @@ if __name__ == "__main__":
         )
 
     if INTERACTIVE_MODE:
-        main()
+        main_menu()
     elif args.start:
         print("Starting Red...")
         run_red(args.instancename, autorestart=args.auto_restart)
+
+
+args = parse_cli_args()
+
+if __name__ == "__main__":
+    main()

--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -181,8 +181,9 @@ def main_menu():
         print("1. Run Red w/ autorestart in case of issues")
         print("2. Run Red")
         print("3. Update Red")
-        print("4. Create Instance")
-        print("5. Debug information (use this if having issues with the launcher or bot)")
+        print("4. Update Red (development version")
+        print("5. Create Instance")
+        print("6. Debug information (use this if having issues with the launcher or bot)")
         print("0. Exit")
         choice = user_choice()
         if choice == "1":
@@ -196,12 +197,33 @@ def main_menu():
                 run_red(instance, autorestart=False)
             wait()
         elif choice == "3":
-            update_red(dev=True, voice=True)
+            print("Enter any extra requirements you want installed\n")
+            print("Options are: voice, docs, test, mongo\n")
+            selected = user_choice()
+            selected = selected.split()
+            update_red(
+                dev=False, voice=True if "voice" in selected else False,
+                docs=True if "docs" in selected else False,
+                test=True if "test" in selected else False,
+                mongo=True if "mongo" in selected else False
+            )
             wait()
         elif choice == "4":
-            basic_setup()
+            print("Enter any extra requirements you want installed\n")
+            print("Options are: voice, docs, test, mongo\n")
+            selected = user_choice()
+            selected = selected.split()
+            update_red(
+                dev=True, voice=True if "voice" in selected else False,
+                docs=True if "docs" in selected else False,
+                test=True if "test" in selected else False,
+                mongo=True if "mongo" in selected else False
+            )
             wait()
         elif choice == "5":
+            basic_setup()
+            wait()
+        elif choice == "6":
             debug_info()
         elif choice == "0":
             break

--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -66,7 +66,19 @@ def parse_cli_args():
 def update_red(dev=False, voice=False, mongo=False, docs=False, test=False):
     interpreter = sys.executable
     print("Updating Red...")
-    eggs = ""  # for installing extras (e.g. voice, docs, test, mongo)
+    # If the user ran redbot-launcher.exe, updating with pip will fail
+    # on windows since the file is open and pip will try to overwrite it.
+    # We have to rename redbot-launcher.exe in this case.
+    launcher_script = os.path.abspath(sys.argv[0])
+    old_name = launcher_script + ".exe"
+    new_name = launcher_script + ".old"
+    renamed = False
+    if "redbot-launcher" in launcher_script and IS_WINDOWS:
+        renamed = True
+        print("Renaming {} to {}".format(old_name, new_name))
+        if os.path.exists(new_name):
+            os.remove(new_name)
+        os.rename(old_name, new_name)
     egg_l = []
     if voice:
         egg_l.append("voice")
@@ -77,7 +89,7 @@ def update_red(dev=False, voice=False, mongo=False, docs=False, test=False):
     if test:
         egg_l.append("test")
     if dev:
-        package = "git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop"
+        package = "git+https://github.com/palmtree5/Red-DiscordBot@V3/launcher"
         if egg_l:
             package += "#egg=Red-DiscordBot[{}]".format(", ".join(egg_l))
     else:
@@ -94,6 +106,12 @@ def update_red(dev=False, voice=False, mongo=False, docs=False, test=False):
         print("Red has been updated")
     else:
         print("Something went wrong while updating!")
+
+    # If redbot wasn't updated, we renamed our .exe file and didn't replace it
+    scripts = os.listdir(os.path.dirname(launcher_script))
+    if renamed and "redbot-launcher.exe" not in scripts:
+        print("Renaming {} to {}".format(new_name, old_name))
+        os.rename(new_name, old_name)
 
 
 def run_red(selected_instance, autorestart=False):

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,8 @@ setup(
     entry_points={
         'console_scripts': [
             'redbot=redbot.__main__:main',
-            'redbot-setup=redbot.setup:basic_setup']
+            'redbot-setup=redbot.setup:basic_setup',
+            'redbot-launcher=redbot.launcher:main']
     },
     python_requires='>=3.5',
     setup_requires=get_requirements(),


### PR DESCRIPTION
This PR adds a launcher for V3.

**Features:**
* Starting Red (with or without autorestart)
  - Lists available instances on the spot and has the user select one to be used
* Updating Red (though only what is on PyPI atm)
* Instance creation (using `redbot-setup` via an import) (requested in #850)
* Some basic debug info (Python version, Red version, OS version/arch, user who ran the bot) (as requested in #850)

Obviously there's some improvements to be made still but this is a starting point for an actual launcher