### PR TITLE
[V3 Core] add traceback, invite, leave, and servers commands

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -47,7 +47,7 @@ class RedBase(BotBase, RpcMethodMixin):
         self.db = Config.get_core_conf(force_registration=True)
         self._co_owners = cli_flags.co_owner
         self.rpc_enabled = cli_flags.rpc
-
+        self._last_exception = None
         self.db.register_global(
             token=None,
             prefix=[],

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -63,7 +63,7 @@ class Core:
 
     @commands.command()
     @checks.is_owner()
-    async def join(self, ctx):
+    async def invite(self, ctx):
         """Show's Red's invite url"""
         if self.bot.user.bot:
             await ctx.author.send(discord.utils.oauth_url(self.bot.user.id))


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes
This ports `[p]traceback`, `[p]join`, `[p]leave`, and `[p]servers` from v2. These commands are in `redbot/core/core_commands.py`. The functionality is pretty much the same as from v2