### PR TITLE
[V3 Config] Limit config objects to a single one per cog

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -466,8 +466,8 @@ class Config:
         cog_name = cog_path_override.stem
         uuid = str(hash(identifier))
 
-        if cog_name in _config_cogrefs and _config_cogrefs[cog_name] is not None:
-            return _config_cogrefs[cog_name]
+        if cog_name in _config_cogrefs and _config_cogrefs[cog_name]() is not None:
+            return _config_cogrefs[cog_name]()
 
         # We have to import this here otherwise we have a circular dependency
         from .data_manager import basic_config
@@ -501,8 +501,8 @@ class Config:
 
         """
         global _config_coreref
-        if _config_coreref is not None:
-            return _config_coreref
+        if _config_coreref() is not None:
+            return _config_coreref()
 
         core_path = core_data_path()
 

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -502,7 +502,7 @@ class Config:
 
         """
         global _config_coreref
-        if _config_coreref() is not None:
+        if _config_coreref is not None and _config_coreref() is not None:
             return _config_coreref()
 
         core_path = core_data_path()

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -468,7 +468,9 @@ class Config:
         uuid = str(hash(identifier))
 
         with contextlib.suppress(KeyError):
-            return _config_cogrefs[cog_name]()
+            conf = _config_cogrefs[cog_name]()
+            if conf is not None:
+                return conf
 
         # We have to import this here otherwise we have a circular dependency
         from .data_manager import basic_config

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import collections
 from weakref import ref
@@ -466,7 +467,7 @@ class Config:
         cog_name = cog_path_override.stem
         uuid = str(hash(identifier))
 
-        if cog_name in _config_cogrefs and _config_cogrefs[cog_name]() is not None:
+        with contextlib.suppress(KeyError):
             return _config_cogrefs[cog_name]()
 
         # We have to import this here otherwise we have a circular dependency


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
There must only exist a single instance of a config object for any particular cog because of the way that the JSON driver operates. If multiple instances exist, each JSON driver instance will have it's own copy of the stored file data in memory. If one instance modifies and saves that data, another will not know about it and has the potential to overwrite any changes it does not know about.