### PR TITLE
[V2] Update .gitignore to include all automatically-generated files/folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ data
 !data/audio/playlists/*
 *.exe
 *.dll
+start_red*.bat

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,7 @@ data
 !data/audio/playlists/*
 *.exe
 *.dll
-start_red*.bat
+start_red*
+start_launcher.sh
+start_launcher.command
+lib


### PR DESCRIPTION
### Type

- [X] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Whenever Red is ran, the two files `start_red.bat` and `start_red_autorestart.bat` will be automatically generated, and `lib` will be populated when requirements are installed. Also in the case of OSX/Unix, the files `start_launcher.command` and `start_launcher.sh` will be generated, respectively. This patch will cause `.gitignore` to not include these files/folders automatically on commit.