### PR TITLE
[V3 Events] Make the vague error message a fallback

### DIFF
--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -172,7 +172,8 @@ def init_events(bot, cli_flags):
             exception_log += "".join(traceback.format_exception(type(error),
                                      error, error.__traceback__))
             bot._last_exception = exception_log
-            await ctx.send(inline(message))
+            if not hasattr(ctx.cog, "_{0.command.cog_name}__error".format(ctx)):
+                await ctx.send(inline(message))
         elif isinstance(error, commands.CommandNotFound):
             pass
         elif isinstance(error, commands.CheckFailure):


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
modify CommandInvokeError handler in `on_command_error` to use the vague message as a fallback if a cog doesn't provide its own `__error` function
See #1278