### PR TITLE
[V3 Bank] Fix can_spend and withdraw_credits

### DIFF
--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -143,7 +143,7 @@ async def can_spend(member: discord.Member, amount: int) -> bool:
     """
     if _invalid_amount(amount):
         return False
-    return await get_balance(member) > amount
+    return await get_balance(member) >= amount
 
 
 async def set_balance(member: discord.Member, amount: int) -> int:

--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -215,7 +215,7 @@ async def withdraw_credits(member: discord.Member, amount: int) -> int:
         raise ValueError("Invalid withdrawal amount {} <= 0".format(amount))
 
     bal = await get_balance(member)
-    if amount > bal:
+    if amount >= bal:
         raise ValueError("Insufficient funds {} > {}".format(amount, bal))
 
     return await set_balance(member, bal - amount)

--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -215,7 +215,7 @@ async def withdraw_credits(member: discord.Member, amount: int) -> int:
         raise ValueError("Invalid withdrawal amount {} <= 0".format(amount))
 
     bal = await get_balance(member)
-    if amount >= bal:
+    if amount > bal:
         raise ValueError("Insufficient funds {} > {}".format(amount, bal))
 
     return await set_balance(member, bal - amount)


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Changed the equality operator for can_spend ~~and withdraw_credits~~ function from > to >=. In the current release you cannot use an amount that equals the member's balance.

**Steps to reproduce:**
set your balance to 100

make a bet in slots for 100.
[p]slot 100

EDIT: Withdraw_credits is fine.


  