### PR TITLE
Fix typing module for 3.5.1

### DIFF
--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -1,0 +1,15 @@
+import sys
+import typing
+import discord
+
+# Let's do all the dumb version checking in one place.
+
+
+if sys.version_info < (3, 5, 2):
+    typing.TYPE_CHECKING = False
+
+if discord.version_info.major < 1:
+    print("You are not running the rewritten version of discord.py.\n\n"
+          "In order to use Red v3 you MUST be running d.py version"
+          " >= 1.0.0.")
+    sys.exit(1)

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -3,15 +3,7 @@
 # Discord Version check
 
 import sys
-
 import discord
-
-if discord.version_info.major < 1:
-    print("You are not running the rewritten version of discord.py.\n\n"
-          "In order to use Red v3 you MUST be running d.py version"
-          " >= 1.0.0.")
-    sys.exit(1)
-
 from redbot.core.bot import Red, ExitCodes
 from redbot.core.cog_manager import CogManagerUI
 from redbot.core.data_manager import load_basic_configuration


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Because `typing.TYPE_CHECKING` was added in 3.5.**2** we have to fake it.
