### PR TITLE
[V3 Config] Fix async context manager bug and add test

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -171,7 +171,7 @@ class Group(Value):
 
     @property
     def defaults(self):
-        return self._defaults.copy()
+        return deepcopy(self._defaults)
 
     # noinspection PyTypeChecker
     def __getattr__(self, item: str) -> Union["Group", Value]:

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -31,7 +31,7 @@ class _ValueCtxManager:
         return self.coro.__await__()
 
     async def __aenter__(self):
-        self.raw_value = deepcopy(await self)
+        self.raw_value = await self
         if not isinstance(self.raw_value, (list, dict)):
             raise TypeError("Type of retrieved value must be mutable (i.e. "
                             "list or dict) in order to use a config value as "
@@ -428,7 +428,7 @@ class Config:
 
     @property
     def defaults(self):
-        return self._defaults.copy()
+        return deepcopy(self._defaults)
 
     @classmethod
     def get_conf(cls, cog_instance, identifier: int,
@@ -669,7 +669,7 @@ class Config:
         # noinspection PyTypeChecker
         return Group(
             identifiers=(self.unique_identifier, key) + identifiers,
-            defaults=self._defaults.get(key, {}),
+            defaults=self.defaults.get(key, {}),
             spawner=self.spawner,
             force_registration=self.force_registration
         )

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -31,7 +31,7 @@ class _ValueCtxManager:
         return self.coro.__await__()
 
     async def __aenter__(self):
-        self.raw_value =  await self
+        self.raw_value = deepcopy(await self)
         if not isinstance(self.raw_value, (list, dict)):
             raise TypeError("Type of retrieved value must be mutable (i.e. "
                             "list or dict) in order to use a config value as "

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -376,3 +376,15 @@ async def test_value_ctxmgr_immutable(config):
 
     foo = await config.foo()
     assert foo is True
+
+
+@pytest.mark.asyncio
+async def test_ctxmgr_no_shared_default(config, member_factory):
+    config.register_member(foo=[])
+    m1 = member_factory.get()
+    m2 = member_factory.get()
+
+    async with config.member(m1).foo() as foo:
+        foo.append(1)
+
+    assert 1 not in await config.member(m2).foo()


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes the issue where the default mutable value would be shared between all entries in that category.

Fixes #1294 