### PR TITLE
[Core V3] add instance listing cli flag

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -14,7 +14,8 @@ if discord.version_info.major < 1:
 
 from redbot.core.bot import Red, ExitCodes
 from redbot.core.cog_manager import CogManagerUI
-from redbot.core.data_manager import load_basic_configuration
+from redbot.core.data_manager import load_basic_configuration, config_file
+from redbot.core.json_io import JsonIO
 from redbot.core.global_checks import init_global_checks
 from redbot.core.events import init_events
 from redbot.core.sentry_setup import init_sentry_logging
@@ -89,8 +90,27 @@ async def _get_prefix_and_token(red, indict):
     indict['enable_sentry'] = await red.db.enable_sentry()
 
 
+def list_instances():
+    if not config_file.exists():
+        print("No instances have been configured! Configure one "
+              "using `redbot-setup` before trying to run the bot!")
+        sys.exit(1)
+    else:
+        data = JsonIO(config_file)._load_json()
+        text = "Configured Instances:\n\n"
+        for instance_name in data.keys():
+            text += "{}\n".format(instance_name)
+        print(text)
+        sys.exit(0)
+
+
 def main():
     cli_flags = parse_cli_flags(sys.argv[1:])
+    if cli_flags.list_instances:
+        list_instances()
+    elif not cli_flags.instance_name:
+        print("Error: No instance name was provided!")
+        sys.exit(1)
     load_basic_configuration(cli_flags.instance_name)
     log, sentry_log = init_loggers(cli_flags)
     description = "Red v3 - Alpha"

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -98,7 +98,7 @@ def list_instances():
     else:
         data = JsonIO(config_file)._load_json()
         text = "Configured Instances:\n\n"
-        for instance_name in data.keys():
+        for instance_name in sorted(data.keys()):
             text += "{}\n".format(instance_name)
         print(text)
         sys.exit(0)

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -63,6 +63,9 @@ def ask_sentry(red: Red):
 
 def parse_cli_flags(args):
     parser = argparse.ArgumentParser(description="Red - Discord Bot")
+    parser.add_argument("--list-instances", action="store_true",
+                        help="List all instance names setup "
+                             "with 'redbot-setup'")
     parser.add_argument("--owner", type=int,
                         help="ID of the owner. Only who hosts "
                              "Red should be owner, this has "
@@ -106,7 +109,7 @@ def parse_cli_flags(args):
                         action="store_true",
                         help="Enables the built-in RPC server. Please read the docs"
                              "prior to enabling this!")
-    parser.add_argument("instance_name",
+    parser.add_argument("instance_name", nargs="?",
                         help="Name of the bot instance created during `redbot-setup`.")
 
     args = parser.parse_args(args)


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Adds a cli flag (`--list-instances`) that lists the names of all instances setup with `redbot-setup`. This flag is checked for immediately after parsing cli flags but before even basic config is loaded (because if this flag is present, an instance name is not necessary as it'll just print a list of valid instance names and then exit). I made it so that `instance_name` could potentially be empty but that's checked for before basic config could be loaded (as if no name is provided, it needs to exit and print a message to the user indicating that no name was provided and pointing them towards `redbot-setup)