### PR TITLE
[V3] add a script for regenerating all strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,17 @@ install:
 script:
   - python -m compileall ./redbot/cogs
   - python -m pytest
+before_deploy:
+  - curl https://artifacts.crowdin.com/repo/GPG-KEY-crowdin | sudo apt-key add -
+  - echo "deb https://artifacts.crowdin.com/repo/deb/ /" | sudo tee -a /etc/apt/sources.list
+  - sudo apt-get update -qq
+  - sudo apt-get install -y crowdin
+deploy:
+  provider: script
+  script: python3 ./generate_strings.py
+  on:
+    branch: V3/develop
+    python: 3.5.3
 cache: pip
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,42 @@
 dist: trusty
 language: python
 python:
-  - "3.5.3"
-  - "3.6.1"
+- 3.5.3
+- 3.6.1
 install:
-  - echo "pytest>3" >> requirements.txt
-  - echo "pytest-asyncio" >> requirements.txt
-  - echo "git+https://github.com/Rapptz/discord.py.git@rewrite#egg=discord.py[voice]" >> requirements.txt
-  - pip install -r requirements.txt
-  - pip install -e .
+- echo "pytest>3" >> requirements.txt
+- echo "pytest-asyncio" >> requirements.txt
+- echo "git+https://github.com/Rapptz/discord.py.git@rewrite#egg=discord.py[voice]"
+  >> requirements.txt
+- pip install -r requirements.txt
+- pip install -e .
 script:
-  - python -m compileall ./redbot/cogs
-  - python -m pytest
+- python -m compileall ./redbot/cogs
+- python -m pytest
 before_deploy:
-  - curl https://artifacts.crowdin.com/repo/GPG-KEY-crowdin | sudo apt-key add -
-  - echo "deb https://artifacts.crowdin.com/repo/deb/ /" | sudo tee -a /etc/apt/sources.list
-  - sudo apt-get update -qq
-  - sudo apt-get install -y crowdin
+- curl https://artifacts.crowdin.com/repo/GPG-KEY-crowdin | sudo apt-key add -
+- echo "deb https://artifacts.crowdin.com/repo/deb/ /" | sudo tee -a /etc/apt/sources.list
+- sudo apt-get update -qq
+- sudo apt-get install -y crowdin
 deploy:
-  skip_cleanup: true
-  provider: script
-  script: python3 ./generate_strings.py
-  on:
-    repo: Cog-Creators/Red-DiscordBot
-    branch: V3/develop
-    python: 3.5.3
-    tag: true
+  - provider: pypi
+    user: Red-DiscordBot
+    password:
+      secure: Ty9vYnd/wCuQkVC/OsS4E2jT9LVDVfzsFrQc4U2hMYcTJnYbl/3omyObdCWCOBC40vUDkVHAQU8ULHzoCA+2KX9Ds/7/P5zCumAA0uJRR9Smw7OlRzSMxJI+/lGq4CwXKzxDZKuo5rsxXEbW5qmYjtO8Mk6KuLkvieb1vyr2DcqWEFzg/7TZNDfD1oP8et8ITQ26lLP1dtQx/jlAiIBzgK9wziuwj1Divb9A///VsGz43N8maZ+jfsDjYqrfUVWTy3ar7JPUplletenYCR1PmQ5C46XfV0kitKd1aITJ48YPAKyYgKy8AIT+Uz1JArTnqdzLSFRNELS57qS00lzgllbteCyWQ8Uzy0Zpxb/5DDH8/mL1n0MyJrF8qjZd2hLNAXg3z/k9bGXeiMLGwoxRlGXkL2XpiVgI93UKKyVyooGNMgPTc/QdSc7krjAWcOtX/HgLR34jxeLPFEdzJNAFIimfDD8N+XTFcNBw6EvOYm/n5MXkckNoX/G+ThNobHZ7VKSASltZ9zBRAJ2dDh35G3CYmVEk33U77RKbL9le/Za9QVBcAO8i6rqVGYkdO7thHHKHc/1CB1jNnjsFSDt0bURtNfAqfwKCurQC8487zbEzT+2fog3Wygv7g3cklaRg4guY8UjZuFWStYGqbroTsOCd9ATNqeO5B13pNhllSzU=
+    skip_cleanup: true
+    on:
+      repo: Cog-Creators/Red-DiscordBot
+      branch: V3/develop
+      python: 3.5.3
+      tags: true
+  - provider: script
+    script: python3 ./generate_strings.py
+    skip_cleanup: true
+    on:
+      repo: Cog-Creators/Red-DiscordBot
+      branch: V3/develop
+      python: 3.5.3
+      tags: true
 cache: pip
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,14 @@ before_deploy:
   - sudo apt-get update -qq
   - sudo apt-get install -y crowdin
 deploy:
+  skip_cleanup: true
   provider: script
   script: python3 ./generate_strings.py
   on:
+    repo: Cog-Creators/Red-DiscordBot
     branch: V3/develop
     python: 3.5.3
+    tag: true
 cache: pip
 notifications:
   email: false

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,6 +1,5 @@
 api_key_env: CROWDIN_API_KEY
 project_identifier_env: CROWDIN_PROJECT_ID
-base_path_env: CROWDIN_BASE_PATH
 files:
   - source: /**/*.pot
     translation: /%original_path%/%locale%.po

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,6 @@
+api_key_env: CROWDIN_API_KEY
+project_identifier_env: CROWDIN_PROJECT_ID
+base_path_env: CROWDIN_BASE_PATH
 files:
   - source: /**/*.pot
-    translation: /%original_path%/%two_letters_code%.po
+    translation: /%original_path%/%locale%.po

--- a/generate_strings.py
+++ b/generate_strings.py
@@ -1,0 +1,31 @@
+import subprocess
+import os
+import sys
+
+
+def main():
+    interpreter = sys.executable
+    print(interpreter)
+    root_dir = os.getcwd()
+    cogs = [i for i in os.listdir("redbot/cogs") if os.path.isdir(os.path.join("redbot/cogs", i))]
+    for d in cogs:
+        if "locales" in os.listdir(os.path.join("redbot/cogs", d)):
+            os.chdir(os.path.join("redbot/cogs", d, "locales"))
+            if "regen_messages.py" not in os.listdir(os.getcwd()):
+                print("Directory 'locales' exists for {} but no 'regen_messages.py' is available!".format(d))
+                exit(1)
+            else:
+                print("Running 'regen_messages.py' for {}".format(d))
+                retval = subprocess.run([interpreter, "regen_messages.py"])
+                if retval.returncode != 0:
+                    exit(1)
+                os.chdir(root_dir)
+    os.chdir("redbot/core/locales")
+    print("Running 'regen_messages.py' for core")
+    retval = subprocess.run([interpreter, "regen_messages.py"])
+    if retval.returncode != 0:
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/generate_strings.py
+++ b/generate_strings.py
@@ -25,6 +25,8 @@ def main():
     retval = subprocess.run([interpreter, "regen_messages.py"])
     if retval.returncode != 0:
         exit(1)
+    os.chdir(root_dir)
+    subprocess.run(["crowdin", "upload"])
 
 
 if __name__ == "__main__":

--- a/redbot/cogs/admin/locales/messages.pot
+++ b/redbot/cogs/admin/locales/messages.pot
@@ -15,11 +15,3 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 
 
-#: ../cleanup.py:150
-msgid "This command can only be used on bots with bot accounts."
-msgstr ""
-
-#: ../cleanup.py:157
-msgid "Message not found."
-msgstr ""
-

--- a/redbot/cogs/admin/locales/regen_messages.py
+++ b/redbot/cogs/admin/locales/regen_messages.py
@@ -1,0 +1,15 @@
+import subprocess
+
+TO_TRANSLATE = [
+    '../admin.py'
+]
+
+
+def regen_messages():
+    subprocess.run(
+        ['pygettext', '-n'] + TO_TRANSLATE
+    )
+
+
+if __name__ == "__main__":
+    regen_messages()

--- a/redbot/cogs/alias/locales/messages.pot
+++ b/redbot/cogs/alias/locales/messages.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-26 17:23+EDT\n"
+"POT-Creation-Date: 2018-02-18 14:42+AKST\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,51 +15,75 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 
 
-#: ../alias.py:138
+#: ../alias.py:129
 msgid "No prefix found."
 msgstr ""
 
-#: ../alias.py:234
+#: ../alias.py:198
+msgid "You attempted to create a new alias with the name {} but that name is already a command on this bot."
+msgstr ""
+
+#: ../alias.py:205
+msgid "You attempted to create a new alias with the name {} but that alias already exists on this server."
+msgstr ""
+
+#: ../alias.py:212
+msgid "You attempted to create a new alias with the name {} but that name is an invalid alias name. Alias names may not contain spaces."
+msgstr ""
+
+#: ../alias.py:224
 msgid "A new alias with the trigger `{}` has been created."
 msgstr ""
 
-#: ../alias.py:270
+#: ../alias.py:236
+msgid "You attempted to create a new global alias with the name {} but that name is already a command on this bot."
+msgstr ""
+
+#: ../alias.py:243
+msgid "You attempted to create a new global alias with the name {} but that alias already exists on this server."
+msgstr ""
+
+#: ../alias.py:250
+msgid "You attempted to create a new global alias with the name {} but that name is an invalid alias name. Alias names may not contain spaces."
+msgstr ""
+
+#: ../alias.py:259
 msgid "A new global alias with the trigger `{}` has been created."
 msgstr ""
 
-#: ../alias.py:285
+#: ../alias.py:274
 msgid "No such alias exists."
 msgstr ""
 
-#: ../alias.py:294
+#: ../alias.py:283
 msgid "The `{}` alias will execute the command `{}`"
 msgstr ""
 
-#: ../alias.py:297
+#: ../alias.py:286
 msgid "There is no alias with the name `{}`"
 msgstr ""
 
-#: ../alias.py:309
+#: ../alias.py:298
 msgid "There are no aliases on this guild."
 msgstr ""
 
-#: ../alias.py:313 ../alias.py:331
+#: ../alias.py:302 ../alias.py:320
 msgid "Alias with the name `{}` was successfully deleted."
 msgstr ""
 
-#: ../alias.py:316 ../alias.py:334
+#: ../alias.py:305 ../alias.py:323
 msgid "Alias with name `{}` was not found."
 msgstr ""
 
-#: ../alias.py:327
+#: ../alias.py:316
 msgid "There are no aliases on this bot."
 msgstr ""
 
-#: ../alias.py:342 ../alias.py:353
+#: ../alias.py:331 ../alias.py:342
 msgid "Aliases:"
 msgstr ""
 
-#: ../alias.py:344 ../alias.py:355
+#: ../alias.py:333 ../alias.py:344
 msgid "There are no aliases on this server."
 msgstr ""
 

--- a/redbot/cogs/alias/locales/regen_messages.py
+++ b/redbot/cogs/alias/locales/regen_messages.py
@@ -1,0 +1,15 @@
+import subprocess
+
+TO_TRANSLATE = [
+    '../alias.py'
+]
+
+
+def regen_messages():
+    subprocess.run(
+        ['pygettext', '-n'] + TO_TRANSLATE
+    )
+
+
+if __name__ == "__main__":
+    regen_messages()

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -4,6 +4,10 @@ import os
 import youtube_dl
 import discord
 
+from redbot.core.i18n import CogI18n
+
+_ = CogI18n("Audio", __file__)
+
 
 # Just a little experimental audio cog not meant for final release
 
@@ -18,7 +22,7 @@ class Audio:
     async def local(self, ctx, *, filename: str):
         """Play mp3"""
         if ctx.author.voice is None:
-            await ctx.send("Join a voice channel first!")
+            await ctx.send(_("Join a voice channel first!"))
             return
 
         if ctx.voice_client:
@@ -26,22 +30,22 @@ class Audio:
                 await ctx.voice_client.disconnect()
         path = os.path.join("cogs", "audio", "songs", filename + ".mp3")
         if not os.path.isfile(path):
-            await ctx.send("Let's play a file that exists pls")
+            await ctx.send(_("Let's play a file that exists pls"))
             return
         player = PCMVolumeTransformer(FFmpegPCMAudio(path), volume=1)
         voice = await ctx.author.voice.channel.connect()
         voice.play(player)
-        await ctx.send("{} is playing a song...".format(ctx.author))
+        await ctx.send(_("{} is playing a song...").format(ctx.author))
 
     @commands.command()
     async def play(self, ctx, url: str):
         """Play youtube url"""
         url = url.strip("<").strip(">")
         if ctx.author.voice is None:
-            await ctx.send("Join a voice channel first!")
+            await ctx.send(_("Join a voice channel first!"))
             return
         elif "youtube.com" not in url.lower():
-            await ctx.send("Youtube links pls")
+            await ctx.send(_("Youtube links pls"))
             return
 
         if ctx.voice_client:
@@ -51,7 +55,7 @@ class Audio:
         player = PCMVolumeTransformer(yt, volume=1)
         voice = await ctx.author.voice.channel.connect()
         voice.play(player)
-        await ctx.send("{} is playing a song...".format(ctx.author))
+        await ctx.send(_("{} is playing a song...").format(ctx.author))
 
     @commands.command()
     async def stop(self, ctx):
@@ -60,7 +64,7 @@ class Audio:
             ctx.voice_client.source.cleanup()
             await ctx.voice_client.disconnect()
         else:
-            await ctx.send("I'm not even connected to a voice channel!", delete_after=2)
+            await ctx.send(_("I'm not even connected to a voice channel!"), delete_after=2)
         await ctx.message.delete()
 
     @commands.command()
@@ -70,7 +74,7 @@ class Audio:
             ctx.voice_client.pause()
             await ctx.send("👌", delete_after=2)
         else:
-            await ctx.send("I'm not even connected to a voice channel!", delete_after=2)
+            await ctx.send(_("I'm not even connected to a voice channel!"), delete_after=2)
         await ctx.message.delete()
 
     @commands.command()
@@ -80,7 +84,7 @@ class Audio:
             ctx.voice_client.resume()
             await ctx.send("👌", delete_after=2)
         else:
-            await ctx.send("I'm not even connected to a voice channel!", delete_after=2)
+            await ctx.send(_("I'm not even connected to a voice channel!"), delete_after=2)
         await ctx.message.delete()
 
     @commands.command(hidden=True)
@@ -88,9 +92,9 @@ class Audio:
         """Sets the volume"""
         if ctx.voice_client:
             ctx.voice_client.source.volume = n
-            await ctx.send("Volume set.", delete_after=2)
+            await ctx.send(_("Volume set."), delete_after=2)
         else:
-            await ctx.send("I'm not even connected to a voice channel!", delete_after=2)
+            await ctx.send(_("I'm not even connected to a voice channel!"), delete_after=2)
         await ctx.message.delete()
 
     def __unload(self):

--- a/redbot/cogs/audio/locales/messages.pot
+++ b/redbot/cogs/audio/locales/messages.pot
@@ -15,11 +15,27 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 
 
-#: ../cleanup.py:150
-msgid "This command can only be used on bots with bot accounts."
+#: ../audio.py:25 ../audio.py:45
+msgid "Join a voice channel first!"
 msgstr ""
 
-#: ../cleanup.py:157
-msgid "Message not found."
+#: ../audio.py:33
+msgid "Let's play a file that exists pls"
+msgstr ""
+
+#: ../audio.py:38 ../audio.py:58
+msgid "{} is playing a song..."
+msgstr ""
+
+#: ../audio.py:48
+msgid "Youtube links pls"
+msgstr ""
+
+#: ../audio.py:67 ../audio.py:77 ../audio.py:87 ../audio.py:97
+msgid "I'm not even connected to a voice channel!"
+msgstr ""
+
+#: ../audio.py:95
+msgid "Volume set."
 msgstr ""
 

--- a/redbot/cogs/audio/locales/regen_messages.py
+++ b/redbot/cogs/audio/locales/regen_messages.py
@@ -1,0 +1,15 @@
+import subprocess
+
+TO_TRANSLATE = [
+    '../audio.py'
+]
+
+
+def regen_messages():
+    subprocess.run(
+        ['pygettext', '-n'] + TO_TRANSLATE
+    )
+
+
+if __name__ == "__main__":
+    regen_messages()

--- a/redbot/cogs/bank/locales/messages.pot
+++ b/redbot/cogs/bank/locales/messages.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-26 17:32+EDT\n"
+"POT-Creation-Date: 2018-02-18 14:42+AKST\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/redbot/cogs/bank/locales/regen_messages.py
+++ b/redbot/cogs/bank/locales/regen_messages.py
@@ -1,0 +1,15 @@
+import subprocess
+
+TO_TRANSLATE = [
+    '../bank.py'
+]
+
+
+def regen_messages():
+    subprocess.run(
+        ['pygettext', '-n'] + TO_TRANSLATE
+    )
+
+
+if __name__ == "__main__":
+    regen_messages()

--- a/redbot/cogs/cleanup/locales/regen_messages.py
+++ b/redbot/cogs/cleanup/locales/regen_messages.py
@@ -1,0 +1,15 @@
+import subprocess
+
+TO_TRANSLATE = [
+    '../cleanup.py'
+]
+
+
+def regen_messages():
+    subprocess.run(
+        ['pygettext', '-n'] + TO_TRANSLATE
+    )
+
+
+if __name__ == "__main__":
+    regen_messages()

--- a/redbot/cogs/customcom/locales/messages.pot
+++ b/redbot/cogs/customcom/locales/messages.pot
@@ -5,63 +5,63 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-27 19:40-0800\n"
+"POT-Creation-Date: 2018-02-18 14:42+AKST\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: ENCODING\n"
 "Generated-By: pygettext.py 1.5\n"
 
 
-#: customcom.py:44
+#: ../customcom.py:44
 msgid ""
 "Welcome to the interactive random {} maker!\n"
 "Every message you send will be added as one of the random response to choose from once this {} is triggered. To exit this interactive menu, type `{}`"
 msgstr ""
 
-#: customcom.py:56
+#: ../customcom.py:56
 msgid "Add a random response:"
 msgstr ""
 
-#: customcom.py:119
+#: ../customcom.py:119
 msgid "Do you want to create a 'randomized' cc? {}"
 msgstr ""
 
-#: customcom.py:126
+#: ../customcom.py:126
 msgid "What response do you want?"
 msgstr ""
 
-#: customcom.py:205 customcom.py:235
+#: ../customcom.py:205 ../customcom.py:235
 msgid "Custom command successfully added."
 msgstr ""
 
-#: customcom.py:207 customcom.py:237
+#: ../customcom.py:207 ../customcom.py:237
 msgid "This command already exists. Use `{}` to edit it."
 msgstr ""
 
-#: customcom.py:229
+#: ../customcom.py:229
 msgid "That command is already a standard command."
 msgstr ""
 
-#: customcom.py:261
+#: ../customcom.py:261
 msgid "Custom command successfully edited."
 msgstr ""
 
-#: customcom.py:263
+#: ../customcom.py:263
 msgid "That command doesn't exist. Use `{}` to add it."
 msgstr ""
 
-#: customcom.py:282
+#: ../customcom.py:282
 msgid "Custom command successfully deleted."
 msgstr ""
 
-#: customcom.py:284
+#: ../customcom.py:284
 msgid "That command doesn't exist."
 msgstr ""
 
-#: customcom.py:294
+#: ../customcom.py:294
 msgid "There are no custom commands in this guild. Use `{}` to start adding some."
 msgstr ""
 

--- a/redbot/cogs/customcom/locales/regen_messages.py
+++ b/redbot/cogs/customcom/locales/regen_messages.py
@@ -1,0 +1,15 @@
+import subprocess
+
+TO_TRANSLATE = [
+    '../customcom.py'
+]
+
+
+def regen_messages():
+    subprocess.run(
+        ['pygettext', '-n'] + TO_TRANSLATE
+    )
+
+
+if __name__ == "__main__":
+    regen_messages()

--- a/redbot/cogs/downloader/locales/messages.pot
+++ b/redbot/cogs/downloader/locales/messages.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-26 16:24+EDT\n"
+"POT-Creation-Date: 2018-02-18 14:42+AKST\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,71 +15,71 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 
 
-#: ../downloader.py:202
+#: ../downloader.py:215
 msgid "That git repo has already been added under another name."
 msgstr ""
 
-#: ../downloader.py:204 ../downloader.py:205
+#: ../downloader.py:217 ../downloader.py:218
 msgid "Something went wrong during the cloning process."
 msgstr ""
 
-#: ../downloader.py:207
+#: ../downloader.py:220
 msgid "Repo `{}` successfully added."
 msgstr ""
 
-#: ../downloader.py:216
+#: ../downloader.py:229
 msgid "The repo `{}` has been deleted successfully."
 msgstr ""
 
-#: ../downloader.py:224
+#: ../downloader.py:237
 msgid ""
 "Installed Repos:\n"
 msgstr ""
 
-#: ../downloader.py:244
+#: ../downloader.py:258
 msgid "Error, there is no cog by the name of `{}` in the `{}` repo."
 msgstr ""
 
-#: ../downloader.py:249
+#: ../downloader.py:263
 msgid "Failed to install the required libraries for `{}`: `{}`"
 msgstr ""
 
-#: ../downloader.py:259
+#: ../downloader.py:273
 msgid "`{}` cog successfully installed."
 msgstr ""
 
-#: ../downloader.py:275
+#: ../downloader.py:289
 msgid "`{}` was successfully removed."
 msgstr ""
 
-#: ../downloader.py:277
+#: ../downloader.py:291
 msgid "That cog was installed but can no longer be located. You may need to remove it's files manually if it is still usable."
 msgstr ""
 
-#: ../downloader.py:301
+#: ../downloader.py:315
 msgid "Cog update completed successfully."
 msgstr ""
 
-#: ../downloader.py:309
+#: ../downloader.py:323
 msgid ""
 "Available Cogs:\n"
 msgstr ""
 
-#: ../downloader.py:321
+#: ../downloader.py:335
 msgid "There is no cog `{}` in the repo `{}`"
 msgstr ""
 
-#: ../downloader.py:326
+#: ../downloader.py:340
 msgid ""
 "Information on {}:\n"
 "{}"
 msgstr ""
 
-#: ../downloader.py:350
+#: ../downloader.py:381
 msgid "Missing from info.json"
 msgstr ""
 
-#: ../downloader.py:359
+#: ../downloader.py:390
 msgid ""
 "Command: {}\n"
 "Made by: {}\n"
@@ -87,7 +87,7 @@ msgid ""
 "Cog name: {}"
 msgstr ""
 
-#: ../downloader.py:383
+#: ../downloader.py:422
 msgid "That command doesn't seem to exist."
 msgstr ""
 

--- a/redbot/cogs/downloader/locales/regen_messages.py
+++ b/redbot/cogs/downloader/locales/regen_messages.py
@@ -1,0 +1,15 @@
+import subprocess
+
+TO_TRANSLATE = [
+    '../downloader.py'
+]
+
+
+def regen_messages():
+    subprocess.run(
+        ['pygettext', '-n'] + TO_TRANSLATE
+    )
+
+
+if __name__ == "__main__":
+    regen_messages()

--- a/redbot/cogs/economy/locales/messages.pot
+++ b/redbot/cogs/economy/locales/messages.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-26 17:40+EDT\n"
+"POT-Creation-Date: 2018-02-18 14:42+AKST\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,35 +15,35 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 
 
-#: ../economy.py:38
+#: ../economy.py:40
 msgid "JACKPOT! 226! Your bid has been multiplied * 2500!"
 msgstr ""
 
-#: ../economy.py:42
+#: ../economy.py:44
 msgid "4LC! +1000!"
 msgstr ""
 
-#: ../economy.py:46
+#: ../economy.py:48
 msgid "Three cherries! +800!"
 msgstr ""
 
-#: ../economy.py:50
+#: ../economy.py:52
 msgid "2 6! Your bid has been multiplied * 4!"
 msgstr ""
 
-#: ../economy.py:54
+#: ../economy.py:56
 msgid "Two cherries! Your bid has been multiplied * 3!"
 msgstr ""
 
-#: ../economy.py:58
+#: ../economy.py:60
 msgid "Three symbols! +500!"
 msgstr ""
 
-#: ../economy.py:62
+#: ../economy.py:64
 msgid "Two consecutive symbols! Your bid has been multiplied * 2!"
 msgstr ""
 
-#: ../economy.py:66
+#: ../economy.py:68
 msgid ""
 "Slot machine payouts:\n"
 "{two.value} {two.value} {six.value} Bet * 2500\n"
@@ -56,61 +56,61 @@ msgid ""
 "Two symbols: Bet * 2"
 msgstr ""
 
-#: ../economy.py:155
+#: ../economy.py:157
 msgid "{}'s balance is {} {}"
 msgstr ""
 
-#: ../economy.py:169
+#: ../economy.py:171
 msgid "{} transferred {} {} to {}"
 msgstr ""
 
-#: ../economy.py:189
+#: ../economy.py:191
 msgid "{} added {} {} to {}'s account."
 msgstr ""
 
-#: ../economy.py:194
+#: ../economy.py:196
 msgid "{} removed {} {} from {}'s account."
 msgstr ""
 
-#: ../economy.py:199
+#: ../economy.py:201
 msgid "{} set {}'s account to {} {}."
 msgstr ""
 
-#: ../economy.py:210
+#: ../economy.py:212
 msgid ""
 "This will delete all bank accounts for {}.\n"
-"If you're sure, type {}bank reset yes"
+"If you're sure, type `{}bank reset yes`"
 msgstr ""
 
-#: ../economy.py:227
+#: ../economy.py:229
 msgid "All bank accounts of this guild have been deleted."
 msgstr ""
 
-#: ../economy.py:246 ../economy.py:266
+#: ../economy.py:248 ../economy.py:268
 msgid "{} Here, take some {}. Enjoy! (+{} {}!)"
 msgstr ""
 
-#: ../economy.py:256 ../economy.py:274
+#: ../economy.py:258 ../economy.py:276
 msgid "{} Too soon. For your next payday you have to wait {}."
 msgstr ""
 
-#: ../economy.py:311
+#: ../economy.py:313
 msgid "There are no accounts in the bank."
 msgstr ""
 
-#: ../economy.py:337
+#: ../economy.py:339
 msgid "You're on cooldown, try again in a bit."
 msgstr ""
 
-#: ../economy.py:340
+#: ../economy.py:342
 msgid "That's an invalid bid amount, sorry :/"
 msgstr ""
 
-#: ../economy.py:343
+#: ../economy.py:345
 msgid "You ain't got enough money, friend."
 msgstr ""
 
-#: ../economy.py:389
+#: ../economy.py:391
 msgid ""
 "{}\n"
 "{} {}\n"
@@ -119,7 +119,7 @@ msgid ""
 "{} → {}!"
 msgstr ""
 
-#: ../economy.py:396
+#: ../economy.py:398
 msgid ""
 "{}\n"
 "{} Nothing!\n"
@@ -127,7 +127,7 @@ msgid ""
 "{} → {}!"
 msgstr ""
 
-#: ../economy.py:421
+#: ../economy.py:423
 msgid ""
 "Minimum slot bid: {}\n"
 "Maximum slot bid: {}\n"
@@ -137,63 +137,63 @@ msgid ""
 "Amount given at account registration: {}"
 msgstr ""
 
-#: ../economy.py:431
+#: ../economy.py:433
 msgid "Current Economy settings:"
 msgstr ""
 
-#: ../economy.py:439
+#: ../economy.py:441
 msgid "Invalid min bid amount."
 msgstr ""
 
-#: ../economy.py:447
+#: ../economy.py:449
 msgid "Minimum bid is now {} {}."
 msgstr ""
 
-#: ../economy.py:454
+#: ../economy.py:456
 msgid "Invalid slotmax bid amount. Must be greater than slotmin."
 msgstr ""
 
-#: ../economy.py:463
+#: ../economy.py:465
 msgid "Maximum bid is now {} {}."
 msgstr ""
 
-#: ../economy.py:473
+#: ../economy.py:475
 msgid "Cooldown is now {} seconds."
 msgstr ""
 
-#: ../economy.py:483
+#: ../economy.py:485
 msgid "Value modified. At least {} seconds must pass between each payday."
 msgstr ""
 
-#: ../economy.py:492
+#: ../economy.py:494
 msgid "Har har so funny."
 msgstr ""
 
-#: ../economy.py:498
+#: ../economy.py:500
 msgid "Every payday will now give {} {}."
 msgstr ""
 
-#: ../economy.py:509
+#: ../economy.py:511
 msgid "Registering an account will now give {} {}."
 msgstr ""
 
-#: ../economy.py:515
+#: ../economy.py:517
 msgid "weeks"
 msgstr ""
 
-#: ../economy.py:516
+#: ../economy.py:518
 msgid "days"
 msgstr ""
 
-#: ../economy.py:517
+#: ../economy.py:519
 msgid "hours"
 msgstr ""
 
-#: ../economy.py:518
+#: ../economy.py:520
 msgid "minutes"
 msgstr ""
 
-#: ../economy.py:519
+#: ../economy.py:521
 msgid "seconds"
 msgstr ""
 

--- a/redbot/cogs/economy/locales/regen_messages.py
+++ b/redbot/cogs/economy/locales/regen_messages.py
@@ -1,0 +1,15 @@
+import subprocess
+
+TO_TRANSLATE = [
+    '../economy.py'
+]
+
+
+def regen_messages():
+    subprocess.run(
+        ['pygettext', '-n'] + TO_TRANSLATE
+    )
+
+
+if __name__ == "__main__":
+    regen_messages()

--- a/redbot/cogs/filter/locales/messages.pot
+++ b/redbot/cogs/filter/locales/messages.pot
@@ -5,61 +5,61 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-11-28 13:25-0900\n"
+"POT-Creation-Date: 2018-02-18 14:42+AKST\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: ENCODING\n"
 "Generated-By: pygettext.py 1.5\n"
 
 
-#: filter.py:62
+#: ../filter.py:62
 msgid "Filtered in this server:"
 msgstr ""
 
-#: filter.py:67
+#: ../filter.py:67
 msgid "I can't send direct messages to you."
 msgstr ""
 
-#: filter.py:96
+#: ../filter.py:96
 msgid "Words added to filter."
 msgstr ""
 
-#: filter.py:98
+#: ../filter.py:98
 msgid "Words already in the filter."
 msgstr ""
 
-#: filter.py:127
+#: ../filter.py:127
 msgid "Words removed from filter."
 msgstr ""
 
-#: filter.py:129
+#: ../filter.py:129
 msgid "Those words weren't in the filter."
 msgstr ""
 
-#: filter.py:142
+#: ../filter.py:142
 msgid "Names and nicknames will no longer be checked against the filter"
 msgstr ""
 
-#: filter.py:147
+#: ../filter.py:147
 msgid "Names and nicknames will now be checked against the filter"
 msgstr ""
 
-#: filter.py:160
+#: ../filter.py:160
 msgid "The name to use on filtered names has been set"
 msgstr ""
 
-#: filter.py:171
+#: ../filter.py:171
 msgid "Count and timeframe either both need to be 0 or both need to be greater than 0!"
 msgstr ""
 
-#: filter.py:179
+#: ../filter.py:179
 msgid "Autoban disabled."
 msgstr ""
 
-#: filter.py:183
+#: ../filter.py:183
 msgid "Count and time have been set."
 msgstr ""
 

--- a/redbot/cogs/filter/locales/regen_messages.py
+++ b/redbot/cogs/filter/locales/regen_messages.py
@@ -1,0 +1,15 @@
+import subprocess
+
+TO_TRANSLATE = [
+    '../filter.py'
+]
+
+
+def regen_messages():
+    subprocess.run(
+        ['pygettext', '-n'] + TO_TRANSLATE
+    )
+
+
+if __name__ == "__main__":
+    regen_messages()

--- a/redbot/cogs/general/locales/messages.pot
+++ b/redbot/cogs/general/locales/messages.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-26 17:50+EDT\n"
+"POT-Creation-Date: 2018-02-18 14:42+AKST\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,219 +15,227 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 
 
-#: ../general.py:40
+#: ../general.py:42
 msgid "As I see it, yes"
 msgstr ""
 
-#: ../general.py:40
+#: ../general.py:42
 msgid "It is certain"
 msgstr ""
 
-#: ../general.py:40
+#: ../general.py:42
 msgid "It is decidedly so"
 msgstr ""
 
-#: ../general.py:41
+#: ../general.py:43
 msgid "Most likely"
 msgstr ""
 
-#: ../general.py:41
+#: ../general.py:43
 msgid "Outlook good"
 msgstr ""
 
-#: ../general.py:41
+#: ../general.py:43
 msgid "Signs point to yes"
 msgstr ""
 
-#: ../general.py:42
+#: ../general.py:44
 msgid "Without a doubt"
 msgstr ""
 
-#: ../general.py:42
+#: ../general.py:44
 msgid "Yes"
 msgstr ""
 
-#: ../general.py:42
+#: ../general.py:44
 msgid "Yes – definitely"
 msgstr ""
 
-#: ../general.py:42
+#: ../general.py:44
 msgid "You may rely on it"
 msgstr ""
 
-#: ../general.py:43
+#: ../general.py:45
 msgid "Ask again later"
 msgstr ""
 
-#: ../general.py:43
+#: ../general.py:45
 msgid "Reply hazy, try again"
 msgstr ""
 
-#: ../general.py:44
+#: ../general.py:46
 msgid "Better not tell you now"
 msgstr ""
 
-#: ../general.py:44
+#: ../general.py:46
 msgid "Cannot predict now"
 msgstr ""
 
-#: ../general.py:45
+#: ../general.py:47
 msgid "Concentrate and ask again"
 msgstr ""
 
-#: ../general.py:45
+#: ../general.py:47
 msgid "Don't count on it"
 msgstr ""
 
-#: ../general.py:45
+#: ../general.py:47
 msgid "My reply is no"
 msgstr ""
 
-#: ../general.py:46
+#: ../general.py:48
 msgid "My sources say no"
 msgstr ""
 
-#: ../general.py:46
+#: ../general.py:48
 msgid "Outlook not so good"
 msgstr ""
 
-#: ../general.py:46
+#: ../general.py:48
 msgid "Very doubtful"
 msgstr ""
 
-#: ../general.py:62
+#: ../general.py:64
 msgid "Not enough choices to pick from."
 msgstr ""
 
-#: ../general.py:76
+#: ../general.py:78
 msgid "{} :game_die: {} :game_die:"
 msgstr ""
 
-#: ../general.py:79
+#: ../general.py:81
 msgid "{} Maybe higher than 1? ;P"
 msgstr ""
 
-#: ../general.py:91
+#: ../general.py:93
 msgid ""
 "Nice try. You think this is funny?How about *this* instead:\n"
 "\n"
 msgstr ""
 
-#: ../general.py:104
+#: ../general.py:106
 msgid "*flips a coin and... "
 msgstr ""
 
-#: ../general.py:104
+#: ../general.py:106
 msgid "HEADS!*"
 msgstr ""
 
-#: ../general.py:104
+#: ../general.py:106
 msgid "TAILS!*"
 msgstr ""
 
-#: ../general.py:128
+#: ../general.py:130
 msgid "{} You win {}!"
 msgstr ""
 
-#: ../general.py:132
+#: ../general.py:134
 msgid "{} You lose {}!"
 msgstr ""
 
-#: ../general.py:136
+#: ../general.py:138
 msgid "{} We're square {}!"
 msgstr ""
 
-#: ../general.py:149
+#: ../general.py:151
 msgid "That doesn't look like a question."
 msgstr ""
 
-#: ../general.py:157
+#: ../general.py:159
 msgid " Stopwatch started!"
 msgstr ""
 
-#: ../general.py:161
+#: ../general.py:163
 msgid " Stopwatch stopped! Time: **"
 msgstr ""
 
-#: ../general.py:214 ../general.py:215
+#: ../general.py:216 ../general.py:217
 msgid ""
 "{}\n"
 "({} days ago)"
 msgstr ""
 
-#: ../general.py:217
+#: ../general.py:219
 msgid "Chilling in {} status"
 msgstr ""
 
-#: ../general.py:220
-msgid "Streaming: [{}]({})"
-msgstr ""
-
-#: ../general.py:222
+#: ../general.py:223
 msgid "Playing {}"
 msgstr ""
 
+#: ../general.py:225
+msgid "Streaming [{}]({})"
+msgstr ""
+
 #: ../general.py:227
+msgid "Listening to {}"
+msgstr ""
+
+#: ../general.py:229
+msgid "Watching {}"
+msgstr ""
+
+#: ../general.py:234
 msgid "None"
 msgstr ""
 
-#: ../general.py:230
+#: ../general.py:237
 msgid "Joined Discord on"
 msgstr ""
 
-#: ../general.py:231
+#: ../general.py:238
 msgid "Joined this guild on"
 msgstr ""
 
-#: ../general.py:232 ../general.py:277
+#: ../general.py:239 ../general.py:286
 msgid "Roles"
 msgstr ""
 
-#: ../general.py:233
+#: ../general.py:240
 msgid "Member #{} | User ID: {}"
 msgstr ""
 
-#: ../general.py:248 ../general.py:290
+#: ../general.py:257 ../general.py:299
 msgid "I need the `Embed links` permission to send this."
 msgstr ""
 
-#: ../general.py:263
+#: ../general.py:272
 msgid "Since {}. That's over {} days ago!"
 msgstr ""
 
-#: ../general.py:273
+#: ../general.py:282
 msgid "Region"
 msgstr ""
 
-#: ../general.py:274
+#: ../general.py:283
 msgid "Users"
 msgstr ""
 
-#: ../general.py:275
+#: ../general.py:284
 msgid "Text Channels"
 msgstr ""
 
-#: ../general.py:276
+#: ../general.py:285
 msgid "Voice Channels"
 msgstr ""
 
-#: ../general.py:278
+#: ../general.py:287
 msgid "Owner"
 msgstr ""
 
-#: ../general.py:279
+#: ../general.py:288
 msgid "Guild ID: "
 msgstr ""
 
-#: ../general.py:334
+#: ../general.py:343
 msgid "Your search terms gave no results."
 msgstr ""
 
-#: ../general.py:336
+#: ../general.py:345
 msgid "There is no definition #{}"
 msgstr ""
 
-#: ../general.py:338
+#: ../general.py:347
 msgid "Error."
 msgstr ""
 

--- a/redbot/cogs/general/locales/regen_messages.py
+++ b/redbot/cogs/general/locales/regen_messages.py
@@ -1,0 +1,15 @@
+import subprocess
+
+TO_TRANSLATE = [
+    '../general.py'
+]
+
+
+def regen_messages():
+    subprocess.run(
+        ['pygettext', '-n'] + TO_TRANSLATE
+    )
+
+
+if __name__ == "__main__":
+    regen_messages()

--- a/redbot/cogs/image/locales/messages.pot
+++ b/redbot/cogs/image/locales/messages.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-26 17:57+EDT\n"
+"POT-Creation-Date: 2018-02-18 14:42+AKST\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,32 +15,32 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 
 
-#: ../image.py:48
+#: ../image.py:49
 msgid "Your search returned no results"
 msgstr ""
 
-#: ../image.py:51
+#: ../image.py:52
 msgid ""
 "Search results...\n"
 msgstr ""
 
-#: ../image.py:57 ../image.py:99
+#: ../image.py:58 ../image.py:100
 msgid "Something went wrong. Error code is {}"
 msgstr ""
 
-#: ../image.py:69
+#: ../image.py:70
 msgid "Only 'new' and 'top' are a valid sort type."
 msgstr ""
 
-#: ../image.py:97 ../image.py:134 ../image.py:156
+#: ../image.py:98 ../image.py:135 ../image.py:157
 msgid "No results found."
 msgstr ""
 
-#: ../image.py:114
+#: ../image.py:115
 msgid "Set the imgur client id!"
 msgstr ""
 
-#: ../image.py:136 ../image.py:158
+#: ../image.py:137 ../image.py:159
 msgid "Error contacting the API"
 msgstr ""
 

--- a/redbot/cogs/image/locales/regen_messages.py
+++ b/redbot/cogs/image/locales/regen_messages.py
@@ -1,0 +1,15 @@
+import subprocess
+
+TO_TRANSLATE = [
+    '../image.py'
+]
+
+
+def regen_messages():
+    subprocess.run(
+        ['pygettext', '-n'] + TO_TRANSLATE
+    )
+
+
+if __name__ == "__main__":
+    regen_messages()

--- a/redbot/cogs/mod/locales/messages.pot
+++ b/redbot/cogs/mod/locales/messages.pot
@@ -5,266 +5,282 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-11-28 13:26-0900\n"
+"POT-Creation-Date: 2018-02-18 14:42+AKST\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: ENCODING\n"
 "Generated-By: pygettext.py 1.5\n"
 
 
-#: mod.py:209
+#: ../mod.py:209
 msgid "Role hierarchy will be checked when moderation commands are issued."
 msgstr ""
 
-#: mod.py:213
+#: ../mod.py:213
 msgid "Role hierarchy will be ignored when moderation commands are issued."
 msgstr ""
 
-#: mod.py:228
+#: ../mod.py:228
 msgid "Autoban for mention spam enabled. Anyone mentioning {} or more different people in a single message will be autobanned."
 msgstr ""
 
-#: mod.py:239
+#: ../mod.py:239
 msgid "Autoban for mention spam disabled."
 msgstr ""
 
-#: mod.py:249
+#: ../mod.py:249
 msgid "Messages repeated up to 3 times will be deleted."
 msgstr ""
 
-#: mod.py:253
+#: ../mod.py:253
 msgid "Repeated messages will be ignored."
 msgstr ""
 
-#: mod.py:267
+#: ../mod.py:267
 msgid "Command deleting disabled."
 msgstr ""
 
-#: mod.py:270
+#: ../mod.py:270
 msgid "Delete delay set to {} seconds."
 msgstr ""
 
-#: mod.py:275
+#: ../mod.py:275
 msgid "Bot will delete command messages after {} seconds. Set this value to -1 to stop deleting messages"
 msgstr ""
 
-#: mod.py:279
+#: ../mod.py:279
 msgid "I will not delete command messages."
 msgstr ""
 
-#: mod.py:292
+#: ../mod.py:292
 msgid "Users unbanned with {} will be reinvited."
 msgstr ""
 
-#: mod.py:295
+#: ../mod.py:295
 msgid "Users unbanned with {} will not be reinvited."
 msgstr ""
 
-#: mod.py:309 mod.py:349 mod.py:505
+#: ../mod.py:309 ../mod.py:349 ../mod.py:506
 msgid "I cannot let you do that. Self-harm is bad {}"
 msgstr ""
 
-#: mod.py:313 mod.py:353 mod.py:509
+#: ../mod.py:313 ../mod.py:353 ../mod.py:510
 msgid "I cannot let you do that. You are not higher than the user in the role hierarchy."
 msgstr ""
 
-#: mod.py:323 mod.py:379 mod.py:569
+#: ../mod.py:323 ../mod.py:379 ../mod.py:570
 msgid "I'm not allowed to do that."
 msgstr ""
 
-#: mod.py:327
+#: ../mod.py:327
 msgid "Done. That felt good."
 msgstr ""
 
-#: mod.py:369
+#: ../mod.py:369
 msgid "Invalid days. Must be between 0 and 7."
 msgstr ""
 
-#: mod.py:384
+#: ../mod.py:384
 msgid "Done. It was about time."
 msgstr ""
 
-#: mod.py:413
+#: ../mod.py:413
 msgid "User is already banned."
 msgstr ""
 
-#: mod.py:429
+#: ../mod.py:429
 msgid "User not found. Have you provided the correct user ID?"
 msgstr ""
 
-#: mod.py:433
+#: ../mod.py:433
 msgid "I lack the permissions to do this."
 msgstr ""
 
-#: mod.py:435
+#: ../mod.py:435
 msgid "Done. The user will not be able to join this guild."
 msgstr ""
 
-#: mod.py:471 mod.py:524
+#: ../mod.py:472
+msgid "You have been temporarily banned from {} until {}. Here is an invite for when your ban expires: {}"
+msgstr ""
+
+#: ../mod.py:481
+msgid "I can't do that for some reason."
+msgstr ""
+
+#: ../mod.py:483
+msgid "Something went wrong while banning"
+msgstr ""
+
+#: ../mod.py:485
+msgid "Done. Enough chaos for now"
+msgstr ""
+
+#: ../mod.py:525
 msgid ""
 "You have been banned and then unbanned as a quick way to delete your messages.\n"
 "You can now join the guild again. {}"
 msgstr ""
 
-#: mod.py:536
+#: ../mod.py:537
 msgid "My role is not high enough to softban that user."
 msgstr ""
 
-#: mod.py:552
+#: ../mod.py:553
 msgid "Done. Enough chaos."
 msgstr ""
 
-#: mod.py:586
+#: ../mod.py:587
 msgid "Couldn't find a user with that ID!"
 msgstr ""
 
-#: mod.py:592
+#: ../mod.py:593
 msgid "It seems that user isn't banned!"
 msgstr ""
 
-#: mod.py:600
+#: ../mod.py:601
 msgid "Something went wrong while attempting to unban that user"
 msgstr ""
 
-#: mod.py:603
+#: ../mod.py:604
 msgid "Unbanned that user from this guild"
 msgstr ""
 
-#: mod.py:618
+#: ../mod.py:619
 msgid ""
 "You've been unbanned from {}.\n"
 "Here is an invite for that guild: {}"
 msgstr ""
 
-#: mod.py:622
+#: ../mod.py:623
 msgid ""
 "I failed to send an invite to that user. Perhaps you may be able to send it for me?\n"
 "Here's the invite link: {}"
 msgstr ""
 
-#: mod.py:628
+#: ../mod.py:629
 msgid "Something went wrong when attempting to send that useran invite. Here's the link so you can try: {}"
 msgstr ""
 
-#: mod.py:672 mod.py:709
+#: ../mod.py:673 ../mod.py:710
 msgid "No voice state for that user!"
 msgstr ""
 
-#: mod.py:686
+#: ../mod.py:687
 msgid "That user is already muted and deafened guild-wide!"
 msgstr ""
 
-#: mod.py:689
+#: ../mod.py:690
 msgid "User has been banned from speaking or listening in voice channels"
 msgstr ""
 
-#: mod.py:721
+#: ../mod.py:722
 msgid "That user isn't muted or deafened by the guild!"
 msgstr ""
 
-#: mod.py:724
+#: ../mod.py:725
 msgid "User is now allowed to speak and listen in voice channels"
 msgstr ""
 
-#: mod.py:753
+#: ../mod.py:754
 msgid "I cannot do that, I lack the '{}' permission."
 msgstr ""
 
-#: mod.py:782
+#: ../mod.py:783
 msgid "Muted {}#{} in channel {}"
 msgstr ""
 
-#: mod.py:796
+#: ../mod.py:797
 msgid "That user is already muted in {}!"
 msgstr ""
 
-#: mod.py:799 mod.py:931
+#: ../mod.py:800 ../mod.py:932
 msgid "That user is not in a voice channel right now!"
 msgstr ""
 
-#: mod.py:801 mod.py:933
+#: ../mod.py:802 ../mod.py:934
 msgid "No voice state for the target!"
 msgstr ""
 
-#: mod.py:821
+#: ../mod.py:822
 msgid "User has been muted in this channel."
 msgstr ""
 
-#: mod.py:857
+#: ../mod.py:858
 msgid "User has been muted in this guild."
 msgstr ""
 
-#: mod.py:918
+#: ../mod.py:919
 msgid "Unmuted {}#{} in channel {}"
 msgstr ""
 
-#: mod.py:928
+#: ../mod.py:929
 msgid "That user is already unmuted in {}!"
 msgstr ""
 
-#: mod.py:948
+#: ../mod.py:949
 msgid "User unmuted in this channel."
 msgstr ""
 
-#: mod.py:957
+#: ../mod.py:958
 msgid "Unmute failed. Reason: {}"
 msgstr ""
 
-#: mod.py:980
+#: ../mod.py:981
 msgid "User has been unmuted in this guild."
 msgstr ""
 
-#: mod.py:1044
+#: ../mod.py:1045
 msgid "Channel added to ignore list."
 msgstr ""
 
-#: mod.py:1046
+#: ../mod.py:1047
 msgid "Channel already in ignore list."
 msgstr ""
 
-#: mod.py:1055
+#: ../mod.py:1055
 msgid "This guild has been added to the ignore list."
 msgstr ""
 
-#: mod.py:1057
+#: ../mod.py:1057
 msgid "This guild is already being ignored."
 msgstr ""
 
-#: mod.py:1078
+#: ../mod.py:1078
 msgid "Channel removed from ignore list."
 msgstr ""
 
-#: mod.py:1080
+#: ../mod.py:1080
 msgid "That channel is not in the ignore list."
 msgstr ""
 
-#: mod.py:1089
+#: ../mod.py:1088
 msgid "This guild has been removed from the ignore list."
 msgstr ""
 
-#: mod.py:1091
+#: ../mod.py:1090
 msgid "This guild is not in the ignore list."
 msgstr ""
 
-#: mod.py:1103
+#: ../mod.py:1102
 msgid ""
 "Currently ignoring:\n"
 "{} channels\n"
 "{} guilds\n"
 msgstr ""
 
-#: mod.py:1131
+#: ../mod.py:1133
 msgid "**Past 20 names**:"
 msgstr ""
 
-#: mod.py:1138
+#: ../mod.py:1140
 msgid "**Past 20 nicknames**:"
 msgstr ""
 
-#: mod.py:1144
+#: ../mod.py:1146
 msgid "That user doesn't have any recorded name or nickname change."
 msgstr ""
 

--- a/redbot/cogs/mod/locales/regen_messages.py
+++ b/redbot/cogs/mod/locales/regen_messages.py
@@ -1,0 +1,15 @@
+import subprocess
+
+TO_TRANSLATE = [
+    '../mod.py'
+]
+
+
+def regen_messages():
+    subprocess.run(
+        ['pygettext', '-n'] + TO_TRANSLATE
+    )
+
+
+if __name__ == "__main__":
+    regen_messages()

--- a/redbot/cogs/modlog/locales/messages.pot
+++ b/redbot/cogs/modlog/locales/messages.pot
@@ -5,13 +5,57 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-22 16:34-0800\n"
+"POT-Creation-Date: 2018-02-18 14:42+AKST\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=cp1252\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: ENCODING\n"
 "Generated-By: pygettext.py 1.5\n"
 
+
+#: ../modlog.py:36
+msgid "Mod events will be sent to {}"
+msgstr ""
+
+#: ../modlog.py:42
+msgid "I do not have permissions to send messages in {}!"
+msgstr ""
+
+#: ../modlog.py:52
+msgid "Mod log deactivated."
+msgstr ""
+
+#: ../modlog.py:63
+msgid "Current settings:"
+msgstr ""
+
+#: ../modlog.py:75
+msgid "That action is not registered"
+msgstr ""
+
+#: ../modlog.py:82
+msgid "Case creation for {} actions is now {}."
+msgstr ""
+
+#: ../modlog.py:94
+msgid "Cases have been reset."
+msgstr ""
+
+#: ../modlog.py:103
+msgid "That case does not exist for that guild"
+msgstr ""
+
+#: ../modlog.py:122
+msgid "That case does not exist!"
+msgstr ""
+
+#: ../modlog.py:146
+msgid "You are not authorized to modify that case!"
+msgstr ""
+
+#: ../modlog.py:155
+msgid "Reason has been updated."
+msgstr ""
 

--- a/redbot/cogs/modlog/locales/regen_messages.py
+++ b/redbot/cogs/modlog/locales/regen_messages.py
@@ -1,0 +1,15 @@
+import subprocess
+
+TO_TRANSLATE = [
+    '../modlog.py'
+]
+
+
+def regen_messages():
+    subprocess.run(
+        ['pygettext', '-n'] + TO_TRANSLATE
+    )
+
+
+if __name__ == "__main__":
+    regen_messages()

--- a/redbot/cogs/streams/locales/messages.pot
+++ b/redbot/cogs/streams/locales/messages.pot
@@ -15,11 +15,3 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 
 
-#: ../cleanup.py:150
-msgid "This command can only be used on bots with bot accounts."
-msgstr ""
-
-#: ../cleanup.py:157
-msgid "Message not found."
-msgstr ""
-

--- a/redbot/cogs/streams/locales/regen_messages.py
+++ b/redbot/cogs/streams/locales/regen_messages.py
@@ -1,0 +1,15 @@
+import subprocess
+
+TO_TRANSLATE = [
+    '../mod.py'
+]
+
+
+def regen_messages():
+    subprocess.run(
+        ['pygettext', '-n'] + TO_TRANSLATE
+    )
+
+
+if __name__ == "__main__":
+    regen_messages()

--- a/redbot/cogs/trivia/locales/messages.pot
+++ b/redbot/cogs/trivia/locales/messages.pot
@@ -15,11 +15,3 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 
 
-#: ../cleanup.py:150
-msgid "This command can only be used on bots with bot accounts."
-msgstr ""
-
-#: ../cleanup.py:157
-msgid "Message not found."
-msgstr ""
-

--- a/redbot/cogs/trivia/locales/regen_messages.py
+++ b/redbot/cogs/trivia/locales/regen_messages.py
@@ -1,0 +1,15 @@
+import subprocess
+
+TO_TRANSLATE = [
+    '../mod.py'
+]
+
+
+def regen_messages():
+    subprocess.run(
+        ['pygettext', '-n'] + TO_TRANSLATE
+    )
+
+
+if __name__ == "__main__":
+    regen_messages()

--- a/redbot/core/locales/messages.pot
+++ b/redbot/core/locales/messages.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-01-28 15:46+AKST\n"
+"POT-Creation-Date: 2018-02-18 14:42+AKST\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,7 +22,7 @@ msgid ""
 msgstr ""
 
 #: ../cog_manager.py:324
-msgid "That path is does not exist or does not point to a valid directory."
+msgid "That path does not exist or does not point to a valid directory."
 msgstr ""
 
 #: ../cog_manager.py:333
@@ -57,211 +57,219 @@ msgstr ""
 msgid "The bot will install new cogs to the `{}` directory."
 msgstr ""
 
-#: ../core_commands.py:189 ../core_commands.py:223
+#: ../core_commands.py:224 ../core_commands.py:258
 msgid "No module by that name was found in any cog path."
 msgstr ""
 
-#: ../core_commands.py:197
+#: ../core_commands.py:232
 msgid "Failed to load package. Check your console or logs for details."
 msgstr ""
 
-#: ../core_commands.py:201 ../core_commands.py:210 ../core_commands.py:235
-#: ../core_commands.py:324 ../core_commands.py:388 ../core_commands.py:402
+#: ../core_commands.py:236 ../core_commands.py:245 ../core_commands.py:270
+#: ../core_commands.py:359 ../core_commands.py:447 ../core_commands.py:461
 msgid "Done."
 msgstr ""
 
-#: ../core_commands.py:212
+#: ../core_commands.py:247
 msgid "That extension is not loaded."
 msgstr ""
 
-#: ../core_commands.py:232
+#: ../core_commands.py:267
 msgid "Failed to reload package. Check your console or logs for details."
 msgstr ""
 
-#: ../core_commands.py:245
+#: ../core_commands.py:280
 msgid "Shutting down... "
 msgstr ""
 
-#: ../core_commands.py:260
+#: ../core_commands.py:295
 msgid "Restarting..."
 msgstr ""
 
-#: ../core_commands.py:297
+#: ../core_commands.py:332
 msgid "The admin role for this guild has been set."
 msgstr ""
 
-#: ../core_commands.py:305
+#: ../core_commands.py:340
 msgid "The mod role for this guild has been set."
 msgstr ""
 
-#: ../core_commands.py:318
+#: ../core_commands.py:353
 msgid "Failed. Remember that you can edit my avatar up to two times a hour. The URL must be a direct link to a JPG / PNG."
 msgstr ""
 
-#: ../core_commands.py:322
+#: ../core_commands.py:357
 msgid "JPG / PNG format only."
 msgstr ""
 
-#: ../core_commands.py:337
+#: ../core_commands.py:372
 msgid "Game set."
 msgstr ""
 
-#: ../core_commands.py:366
+#: ../core_commands.py:384
+msgid "Listening set."
+msgstr ""
+
+#: ../core_commands.py:396
+msgid "Watching set."
+msgstr ""
+
+#: ../core_commands.py:425
 msgid "Status changed to %s."
 msgstr ""
 
-#: ../core_commands.py:397
+#: ../core_commands.py:456
 msgid "Failed to change name. Remember that you can only do it up to 2 times an hour. Use nicknames if you need frequent changes. `{}set nickname`"
 msgstr ""
 
-#: ../core_commands.py:412
+#: ../core_commands.py:471
 msgid "I lack the permissions to change my own nickname."
 msgstr ""
 
-#: ../core_commands.py:426 ../core_commands.py:439
+#: ../core_commands.py:485 ../core_commands.py:498
 msgid "Prefix set."
 msgstr ""
 
-#: ../core_commands.py:435
+#: ../core_commands.py:494
 msgid "Guild prefixes have been reset."
 msgstr ""
 
-#: ../core_commands.py:458
+#: ../core_commands.py:517
 msgid ""
 "\n"
 "Verification token:"
 msgstr ""
 
-#: ../core_commands.py:461
+#: ../core_commands.py:520
 msgid ""
 "Remember:\n"
 msgstr ""
 
-#: ../core_commands.py:464
+#: ../core_commands.py:523
 msgid "I have printed a one-time token in the console. Copy and paste it here to confirm you are the owner."
 msgstr ""
 
-#: ../core_commands.py:472
+#: ../core_commands.py:531
 msgid "The set owner request has timed out."
 msgstr ""
 
-#: ../core_commands.py:478
+#: ../core_commands.py:537
 msgid "You have been set as owner."
 msgstr ""
 
-#: ../core_commands.py:480
+#: ../core_commands.py:539
 msgid "Invalid token."
 msgstr ""
 
-#: ../core_commands.py:492
+#: ../core_commands.py:551
 msgid "Locale has been set."
 msgstr ""
 
-#: ../core_commands.py:506
+#: ../core_commands.py:565
 msgid "Done. Sentry logging is now enabled."
 msgstr ""
 
-#: ../core_commands.py:509
+#: ../core_commands.py:568
 msgid "Done. Sentry logging is now disabled."
 msgstr ""
 
-#: ../core_commands.py:519
+#: ../core_commands.py:578
 msgid "User ID: %s"
 msgstr ""
 
-#: ../core_commands.py:522
+#: ../core_commands.py:581
 msgid "through DM"
 msgstr ""
 
-#: ../core_commands.py:524
+#: ../core_commands.py:583
 msgid "from {}"
 msgstr ""
 
-#: ../core_commands.py:525
+#: ../core_commands.py:584
 msgid " | Server ID: %s"
 msgstr ""
 
-#: ../core_commands.py:534
+#: ../core_commands.py:593
 msgid "Use `{}dm {} <text>` to reply to this user"
 msgstr ""
 
-#: ../core_commands.py:542
+#: ../core_commands.py:601
 msgid "Sent by {} {}"
 msgstr ""
 
-#: ../core_commands.py:554
+#: ../core_commands.py:613
 msgid "I cannot send your message, I'm unable to find my owner... *sigh*"
 msgstr ""
 
-#: ../core_commands.py:557
+#: ../core_commands.py:616
 msgid "I'm unable to deliver your message. Sorry."
 msgstr ""
 
-#: ../core_commands.py:559
+#: ../core_commands.py:618
 msgid "Your message has been sent."
 msgstr ""
 
-#: ../core_commands.py:573
+#: ../core_commands.py:632
 msgid "Invalid ID or user not found. You can only send messages to people I share a server with."
 msgstr ""
 
-#: ../core_commands.py:579
+#: ../core_commands.py:638
 msgid "Owner of %s"
 msgstr ""
 
-#: ../core_commands.py:583
+#: ../core_commands.py:642
 msgid "You can reply to this message with %scontact"
 msgstr ""
 
-#: ../core_commands.py:593
+#: ../core_commands.py:652
 msgid "Sorry, I couldn't deliver your message to %s"
 msgstr ""
 
-#: ../core_commands.py:596
+#: ../core_commands.py:655
 msgid "Message delivered to %s"
 msgstr ""
 
-#: ../core_commands.py:616
+#: ../core_commands.py:675
 msgid "User added to whitelist."
 msgstr ""
 
-#: ../core_commands.py:625
+#: ../core_commands.py:684
 msgid "Whitelisted Users:"
 msgstr ""
 
-#: ../core_commands.py:645
+#: ../core_commands.py:704
 msgid "User has been removed from whitelist."
 msgstr ""
 
-#: ../core_commands.py:647
+#: ../core_commands.py:706
 msgid "User was not in the whitelist."
 msgstr ""
 
-#: ../core_commands.py:655
+#: ../core_commands.py:714
 msgid "Whitelist has been cleared."
 msgstr ""
 
-#: ../core_commands.py:672
+#: ../core_commands.py:731
 msgid "You cannot blacklist an owner!"
 msgstr ""
 
-#: ../core_commands.py:679
+#: ../core_commands.py:738
 msgid "User added to blacklist."
 msgstr ""
 
-#: ../core_commands.py:688
+#: ../core_commands.py:747
 msgid "blacklisted Users:"
 msgstr ""
 
-#: ../core_commands.py:708
+#: ../core_commands.py:767
 msgid "User has been removed from blacklist."
 msgstr ""
 
-#: ../core_commands.py:710
+#: ../core_commands.py:769
 msgid "User was not in the blacklist."
 msgstr ""
 
-#: ../core_commands.py:718
+#: ../core_commands.py:777
 msgid "blacklist has been cleared."
 msgstr ""
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This script regenerates all `messages.pot` files in one go by looping through all of the cog dirs and running `regen_messages.py` in the cog's `locales` dir (if it exists).

This could also be made to deploy to Crowdin on a successful Travis build (hence the changes to both `.travis.yml` and `crowdin.yml`)