### PR TITLE
[Modlog] bugfix for case type enabled/disabled status

### DIFF
--- a/redbot/cogs/modlog/modlog.py
+++ b/redbot/cogs/modlog/modlog.py
@@ -58,7 +58,7 @@ class ModLog:
         guild = ctx.guild
 
         if action is None:  # No args given
-            casetypes = await modlog.get_all_casetypes()
+            casetypes = await modlog.get_all_casetypes(guild)
             await self.bot.send_cmd_help(ctx)
             title = _("Current settings:")
             msg = ""


### PR DESCRIPTION
Figured out that `[p]modlogset cases` with no arguments was just showing every case type as disabled. This PR fixes that