### PR TITLE
Add os import in dev commands

### DIFF
--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -3,6 +3,7 @@ import inspect
 import io
 import textwrap
 import traceback
+import os
 from contextlib import redirect_stdout
 from copy import copy
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

When using dev commands, this is a bit annoying to import every time os, as this is a module needed very often (especially in `[p]debug` where you need to do `__import__('os')` instead of just `os` if already imported).
That module was already default imported on v2 and that was much easier when debugging.
