### PR TITLE
[V3 Mod] fix some issues relating to ignore

### DIFF
--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -1047,7 +1047,6 @@ class Mod:
             await ctx.send(_("Channel already in ignore list."))
 
     @ignore.command(name="guild", aliases=["server"])
-    @commands.has_permissions(manage_guild=True)
     async def ignore_guild(self, ctx: RedContext):
         """Ignores current guild"""
         guild = ctx.guild
@@ -1081,7 +1080,6 @@ class Mod:
             await ctx.send(_("That channel is not in the ignore list."))
 
     @unignore.command(name="guild", aliases=["server"])
-    @commands.has_permissions(manage_guild=True)
     async def unignore_guild(self, ctx: RedContext):
         """Removes current guild from ignore list"""
         guild = ctx.message.guild

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -121,15 +121,13 @@ class RedBase(BotBase, RpcMethodMixin):
     async def is_admin(self, member: discord.Member):
         """Checks if a member is an admin of their guild."""
         admin_role = await self.db.guild(member.guild).admin_role()
-        return (not admin_role or
-                any(role.id == admin_role for role in member.roles))
+        return any(role.id == admin_role for role in member.roles)
 
     async def is_mod(self, member: discord.Member):
         """Checks if a member is a mod or admin of their guild."""
         mod_role = await self.db.guild(member.guild).mod_role()
         admin_role = await self.db.guild(member.guild).admin_role()
-        return (not (admin_role or mod_role) or
-                any(role.id in (mod_role, admin_role) for role in member.roles))
+        return any(role.id in (mod_role, admin_role) for role in member.roles)
 
     async def get_context(self, message, *, cls=RedContext):
         return await super().get_context(message, cls=cls)


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
First, this fixes `[ignore|unignore] guild` being unusable without the manage guild perm

Second, this fixes the actual check that happens with ignores so that it doesn't automatically permit if the admin role isn't set (because is_admin was returning True before if the admin role wasn't set, and the same was true with is_mod but with the mod role in play there)