### PR TITLE
Command doesn't work unless you put git+ in url

### DIFF
--- a/docs/guide_cog_creation.rst
+++ b/docs/guide_cog_creation.rst
@@ -19,7 +19,7 @@ Getting started
 
 To start off, be sure that you have installed Python 3.5 or higher (if you
 are on Windows, stick with 3.5). Open a terminal or command prompt and type
-:code:`pip install --process-dependency-links -U https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=redbot[test]`
+:code:`pip install --process-dependency-links -U git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=redbot[test]`
 (note that if you get an error with this, try again but put :code:`python -m` in front of the command
 This will install the latest version of V3. 
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

The installation command on http://red-discordbot.readthedocs.io/en/v3-develop/guide_cog_creation.html didn't work. I adjusted the docs to reflect what I had to do to get it working