### PR TITLE
[V3 Utils] Improve bordered function and add tests

### DIFF
--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,0 +1,48 @@
+import textwrap
+from redbot.core.utils import chat_formatting
+
+
+def test_bordered_symmetrical():
+    expected = textwrap.dedent("""\
+    ┌──────────────┐    ┌─────────────┐
+    │one           │    │four         │
+    │two           │    │five         │
+    │three         │    │six          │
+    └──────────────┘    └─────────────┘""")
+    col1, col2 = ['one', 'two', 'three'],  ['four', 'five', 'six']
+    assert chat_formatting.bordered(col1, col2) == expected
+
+
+def test_bordered_asymmetrical():
+    expected = textwrap.dedent("""\
+    ┌──────────────┐    ┌──────────────┐
+    │one           │    │four          │
+    │two           │    │five          │
+    │three         │    │six           │
+    └──────────────┘    │seven         │
+                        └──────────────┘""")
+    col1, col2 = ['one', 'two', 'three'],  ['four', 'five', 'six', 'seven']
+    assert chat_formatting.bordered(col1, col2) == expected
+
+
+def test_bordered_asymmetrical_2():
+    expected = textwrap.dedent("""\
+    ┌──────────────┐    ┌─────────────┐
+    │one           │    │five         │
+    │two           │    │six          │
+    │three         │    └─────────────┘
+    │four          │                   
+    └──────────────┘                   """)
+    col1, col2 = ['one', 'two', 'three', 'four'], ['five', 'six']
+    assert chat_formatting.bordered(col1, col2) == expected
+
+
+def test_bordered_ascii():
+    expected = textwrap.dedent("""\
+    ----------------    ---------------
+    |one           |    |four         |
+    |two           |    |five         |
+    |three         |    |six          |
+    ----------------    ---------------""")
+    col1, col2 = ['one', 'two', 'three'],  ['four', 'five', 'six']
+    assert chat_formatting.bordered(col1, col2, ascii_border=True) == expected


### PR DESCRIPTION
### Type

- Enhancement

### Description of the changes
The `bordered` function from utils has been improved, so it can have as many rows and columns as it likes, and can also be made purely ASCII.

This is a step towards #1117.

I've also added some tests for the bordered function, since it was previously lacking in that area.