### PR TITLE
[V3] Remove mentions of Red being in Alpha and update README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,3 +33,6 @@ To install requirements for voice::
 To install all requirements for docs and tests::
 
     pip install --process-dependency-links -U Red-DiscordBot[test,docs]
+
+For the latest git build, replace ``Red-DiscordBot`` in the above commands with
+``git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop``.

--- a/README.rst
+++ b/README.rst
@@ -14,22 +14,22 @@
 Red - Discord Bot v3
 ********************
 
-**This is alpha and very much a work in progress. Regular use is not recommended.
-There will not be any effort not to break current installations.**
+**This is in beta and very much a work in progress. Regular use is not recommended.
+There will not be any effort made to prevent the breaking of current installations.**
 
 How to install
 ^^^^^^^^^^^^^^
 
 Using python3 pip::
 
-    pip install --process-dependency-links -U git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop
+    pip install --process-dependency-links -U Red-DiscordBot
     redbot-setup
     redbot <name>
 
 To install requirements for voice::
 
-    pip install --process-dependency-links -U git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot[voice]
+    pip install --process-dependency-links -U Red-DiscordBot[voice]
 
 To install all requirements for docs and tests::
 
-    pip install --process-dependency-links -U git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot[test,docs]
+    pip install --process-dependency-links -U Red-DiscordBot[test,docs]

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -21,7 +21,7 @@ from redbot.core.sentry_setup import init_sentry_logging
 from redbot.core.cli import interactive_config, confirm, parse_cli_flags, ask_sentry
 from redbot.core.core_commands import Core
 from redbot.core.dev_commands import Dev
-from redbot.core import rpc
+from redbot.core import rpc, __version__
 import asyncio
 import logging.handlers
 import logging
@@ -93,7 +93,7 @@ def main():
     cli_flags = parse_cli_flags(sys.argv[1:])
     load_basic_configuration(cli_flags.instance_name)
     log, sentry_log = init_loggers(cli_flags)
-    description = "Red v3 - Alpha"
+    description = "Red - Version {}".format(__version__)
     red = Red(cli_flags, description=description, pm_help=None)
     init_global_checks(red)
     init_events(red, cli_flags)

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -48,7 +48,7 @@ def interactive_config(red, token_set, prefix_set):
 
 def ask_sentry(red: Red):
     loop = asyncio.get_event_loop()
-    print("\nThank you for installing Red V3 alpha! The current version\n"
+    print("\nThank you for installing Red V3 beta! The current version\n"
           " is not suited for production use and is aimed at testing\n"
           " the current and upcoming featureset, that's why we will\n"
           " also collect the fatal error logs to help us fix any new\n"


### PR DESCRIPTION
### Type

- Bugfix

### Description of the changes
Now that Red V3 is in beta, I thought it was appropriate to remove any messages suggesting it is still in Alpha. This includes:
- Top of the help message
- The README
- The sentry logging query on startup

Also since our README was outdated I updated it to encourage users to install from PyPI, although the git build is still listed on there as an option.