### PR TITLE
[V3 Config] Correct Mongo connection URI without credentials

### DIFF
--- a/redbot/core/drivers/red_mongo.py
+++ b/redbot/core/drivers/red_mongo.py
@@ -13,7 +13,7 @@ def _initialize(**kwargs):
     admin_user = kwargs['USERNAME']
     admin_pass = kwargs['PASSWORD']
     db_name = kwargs.get('DB_NAME', 'default_db')
-    
+
     if admin_user is not None and admin_pass is not None:
         url = "mongodb://{}:{}@{}:{}/{}".format(
             admin_user, admin_pass, host, port,

--- a/redbot/core/drivers/red_mongo.py
+++ b/redbot/core/drivers/red_mongo.py
@@ -13,11 +13,16 @@ def _initialize(**kwargs):
     admin_user = kwargs['USERNAME']
     admin_pass = kwargs['PASSWORD']
     db_name = kwargs.get('DB_NAME', 'default_db')
-
-    url = "mongodb://{}:{}@{}:{}/{}".format(
-        admin_user, admin_pass, host, port,
-        db_name
-    )
+    
+    if admin_user is not None and admin_pass is not None:
+        url = "mongodb://{}:{}@{}:{}/{}".format(
+            admin_user, admin_pass, host, port,
+            db_name
+        )
+    else:
+        url = "mongodb://{}:{}/{}".format(
+            host, port, db_name
+        )
 
     global _conn
     _conn = motor.motor_asyncio.AsyncIOMotorClient(url)


### PR DESCRIPTION
### Type
- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
During Mongo setup, if the user did not supply a username and password for their database (because Mongo authentication is turned off) connecting to the database would fail with the error `pymongo.errors.OperationFailure: Authentication failed.`, indicating that authentication failed, even though it isn't enabled.

This was due to how the Mongo connection string was being created. In the event that there was not a username and password, the connection string would still include them, even though they had no value. So the resulting connection string was `mongodb://None:None@{host}:{port}/{db_name}`. And unless there is a Mongo user with name `None` and password `None`, this would fail with the error above.

The solution was to construct the connection string differently based on the presence of a username and password. If they both have values, that piece of the string is included; if not, it is omitted.