### PR TITLE
[V3 Downloader] Make shared libraries work and make repo handling smarter

### DIFF
--- a/redbot/cogs/downloader/converters.py
+++ b/redbot/cogs/downloader/converters.py
@@ -15,7 +15,7 @@ class InstalledCog(commands.Converter):
         if downloader is None:
             raise commands.CommandError("Downloader not loaded.")
 
-        cog = discord.utils.get(downloader.installed_cogs, name=arg)
+        cog = discord.utils.get(await downloader.installed_cogs(), name=arg)
         if cog is None:
             raise commands.BadArgument(
                 "That cog is not installed"

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -7,6 +7,7 @@ from typing import Tuple, Union
 import discord
 from redbot.core import Config
 from redbot.core import checks
+from redbot.core.data_manager import cog_data_path
 from redbot.core.i18n import CogI18n
 from redbot.core.utils.chat_formatting import box, pagify
 from discord.ext import commands
@@ -35,7 +36,7 @@ class Downloader:
 
         self.already_agreed = False
 
-        self.LIB_PATH = self.bot.main_dir / "lib"
+        self.LIB_PATH = cog_data_path(self) / "lib"
         self.SHAREDLIB_PATH = self.LIB_PATH / "cog_shared"
         self.SHAREDLIB_INIT = self.SHAREDLIB_PATH / "__init__.py"
 

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -30,7 +30,6 @@ class Downloader:
                                     force_registration=True)
 
         self.conf.register_global(
-            repos={},
             installed=[]
         )
 
@@ -73,7 +72,7 @@ class Downloader:
         """
         installed = await self.conf.installed()
         # noinspection PyTypeChecker
-        return tuple(Installable.from_json(v) for v in installed)
+        return tuple(Installable.from_json(v, self._repo_manager) for v in installed)
 
     async def _add_to_installed(self, cog: Installable):
         """Mark a cog as installed.
@@ -289,29 +288,37 @@ class Downloader:
             await ctx.send(_("`{}` was successfully removed.").format(real_name))
         else:
             await ctx.send(_("That cog was installed but can no longer"
-                           " be located. You may need to remove it's"
-                           " files manually if it is still usable."))
+                             " be located. You may need to remove it's"
+                             " files manually if it is still usable."))
 
     @cog.command(name="update")
     async def _cog_update(self, ctx, cog_name: InstalledCog=None):
         """
         Updates all cogs or one of your choosing.
         """
+        installed_cogs = set(await self.installed_cogs())
+
         if cog_name is None:
             updated = await self._repo_manager.update_all_repos()
-            installed_cogs = set(await self.installed_cogs())
-            updated_cogs = set(cog for repo in updated.keys() for cog in repo.available_cogs)
 
-            installed_and_updated = updated_cogs & installed_cogs
+        else:
+            try:
+                updated = await self._repo_manager.update_repo(cog_name.repo_name)
+            except KeyError:
+                # Thrown if the repo no longer exists
+                updated = {}
 
-            # noinspection PyTypeChecker
-            await self._reinstall_requirements(installed_and_updated)
+        updated_cogs = set(cog for repo in updated.keys() for cog in repo.available_cogs)
+        installed_and_updated = updated_cogs & installed_cogs
 
-            # noinspection PyTypeChecker
-            await self._reinstall_cogs(installed_and_updated)
+        # noinspection PyTypeChecker
+        await self._reinstall_requirements(installed_and_updated)
 
-            # noinspection PyTypeChecker
-            await self._reinstall_libraries(installed_and_updated)
+        # noinspection PyTypeChecker
+        await self._reinstall_cogs(installed_and_updated)
+
+        # noinspection PyTypeChecker
+        await self._reinstall_libraries(installed_and_updated)
         await ctx.send(_("Cog update completed successfully."))
 
     @cog.command(name="list")

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -407,14 +407,17 @@ class Repo(RepoJSONMixin):
             The success of the installation.
 
         """
-        if libraries:
+        if len(libraries) > 0:
             if not all([i in self.available_libraries for i in libraries]):
                 raise ValueError("Some given libraries are not available in this repo.")
         else:
             libraries = self.available_libraries
 
-        if libraries:
-            return all([lib.copy_to(target_dir=target_dir) for lib in libraries])
+        if len(libraries) > 0:
+            ret = True
+            for lib in libraries:
+                ret = ret and await lib.copy_to(target_dir=target_dir)
+            return ret
         return True
 
     async def install_requirements(self, cog: Installable, target_dir: Path) -> bool:

--- a/tests/cogs/downloader/test_installable.py
+++ b/tests/cogs/downloader/test_installable.py
@@ -66,6 +66,6 @@ def test_repo_name(installable):
 
 def test_serialization(installable):
     data = installable.to_json()
-    location = data["location"]
+    cog_name = data["cog_name"]
 
-    assert location[-1] == "test_cog"
+    assert cog_name == "test_cog"


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
* Made repo handling a bit smarter by removing reliance on known repos.
* Single cog update now implemented.
* Python packages identified as shared libraries are now actually installed and available via the following:
```py
from cog_shared import SHARED_LIB_NAME
```