### PR TITLE
[V3 Audio] Download Lavalink jar at Audio load

### DIFF
--- a/redbot/cogs/audio/__init__.py
+++ b/redbot/cogs/audio/__init__.py
@@ -1,8 +1,49 @@
+from pathlib import Path
+from aiohttp import ClientSession
+import shutil
+
 from .audio import Audio
 from discord.ext import commands
+from redbot.core.data_manager import cog_data_path
+
+LAVALINK_BUILD = 3065
+LAVALINK_BUILD_URL = (
+    "https://ci.fredboat.com/repository/download/"
+    "Lavalink_Build/{}:id/Lavalink.jar?guest=1"
+).format(LAVALINK_BUILD)
+
+LAVALINK_DOWNLOAD_DIR = cog_data_path(raw_name="Audio")
+LAVALINK_JAR_FILE = LAVALINK_DOWNLOAD_DIR / "Lavalink.jar"
+
+APP_YML_FILE = LAVALINK_DOWNLOAD_DIR / "application.yml"
+BUNDLED_APP_YML_FILE = Path(__file__).parent / "application.yml"
+
+
+async def download_lavalink(session):
+    with LAVALINK_JAR_FILE.open(mode='wb') as f:
+        async with session.get(LAVALINK_BUILD_URL) as resp:
+            while True:
+                chunk = await resp.content.read(512)
+                if not chunk:
+                    break
+                f.write(chunk)
+
+
+async def maybe_download_lavalink(loop, cog):
+    jar_exists = LAVALINK_JAR_FILE.exists()
+    current_build = await cog.config.current_build()
+
+    if not jar_exists or current_build < LAVALINK_BUILD:
+        LAVALINK_DOWNLOAD_DIR.mkdir(parents=True, exist_ok=True)
+        with ClientSession(loop=loop) as session:
+            await download_lavalink(session)
+        await cog.config.current_build.set(LAVALINK_BUILD)
+
+    shutil.copyfile(str(BUNDLED_APP_YML_FILE), str(APP_YML_FILE))
 
 
 async def setup(bot: commands.Bot):
     cog = Audio(bot)
+    await maybe_download_lavalink(bot.loop, cog)
     await cog.init_config()
     bot.add_cog(cog)

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -13,9 +13,6 @@ __version__ = "2.0.2.9.b"
 __author__ = ["aikaterna", "billy/bollo/ati"]
 
 
-LAVALINK_BUILD = 3065
-
-
 class Audio:
     def __init__(self, bot):
         self.bot = bot
@@ -25,7 +22,8 @@ class Audio:
             "host": 'localhost',
             "port": '2332',
             "passw": 'youshallnotpass',
-            "status": False
+            "status": False,
+            "current_build": 0
         }
 
         default_guild = {
@@ -39,10 +37,6 @@ class Audio:
         self.config.register_global(**default_global)
 
         self._lavalink = None
-        self._lavalink_build_url = (
-            "https://ci.fredboat.com/repository/download/"
-            "Lavalink_Build/{}:id/Lavalink.jar"
-        ).format(LAVALINK_BUILD)
 
     async def init_config(self):
         host = await self.config.host()


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This will download the lavalink jar when the audio cog is loaded. The next PR will include a lavalink runtime manager to startup/shutdown the jar when required.