### PR TITLE
Added `[p]load` and `[p]reload` command errors in the `[p]traceback` command log file

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3,6 +3,7 @@ import importlib
 import itertools
 import logging
 import sys
+import traceback
 from collections import namedtuple
 from random import SystemRandom
 from string import ascii_letters, digits
@@ -225,6 +226,13 @@ class Core:
             ctx.bot.load_extension(spec)
         except Exception as e:
             log.exception("Package loading failed", exc_info=e)
+
+            exception_log = ("Exception in command '{}'\n"
+                             "".format(ctx.command.qualified_name))
+            exception_log += "".join(traceback.format_exception(type(e),
+                                     e, e.__traceback__))
+            self.bot._last_exception = exception_log
+
             await ctx.send(_("Failed to load package. Check your console or "
                              "logs for details."))
         else:
@@ -260,6 +268,13 @@ class Core:
             ctx.bot.load_extension(spec)
         except Exception as e:
             log.exception("Package reloading failed", exc_info=e)
+
+            exception_log = ("Exception in command '{}'\n"
+                             "".format(ctx.command.qualified_name))
+            exception_log += "".join(traceback.format_exception(type(e),
+                                     e, e.__traceback__))
+            self.bot._last_exception = exception_log
+
             await ctx.send(_("Failed to reload package. Check your console or "
                              "logs for details."))
         else:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

When loading or reloading a package, this message can appear
```
Failed to load/reload package. Check your console or logs for details.
```
That print an error in the console but, unlike normal errors (`Exception in command ...`), they won't show using the `[p]traceback` command, forcing us to upload the log file using debug if we don't have access to the VPS... That change will make the loading/reloading cog errors showing with the `[p]traceback` command.