### PR TITLE
[V3 JSON Driver] Don't save json if it exists

### DIFF
--- a/redbot/core/drivers/red_json.py
+++ b/redbot/core/drivers/red_json.py
@@ -32,14 +32,14 @@ class JSON(BaseDriver):
         self.data_path.mkdir(parents=True, exist_ok=True)
 
         self.data_path = self.data_path / self.file_name
-        
+
         self.jsonIO = JsonIO(self.data_path)
 
         try:
             self.data = self.jsonIO._load_json()
         except FileNotFoundError:
             self.data = {}
-        self.jsonIO._save_json(self.data)
+            self.jsonIO._save_json(self.data)
 
     def get_driver(self):
         return self


### PR DESCRIPTION
### Type

- Enhancement

### Issue
JSON files are currently being saved every time its driver is instantiated. When the JSON file already exists, this does nothing; it just loads the JSON and saves it again.

### Description of the changes
This PR makes sure the JSON is only saved if it does not already exist. Perhaps someone just missed an indent.