### PR TITLE
[V3 Config] Fix for all() method to correctly return nested data

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -324,7 +324,7 @@ class Group(Value):
         defaults_copy = deepcopy(defaults)
 
         for key, value in current.items():
-            if isinstance(value, collections.Mapping) and value:
+            if isinstance(value, collections.Mapping):
                 result = self.nested_update(defaults_copy.get(key, {}), value)
                 defaults_copy[key] = result
             else:


### PR DESCRIPTION
Adds nested support to all() and retains immutability

### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

**Reproduction**
Added a helper function to handle dict.update() when there is unknown depth and must retain immutability.
The current behavior of all() does not include the registered defaults when data has been set. all()'s implementation can be simply observed by testing the following:
```Python
data = {'foo': {'bar': 0, 'baz': 1}}
data.update({'foo': {'baz': 2}})
print(data)
```

**Solution and Test**
The committed changes handles nested data and retains immutability.
In addition, this PR is passing the following test provided by @Tobotimus:
```Python
@pytest.mark.asyncio
 async def test_immutable_default(config, empty_guild):
     """Test immutability of defaults of a `Group` object."""
     config.register_guild(foo__bar=True)
     guild_data = await config.guild(empty_guild).all()
     guild_data['foo']['baz'] = False
 
     foo = await config.guild(empty_guild).foo.all()
     assert 'baz' not in foo``` 