### PR TITLE
[V3][Cleanup] change cleanup commands to use channel.purge

### DIFF
--- a/redbot/cogs/cleanup/__init__.py
+++ b/redbot/cogs/cleanup/__init__.py
@@ -3,4 +3,4 @@ from redbot.core.bot import Red
 
 
 def setup(bot: Red):
-    bot.add_cog(Cleanup(bot))
+    bot.add_cog(Cleanup())

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -5,7 +5,6 @@ import discord
 from discord.ext import commands
 
 from redbot.core import checks
-from redbot.core.bot import Red
 from redbot.core.i18n import CogI18n
 from redbot.core.utils.mod import slow_deletion, mass_purge
 from redbot.cogs.mod.log import log
@@ -16,9 +15,6 @@ _ = CogI18n("Cleanup", __file__)
 
 class Cleanup:
     """Commands for cleaning messages"""
-
-    def __init__(self, bot: Red):
-        self.bot = bot
 
     @commands.group()
     @checks.mod_or_permissions(manage_messages=True)
@@ -40,7 +36,7 @@ class Cleanup:
 
         channel = ctx.channel
         author = ctx.author
-        is_bot = self.bot.user.bot
+        is_bot = ctx.bot.user.bot
 
         def check(m):
             if text in m.content:
@@ -87,7 +83,7 @@ class Cleanup:
 
         channel = ctx.channel
         author = ctx.author
-        is_bot = self.bot.user.bot
+        is_bot = ctx.bot.user.bot
 
         def check(m):
             if isinstance(user, discord.Member) and m.author == user:
@@ -140,7 +136,7 @@ class Cleanup:
 
         channel = ctx.channel
         author = ctx.author
-        is_bot = self.bot.user.bot
+        is_bot = ctx.bot.user.bot
 
         if not is_bot:
             await ctx.send(_("This command can only be used on bots with "
@@ -180,7 +176,7 @@ class Cleanup:
         channel = ctx.channel
         author = ctx.author
 
-        is_bot = self.bot.user.bot
+        is_bot = ctx.bot.user.bot
 
         to_delete = []
         tmp = ctx.message
@@ -215,29 +211,29 @@ class Cleanup:
 
         channel = ctx.message.channel
         author = ctx.message.author
-        is_bot = self.bot.user.bot
+        is_bot = ctx.bot.user.bot
 
-        prefixes = self.bot.command_prefix
+        prefixes = ctx.bot.command_prefix
         if isinstance(prefixes, str):
             prefixes = [prefixes]
         elif callable(prefixes):
             if asyncio.iscoroutine(prefixes):
                 await ctx.send(_('Coroutine prefixes not yet implemented.'))
                 return
-            prefixes = prefixes(self.bot, ctx.message)
+            prefixes = prefixes(ctx.bot, ctx.message)
 
         # In case some idiot sets a null prefix
         if '' in prefixes:
             prefixes.remove('')
 
         def check(m):
-            if m.author.id == self.bot.user.id:
+            if m.author.id == ctx.bot.user.id:
                 return True
             elif m == ctx.message:
                 return True
             p = discord.utils.find(m.content.startswith, prefixes)
             if p and len(p) > 0:
-                return m.content[len(p):].startswith(tuple(self.bot.commands))
+                return m.content[len(p):].startswith(tuple(ctx.bot.commands))
             return False
 
         to_delete = [ctx.message]
@@ -279,7 +275,7 @@ class Cleanup:
         """
         channel = ctx.channel
         author = ctx.message.author
-        is_bot = self.bot.user.bot
+        is_bot = ctx.bot.user.bot
 
         # You can always delete your own messages, this is needed to purge
         can_mass_purge = False
@@ -304,7 +300,7 @@ class Cleanup:
                 return True
 
         def check(m):
-            if m.author.id != self.bot.user.id:
+            if m.author.id != ctx.bot.user.id:
                 return False
             elif content_match(m.content):
                 return True
@@ -312,7 +308,7 @@ class Cleanup:
 
         to_delete = []
         # Selfbot convenience, delete trigger message
-        if author == self.bot.user:
+        if author == ctx.bot.user:
             to_delete.append(ctx.message)
             number += 1
         too_old = False

--- a/redbot/core/utils/mod.py
+++ b/redbot/core/utils/mod.py
@@ -1,10 +1,30 @@
-import asyncio
-from typing import List
+from datetime import datetime
 
 import discord
 
 from redbot.core import Config
 from redbot.core.bot import Red
+
+
+def get_min_time():
+    now = datetime.utcnow().timestamp()
+    twoweeks = 14 * 86400
+    return datetime.fromtimestamp(now - twoweeks)
+
+
+async def check_purge(ctx, messages):
+    """Checks messages in the list, removing any
+    that don't pass the check or that are too old,
+    then deletes the remaining messages"""
+    # Sort from newest to oldest
+    to_delete = sorted(messages, key=lambda m: m.created_at, reverse=True)
+    if ctx.bot.user.bot:
+        while to_delete:
+            await ctx.channel.delete_messages(to_delete[:100])
+            to_delete = to_delete[100:]
+    else:  # Not a bot, so cannot bulk delete
+        for message in to_delete:
+            await message.delete()
 
 
 def get_audit_reason(author: discord.Member, reason: str = None):

--- a/redbot/core/utils/mod.py
+++ b/redbot/core/utils/mod.py
@@ -7,26 +7,6 @@ from redbot.core import Config
 from redbot.core.bot import Red
 
 
-async def mass_purge(messages: List[discord.Message],
-                     channel: discord.TextChannel):
-    while messages:
-        if len(messages) > 1:
-            await channel.delete_messages(messages[:100])
-            messages = messages[100:]
-        else:
-            await messages[0].delete()
-            messages = []
-        await asyncio.sleep(1.5)
-
-
-async def slow_deletion(messages: List[discord.Message]):
-    for message in messages:
-        try:
-            await message.delete()
-        except discord.HTTPException:
-            pass
-
-
 def get_audit_reason(author: discord.Member, reason: str = None):
     """Helper function to construct a reason to be provided
     as the reason to appear in the audit log."""


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This changes all of the cleanup commands to use [discord.TextChannel.purge](http://discordpy.readthedocs.io/en/rewrite/api.html#discord.TextChannel.purge)

As such, I removed the `mass_purge` and `slow_deletion` functions that I had ported over from v2 when I rewrote cleanup from `redbot.core.utils.mod`.