### PR TITLE
[Audio] Song notifs / autodc, queue list improvements

### DIFF
--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -1213,6 +1213,7 @@ class Audio:
         else:
             await self.bot.say("No longer notifying when a new track plays.")
         self.save_settings()
+
     @audioset.command(name="player")
     @checks.is_owner()
     async def audioset_player(self):
@@ -1894,9 +1895,9 @@ class Audio:
         sections = 12
         loc_time = round((elapsed_time/total_time) * sections)  # 10 sections
 
-        bar_char = '━'
-        seek_char = ':radio_button:'
-        play_char = ':arrow_forward:'
+        bar_char = '\N{BOX DRAWINGS HEAVY HORIZONTAL}'
+        seek_char = '\N{RADIO BUTTON}'
+        play_char = '\N{BLACK RIGHT-POINTING TRIANGLE}'
 
         msg = "\n" + play_char + " "
 

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -1874,7 +1874,6 @@ class Audio:
         msg += "\n***Next up:***\n" + "\n".join(song_info)
         em.description = msg.replace('None', '-')
         if more_songs > 0:
-            msg += "\n\n**And {} more songs...**".format(more_songs)
             em.set_footer(text="And {} more songs...".format(more_songs))
         await self.bot.say(embed=em)
 

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -1250,12 +1250,14 @@ class Audio:
         self.set_server_setting(server, "TIMER_DISCONNECT",
                                 not timer_disconnect)
         if not timer_disconnect:
-            await self.bot.say("If there is no one left in the voice channel"
-                               " the bot will automatically disconnect after"
-                               " five minutes.")
+            await self.bot.say("The bot will automatically disconnect after"
+                               " playback is stopped and five minutes have"
+                               " elapsed. Disable this setting to stop the"
+                               " bot from disconnecting with other music cogs"
+                               " playing.")
         else:
             await self.bot.say("The bot will no longer auto disconnect"
-                               " if the voice channel is empty.")
+                               " while other music cogs are playing.")
         self.save_settings()
 
     @audioset.command(pass_context=True, name="volume", no_pm=True)

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -1844,6 +1844,8 @@ class Audio:
             msg += "\n***Currently playing:***\n{} ({})\n".format(now_playing.title,
                 str(datetime.timedelta(seconds=now_playing.duration)))
             msg += self._draw_play(now_playing) + "\n"  # draw play thing
+            if now_playing.thumbnail is None:
+                now_playing.thumbnail = (self.bot.user.avatar_url).replace('webp', 'png')
             em.set_thumbnail(url=now_playing.thumbnail)
 
         queued_song_list = self._get_queue(server, 10)
@@ -2062,6 +2064,10 @@ class Audio:
                 song.view_count = None
             if not hasattr(song, 'uploader'):
                 song.uploader = None
+            if song.rating is None:
+                song.rating = 0
+            if song.thumbnail is None:
+                song.thumbnail = (self.bot.user.avatar_url).replace('webp', 'png')
             if hasattr(song, 'duration'):
                 m, s = divmod(song.duration, 60)
                 h, m = divmod(m, 60)
@@ -2079,7 +2085,10 @@ class Audio:
             msg += self._draw_play(song) + "\n"
             colour = ''.join([choice('0123456789ABCDEF') for x in range(6)])
             em = discord.Embed(description="", colour=int(colour, 16))
-            em.set_author(name=song.title, url=song.webpage_url)
+            if 'http' not in song.webpage_url:
+                em.set_author(name=song.title)
+            else:
+                em.set_author(name=song.title, url=song.webpage_url)
             em.set_thumbnail(url=song.thumbnail)
             em.description = msg.replace('None', '-')
 

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -1856,6 +1856,7 @@ class Audio:
 
         song_info = []
         for num, song in enumerate(tempqueue_song_list, 1):
+            str_duration = str(datetime.timedelta(seconds=song.duration))
             try:
                 song_info.append("**[{}]** {.title} ({})".format(num, song, str_duration))
             except AttributeError:

--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -2361,7 +2361,7 @@ class Audio:
 
         colour = ''.join([choice('0123456789ABCDEF') for x in range(6)])
         em = discord.Embed(description="", colour=int(colour, 16))
-        if '\\' in song.webpage_url:
+        if 'http' not in song.webpage_url:
             em.set_author(name=song.title)
         else:
             em.set_author(name=song.title, url=song.webpage_url)


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [x] New feature

### Description of the changes
Credit goes to Stevy for the queue and song changes.

- audioset notify - a toggle for the bot sending "Now Playing" messages on song change
- audioset notifychannel - a command to specify the channel for the bot to announce in
- Queue changes - add song duration, number of songs left in the queue, queue draws now playing duration for currently playing song, increase song details to 10 songs, make queue an embed
- Song changes - add "np" alias for Now Playing, song information now in embed with duration
- audioset timerdisconnect was added to facilitate audio add-on cogs. When this is toggled to False (True is the default, and previous audio behavior), the bot will not disconnect when other audio-based cogs are in use. I admit this is sort of a selfish part of the PR, I have a radio add-on cog that Paddo originally created that I've been adding to. It will be able to interact with the audio cog and play icecast/http streams, but the bot was disconnecting after 300 seconds because of this loop. There didn't seem to be a way to cancel the Task outside of the audio cog.

One possible improvment/change: embed color could use the bot's top role color instead of a randomly generated color.
  