### PR TITLE
[V3 General] Fix error in [p]userinfo when game is not set

### DIFF
--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -215,10 +215,10 @@ class General:
 
         created_on = _("{}\n({} days ago)").format(user_created, since_created)
         joined_on = _("{}\n({} days ago)").format(user_joined, since_joined)
-
         
+        game = _("Chilling in {} status").format(user.status)
         if user.game is None:  # Default status
-            game = _("Chilling in {} status").format(user.status)
+            pass
         elif user.game.type == 0:  # "Playing" status
             game = _("Playing {}").format(user.game.name)
         elif user.game.type == 1:  # "Streaming" status
@@ -227,8 +227,6 @@ class General:
             game = _("Listening to {}").format(user.game.name)
         elif user.game.type == 3:  # "Watching" status
             game = _("Watching {}").format(user.game.name)
-        else:
-            game = "please go bother <@111655405708455936> as somehow something broke"
 
         if roles:
             roles = ", ".join([x.name for x in roles])

--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -216,6 +216,7 @@ class General:
         created_on = _("{}\n({} days ago)").format(user_created, since_created)
         joined_on = _("{}\n({} days ago)").format(user_joined, since_joined)
 
+        
         if user.game is None:  # Default status
             game = _("Chilling in {} status").format(user.status)
         elif user.game.type == 0:  # "Playing" status
@@ -226,6 +227,8 @@ class General:
             game = _("Listening to {}").format(user.game.name)
         elif user.game.type == 3:  # "Watching" status
             game = _("Watching {}").format(user.game.name)
+        else:
+            game = "please go bother <@111655405708455936> as somehow something broke"
 
         if roles:
             roles = ", ".join([x.name for x in roles])

--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -216,10 +216,9 @@ class General:
         created_on = _("{}\n({} days ago)").format(user_created, since_created)
         joined_on = _("{}\n({} days ago)").format(user_joined, since_joined)
 
-        game = _("Chilling in {} status").format(user.status)
-
-        # Check if the user has a special status
-        if user.game.type == 0:  # "Playing" status
+        if user.game is None:  # Default status
+            game = _("Chilling in {} status").format(user.status)
+        elif user.game.type == 0:  # "Playing" status
             game = _("Playing {}").format(user.game.name)
         elif user.game.type == 1:  # "Streaming" status
             game = _("Streaming [{}]({})").format(user.game.name, user.game.url)


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Modifies the game-checking lines so that they don't assume `user.game` is not a NoneType object.

Fixes #1321 