### PR TITLE
Fix #989: Unable to repeat queue on latest commit

### DIFF
--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -2177,7 +2177,7 @@ class Audio:
                     return
                 if repeat and last_song:
                     queued_last_song = QueuedSong(last_song.webpage_url, last_song_channel)
-                    queue.append(last_song.webpage_url)
+                    queue.append(queued_last_song)
             else:
                 song = None
             self._set_queue_nowplaying(server, song, channel)


### PR DESCRIPTION
Resolves an issue where repeat would break the queue. Turns out I forgot to replace a URL string with a Queued_Song instance (that I had already instantiated).

Fixes https://github.com/Cog-Creators/Red-DiscordBot/issues/989.