### PR TITLE
[V3 Cog/Data Manager] Bundled Cog Data

### DIFF
--- a/redbot/core/__init__.py
+++ b/redbot/core/__init__.py
@@ -5,4 +5,7 @@ from .context import RedContext
 
 __all__ = ["Config", "RedContext", "__version__"]
 
-__version__ = version = pkg_resources.require("Red-DiscordBot")[0].version
+try:
+    __version__ = pkg_resources.require("Red-DiscordBot")[0].version
+except pkg_resources.DistributionNotFound:
+    __version__ = "3.0.0"

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -68,7 +68,7 @@ class Core:
         """Reloads a package"""
         ctx.bot.unload_extension(cog_name)
 
-        spec = await find_spec(ctx.bot, cog_name)
+        spec = await ctx.bot.cog_mgr.find_cog(cog_name)
         if spec is None:
             await ctx.send(_("No module by that name was found in any"
                              " cog path."))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -14,9 +14,7 @@ from discord.ext import commands
 from redbot.core import checks
 from redbot.core import i18n
 
-import redbot.cogs  # Don't remove this line or core cogs won't load
-
-__all__ = ["find_spec", "Core"]
+__all__ = ["Core"]
 
 log = logging.getLogger("red")
 
@@ -24,20 +22,6 @@ OWNER_DISCLAIMER = ("⚠ **Only** the person who is hosting Red should be "
                     "owner. **This has SERIOUS security implications. The "
                     "owner can access any data that is present on the host "
                     "system.** ⚠")
-
-
-async def find_spec(bot, cog_name: str):
-    try:
-        spec = await bot.cog_mgr.find_cog(cog_name)
-    except RuntimeError:
-        real_name = ".{}".format(cog_name)
-        try:
-            mod = importlib.import_module(real_name, package='redbot.cogs')
-        except ImportError:
-            spec = None
-        else:
-            spec = mod.__spec__
-    return spec
 
 
 _ = i18n.CogI18n("Core", __file__)
@@ -50,8 +34,9 @@ class Core:
     @checks.is_owner()
     async def load(self, ctx, *, cog_name: str):
         """Loads a package"""
-        spec = await find_spec(ctx.bot, cog_name)
-        if spec is None:
+        try:
+            spec = await ctx.bot.cog_mgr.find_cog(cog_name)
+        except RuntimeError:
             await ctx.send(_("No module by that name was found in any"
                              " cog path."))
             return

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -13,7 +13,8 @@ if TYPE_CHECKING:
     from . import Config
 
 __all__ = ['load_basic_configuration', 'cog_data_path', 'core_data_path',
-           'load_bundled_data', 'storage_details', 'storage_type']
+           'load_bundled_data', 'bundled_data_path', 'storage_details',
+           'storage_type']
 
 log = logging.getLogger("red.data_manager")
 
@@ -220,6 +221,35 @@ def load_bundled_data(cog_instance, init_location: str):
     cog_data_folder = cog_data_path(cog_instance) / 'data'
 
     _compare_and_copy(to_copy, bundled_data_folder, cog_data_folder)
+
+
+def bundled_data_path(cog_instance) -> Path:
+    """
+    The "data" directory that has been copied from installed cogs.
+
+    Parameters
+    ----------
+    cog_instance
+
+    Returns
+    -------
+    pathlib.Path
+        Path object to the bundled data folder.
+
+    Raises
+    ------
+    FileNotFoundError
+        If no bundled data folder exists or if it hasn't been loaded yet.
+    """
+
+    bundled_path = cog_data_path(cog_instance) / 'data'
+
+    if not bundled_path.is_dir():
+        raise FileNotFoundError("No such directory {}".format(
+            bundled_path
+        ))
+
+    return bundled_path
 
 
 def storage_type() -> str:

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -129,11 +129,11 @@ def _find_data_files(init_location: str) -> (Path, List[Path]):
     if not init_file.is_file():
         return []
 
-    package_folder = init_file.parent
+    package_folder = init_file.parent.resolve() / 'data'
     if not package_folder.is_dir():
         return []
 
-    all_files = package_folder.glob("**")
+    all_files = list(package_folder.rglob("*"))
 
     return package_folder, [p.resolve()
                             for p in all_files
@@ -168,7 +168,7 @@ def _compare_and_copy(to_copy: List[Path], bundled_data_dir: Path, cog_data_dir:
     lookup = {p: cog_data_dir.joinpath(p.relative_to(bundled_data_dir))
               for p in to_copy}
 
-    for orig, poss_existing in lookup:
+    for orig, poss_existing in lookup.items():
         if not poss_existing.is_file():
             poss_existing.parent.mkdir(exist_ok=True, parents=True)
             exists_checksum = None
@@ -182,8 +182,8 @@ def _compare_and_copy(to_copy: List[Path], bundled_data_dir: Path, cog_data_dir:
                 orig.open('rb')), hashlib.sha256())
 
         if exists_checksum != orig_checksum:
-            # shutil.copy(str(orig), str(poss_existing))
-            log.debug("Attempting to copy {} to {}".format(
+            shutil.copy(str(orig), str(poss_existing))
+            log.debug("Copying {} to {}".format(
                 orig, poss_existing
             ))
 

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -1,6 +1,9 @@
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
+import hashlib
+import shutil
+import logging
 
 import appdirs
 
@@ -10,7 +13,9 @@ if TYPE_CHECKING:
     from . import Config
 
 __all__ = ['load_basic_configuration', 'cog_data_path', 'core_data_path',
-           'storage_details', 'storage_type']
+           'load_bundled_data', 'storage_details', 'storage_type']
+
+log = logging.getLogger("red.data_manager")
 
 jsonio = None
 basic_config = None
@@ -106,6 +111,115 @@ def core_data_path() -> Path:
     core_path.mkdir(exist_ok=True, parents=True)
 
     return core_path.resolve()
+
+
+def _find_data_files(init_location: str) -> (Path, List[Path]):
+    """
+    Discovers all files in the bundled data folder of an installed cog.
+
+    Parameters
+    ----------
+    init_location
+
+    Returns
+    -------
+    (pathlib.Path, list of pathlib.Path)
+    """
+    init_file = Path(init_location)
+    if not init_file.is_file():
+        return []
+
+    package_folder = init_file.parent
+    if not package_folder.is_dir():
+        return []
+
+    all_files = package_folder.glob("**")
+
+    return package_folder, [p.resolve()
+                            for p in all_files
+                            if p.is_file()]
+
+
+def _compare_and_copy(to_copy: List[Path], bundled_data_dir: Path, cog_data_dir: Path):
+    """
+    Filters out files from ``to_copy`` that already exist, and are the
+    same, in ``data_dir``. The files that are different are copied into
+    ``data_dir``.
+
+    Parameters
+    ----------
+    to_copy : list of pathlib.Path
+    bundled_data_dir : pathlib.Path
+    cog_data_dir : pathlib.Path
+    """
+
+    def hash_bytestr_iter(bytesiter, hasher, ashexstr=False):
+        for block in bytesiter:
+            hasher.update(block)
+        return hasher.hexdigest() if ashexstr else hasher.digest()
+
+    def file_as_blockiter(afile, blocksize=65536):
+        with afile:
+            block = afile.read(blocksize)
+            while len(block) > 0:
+                yield block
+                block = afile.read(blocksize)
+
+    lookup = {p: cog_data_dir.joinpath(p.relative_to(bundled_data_dir))
+              for p in to_copy}
+
+    for orig, poss_existing in lookup:
+        if not poss_existing.is_file():
+            poss_existing.parent.mkdir(exist_ok=True, parents=True)
+            exists_checksum = None
+        else:
+            exists_checksum = hash_bytestr_iter(file_as_blockiter(
+                poss_existing.open('rb')), hashlib.sha256())
+
+        orig_checksum = ...
+        if exists_checksum is not None:
+            orig_checksum = hash_bytestr_iter(file_as_blockiter(
+                orig.open('rb')), hashlib.sha256())
+
+        if exists_checksum != orig_checksum:
+            # shutil.copy(str(orig), str(poss_existing))
+            log.debug("Attempting to copy {} to {}".format(
+                orig, poss_existing
+            ))
+
+
+def load_bundled_data(cog_instance, init_location: str):
+    """
+    This function copies (and overwrites) data from the ``data/`` folder
+    of the installed cog.
+
+    .. important::
+
+        This function MUST be called from the ``setup()`` function of your
+        cog.
+
+    Examples
+    --------
+    >>> from redbot.core import data_manager
+    >>>
+    >>> def setup(bot):
+    >>>     cog = MyCog()
+    >>>     data_manager.load_bundled_data(cog, __file__)
+    >>>     bot.load_cog(cog)
+
+    Parameters
+    ----------
+    cog_instance
+        An instance of your cog class.
+    init_location : str
+        The ``__file__`` attribute of the file where your ``setup()``
+        function exists.
+    """
+    bundled_data_folder, to_copy = _find_data_files(init_location)
+
+    cog_data_folder = cog_data_path(cog_instance) / 'data'
+
+    _compare_and_copy(to_copy, bundled_data_folder, cog_data_folder)
 
 
 def storage_type() -> str:

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -218,7 +218,7 @@ def load_bundled_data(cog_instance, init_location: str):
     """
     bundled_data_folder, to_copy = _find_data_files(init_location)
 
-    cog_data_folder = cog_data_path(cog_instance) / 'data'
+    cog_data_folder = cog_data_path(cog_instance) / 'bundled_data'
 
     _compare_and_copy(to_copy, bundled_data_folder, cog_data_folder)
 
@@ -226,6 +226,13 @@ def load_bundled_data(cog_instance, init_location: str):
 def bundled_data_path(cog_instance) -> Path:
     """
     The "data" directory that has been copied from installed cogs.
+
+    .. important::
+
+        You should *NEVER* write to this directory. Data manager will
+        overwrite files in this directory each time `load_bundled_data`
+        is called. You should instead write to the directory provided by
+        `cog_data_path`.
 
     Parameters
     ----------
@@ -242,7 +249,7 @@ def bundled_data_path(cog_instance) -> Path:
         If no bundled data folder exists or if it hasn't been loaded yet.
     """
 
-    bundled_path = cog_data_path(cog_instance) / 'data'
+    bundled_path = cog_data_path(cog_instance) / 'bundled_data'
 
     if not bundled_path.is_dir():
         raise FileNotFoundError("No such directory {}".format(

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -206,7 +206,7 @@ def load_bundled_data(cog_instance, init_location: str):
     >>> def setup(bot):
     >>>     cog = MyCog()
     >>>     data_manager.load_bundled_data(cog, __file__)
-    >>>     bot.load_cog(cog)
+    >>>     bot.add_cog(cog)
 
     Parameters
     ----------

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -11,7 +11,6 @@ from discord.ext import commands
 
 from .data_manager import storage_type
 from .utils.chat_formatting import inline, bordered
-from .core_commands import find_spec
 from colorama import Fore, Style
 
 log = logging.getLogger("red")
@@ -48,7 +47,7 @@ def init_events(bot, cli_flags):
 
             for package in packages:
                 try:
-                    spec = await bot.cog_mgr.find_cog(bot, package)
+                    spec = await bot.cog_mgr.find_cog(package)
                     bot.load_extension(spec)
                 except Exception as e:
                     log.exception("Failed to load package {}".format(package),

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -48,7 +48,7 @@ def init_events(bot, cli_flags):
 
             for package in packages:
                 try:
-                    spec = await find_spec(bot, package)
+                    spec = await bot.cog_mgr.find_cog(bot, package)
                     bot.load_extension(spec)
                 except Exception as e:
                     log.exception("Failed to load package {}".format(package),


### PR DESCRIPTION
This PR does a few different things:
* Provides a method for cog creators to use to copy their data into the path available from `data_manager.cog_data_path(self)`
* Fixes some of the issues with cog manager not finding core cogs