### PR TITLE
[V3] Fix help_formatter to obey embed length limits

### DIFF
--- a/redbot/core/help_formatter.py
+++ b/redbot/core/help_formatter.py
@@ -139,7 +139,7 @@ class Help(formatter.HelpFormatter):
 
         if description:
             # <description> portion
-            emb['embed']['description'] = description
+            emb['embed']['description'] = description[:2046]
 
         if isinstance(self.command, discord.ext.commands.core.Command):
             # <signature portion>
@@ -149,11 +149,11 @@ class Help(formatter.HelpFormatter):
             # <long doc> section
             if self.command.help:
                 name = '__{0}__'.format(self.command.help.split('\n\n')[0])
-                name_length = len(name) - 4
+                name_length = len(name)
                 value = self.command.help[name_length:].replace('[p]', self.clean_prefix)
                 if value == '':
                     value = EMPTY_STRING
-                field = EmbedField(name, value, False)
+                field = EmbedField(name[:252], value[:1024], False)
                 emb['fields'].append(field)
 
             # end it here if it's just a regular command


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Help didn't account for docstrings passing embed field length limits which I noticed a while ago and as noticed again when Palm forgot a dual newline in a command docstring.

This PR sees to fix this by enforcing length limits on description, field names and field values