### PR TITLE
[Docs] fix install commands

### DIFF
--- a/docs/install_centos.rst
+++ b/docs/install_centos.rst
@@ -19,7 +19,7 @@ Installing pre-requirements
 Installing Red
 --------------
 
-:code:`pip3 install red-discordbot[voice]`
+:code:`pip3 install -U --process-dependency-links red-discordbot[voice]`
 
 ----------------------
 Setting up an instance

--- a/docs/install_centos.rst
+++ b/docs/install_centos.rst
@@ -19,7 +19,21 @@ Installing pre-requirements
 Installing Red
 --------------
 
+Without audio:
+
+:code:`pip3 install -U --process-dependency-links red-discordbot`
+
+With audio:
+
 :code:`pip3 install -U --process-dependency-links red-discordbot[voice]`
+
+To install the development version (without audio):
+
+:code:`pip3 install -U --process-dependency-links git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot`
+
+To install the development version (with audio):
+
+:code:`pip3 install -U --process-dependency-links git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot[voice]`
 
 ----------------------
 Setting up an instance

--- a/docs/install_debian.rst
+++ b/docs/install_debian.rst
@@ -28,6 +28,14 @@ To install with audio:
 
 :code:`pip3 install -U --process-dependency-links red-discordbot[voice]`
 
+To install the development version (without audio):
+
+:code:`pip3 install -U --process-dependency-links git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot`
+
+To install the development version (with audio):
+
+:code:`pip3 install -U --process-dependency-links git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot[voice]`
+
 ------------------------
 Setting up your instance
 ------------------------

--- a/docs/install_debian.rst
+++ b/docs/install_debian.rst
@@ -22,11 +22,11 @@ Installing the bot
 
 To install without audio:
 
-:code:`pip3 install red-discordbot`
+:code:`pip3 install -U --process-dependency-links red-discordbot`
 
 To install with audio:
 
-:code:`pip3 install red-discordbot[voice]`
+:code:`pip3 install -U --process-dependency-links red-discordbot[voice]`
 
 ------------------------
 Setting up your instance

--- a/docs/install_mac.rst
+++ b/docs/install_mac.rst
@@ -22,7 +22,21 @@ Installing pre-requirements
 Installing Red
 --------------
 
-To install Red, run :code:`pip3 install -U --process-dependency-links red-discordbot[voice]`
+Without audio:
+
+:code:`pip3 install -U --process-dependency-links red-discordbot`
+
+With audio:
+
+:code:`pip3 install -U --process-dependency-links red-discordbot[voice]`
+
+To install the development version (without audio):
+
+:code:`pip3 install -U --process-dependency-links git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot`
+
+To install the development version (with audio):
+
+:code:`pip3 install -U --process-dependency-links git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot[voice]`
 
 ----------------------
 Setting up an instance

--- a/docs/install_mac.rst
+++ b/docs/install_mac.rst
@@ -22,7 +22,7 @@ Installing pre-requirements
 Installing Red
 --------------
 
-To install Red, run :code:`pip3 install red-discordbot[voice]`
+To install Red, run :code:`pip3 install -U --process-dependency-links red-discordbot[voice]`
 
 ----------------------
 Setting up an instance

--- a/docs/install_raspbian.rst
+++ b/docs/install_raspbian.rst
@@ -16,7 +16,7 @@ Installing pre-requirements
 Installing Red
 --------------
 
-:code:`pip3 install red-discordbot[voice]`
+:code:`pip3 install -U --process-dependency-links red-discordbot[voice]`
 
 ----------------------
 Setting up an instance

--- a/docs/install_raspbian.rst
+++ b/docs/install_raspbian.rst
@@ -16,7 +16,21 @@ Installing pre-requirements
 Installing Red
 --------------
 
+Without audio:
+
+:code:`pip3 install -U --process-dependency-links red-discordbot`
+
+With audio:
+
 :code:`pip3 install -U --process-dependency-links red-discordbot[voice]`
+
+To install the development version (without audio):
+
+:code:`pip3 install -U --process-dependency-links git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot`
+
+To install the development version (with audio):
+
+:code:`pip3 install -U --process-dependency-links git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot[voice]`
 
 ----------------------
 Setting up an instance

--- a/docs/install_ubuntu.rst
+++ b/docs/install_ubuntu.rst
@@ -26,6 +26,14 @@ To install with audio:
 
 :code:`pip3 install -U --process-dependency-links red-discordbot[voice]`
 
+To install the development version (without audio):
+
+:code:`pip3 install -U --process-dependency-links git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot`
+
+To install the development version (with audio):
+
+:code:`pip3 install -U --process-dependency-links git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot[voice]`
+
 ------------------------
 Setting up your instance
 ------------------------

--- a/docs/install_ubuntu.rst
+++ b/docs/install_ubuntu.rst
@@ -20,11 +20,11 @@ Installing the bot
 
 To install without audio:
 
-:code:`pip3 install red-discordbot`
+:code:`pip3 install -U --process-dependency-links red-discordbot`
 
 To install with audio:
 
-:code:`pip3 install red-discordbot[voice]`
+:code:`pip3 install -U --process-dependency-links red-discordbot[voice]`
 
 ------------------------
 Setting up your instance

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -28,8 +28,8 @@ Installing Red
 1. Open a command prompt (open Start, search for "command prompt", then click it)
 2. Run the appropriate command, depending on if you want audio or not
 
-  * No audio: :code:`python -m pip install Red-DiscordBot`
-  * Audio: :code:`python -m pip install Red-DiscordBot[voice]`
+  * No audio: :code:`python -m pip install -U --process-dependency-links Red-DiscordBot`
+  * Audio: :code:`python -m pip install -U --process-dependency-links Red-DiscordBot[voice]`
 
 3. Once that has completed, run :code:`redbot-setup` to set up your instance
 

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -30,6 +30,8 @@ Installing Red
 
   * No audio: :code:`python -m pip install -U --process-dependency-links Red-DiscordBot`
   * Audio: :code:`python -m pip install -U --process-dependency-links Red-DiscordBot[voice]`
+  * Development version (without audio): :code:`python -m pip install -U --process-dependency-links git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot`
+  * Development version (with audio): :code:`python -m pip install -U --process-dependency-links git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot[voice]`
 
 3. Once that has completed, run :code:`redbot-setup` to set up your instance
 


### PR DESCRIPTION
This fixes the `pip install` commands to have `-U --process-dependency-links` in them.