### PR TITLE
[V3/Economy] Fix for commands that require guild

### DIFF
--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -144,6 +144,7 @@ class Economy:
             await ctx.send_help()
 
     @_bank.command()
+    @guild_only_check()
     async def balance(self, ctx: commands.Context, user: discord.Member = None):
         """Shows balance of user.
 
@@ -158,6 +159,7 @@ class Economy:
             user.display_name, bal, currency))
 
     @_bank.command()
+    @guild_only_check()
     async def transfer(self, ctx: commands.Context, to: discord.Member, amount: int):
         """Transfer currency to other users"""
         from_ = ctx.author
@@ -173,6 +175,7 @@ class Economy:
         ))
 
     @_bank.command(name="set")
+    @guild_only_check()
     @check_global_setting_admin()
     async def _set(self, ctx: commands.Context, to: discord.Member, creds: SetParser):
         """Sets balance of user's bank account. See help for more operations


### PR DESCRIPTION
Added guild_only_check decorator to _set, transfer, and balance

### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Added the guild_only_check decorator to balance, transfer, and _set. All of these functions require ctx.guild, and therefore **without** the decorator raises a Runtime error for the user. Adding the decorator to these functions sends the `You are not authorized to issue that command` when used without a guild (only when bank is not global. Global still functions as intended). 

----------
**Steps to Reproduce**
Make sure bank is not global
Start a DM with the bot
type `[p]bank balance`

**Solution**
Added decorator now sends the "You are not authorized to issue that command." 
message.
