### PR TITLE
[V3] [Config] Redesign "all_from_XXX" and "clear_all" methods

### DIFF
--- a/redbot/cogs/bank/bank.py
+++ b/redbot/cogs/bank/bank.py
@@ -63,7 +63,7 @@ class Bank:
         If the bank is global, it will become per-guild
         If the bank is per-guild, it will become global"""
         cur_setting = await bank.is_global()
-        await bank.set_global(not cur_setting, ctx.author)
+        await bank.set_global(not cur_setting)
 
         word = _("per-guild") if cur_setting else _("global")
 

--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -274,7 +274,7 @@ async def get_guild_accounts(guild: discord.Guild) -> List[Account]:
         raise RuntimeError("The bank is currently global.")
 
     ret = []
-    accs = await _conf.member(guild.owner).all_from_kind()
+    accs = await _conf.all_members(guild)
     for user_id, acc in accs.items():
         acc_data = acc.copy()  # There ya go kowlin
         acc_data['created_at'] = _decode_time(acc_data['created_at'])
@@ -301,7 +301,7 @@ async def get_global_accounts(user: discord.User) -> List[Account]:
         raise RuntimeError("The bank is not currently global.")
 
     ret = []
-    accs = await _conf.user(user).all_from_kind()  # this is a dict of user -> acc
+    accs = await _conf.all_users()  # this is a dict of user -> acc
     for user_id, acc in accs.items():
         acc_data = acc.copy()
         acc_data['created_at'] = _decode_time(acc_data['created_at'])
@@ -355,19 +355,15 @@ async def is_global() -> bool:
     return await _conf.is_global()
 
 
-async def set_global(global_: bool, user: Union[discord.User, discord.Member]) -> bool:
+async def set_global(global_: bool) -> bool:
     """
-    Sets global status of the bank, requires the user parameter for technical reasons.
+    Sets global status of the bank.
     
     .. important::
         All accounts are reset when you switch!
 
     :param global_:
         :code:`True` will set bank to global mode.
-    :param user:
-        Must be a Member object if changing TO global mode.
-    :type user:
-        discord.User or discord.Member
     :return:
         New bank mode, :code:`True` is global.
     :rtype: 
@@ -379,12 +375,9 @@ async def set_global(global_: bool, user: Union[discord.User, discord.Member]) -
         return global_
 
     if is_global():
-        await _conf.user(user).clear_all()
-    elif isinstance(user, discord.Member):
-        await _conf.member(user).clear_all()
+        await _conf.clear_all_users()
     else:
-        raise RuntimeError("You must provide a member if you're changing to global"
-                           " bank mode.")
+        await _conf.clear_all_members()
 
     await _conf.is_global.set(global_)
     return global_

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -845,7 +845,6 @@ class Config:
             A coroutine which, when awaited, clears all specified member data.
 
         """
-        scopes = [self.MEMBER]
         if guild is not None:
-            scopes.append(guild.id)
-        return self._clear_scope(*scopes)
+            return self._clear_scope(self.MEMBER, guild.id)
+        return self._clear_scope(self.MEMBER)

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -525,6 +525,10 @@ class Config:
             to_add = self._get_defaults_dict(k, v)
             self._update_defaults(to_add, self._defaults[key])
 
+    def _snowflake_dict(self, dict_: dict):
+        """Get a copy of the dict with the keys casted to ints."""
+        return {int(key): value for key, value in dict_.items()}
+
     def register_global(self, **kwargs):
         """
         Registers default values for attributes you wish to store in :py:class:`.Config` at a global level.
@@ -648,3 +652,34 @@ class Config:
         return self._get_base_group(self.MEMBER, member.guild.id, member.id,
                                     group_class=MemberGroup)
 
+    def all_globals(self) -> dict:
+        return self._get_base_group(self.GLOBAL)()
+
+    async def all_guilds(self) -> dict:
+        dict_ = await self._get_base_group(self.GUILD)()
+        return self._snowflake_dict(dict_)
+
+    async def all_channels(self) -> dict:
+        dict_ = await self._get_base_group(self.CHANNEL)()
+        return self._snowflake_dict(dict_)
+
+    async def all_roles(self) -> dict:
+        dict_ = await self._get_base_group(self.ROLE)()
+        return self._snowflake_dict(dict_)
+
+    async def all_users(self) -> dict:
+        dict_ = await self._get_base_group(self.USER)()
+        return self._snowflake_dict(dict_)
+
+    async def all_members(self, guild: discord.Guild=None) -> dict:
+        identifiers = [self.MEMBER]
+        if guild is None:
+            dict_ = await self._get_base_group(self.MEMBER,
+                                               group_class=MemberGroup)()
+            dict_ = {guild_id: self._snowflake_dict(data)
+                     for guild_id, data in dict_.items()}
+        else:
+            dict_ = await self._get_base_group(self.MEMBER, guild.id,
+                                               group_class=MemberGroup)()
+
+        return self._snowflake_dict(dict_)

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -137,7 +137,7 @@ class Group(Value):
     # noinspection PyTypeChecker
     def __getattr__(self, item: str) -> Union["Group", Value]:
         """Get an attribute of this group.
-        
+
         This special method is called whenever dot notation is used on this
         object.
 
@@ -145,13 +145,13 @@ class Group(Value):
         ----------
         item : str
             The name of the attribute being accessed.
-    
+
         Returns
         -------
         `Group` or `Value`
             A child value of this Group. This, of course, can be another
             `Group`, due to Config's composite pattern.
-            
+
         Raises
         ------
         AttributeError
@@ -260,7 +260,7 @@ class Group(Value):
             If this is :code:`True` this function will return a coroutine that
             resolves to a "real" data value when awaited. If :code:`False`,
             this method acts the same as `__getattr__`.
-        
+
         Returns
         -------
         `types.coroutine` or `Value` or `Group`
@@ -301,14 +301,14 @@ class Group(Value):
 
     async def set_attr(self, item: str, value):
         """Set an attribute by its name.
-        
+
         Similar to `get_attr` in the way it can be used to dynamically set
         attributes by name.
 
         Note
         ----
         Use of this method should be avoided wherever possible.
-        
+
         Parameters
         ----------
         item : str
@@ -331,7 +331,7 @@ class Group(Value):
 
 class MemberGroup(Group):
     """A specific group class for use with member data only.
-    
+
     Inherits from `Group`. In this group data is stored as
     :code:`GUILD_ID -> MEMBER_ID -> data`.
     """
@@ -429,7 +429,7 @@ class Config:
         force_registration : `bool`, optional
             Should config require registration of data keys before allowing you
             to get/set values? See `force_registration`.
-            
+
         Returns
         -------
         Config
@@ -447,11 +447,13 @@ class Config:
 
     @classmethod
     def get_core_conf(cls, force_registration: bool=False):
-        """All core modules that require a config instance should use this
+        """Get a Config instance for a core module.
+
+        All core modules that require a config instance should use this
         classmethod instead of `get_conf`.
 
-        identifier : int
-            See `get_conf`.
+        Parameters
+        ----------
         force_registration : `bool`, optional
             See `force_registration`.
 
@@ -463,17 +465,17 @@ class Config:
 
     def __getattr__(self, item: str) -> Union[Group, Value]:
         """Same as `group.__getattr__` except for global data.
-        
+
         Parameters
         ----------
         item : str
             The attribute you want to get.
-            
+
         Returns
         -------
         `Group` or `Value`
             The value for the attribute you want to retrieve
-            
+
         Raises
         ------
         AttributeError
@@ -587,7 +589,7 @@ class Config:
 
     def register_guild(self, **kwargs):
         """Register default values on a per-guild level.
-        
+
         See :py:meth:`register_global` for more details.
         """
         self._register_default(self.GUILD, **kwargs)
@@ -609,16 +611,16 @@ class Config:
 
     def register_user(self, **kwargs):
         """Registers default values on a per-user level.
-        
+
         This means that each user's data is guild-independent.
-        
+
         See `register_global` for more details.
         """
         self._register_default(self.USER, **kwargs)
 
     def register_member(self, **kwargs):
         """Registers default values on a per-member level.
-        
+
         This means that each user's data is guild-dependent.
 
         See `register_global` for more details.
@@ -648,7 +650,7 @@ class Config:
 
     def channel(self, channel: discord.TextChannel) -> Group:
         """Returns a `Group` for the given channel.
-        
+
         This does not discriminate between text and voice channels.
 
         Parameters
@@ -713,7 +715,7 @@ class Config:
             ret[int(k)] = data
         return ret
 
-    def all_guilds(self):
+    async def all_guilds(self) -> dict:
         """Get all guild data as a dict.
 
         Note
@@ -723,14 +725,14 @@ class Config:
 
         Returns
         -------
-        types.coroutine
-            A coroutine object which must be awaited to yield a `dict` mapping
+        dict
+            A dictionary in the form {`int`: `dict`} mapping
             :code:`GUILD_ID -> data`.
 
         """
-        return self._all_from_scope(self.GUILD)
+        return await self._all_from_scope(self.GUILD)
 
-    def all_channels(self):
+    async def all_channels(self) -> dict:
         """Get all channel data as a dict.
 
         Note
@@ -740,14 +742,14 @@ class Config:
 
         Returns
         -------
-        types.coroutine
-            A coroutine object which must be awaited to yield a `dict` mapping
+        dict
+            A dictionary in the form {`int`: `dict`} mapping
             :code:`CHANNEL_ID -> data`.
 
         """
-        return self._all_from_scope(self.CHANNEL)
+        return await self._all_from_scope(self.CHANNEL)
 
-    def all_roles(self):
+    async def all_roles(self) -> dict:
         """Get all role data as a dict.
 
         Note
@@ -757,14 +759,14 @@ class Config:
 
         Returns
         -------
-        types.coroutine
-            A coroutine object which must be awaited to yield a `dict` mapping
+        dict
+            A dictionary in the form {`int`: `dict`} mapping
             :code:`ROLE_ID -> data`.
 
         """
-        return self._all_from_scope(self.ROLE)
+        return await self._all_from_scope(self.ROLE)
 
-    def all_users(self):
+    async def all_users(self) -> dict:
         """Get all user data as a dict.
 
         Note
@@ -774,12 +776,12 @@ class Config:
 
         Returns
         -------
-        types.coroutine
-            A coroutine object which must be awaited to yield a `dict` mapping
+        dict
+            A dictionary in the form {`int`: `dict`} mapping
             :code:`USER_ID -> data`.
 
         """
-        return self._all_from_scope(self.USER)
+        return await self._all_from_scope(self.USER)
 
     def _all_members_from_guild(self, group: Group, guild_data: dict) -> dict:
         ret = {}
@@ -811,7 +813,7 @@ class Config:
         Returns
         -------
         dict
-            A dictionary of all member data from the given scope.
+            A dictionary of all specified member data.
 
         """
         ret = {}
@@ -829,7 +831,7 @@ class Config:
 
     async def _clear_scope(self, *scopes: str):
         """Clear all data in a particular scope.
-        
+
         The only situation where a second scope should be passed in is if
         member data from a specific guild is being cleared.
 
@@ -853,7 +855,7 @@ class Config:
             group = self._get_base_group(*scopes)
         await group.set({})
 
-    def clear_all(self):
+    async def clear_all(self):
         """Clear all data from this Config instance.
 
         This resets all data to its registered defaults.
@@ -862,80 +864,45 @@ class Config:
 
             This cannot be undone.
 
-        Returns
-        -------
-        types.coroutine
-            A coroutine which, when awaited, clears all data.
-
         """
-        return self._clear_scope()
+        await self._clear_scope()
 
-    def clear_all_globals(self):
+    async def clear_all_globals(self):
         """Clear all global data.
 
         This resets all global data to its registered defaults.
-
-        Returns
-        -------
-        types.coroutine
-            A coroutine which, when awaited, clears all global data.
-
         """
-        return self._clear_scope(self.GLOBAL)
+        await self._clear_scope(self.GLOBAL)
 
-    def clear_all_guilds(self):
+    async def clear_all_guilds(self):
         """Clear all guild data.
 
         This resets all guild data to its registered defaults.
-
-        Returns
-        -------
-        types.coroutine
-            A coroutine which, when awaited, clears all guild data.
-
         """
-        return self._clear_scope(self.GUILD)
+        await self._clear_scope(self.GUILD)
 
-    def clear_all_channels(self):
+    async def clear_all_channels(self):
         """Clear all channel data.
 
         This resets all channel data to its registered defaults.
-
-        Returns
-        -------
-        types.coroutine
-            A coroutine which, when awaited, clears all channel data.
-
         """
-        return self._clear_scope(self.CHANNEL)
+        await self._clear_scope(self.CHANNEL)
 
-    def clear_all_roles(self):
+    async def clear_all_roles(self):
         """Clear all role data.
 
         This resets all role data to its registered defaults.
-
-        Returns
-        -------
-        types.coroutine
-            A coroutine which, when awaited, clears all role data.
-
         """
-        return self._clear_scope(self.ROLE)
+        await self._clear_scope(self.ROLE)
 
-    def clear_all_users(self):
+    async def clear_all_users(self):
         """Clear all user data.
 
         This resets all user data to its registered defaults.
-
-        Returns
-        -------
-        types.coroutine
-            A coroutine which, when awaited, clears all user data.
-
         """
-        return self._clear_scope(self.USER)
+        await self._clear_scope(self.USER)
 
-    def clear_all_members(self, guild: discord.Guild=None):
+    async def clear_all_members(self, guild: discord.Guild=None):
         """Clear all member data.
 
         This resets all specified member data to its registered defaults.
@@ -946,12 +913,8 @@ class Config:
             The guild to clear member data from. Omit to clear member data from
             all guilds.
 
-        Returns
-        -------
-        types.coroutine
-            A coroutine which, when awaited, clears all specified member data.
-
         """
         if guild is not None:
-            return self._clear_scope(self.MEMBER, guild.id)
-        return self._clear_scope(self.MEMBER)
+            await self._clear_scope(self.MEMBER, guild.id)
+            return
+        await self._clear_scope(self.MEMBER)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -235,7 +235,7 @@ async def test_membergroup_allguilds(config, empty_member):
     await config.member(empty_member).foo.set(False)
 
     all_servers = await config.all_members()
-    assert str(empty_member.guild.id) in all_servers
+    assert empty_member.guild.id in all_servers
 
 
 @pytest.mark.asyncio
@@ -243,7 +243,7 @@ async def test_membergroup_allmembers(config, empty_member):
     await config.member(empty_member).foo.set(False)
 
     all_members = await config.all_members(empty_member.guild)
-    assert str(empty_member.id) in all_members
+    assert empty_member.id in all_members
 
 
 # Clearing testing

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -234,7 +234,7 @@ async def test_get_dynamic_attr(config):
 async def test_membergroup_allguilds(config, empty_member):
     await config.member(empty_member).foo.set(False)
 
-    all_servers = await config.member(empty_member).all_guilds()
+    all_servers = await config.all_members()
     assert str(empty_member.guild.id) in all_servers
 
 
@@ -242,7 +242,7 @@ async def test_membergroup_allguilds(config, empty_member):
 async def test_membergroup_allmembers(config, empty_member):
     await config.member(empty_member).foo.set(False)
 
-    all_members = await config.member(empty_member).all_from_kind()
+    all_members = await config.all_members(empty_member.guild)
     assert str(empty_member.id) in all_members
 
 
@@ -291,11 +291,11 @@ async def test_member_clear_all(config, member_factory):
         server_ids.append(member.guild.id)
 
     member = member_factory.get()
-    assert len(await config.member(member).all_guilds()) == len(server_ids)
+    assert len(await config.all_members()) == len(server_ids)
 
-    await config.member(member).clear_all()
+    await config.clear_all_members()
 
-    assert len(await config.member(member).all_guilds()) == 0
+    assert len(await config.all_members()) == 0
 
 
 # Get All testing
@@ -309,8 +309,7 @@ async def test_user_get_all_from_kind(config, user_factory):
         user = user_factory.get()
         await config.user(user).foo.set(True)
 
-    user = user_factory.get()
-    all_data = await config.user(user).all_from_kind()
+    all_data = await config.all_users()
 
     assert len(all_data) == 5
 


### PR DESCRIPTION
This PR essentially provides an alternative to config's `Group.all_from_kind` method, with the following changes:
 - An arbitrary object (guild, user, whatever) no longer needs to be passed in to get all of its "sibling's" data. As an example, retrieving all bank accounts for a guild-based bank:
    - Before:
        ```py
        accs = await _conf.member(some_member).all_from_kind()
        ```
    - After:
        ```py
        accs = await _conf.all_members(guild)
        ```
 - Snowflakes (guild IDs, user IDs etc) which are keys in the returned dictionary are now of type `int`.

I am willing to remove `all_from_kind` from this branch entirely if there is no need for it, just thought I'd put this solution out there first before making that change.

This also makes me question whether or not `Group.clear_all` should be refactored in a similar manner.
