### PR TITLE
[V3 Utils] add embed utils with a random_colour function

### DIFF
--- a/redbot/core/utils/embed.py
+++ b/redbot/core/utils/embed.py
@@ -19,11 +19,7 @@ def randomize_colour(embed: discord.Embed) -> discord.Embed:
         The embed with the color set to a random color
 
     """
-    embed.colour = discord.Color(
-        value=int(
-            ''.join([random.choice('0123456789ABCDEF') for x in range(6)]), 16
-        )
-    )
+    embed.colour = discord.Color(value=random.randint(0x000000, 0xFFFFFF))
     return embed
 
 

--- a/redbot/core/utils/embed.py
+++ b/redbot/core/utils/embed.py
@@ -3,21 +3,28 @@ import discord
 import random
 
 
-def random_colour() -> discord.Colour:
+def randomize_colour(embed: discord.Embed) -> discord.Embed:
     """
-    Get a random colour for use in an embed
-    There is an alias for this called random_color
+    Gives the provided embed a random color.
+    There is an alias for this called randomize_color
+
+    Parameters
+    ----------
+    embed : discord.Embed
+        The embed to add a color to
 
     Returns
     -------
-    discord.Colour
-        The random colour
+    discord.Embed
+        The embed with the color set to a random color
+
     """
-    return discord.Color(
+    embed.colour = discord.Color(
         value=int(
             ''.join([random.choice('0123456789ABCDEF') for x in range(6)]), 16
         )
     )
+    return embed
 
 
-random_color = random_colour
+randomize_color = randomize_colour

--- a/redbot/core/utils/embed.py
+++ b/redbot/core/utils/embed.py
@@ -1,0 +1,23 @@
+import discord
+
+import random
+
+
+def random_colour() -> discord.Colour:
+    """
+    Get a random colour for use in an embed
+    There is an alias for this called random_color
+
+    Returns
+    -------
+    discord.Colour
+        The random colour
+    """
+    return discord.Color(
+        value=int(
+            ''.join([random.choice('0123456789ABCDEF') for x in range(6)]), 16
+        )
+    )
+
+
+random_color = random_colour


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This adds a place for embed-related stuff in `redbot.core.utils`. At the moment, the only thing in the new file is a random color generator that would allow for the following:
```py
from redbot.core.utils.embed import random_colour 

class SomeCog:
    
    @commands.command()
    async def test(self, ctx):
        await ctx.send(embed=discord.Embed(title="Test", color=random_colour()))
```

This new function is also aliased to `random_color` (much like `discord.Color` being an alias for `discord.Colour`)