### PR TITLE
[V3 Core] Catch errors when reloading

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -224,8 +224,8 @@ class Core:
                              " cog path."))
             return
 
-        self.cleanup_and_refresh_modules(spec.name)
         try:
+            self.cleanup_and_refresh_modules(spec.name)
             ctx.bot.load_extension(spec)
         except Exception as e:
             log.exception("Package reloading failed", exc_info=e)


### PR DESCRIPTION
### Type

- Bugfix

### Description of the changes
When a module is loaded, then modified to create an error, then reloaded, the command errors. This error should be caught and printed to the console, and the bot should notify the user, just as if the error occurred on initial load.

Step towards #1215, as this will prevent syntax/indentation errors etc. from 3rd party cogs ending up in our sentry log.