### PR TITLE
[V3 Core] add update check

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -9,6 +9,7 @@ from collections import namedtuple
 from pathlib import Path
 from random import SystemRandom
 from string import ascii_letters, digits
+from distutils.version import StrictVersion
 
 import aiohttp
 import discord
@@ -68,6 +69,10 @@ class Core:
         app_info = await self.bot.application_info()
         owner = app_info.owner
 
+        async with aiohttp.ClientSession() as session:
+            async with session.get("http://pypi.python.org/pypi/red-discordbot/json") as r:
+                data = await r.json()
+        outdated = StrictVersion(data["info"]["version"]) > StrictVersion(__version__)
         about = (
             "This is an instance of [Red, an open source Discord bot]({}) "
             "created by [Twentysix]({}) and [improved by many]({}).\n\n"
@@ -81,7 +86,13 @@ class Core:
         embed.add_field(name="Python", value=python_version)
         embed.add_field(name="discord.py", value=dpy_version)
         embed.add_field(name="Red version", value=red_version)
+        if outdated:
+            embed.add_field(name="Outdated", value="Yes, {} is available".format(
+                    data["info"]["version"]
+                )
+            )
         embed.add_field(name="About Red", value=about, inline=False)
+
         embed.set_footer(text="Bringing joy since 02 Jan 2016 (over "
                          "{} days ago!)".format(days_since))
         try:

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -2,6 +2,9 @@ import sys
 import codecs
 import datetime
 import logging
+from distutils.version import StrictVersion
+
+import aiohttp
 import pkg_resources
 import traceback
 from pkg_resources import DistributionNotFound
@@ -105,6 +108,15 @@ def init_events(bot, cli_flags):
             print("Ready. I'm not in any server yet!")
 
         INFO.append('{} cogs with {} commands'.format(len(bot.cogs), len(bot.commands)))
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get("http://pypi.python.org/pypi/red-discordbot/json") as r:
+                data = await r.json()
+        if StrictVersion(data["info"]["version"]) > StrictVersion(__version__):
+            INFO.append(
+                "Outdated version! {} is available "
+                "but you're using {}".format(data["info"]["version"], __version__)
+            )
 
         INFO2 = []
 

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -112,12 +112,21 @@ def init_events(bot, cli_flags):
         async with aiohttp.ClientSession() as session:
             async with session.get("http://pypi.python.org/pypi/red-discordbot/json") as r:
                 data = await r.json()
-        if StrictVersion(data["info"]["version"]) > StrictVersion(__version__):
+        if StrictVersion(data["info"]["version"]) > StrictVersion(red_version):
             INFO.append(
                 "Outdated version! {} is available "
-                "but you're using {}".format(data["info"]["version"], __version__)
+                "but you're using {}".format(data["info"]["version"], red_version)
             )
-
+            owner = discord.utils.get(bot.get_all_members(), id=bot.owner_id)
+            try:
+                await owner.send(
+                    "Your Red instance is out of date! {} is the current "
+                    "version, however you are using {}!".format(
+                        data["info"]["version"], red_version
+                    )
+                )
+            except:
+                pass
         INFO2 = []
 
         sentry = await bot.db.enable_sentry()


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
#1367 

This adds in an update check that is done:
- on startup (if out of date, this is stated when the startup screen is printed)
- in `[p]info` (via a field in the embed)

ATM this doesn't DM the bot owner, though that could certainly be added in if desired