### PR TITLE
[V3 Mod] fix error with [p]names

### DIFF
--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -1122,6 +1122,9 @@ class Mod:
     @commands.command()
     async def names(self, ctx: RedContext, user: discord.Member):
         """Show previous names/nicknames of a user"""
+        async with self.settings.user(user).past_names() as name_list:
+            while None in name_list:  # clean out null entries from a bug
+                name_list.remove(None)
         names = await self.settings.user(user).past_names()
         nicks = await self.settings.member(user).past_nicks()
         msg = ""

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -1343,13 +1343,15 @@ class Mod:
             if entry.target == target:
                 return entry
 
-    async def on_member_update(self, before, after):
+    async def on_member_update(self, before: discord.Member, after: discord.Member):
         if before.name != after.name:
             async with self.settings.user(before).past_names() as name_list:
-                if after.nick in name_list:
+                while None in name_list:  # clean out null entries from a bug
+                    name_list.remove(None)
+                if after.name in name_list:
                     # Ensure order is maintained without duplicates occuring
-                    name_list.remove(after.nick)
-                name_list.append(after.nick)
+                    name_list.remove(after.name)
+                name_list.append(after.name)
                 while len(name_list) > 20:
                     name_list.pop(0)
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This fixes the issues with `[p]names` erroring out when running it. There were two issues at play here:
1. The `on_member_update` function was checking nicknames in the part where it was supposed to be checking names, which was leading to
2. There were `null` values being stored, which is why it was erroring on trying to escape mass mentions

I've fixed the first bit, which will prevent the second bit from happening in the future. I've also put a bit in the `on_member_update` to remove the `null`s and will put that directly in the `names` command as well