### PR TITLE
[V3 Config] Fixed raised Attribute Error Message  

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -215,7 +215,7 @@ class Group(Value):
             )
         elif self.force_registration:
             raise AttributeError(
-                "'{}' is not a valid registered Group"
+                "'{}' is not a valid registered Group "
                 "or value.".format(item)
             )
         else:


### PR DESCRIPTION
Added space in raised Attribute Error message

### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Added a space in raised Attribute Error message

**Before**
foo is not a valid registered Groupor Value.

**After**
foo is not a valid registered Group or Value.