### PR TITLE
[V3 Trivia] Allow to credit author of trivia lists

### DIFF
--- a/redbot/cogs/trivia/session.py
+++ b/redbot/cogs/trivia/session.py
@@ -96,11 +96,7 @@ class TriviaSession():
         In order for the trivia session to be stopped correctly, this should
         only be called internally by `TriviaSession.start`.
         """
-        try:
-            await self._send_startup_msg()
-        except:
-            import traceback
-            traceback.print_exc()
+        await self._send_startup_msg()
         max_score = self.settings["max_score"]
         delay = self.settings["delay"]
         timeout = self.settings["timeout"]

--- a/redbot/cogs/trivia/session.py
+++ b/redbot/cogs/trivia/session.py
@@ -96,10 +96,17 @@ class TriviaSession():
         In order for the trivia session to be stopped correctly, this should
         only be called internally by `TriviaSession.start`.
         """
+        try:
+            await self._send_startup_msg()
+        except:
+            import traceback
+            traceback.print_exc()
         max_score = self.settings["max_score"]
         delay = self.settings["delay"]
         timeout = self.settings["timeout"]
         for question, answers in self._iter_questions():
+            async with self.ctx.typing():
+                await asyncio.sleep(3)
             self.count += 1
             msg = "**Question number {}!**\n\n{}".format(self.count, question)
             await self.ctx.send(msg)
@@ -109,11 +116,14 @@ class TriviaSession():
             if any(score >= max_score for score in self.scores.values()):
                 await self.end_game()
                 break
-            async with self.ctx.typing():
-                await asyncio.sleep(3)
         else:
             await self.ctx.send("There are no more questions!")
             await self.end_game()
+
+    async def _send_startup_msg(self):
+        lists = self.settings["lists"].items()
+        titles = ("{} ({})".format(name, author) for name, author in lists)
+        await self.ctx.send("Starting Trivia: " + ", ".join(titles))
 
     def _iter_questions(self):
         """Iterate over questions and answers for this session.

--- a/redbot/cogs/trivia/session.py
+++ b/redbot/cogs/trivia/session.py
@@ -121,9 +121,24 @@ class TriviaSession():
             await self.end_game()
 
     async def _send_startup_msg(self):
-        lists = self.settings["lists"].items()
-        titles = ("{} ({})".format(name, author) for name, author in lists)
-        await self.ctx.send("Starting Trivia: " + ", ".join(titles))
+        list_names = []
+        for idx, tup in enumerate(self.settings["lists"].items()):
+            name, author = tup
+            if author:
+                title = "{} (by {})".format(name, author)
+            else:
+                title = name
+            list_names.append(title)
+        num_lists = len(list_names)
+        if num_lists > 2:
+            # at least 3 lists, join all but last with comma
+            msg = ", ".join(list_names[:num_lists-1])
+            # join onto last with "and"
+            msg = " and ".join((msg, list_names[num_lists-1]))
+        else:
+            # either 1 or 2 lists, join together with "and"
+            msg = " and ".join(list_names)
+        await self.ctx.send("Starting Trivia: " + msg)
 
     def _iter_questions(self):
         """Iterate over questions and answers for this session.

--- a/redbot/cogs/trivia/trivia.py
+++ b/redbot/cogs/trivia/trivia.py
@@ -178,6 +178,7 @@ class Trivia:
                 "There is already an ongoing trivia session in this channel.")
             return
         trivia_dict = {}
+        authors = []
         for category in reversed(categories):
             # We reverse the categories so that the first list's config takes
             # priority over the others.
@@ -193,6 +194,7 @@ class Trivia:
                                " incorrectly.".format(category))
             else:
                 trivia_dict.update(dict_)
+                authors.append(trivia_dict.pop("AUTHOR", None))
                 continue
             return
         if not trivia_dict:
@@ -203,6 +205,7 @@ class Trivia:
         config = trivia_dict.pop("CONFIG", None)
         if config and settings["allow_override"]:
             settings.update(config)
+        settings["lists"] = dict(zip(categories, reversed(authors)))
         session = TriviaSession.start(ctx, trivia_dict, settings)
         self.trivia_sessions.append(session)
         LOG.debug("New trivia session; #%s in %d", ctx.channel, ctx.guild.id)


### PR DESCRIPTION
### Type

- Enhancement

### Description of the changes
By including the `AUTHOR` key in a trivia list as follows, the author of the trivia list can be credited on startup:
```yaml
AUTHOR: Tobotimus
question1:
- answer1
- answer2
...
```

On startup of the trivia list, the bot now says "Starting trivia: ListName (by Author)". For multiple lists, it will do "Starting trivia: ListName1 (by Author1), ListName2 (by Author2) and ListName3 (by Author3)".