### PR TITLE
[V3 Context] Interactive sending of multiple messages

### DIFF
--- a/redbot/core/context.py
+++ b/redbot/core/context.py
@@ -56,7 +56,7 @@ class RedContext(commands.Context):
             return True
 
     async def send_interactive(self,
-                               pages: Iterable[str],
+                               messages: Iterable[str],
                                box_lang: str=None,
                                timeout: int=15) -> List[discord.Message]:
         """Send multiple messages interactively.
@@ -67,7 +67,7 @@ class RedContext(commands.Context):
 
         Parameters
         ----------
-        pages : `iterable` of `str`
+        messages : `iterable` of `str`
             The messages to send.
         box_lang : str
             If specified, each message will be contained within a codeblock of
@@ -77,20 +77,20 @@ class RedContext(commands.Context):
             After timing out, the bot deletes its prompt message.
 
         """
-        pages = tuple(pages)
+        messages = tuple(messages)
         ret = []
 
         more_check = lambda m: (m.author == self.author and
                                 m.channel == self.channel and
                                 m.content.lower() == "more")
 
-        for idx, page in enumerate(pages, 1):
+        for idx, page in enumerate(messages, 1):
             if box_lang is None:
                 msg = await self.send(page)
             else:
                 msg = await self.send(box(page, lang=box_lang))
             ret.append(msg)
-            n_remaining = len(pages) - idx
+            n_remaining = len(messages) - idx
             if n_remaining > 0:
                 if n_remaining == 1:
                     plural = ""

--- a/redbot/core/context.py
+++ b/redbot/core/context.py
@@ -55,14 +55,15 @@ class RedContext(commands.Context):
         else:
             return True
 
-    async def send_pages_interactive(self,
-                                     pages: Iterable[str],
-                                     box_lang: str=None,
-                                     timeout: int=15) -> List[discord.Message]:
-        """Send pages interactively.
+    async def send_interactive(self,
+                               pages: Iterable[str],
+                               box_lang: str=None,
+                               timeout: int=15) -> List[discord.Message]:
+        """Send multiple messages interactively.
 
         The user will be prompted for whether or not they would like to view
-        the next page, one at a time.
+        the next message, one at a time. They will also be notified of how
+        many messages are remaining on each prompt.
 
         Parameters
         ----------

--- a/redbot/core/context.py
+++ b/redbot/core/context.py
@@ -1,11 +1,14 @@
-"""Module for Red's Context class
-
+"""
 The purpose of this module is to allow for Red to further customise the command
 invocation context provided by discord.py.
 """
+import asyncio
+from typing import Iterable, List
 
 import discord
 from discord.ext import commands
+
+from redbot.core.utils.chat_formatting import box
 
 __all__ = ["RedContext"]
 
@@ -20,9 +23,9 @@ class RedContext(commands.Context):
     This class inherits from `commands.Context <discord.ext.commands.Context>`.
     """
 
-    async def send_help(self):
+    async def send_help(self) -> List[discord.Message]:
         """Send the command help message.
-        
+
         Returns
         -------
         `list` of `discord.Message`
@@ -36,7 +39,7 @@ class RedContext(commands.Context):
             ret.append(await self.send(page))
         return ret
 
-    async def tick(self):
+    async def tick(self) -> bool:
         """Add a tick reaction to the command message.
 
         Returns
@@ -51,3 +54,59 @@ class RedContext(commands.Context):
             return False
         else:
             return True
+
+    async def send_pages_interactive(self,
+                                     pages: Iterable[str],
+                                     box_lang: str=None,
+                                     timeout: int=15) -> List[discord.Message]:
+        """Send pages interactively.
+
+        The user will be prompted for whether or not they would like to view
+        the next page, one at a time.
+
+        Parameters
+        ----------
+        pages : `iterable` of `str`
+            The messages to send.
+        box_lang : str
+            If specified, each message will be contained within a codeblock of
+            this language.
+        timeout : int
+            How long the user has to respond to the prompt before it times out.
+            After timing out, the bot deletes its prompt message.
+
+        """
+        pages = tuple(pages)
+        ret = []
+
+        more_check = lambda m: (m.author == self.author and
+                                m.channel == self.channel and
+                                m.content.lower() == "more")
+
+        for idx, page in enumerate(pages, 1):
+            if box_lang is None:
+                msg = await self.send(page)
+            else:
+                msg = await self.send(box(page, lang=box_lang))
+            ret.append(msg)
+            n_remaining = len(pages) - idx
+            if n_remaining > 0:
+                if n_remaining == 1:
+                    plural = ""
+                    is_are = "is"
+                else:
+                    plural = "s"
+                    is_are = "are"
+                query = await self.send(
+                    "There {} still {} message{} remaining. "
+                    "Type `more` to continue."
+                    "".format(is_are, n_remaining, plural))
+                try:
+                    resp = await self.bot.wait_for(
+                        'message', check=more_check, timeout=timeout)
+                except asyncio.TimeoutError:
+                    await query.delete()
+                    break
+                else:
+                    await self.channel.delete_messages((query, resp))
+        return ret

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -52,6 +52,11 @@ class Dev:
             lang="py")
 
     @staticmethod
+    def get_pages(msg: str):
+        """Pagify the given message for output to the user."""
+        return pagify(msg, delims=["\n", " "], priority=True, shorten_by=10)
+
+    @staticmethod
     def sanitize_output(ctx: commands.Context, input_: str) -> str:
         """Hides the bot's token from a string."""
         token = ctx.bot.http.token
@@ -115,7 +120,7 @@ class Dev:
 
         result = self.sanitize_output(ctx, str(result))
 
-        await ctx.send(box(result, lang="py"))
+        await ctx.send_pages_interactive(self.get_pages(result), box_lang="py")
 
     @commands.command(name='eval')
     @checks.is_owner()
@@ -162,28 +167,24 @@ class Dev:
             return await ctx.send(self.get_syntax_error(e))
 
         func = env['func']
+        result = None
         try:
             with redirect_stdout(stdout):
-                ret = await func()
+                result = await func()
         except:
-            value = stdout.getvalue()
-            await ctx.send(
-                box('\n{}{}'.format(value, traceback.format_exc()), lang="py"))
+            printed = "{}{}".format(stdout.getvalue(), traceback.format_exc())
         else:
-            value = stdout.getvalue()
-            try:
-                await ctx.message.add_reaction('\N{White Heavy Check Mark}')
-            except:
-                pass
+            printed = stdout.getvalue()
+            await ctx.tick()
 
-            if ret is None:
-                if value:
-                    value = self.sanitize_output(ctx, str(value))
-                    await ctx.send(box(value, lang="py"))
-            else:
-                self._last_result = ret
-                ret = self.sanitize_output(ctx, str(ret))
-                await ctx.send(box("{}{}".format(value, ret), lang="py"))
+        if result is not None:
+            self._last_result = result
+            msg = "{}{}".format(printed, result)
+        else:
+            msg = printed
+        msg = self.sanitize_output(ctx, msg)
+
+        await ctx.send_pages_interactive(self.get_pages(msg), box_lang="py")
 
     @commands.command()
     @checks.is_owner()
@@ -208,17 +209,17 @@ class Dev:
         }
 
         if ctx.channel.id in self.sessions:
-            await ctx.send(_('Already running a REPL session in this channel. '
-                             'Exit it with `quit`.'))
+            await ctx.send(
+                _('Already running a REPL session in this channel. '
+                  'Exit it with `quit`.'))
             return
 
         self.sessions.add(ctx.channel.id)
-        await ctx.send(_('Enter code to execute or evaluate.'
-                         ' `exit()` or `quit` to exit.'))
+        await ctx.send(
+            _('Enter code to execute or evaluate.'
+              ' `exit()` or `quit` to exit.'))
 
-        msg_check = lambda m: (m.author == ctx.author and
-                               m.channel == ctx.channel and
-                               m.content.startswith('`'))
+        msg_check = lambda m: (m.author == ctx.author and m.channel == ctx.channel and m.content.startswith('`'))
 
         while True:
             response = await ctx.bot.wait_for("message", check=msg_check)
@@ -260,7 +261,6 @@ class Dev:
                         result = await result
             except:
                 value = stdout.getvalue()
-                value = self.sanitize_output(ctx, value)
                 msg = "{}{}".format(value, traceback.format_exc())
             else:
                 value = stdout.getvalue()
@@ -270,10 +270,11 @@ class Dev:
                 elif value:
                     msg = "{}".format(value)
 
+            msg = self.sanitize_output(ctx, msg)
+
             try:
-                for page in pagify(str(msg), shorten_by=12):
-                    page = self.sanitize_output(ctx, page)
-                    await ctx.send(box(page, "py"))
+                await ctx.send_pages_interactive(
+                    self.get_pages(msg), box_lang="py")
             except discord.Forbidden:
                 pass
             except discord.HTTPException as e:

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -209,17 +209,17 @@ class Dev:
         }
 
         if ctx.channel.id in self.sessions:
-            await ctx.send(
-                _('Already running a REPL session in this channel. '
-                  'Exit it with `quit`.'))
+            await ctx.send(_('Already running a REPL session in this channel. '
+                             'Exit it with `quit`.'))
             return
 
         self.sessions.add(ctx.channel.id)
-        await ctx.send(
-            _('Enter code to execute or evaluate.'
-              ' `exit()` or `quit` to exit.'))
+        await ctx.send(_('Enter code to execute or evaluate.'
+                         ' `exit()` or `quit` to exit.'))
 
-        msg_check = lambda m: (m.author == ctx.author and m.channel == ctx.channel and m.content.startswith('`'))
+        msg_check = lambda m: (m.author == ctx.author and
+                               m.channel == ctx.channel and
+                               m.content.startswith('`'))
 
         while True:
             response = await ctx.bot.wait_for("message", check=msg_check)

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -120,7 +120,7 @@ class Dev:
 
         result = self.sanitize_output(ctx, str(result))
 
-        await ctx.send_pages_interactive(self.get_pages(result), box_lang="py")
+        await ctx.send_interactive(self.get_pages(result), box_lang="py")
 
     @commands.command(name='eval')
     @checks.is_owner()
@@ -184,7 +184,7 @@ class Dev:
             msg = printed
         msg = self.sanitize_output(ctx, msg)
 
-        await ctx.send_pages_interactive(self.get_pages(msg), box_lang="py")
+        await ctx.send_interactive(self.get_pages(msg), box_lang="py")
 
     @commands.command()
     @checks.is_owner()
@@ -273,8 +273,7 @@ class Dev:
             msg = self.sanitize_output(ctx, msg)
 
             try:
-                await ctx.send_pages_interactive(
-                    self.get_pages(msg), box_lang="py")
+                await ctx.send_interactive(self.get_pages(msg), box_lang="py")
             except discord.Forbidden:
                 pass
             except discord.HTTPException as e:


### PR DESCRIPTION
### Type

- New feature

### Description of the changes
Allows multiple messages to be sent to context, however the user is prompted to see the next message before continuing, and also notified of how many messages are left. This is particularly useful for long messages where it could be a bad idea to just pagify and send.

This is essentially the same idea to what RJM has implemented in #1037, however it is added as a method for Red's context.

For now this is only used in dev commands, however it can be used in any command as an alternative to just sending all pages of a long message at once. As such, this PR would supersede #1037.