### PR TITLE
[V3 ModLog] Remove casetypes' dependence on audit log types

### DIFF
--- a/redbot/cogs/modlog/modlog.py
+++ b/redbot/cogs/modlog/modlog.py
@@ -128,16 +128,17 @@ class ModLog:
                 bot_perms = guild.me.guild_permissions
                 if bot_perms.view_audit_log:
                     case_type = await modlog.get_casetype(case_before.action_type, guild)
-                    audit_type = getattr(discord.AuditLogAction, case_type.audit_type)
-                    if audit_type:
-                        audit_case = None
-                        async for entry in guild.audit_logs(action=audit_type):
-                            if entry.target.id == case_before.user.id and \
-                                    entry.user.id == case_before.moderator.id:
-                                audit_case = entry
-                                break
-                        if audit_case:
-                            case_before.moderator = audit_case.user
+                    if case_type is not None and case_type.audit_type is not None:
+                        audit_type = getattr(discord.AuditLogAction, case_type.audit_type)
+                        if audit_type:
+                            audit_case = None
+                            async for entry in guild.audit_logs(action=audit_type):
+                                if entry.target.id == case_before.user.id and \
+                                        entry.user.id == case_before.moderator.id:
+                                    audit_case = entry
+                                    break
+                            if audit_case:
+                                case_before.moderator = audit_case.user
             is_guild_owner = author == guild.owner
             is_case_author = author == case_before.moderator
             author_is_mod = await ctx.bot.is_mod(author)

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -223,13 +223,13 @@ class CaseType:
         The emoji to use for the case type (for example, :boot:)
     case_str: str
         The string representation of the case (example: Ban)
-    audit_type: str
+    audit_type: `str`, optional
         The action type of the action as it would appear in the
         audit log
     """
     def __init__(
             self, name: str, default_setting: bool, image: str,
-            case_str: str, audit_type: str, guild: discord.Guild = None):
+            case_str: str, audit_type: str=None, guild: discord.Guild=None):
         self.name = name
         self.default_setting = default_setting
         self.image = image
@@ -493,7 +493,7 @@ async def get_all_casetypes(guild: discord.Guild=None) -> List[CaseType]:
 
 async def register_casetype(
         name: str, default_setting: bool,
-        image: str, case_str: str, audit_type: str) -> CaseType:
+        image: str, case_str: str, audit_type: str=None) -> CaseType:
     """
     Registers a case type. If the case type exists and
     there are differences between the values passed and
@@ -511,7 +511,7 @@ async def register_casetype(
         The emoji to use for the case type (for example, :boot:)
     case_str: str
         The string representation of the case (example: Ban)
-    audit_type: str
+    audit_type: `str`, optional
         The action type of the action as it would appear in the
         audit log
 
@@ -540,12 +540,13 @@ async def register_casetype(
         raise ValueError("The 'image' is not a string!")
     if not isinstance(case_str, str):
         raise ValueError("The 'case_str' is not a string!")
-    if not isinstance(audit_type, str):
-        raise ValueError("The 'audit_type' is not a string!")
-    try:
-        getattr(discord.AuditLogAction, audit_type)
-    except AttributeError:
-        raise
+    if audit_type is not None: 
+        if not isinstance(audit_type, str):
+            raise ValueError("The 'audit_type' is not a string!")
+        try:
+            getattr(discord.AuditLogAction, audit_type)
+        except AttributeError:
+            raise
     ct = await get_casetype(name)
     if ct is None:
         casetype = CaseType(name, default_setting, image, case_str, audit_type)


### PR DESCRIPTION
### Type

- Enhancement

### Description of the changes
New casetypes no longer require a valid audit type to be instantiated. However, if provided, the audit log integration in `[p]reason` still exists.

### Benefits
Allows custom casetypes to be created which aren't related to any particular audit log action.