### PR TITLE
[V3] move 'distro' out of requirements.txt (blame Windows)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ colorama
 aiohttp-json-rpc
 pyyaml
 Red-Trivia
-distro; sys_platform == "linux"

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from subprocess import run, PIPE
 
 import os
+import sys
 
 from setuptools import find_packages
 
@@ -25,6 +26,8 @@ def get_requirements():
         requirements.remove('git+https://github.com/Rapptz/discord.py.git@rewrite#egg=discord.py[voice]')
     else:
         requirements.append('discord.py>=1.0.0a0')  # Because RTD
+    if sys.platform.startswith("linux"):
+        requirements.append("distro")
     return requirements
 
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Remove `distro` from requirements.txt and have it be appended in `setup.py`'s `get_requirements` function if it's being installed on Linux

This should fix the issue where people are getting
`pkg_resources.RequirementParseError: Expected version spec in distro; sys_platform == "linux" at ; sys_platform == "linux"`
on Windows