### PR TITLE
Changing aiohttp.get to use aiohttp.ClientSession

### DIFF
--- a/cogs/general.py
+++ b/cogs/general.py
@@ -43,6 +43,10 @@ class General:
                      "Ask again later", "Better not tell you now", "Cannot predict now", "Concentrate and ask again",
                      "Don't count on it", "My reply is no", "My sources say no", "Outlook not so good", "Very doubtful"]
         self.poll_sessions = []
+        self.session = aiohttp.ClientSession()
+    
+    def __unload(self):
+        self.session.close()
 
     @commands.command(hidden=True)
     async def ping(self):
@@ -304,7 +308,7 @@ class General:
         search_terms = "+".join([encode(s) for s in search_terms])
         url = "http://api.urbandictionary.com/v0/define?term=" + search_terms
         try:
-            async with aiohttp.get(url) as r:
+            async with self.session.get(url) as r:
                 result = await r.json()
             if result["list"]:
                 definition = result['list'][pos]['definition']

--- a/cogs/image.py
+++ b/cogs/image.py
@@ -20,6 +20,10 @@ class Image:
     def __init__(self, bot):
         self.bot = bot
         self.imgur = ImgurClient(CLIENT_ID, CLIENT_SECRET)
+        self.session = aiohttp.ClientSession()
+    
+    def __unload(self):
+        self.session.close()
 
     @commands.group(name="imgur", no_pm=True, pass_context=True)
     async def _imgur(self, ctx):
@@ -127,7 +131,7 @@ class Image:
         url = ("http://api.giphy.com/v1/gifs/search?&api_key={}&q={}"
                "".format(GIPHY_API_KEY, keywords))
 
-        async with aiohttp.get(url) as r:
+        async with self.session.get(url) as r:
             result = await r.json()
             if r.status == 200:
                 if result["data"]:
@@ -149,7 +153,7 @@ class Image:
         url = ("http://api.giphy.com/v1/gifs/random?&api_key={}&tag={}"
                "".format(GIPHY_API_KEY, keywords))
 
-        async with aiohttp.get(url) as r:
+        async with self.session.get(url) as r:
             result = await r.json()
             if r.status == 200:
                 if result["data"]:

--- a/cogs/streams.py
+++ b/cogs/streams.py
@@ -48,6 +48,10 @@ class Streams:
         settings = dataIO.load_json("data/streams/settings.json")
         self.settings = defaultdict(dict, settings)
         self.messages_cache = defaultdict(list)
+        self.session = aiohttp.ClientSession()
+     
+    def __unload(self):
+        self.session.close()        
 
     @commands.command()
     async def hitbox(self, stream: str):
@@ -341,7 +345,7 @@ class Streams:
     async def hitbox_online(self, stream):
         url = "https://api.hitbox.tv/media/live/" + stream
 
-        async with aiohttp.get(url) as r:
+        async with self.session.get(url) as r:
             data = await r.json(encoding='utf-8')
 
         if "livestream" not in data:
@@ -378,7 +382,7 @@ class Streams:
     async def mixer_online(self, stream):
         url = "https://mixer.com/api/v1/channels/" + stream
 
-        async with aiohttp.get(url) as r:
+        async with self.session.get(url) as r:
             data = await r.json(encoding='utf-8')
         if r.status == 200:
             if data["online"] is True:
@@ -393,7 +397,7 @@ class Streams:
     async def picarto_online(self, stream):
         url = "https://api.picarto.tv/v1/channel/name/" + stream
 
-        async with aiohttp.get(url) as r:
+        async with self.session.get(url) as r:
             data = await r.text(encoding='utf-8')
         if r.status == 200:
             data = json.loads(data)


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
`aiohttp.get` is deprecated on aiohttp 2.3.2 (latest aiohttp I can find)

I seriously don't know if this is bugfix or enhancement, but since this is not a bug on old aiohttp, I chose enhancement