### PR TITLE
[Audio] Handle playlist urls in [p]play

### DIFF
--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -1426,6 +1426,10 @@ class Audio:
         voice_channel = author.voice_channel
         channel = ctx.message.channel
 
+        if "www.youtube.com/playlist" in url:
+            await self.bot.send_message(channel, "Use [p]playlist to manage playlist urls.")
+            return
+
         # Checking if playing in current server
 
         if self.is_playing(server):


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Informs user of the [p]playlist command when a playlist url is used with [p]play instead of erroring out.