### PR TITLE
[V3 Instance setup] Change separator for time in backups

### DIFF
--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -176,7 +176,7 @@ def remove_instance():
         else:
             print("Backing up the instance's data...")
             backup_filename = "redv3-{}-{}.tar.gz".format(
-                selected, dt.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+                selected, dt.utcnow().strftime("%Y-%m-%d %H-%M-%S")
             )
             pth = Path(instance_data["DATA_PATH"])
             home = pth.home()


### PR DESCRIPTION
This moves to using - to separate time components instead of : because Windows doesn't allow : to be used in filenames