### PR TITLE
[Core] QoL for argparser

### DIFF
--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -63,7 +63,7 @@ def ask_sentry(red: Red):
 
 def parse_cli_flags(args):
     parser = argparse.ArgumentParser(description="Red - Discord Bot",
-                                     usage="redbot instance [arguments]")
+                                     usage="redbot <instance_name> [arguments]")
     parser.add_argument("--list-instances", action="store_true",
                         help="List all instance names setup "
                              "with 'redbot-setup'")

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -62,15 +62,16 @@ def ask_sentry(red: Red):
 
 
 def parse_cli_flags(args):
-    parser = argparse.ArgumentParser(description="Red - Discord Bot")
+    parser = argparse.ArgumentParser(description="Red - Discord Bot",
+                                     usage="redbot instance [arguments]")
     parser.add_argument("--list-instances", action="store_true",
                         help="List all instance names setup "
                              "with 'redbot-setup'")
     parser.add_argument("--owner", type=int,
                         help="ID of the owner. Only who hosts "
                              "Red should be owner, this has "
-                             "serious security implications.")
-    parser.add_argument("--co-owner", type=int, action="append", default=[],
+                             "serious security implications if misused.")
+    parser.add_argument("--co-owner", type=int, default=[], nargs="*",
                         help="ID of a co-owner. Only people who have access "
                              "to the system that is hosting Red should be  "
                              "co-owners, as this gives them complete access "
@@ -79,8 +80,7 @@ def parse_cli_flags(args):
                              "multiple.")
     parser.add_argument("--prefix", "-p", action="append",
                         help="Global prefix. Can be multiple")
-    parser.add_argument("--no-prompt",
-                        action="store_true",
+    parser.add_argument("--no-prompt", action="store_true",
                         help="Disables console inputs. Features requiring "
                              "console interaction could be disabled as a "
                              "result")


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

- ``--co-owner`` now accepts ID's in succession, example: ``redbot instance --co-owner 1234 5678``
- The usage field in ``redbot --help`` now makes sense. ``usage: redbot instance [arguments]``
- ``--owner`` is now reunited with its ``if misused`` part of the security implications sentence.