### PR TITLE
[V3] Explicitly define aiohttp version to avoid conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp>=2.0.0,<2.3.0
 appdirs
 youtube_dl
 raven


### PR DESCRIPTION
For whatever reason, using `pkg_resources.requires()` in code causes an aiohttp version mismatch issue. This PR fixes that.