### PR TITLE
[downloader] Only show updates for cog .py files

### DIFF
--- a/cogs/downloader.py
+++ b/cogs/downloader.py
@@ -654,7 +654,13 @@ class Downloader:
                             continue
 
                         status, _, cogpath = f.partition('\t')
-                        cogname = os.path.split(cogpath)[-1][:-3]  # strip .py
+                        split = os.path.split(cogpath)
+                        cogdir, cogname = split[-2:]
+                        cogname = cogname[:-3]  # strip .py
+
+                        if len(split) != 2 or cogdir != cogname:
+                            continue
+
                         if status not in ret:
                             ret[status] = []
                         ret[status].append(cogname)


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
When there are any other .py files in a repo, downloader will try to process them as cogs. Since their folders don't exist, this will crash the cog update process.

This PR adds a check to ensure that the data returned by `update_repo()` fit the assumptions made later on, and that *only* changes to files matching the `cogname/cogname.py` pattern are processed.