### PR TITLE
[V3 Config] Allow users to directly specify cog names

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -509,7 +509,7 @@ class Config:
 
     @classmethod
     def get_conf(cls, cog_instance, identifier: int,
-                 force_registration=False):
+                 force_registration=False, cog_name=None):
         """Get a Config instance for your cog.
 
         Parameters
@@ -524,6 +524,10 @@ class Config:
         force_registration : `bool`, optional
             Should config require registration of data keys before allowing you
             to get/set values? See `force_registration`.
+        cog_name : str, optional
+            Config normally uses ``cog_instance`` to determine tha name of your cog.
+            If you wish you may pass ``None`` to ``cog_instance`` and directly specify
+            the name of your cog here.
 
         Returns
         -------
@@ -531,7 +535,11 @@ class Config:
             A new Config object.
 
         """
-        cog_path_override = cog_data_path(cog_instance)
+        if cog_instance is None and not cog_name is None:
+            cog_path_override = cog_data_path(raw_name=cog_name)
+        else:
+            cog_path_override = cog_data_path(cog_instance=cog_instance)
+
         cog_name = cog_path_override.stem
         uuid = str(hash(identifier))
 

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -80,15 +80,19 @@ def _base_data_path() -> Path:
     return Path(path).resolve()
 
 
-def cog_data_path(cog_instance=None) -> Path:
+def cog_data_path(cog_instance=None, raw_name: str=None) -> Path:
     """Gets the base cog data path. If you want to get the folder with
     which to store your own cog's data please pass in an instance
     of your cog class.
+
+    Either ``cog_instance`` or ``raw_name`` will be used, not both.
 
     Parameters
     ----------
     cog_instance
         The instance of the cog you wish to get a data path for.
+    raw_name : str
+        The name of the cog to get a data path for.
 
     Returns
     -------
@@ -103,7 +107,10 @@ def cog_data_path(cog_instance=None) -> Path:
         raise RuntimeError("You must load the basic config before you"
                            " can get the cog data path.") from e
     cog_path = base_data_path / basic_config['COG_PATH_APPEND']
-    if cog_instance:
+
+    if raw_name is not None:
+        cog_path = cog_path / raw_name
+    elif cog_instance is not None:
         cog_path = cog_path / cog_instance.__class__.__name__
     cog_path.mkdir(exist_ok=True, parents=True)
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This will allow developers to directly specify cog names rather than attempting to use a cog's instance to determine the cog name.

**Depends on #1337**

Resolves #1260 