### PR TITLE
[V3 Mod/Filter] Fix #1202

### DIFF
--- a/redbot/cogs/filter/filter.py
+++ b/redbot/cogs/filter/filter.py
@@ -249,10 +249,12 @@ class Filter:
             return
         author = message.author
         valid_user = isinstance(author, discord.Member) and not author.bot
-
+        if not valid_user:
+            return
+        
         #  Bots and mods or superior are ignored from the filter
         mod_or_superior = await is_mod_or_superior(self.bot, obj=author)
-        if not valid_user or mod_or_superior:
+        if mod_or_superior:
             return
 
         await self.check_filter(message)
@@ -261,10 +263,13 @@ class Filter:
         author = message.author
         if message.guild is None or self.bot.user == author:
             return
-
         valid_user = isinstance(author, discord.Member) and not author.bot
+        if not valid_user:
+            return
+        
+        #  Bots and mods or superior are ignored from the filter
         mod_or_superior = await is_mod_or_superior(self.bot, obj=author)
-        if not valid_user or mod_or_superior:
+        if mod_or_superior:
             return
 
         await self.check_filter(message)

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -1241,10 +1241,12 @@ class Mod:
         if message.guild is None or self.bot.user == author:
             return
         valid_user = isinstance(author, discord.Member) and not author.bot
-
+        if not valid_user:
+            return
+        
         #  Bots and mods or superior are ignored from the filter
         mod_or_superior = await is_mod_or_superior(self.bot, obj=author)
-        if not valid_user or mod_or_superior:
+        if mod_or_superior:
             return
         deleted = await self.check_duplicates(message)
         if not deleted:

--- a/redbot/core/utils/mod.py
+++ b/redbot/core/utils/mod.py
@@ -124,7 +124,7 @@ async def is_mod_or_superior(
     user = None
     if isinstance(obj, discord.Message):
         user = obj.author
-    elif isinstance(obj, discord.Member) or isinstance(obj, discord.User):
+    elif isinstance(obj, discord.Member):
         user = obj
     elif isinstance(obj, discord.Role):
         pass
@@ -214,7 +214,7 @@ async def is_admin_or_superior(
     user = None
     if isinstance(obj, discord.Message):
         user = obj.author
-    elif isinstance(obj, discord.Member) or isinstance(obj, discord.User):
+    elif isinstance(obj, discord.Member):
         user = obj
     elif isinstance(obj, discord.Role):
         pass


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Rearranges type-checks to ensure `author` is of `Member` class in `mod.py` and `filter.py` before calling `is_mod_or_superior`. Also makes `is_mod_or_superior` correctly raise a `TypeError` when a `User` object is  passed in.