### PR TITLE
[V3 Audio] Fix repeat, Message deletions

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -1,6 +1,7 @@
 # Lavalink.py cog for Red v3 beta 7+
 # Cog base thanks to Kromatic's example cog.
 import asyncio
+import datetime
 import discord
 import heapq
 import lavalink
@@ -159,12 +160,18 @@ class Audio:
         server_num = await self._get_playing()
         server_ids = self.bot.lavalink.players._players
         server_list = []
+
         for k, v in server_ids.items():
             guild_id = k
             player = v
+            connect_start = v.fetch('connect')
             try:
-                server_list.append(
-                    self.bot.get_guild(guild_id).name + ': **[{}]({})**'.format(v.current.title, v.current.uri))
+                connect_dur = self._dynamic_time((datetime.datetime.utcnow() - connect_start).seconds)
+            except TypeError:
+                connect_dur = 0
+            try:
+                server_list.append('{} [`{}`]: **[{}]({})**'.format(self.bot.get_guild(guild_id).name, connect_dur, 
+                                   v.current.title, v.current.uri))
             except AttributeError:
                 pass
             servers = '\n'.join(server_list)
@@ -331,6 +338,7 @@ class Audio:
         await self._data_check(ctx)
 
         if not player.is_connected:
+            player.store('connect', datetime.datetime.utcnow())
             await player.connect(ctx.author.voice.channel.id)
 
         query = query.strip('<>')
@@ -471,6 +479,7 @@ class Audio:
         if not ctx.author.voice or (player.is_connected and ctx.author.voice.channel.id != int(player.channel_id)):
             return await self._embed_msg(ctx, 'You must be in the voice channel to enqueue songs.')
         if not player.is_connected:
+            player.store('connect', datetime.datetime.utcnow())
             await player.connect(ctx.author.voice.channel.id)
 
         query = query.strip('<>')
@@ -724,6 +733,31 @@ class Audio:
             else:
                 msg += bar
         return msg
+
+    def _dynamic_time(self, time):
+        m, s = divmod(time, 60)
+        h, m = divmod(m, 60)
+        d, h = divmod(h, 24)
+
+        if d > 0:
+            msg = "{0}d"
+            if h > 0 and m > 0 and s > 0:
+                msg += " {1}h"
+            elif m > 0 and d == 0 and h == 0 and s == 0:
+                pass
+            elif s > 0 and d == 0 and h == 0 and m == 0:
+                pass
+            elif d == 0 and m == 0 and h == 0 and s == 0:
+                pass
+            else:
+                msg += " {1}h"
+        elif d == 0 and h > 0:
+            msg = "{1}h 0m" if m == 0 else "{1}h {2}m"
+        elif d == 0 and h == 0 and m > 0:
+            msg = "{2}m 0s" if s == 0 else "{2}m {3}s"
+        elif d == 0 and h == 0 and m == 0 and s > 0:
+            msg = "{3}s"
+        return msg.format(d, h, m, s)
 
     async def _embed_msg(self, ctx, title):
         embed = discord.Embed(colour=ctx.guild.me.top_role.colour, title=title)

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -75,10 +75,14 @@ class Audio:
             c = player.fetch('channel')
             if c:
                 c = self.bot.get_channel(c)
-                if c:
-                    embed = discord.Embed(colour=c.guild.me.top_role.colour, title='Now Playing',
-                                          description='**[{}]({})**'.format(player.current.title, player.current.uri))
-                    await c.send(embed=embed)
+                if player.fetch('notify_message') is not None:
+                    try:
+                        await player.fetch('notify_message').delete()
+                    except discord.errors.NotFound:
+                        pass
+                embed = discord.Embed(colour=c.guild.me.top_role.colour, title='Now Playing', description='**[{}]({})**'.format(player.current.title, player.current.uri))
+                notify_message = await c.send(embed=embed)
+                player.store('notify_message', notify_message)
 
         if event == 'TrackStartEvent' and status:
             if playing_servers > 1:

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -579,7 +579,10 @@ class Audio:
             else:
                 time_sec = seconds * 1000
                 seek = player.position + time_sec
-                await self._embed_msg(ctx, 'Moved {}s to {}'.format(seconds, lavalink.Utils.format_time(seek)))
+                if abs(time_sec) > player.position:
+                    await self._embed_msg(ctx, 'Moved {}s to 00:00:00'.format(seconds))
+                else:
+                    await self._embed_msg(ctx, 'Moved {}s to {}'.format(seconds, lavalink.Utils.format_time(seek)))
                 return await player.seek(seek)
 
     @commands.command()

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -9,7 +9,7 @@ import math
 from discord.ext import commands
 from redbot.core import Config, checks
 
-__version__ = "2.0.2.9.a"
+__version__ = "2.0.2.9.b"
 __author__ = ["aikaterna", "billy/bollo/ati"]
 
 

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -414,13 +414,12 @@ class Audio:
         if not ctx.author.voice or (player.is_connected and ctx.author.voice.channel.id != int(player.channel_id)):
             return await self._embed_msg(ctx, 'You must be in the voice channel to toggle repeat.')
 
-        if not player.is_playing:
-            return await self._embed_msg(ctx, 'Nothing playing.')
-
         repeat = await self.config.guild(ctx.guild).repeat()
         await self.config.guild(ctx.guild).repeat.set(not repeat)
-        get_repeat = await self.config.guild(ctx.guild).repeat()
-        await self._embed_msg(ctx, 'Repeat songs: {}.'.format(get_repeat))
+        repeat = await self.config.guild(ctx.guild).repeat()
+        if player.repeat != repeat:
+            player.repeat = repeat
+        await self._embed_msg(ctx, 'Repeat songs: {}.'.format(repeat))
 
     @commands.command()
     async def remove(self, ctx, index: int):

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -80,7 +80,8 @@ class Audio:
                         await player.fetch('notify_message').delete()
                     except discord.errors.NotFound:
                         pass
-                embed = discord.Embed(colour=c.guild.me.top_role.colour, title='Now Playing', description='**[{}]({})**'.format(player.current.title, player.current.uri))
+                embed = discord.Embed(colour=c.guild.me.top_role.colour, title='Now Playing',
+                                      description='**[{}]({})**'.format(player.current.title, player.current.uri))
                 notify_message = await c.send(embed=embed)
                 player.store('notify_message', notify_message)
 

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -220,9 +220,15 @@ class Audio:
             req_user = self.bot.get_user(player.current.requester)
             song = '**[{}]({})**\nRequested by: **{}**\n\n{}`{}`/`{}`'.format(player.current.title, player.current.uri,
                                                                               req_user, arrow, pos, dur)
+        if player.fetch('np_message') is not None:
+            try:
+                await player.fetch('np_message').delete()
+            except discord.errors.NotFound:
+                pass
 
         embed = discord.Embed(colour=ctx.guild.me.top_role.colour, title='Now Playing', description=song)
         message = await ctx.send(embed=embed)
+        player.store('np_message', message)
 
         def check(r, u):
             return r.message.id == message.id and u == ctx.message.author


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
- Fix repeat not toggling correctly
- Auto-delete existing message when [p]np is used
- Auto-delete existing message for new song notify message
- Add player connected duration to audiostats
- Seeking in reverse past song start will now return 00:00:00 instead of a negative number