### PR TITLE
[mod] A small tweak to allow external custom case creation :)

### DIFF
--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -1356,14 +1356,14 @@ class Mod:
         else:
             return mod.top_role.position > user.top_role.position or is_special
 
-    async def new_case(self, server, *, action, mod=None, user, reason=None, until=None, channel=None):
+    async def new_case(self, server, *, action, mod=None, user, reason=None, until=None, channel=None, force_create=False):
         action_type = action.lower() + "_cases"
-        if not self.settings[server.id].get(action_type, default_settings[action_type]):
-            return
+        if not force_create and not self.settings.get(server.id, {}).get(action_type, default_settings.get(action_type)):
+            return False
 
         mod_channel = server.get_channel(self.settings[server.id]["mod-log"])
         if mod_channel is None:
-            return
+            return None
 
         if server.id not in self.cases:
             self.cases[server.id] = {}
@@ -1384,7 +1384,7 @@ class Mod:
             "amended_by"   : None,
             "amended_id"   : None,
             "message"      : None,
-            "until"        : None,
+            "until"        : until.timestamp() if until else None,
         }
 
         case_msg = self.format_case_msg(case)
@@ -1401,6 +1401,8 @@ class Mod:
             self.last_case[server.id][mod.id] = case_n
 
         dataIO.save_json("data/mod/modlog.json", self.cases)
+
+        return case_n
 
     async def update_case(self, server, *, case, mod=None, reason=None,
                           until=False):

--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -1358,7 +1358,9 @@ class Mod:
 
     async def new_case(self, server, *, action, mod=None, user, reason=None, until=None, channel=None, force_create=False):
         action_type = action.lower() + "_cases"
-        if not force_create and not self.settings.get(server.id, {}).get(action_type, default_settings.get(action_type)):
+        
+        enabled_case = self.settings.get(server.id, {}).get(action_type, default_settings.get(action_type))
+        if not force_create and not enabled_case:
             return False
 
         mod_channel = server.get_channel(self.settings[server.id]["mod-log"])


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

As a follow-up to #672, I've made a minimal set of changes to the mod cog to allow external creation of custom cases.

The alternative to this is adding a case to `mod.cases[server.id]` directly, injecting a `punish_cases` key into `mod.settings[server.id]`, or patching `cogs.mod.default_settings` (no, irdumb). None of these have any harmful side effects, but they're annoying to maintain, and the caller has no way to know the case ID in the last two options. Oh, and the `until` field isn't actually processed when making a new case, despite being an argument to the function. That's what this PR is for.