### PR TITLE
[V3 Docs] Fixed incorrect link in description in Docs

### DIFF
--- a/docs/guide_migration.rst
+++ b/docs/guide_migration.rst
@@ -24,8 +24,8 @@ V3, this becomes :code:`from redbot.core.utils.chat_formatting import pagify`)
 Cogs as packages
 ----------------
 
-V3 makes cogs into packages. See `the cog creation guide </guide_cog_creation>`_
-for more on how to create packages for V3
+V3 makes cogs into packages. See :doc:`/guide_cog_creation`
+for more on how to create packages for V3.
 
 ------
 Config


### PR DESCRIPTION
This fixes the bug I reported here: https://github.com/Cog-Creators/Red-DiscordBot/issues/1091

(Tested locally in sphinx — I didn’t pray, Kowlin ;)