### PR TITLE
[V3 Context] Fix perms issue with ctx.send_interactive

### DIFF
--- a/redbot/core/context.py
+++ b/redbot/core/context.py
@@ -109,5 +109,10 @@ class RedContext(commands.Context):
                     await query.delete()
                     break
                 else:
-                    await self.channel.delete_messages((query, resp))
+                    try:
+                        await self.channel.delete_messages((query, resp))
+                    except discord.HTTPException:
+                        # In case the bot can't delete other users' messages,
+                        # or is not a bot account
+                        await query.delete()
         return ret


### PR DESCRIPTION
### Type

-  Bugfix

### Description of the changes
Handles the bot's inability do delete other users' messages, i.e. the message "more" sent by the user. Instead, if it can't delete that message, it leaves it there.