### PR TITLE
[V3] fix unban and case numbering problems

### DIFF
--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -508,7 +508,7 @@ class Mod:
         finding the user, right-clicking, and selecting 'Copy ID'"""
         guild = ctx.guild
         author = ctx.author
-        user = self.bot.get_user_info(user_id)
+        user = await self.bot.get_user_info(user_id)
         if not user:
             await ctx.send(_("Couldn't find a user with that ID!"))
             return

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -307,6 +307,7 @@ async def get_next_case_number(guild: discord.Guild) -> str:
     """
     cases = sorted(
         (await _conf.guild(guild).get_attr("cases")),
+        key=lambda x: int(x),
         reverse=True
     )
     return str(int(cases[0]) + 1) if cases else "1"


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This PR fixes `[p]unban` which was previously not working due to `bot.get_user_info` not being awaited when it should've been (my fault). This also fixes an issue with case numbering that would lead to the reuse of the number 10 due to an oversight on my part