### PR TITLE
Updated picarto stream thumbnail URIs for new load-balanced thumbnails

### DIFF
--- a/cogs/streams.py
+++ b/cogs/streams.py
@@ -497,8 +497,7 @@ class Streams:
         avatar = ("https://picarto.tv/user_data/usrimg/{}/dsdefault.jpg{}"
                   "".format(data["name"].lower(), self.rnd_attr()))
         url = "https://picarto.tv/" + data["name"]
-        thumbnail = ("https://thumb.picarto.tv/thumbnail/{}.jpg"
-                     "".format(data["name"]))
+        thumbnail = data["thumbnails"]["web"]
         embed = discord.Embed(title=data["title"], url=url)
         embed.set_author(name=data["name"])
         embed.set_image(url=thumbnail + self.rnd_attr())


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Thumbnails for Picarto.TV now use the updated API spec, pulling thumbnails from the load-balanced URI.

This change was made to the API within the last 2 or so weeks, and thumb.picarto.tv no longer gets updated thumbnails and is deprecated.