### PR TITLE
pin all dependencies except youtube-dl, and Red-Trivia.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 yarl==0.18.0
 aiohttp>=2.0.0,<2.3.0
-appdirs
+appdirs==2.2.5
 youtube_dl
-raven
-colorama
-aiohttp-json-rpc<=0.8.7
-pyyaml
+raven==6.5.0
+colorama==0.3.9
+aiohttp-json-rpc==0.8.7
+pyyaml==3.12
 Red-Trivia

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 yarl==0.18.0
 aiohttp>=2.0.0,<2.3.0
-appdirs==1.3.4
+appdirs==1.4.3
 youtube_dl
 raven==6.5.0
 colorama==0.3.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 yarl==0.18.0
 aiohttp>=2.0.0,<2.3.0
-appdirs==2.2.5
+appdirs==1.3.4
 youtube_dl
 raven==6.5.0
 colorama==0.3.9


### PR DESCRIPTION
The ranges on these might be expandable, but I can personally confirm the versions
of packages pinned to work This prevents recurring issues with dependency conflicts
(see #1312 , #1262)

### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature
