### PR TITLE
Fix #1323

### DIFF
--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -639,7 +639,7 @@ class RepoManager:
         """
         ret = {}
         for repo_name, _ in self._repos.items():
-            repo, (old, new) = await self.update_repo(repo_name)
+            repo, (old, new) = (await self.update_repo(repo_name)).popitem()
             if old != new:
                 ret[repo] = (old, new)
         return ret


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

The use of `popitem` makes the right side of line 642 return a tuple of the form `(repo, (old, new))` instead of a dictionary of the form `{repo: (old, new)}`, as expected by the left hand side of the same line.