### PR TITLE
V3/start screen

### DIFF
--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -1,21 +1,30 @@
 import datetime
 import logging
+import pkg_resources
 import traceback
 
 import discord
 from .sentry_setup import should_log
 from discord.ext import commands
 
-from .utils.chat_formatting import inline
+
+from . import data_manager
+from .utils.chat_formatting import inline, bordered
 from .core_commands import find_spec
+from colorama import Fore, Style
 
 log = logging.getLogger("red")
 sentry_log = logging.getLogger("red.sentry")
 
-INTRO = ("{0}===================\n"
-         "{0} Red - Discord Bot \n"
-         "{0}===================\n"
-         "".format(" " * 20))
+
+INTRO = """
+______         _           ______ _                       _  ______       _   
+| ___ \       | |          |  _  (_)                     | | | ___ \     | |  
+| |_/ /___  __| |  ______  | | | |_ ___  ___ ___  _ __ __| | | |_/ / ___ | |_ 
+|    // _ \/ _` | |______| | | | | / __|/ __/ _ \| '__/ _` | | ___ \/ _ \| __|
+| |\ \  __/ (_| |          | |/ /| \__ \ (_| (_) | | | (_| | | |_/ / (_) | |_ 
+\_| \_\___|\__,_|          |___/ |_|___/\___\___/|_|  \__,_| \____/ \___/ \__|
+"""
 
 
 def init_events(bot, cli_flags):
@@ -31,8 +40,6 @@ def init_events(bot, cli_flags):
             return
 
         bot.uptime = datetime.datetime.utcnow()
-
-        print(INTRO)
 
         if cli_flags.no_cogs is False:
             print("Loading packages...")
@@ -62,11 +69,33 @@ def init_events(bot, cli_flags):
             else:
                 invite_url = None
 
+        prefixes = await bot.db.prefix()
+        lang = await bot.db.locale()
+        INFO = [str(bot.user), "Prefixes: {}".format(', '.join(prefixes)),
+                "Version: {}".format(pkg_resources.get_distribution('Red_DiscordBot').version),
+                'Language: {}'.format(lang)]
         if guilds:
-            print("Ready and operational on {} servers with a total of {} "
-                  "users.".format(guilds, users))
+            INFO.extend(("Servers: {}".format(guilds), "Users: {}".format(users)))
         else:
             print("Ready. I'm not in any server yet!")
+
+        INFO.append('{} cogs with {} commands'.format(len(bot.cogs), len(bot.commands)))
+
+        INFO2 = []
+        sentry = await bot.db.enable_sentry()
+        if sentry:
+            INFO2.append("√ Report Errors")
+        else:
+            INFO2.append("X Report Errors")
+
+        if data_manager.basic_config['STORAGE_TYPE'] == "JSON":
+            INFO2.append("X MongoDB")
+        else:
+            INFO2.append("√ MongoDB")
+
+        print(Fore.RED + INTRO)
+        print(Style.RESET_ALL)
+        print(bordered('\n'.join(INFO), '\n'.join(INFO2)))
 
         if invite_url:
             print("\nInvite URL: {}\n".format(invite_url))

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -3,19 +3,18 @@ import logging
 import pkg_resources
 import traceback
 
+
 import discord
 from .sentry_setup import should_log
 from discord.ext import commands
 
-
-from . import data_manager
+from .data_manager import storage_type
 from .utils.chat_formatting import inline, bordered
 from .core_commands import find_spec
 from colorama import Fore, Style
 
 log = logging.getLogger("red")
 sentry_log = logging.getLogger("red.sentry")
-
 
 INTRO = """
 ______         _           ______ _                       _  ______       _   
@@ -83,15 +82,20 @@ def init_events(bot, cli_flags):
 
         INFO2 = []
         sentry = await bot.db.enable_sentry()
+        shards = bot.shard_count
         if sentry:
             INFO2.append("√ Report Errors")
         else:
             INFO2.append("X Report Errors")
 
-        if data_manager.basic_config['STORAGE_TYPE'] == "JSON":
+        if storage_type() == "JSON":
             INFO2.append("X MongoDB")
         else:
             INFO2.append("√ MongoDB")
+        if shards < 2:
+            INFO2.append("{} Shard".format(shards))
+        else:
+            INFO2.append("{} Shards".format(shards))
 
         print(Fore.RED + INTRO)
         print(Style.RESET_ALL)

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -1,7 +1,8 @@
 import datetime
 import logging
-import pkg_resources
 import traceback
+from pkg_resources import get_distribution
+from importlib.util import find_spec as find_package
 
 
 import discord
@@ -71,18 +72,25 @@ def init_events(bot, cli_flags):
         prefixes = await bot.db.prefix()
         lang = await bot.db.locale()
         INFO = [str(bot.user), "Prefixes: {}".format(', '.join(prefixes)),
-                "Version: {}".format(pkg_resources.get_distribution('Red_DiscordBot').version),
-                'Language: {}'.format(lang)]
+                'Language: {}'.format(lang),
+                "Red Bot Version: {}".format(get_distribution('Red_DiscordBot').version),
+                "Discord.py Version: {}".format(get_distribution('discord.py').version),
+                "Shards: {}".format(bot.shard_count)]
         if guilds:
             INFO.extend(("Servers: {}".format(guilds), "Users: {}".format(users)))
         else:
             print("Ready. I'm not in any server yet!")
 
+
+
         INFO.append('{} cogs with {} commands'.format(len(bot.cogs), len(bot.commands)))
 
         INFO2 = []
         sentry = await bot.db.enable_sentry()
-        shards = bot.shard_count
+        test_docs = all(find_package(x) for x in ['sphinx', 'sphinxcontrib', 'sphinx_rtd_theme',
+                                                  'pytest_asyncio', 'pytest'])
+        voice = find_package('PyNaCl')
+        
         if sentry:
             INFO2.append("√ Report Errors")
         else:
@@ -92,14 +100,21 @@ def init_events(bot, cli_flags):
             INFO2.append("X MongoDB")
         else:
             INFO2.append("√ MongoDB")
-        if shards < 2:
-            INFO2.append("{} Shard".format(shards))
+
+        if voice:
+            INFO2.append("√ Voice")
         else:
-            INFO2.append("{} Shards".format(shards))
+            INFO2.append("X Voice")
+
+        if test_docs:
+            INFO2.append("√ Tests and Docs")
+        else:
+            INFO2.append("X Tests and Docs")
+
 
         print(Fore.RED + INTRO)
         print(Style.RESET_ALL)
-        print(bordered('\n'.join(INFO), '\n'.join(INFO2)))
+        print(bordered(INFO, INFO2))
 
         if invite_url:
             print("\nInvite URL: {}\n".format(invite_url))

--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -1,3 +1,5 @@
+import itertools
+
 def error(text):
     return "\N{NO ENTRY SIGN} {}".format(text)
 
@@ -29,6 +31,26 @@ def inline(text):
 
 def italics(text):
     return "*{}*".format(text)
+
+
+def bordered(text1, text2):
+    lines1 = text1.splitlines()
+    lines2 = text2.splitlines()
+    width1 = max(len(s) + 9 for s in lines1)
+    width2 = max(len(s) + 9 for s in lines2)
+    res = ['┌{}┐{}┌{}┐'.format("─"*width1, " "*4, "─"*width2)]
+    flag = True
+    for x, y in itertools.zip_longest(lines1,lines2):
+        if y:
+            m = "│{}│{}│{}│".format((x + " " * width1)[:width1], " "*4, (y + " " * width2)[:width2])
+        elif x and flag and not y:
+            m = "│{}│{}└{}┘".format((x + " " * width1)[:width1], " " * 4, "─" * width2)
+            flag = False
+        else:
+            m = "│{}│".format((x + " " * width1)[:width1])
+        res.append(m)
+    res.append("└" + "─" * width1 + "┘")
+    return "\n".join(res)
 
 
 def pagify(text, delims=["\n"], *, escape_mass_mentions=True, shorten_by=8,

--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -33,18 +33,15 @@ def italics(text):
     return "*{}*".format(text)
 
 
-def bordered(text1, text2):
-    lines1 = text1.splitlines()
-    lines2 = text2.splitlines()
-    width1 = max(len(s) + 9 for s in lines1)
-    width2 = max(len(s) + 9 for s in lines2)
+def bordered(text1: list, text2: list):
+    width1, width2 = max((len(s1) + 9, len(s2) + 9) for s1 in text1 for s2 in text2)
     res = ['┌{}┐{}┌{}┐'.format("─"*width1, " "*4, "─"*width2)]
     flag = True
-    for x, y in itertools.zip_longest(lines1,lines2):
+    for x, y in itertools.zip_longest(text1, text2):
         if y:
             m = "│{}│{}│{}│".format((x + " " * width1)[:width1], " "*4, (y + " " * width2)[:width2])
         elif x and flag and not y:
-            m = "│{}│{}└{}┘".format((x + " " * width1)[:width1], " " * 4, "─" * width2)
+            m = "│{}│{}└{}┘".format((x + " " * width1)[:width1], " "*4, "─" *  width2)
             flag = False
         else:
             m = "│{}│".format((x + " " * width1)[:width1])


### PR DESCRIPTION
Created a new screen for Red's start-up. Includes the following information:

- Bot Name
- Prefixes
- Red's Version
- Language
- Servers
- Users
- Cogs
- Commands
- If Sentry is reporting Errors
- If MongoDB is being used.
- Number of shards

![image](https://user-images.githubusercontent.com/18455011/31774361-1a10c602-b4ab-11e7-8537-01f836445e34.png)

This PR also adds a required bordered function I made to create the boxes. I stuck it in chat_utils incase someone else wanted to use it.