### PR TITLE
[V3] Set token command

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -580,8 +580,18 @@ class Core:
     async def token(self, ctx, token: str):
         """Change bot token."""
         if not not isinstance(ctx.channel, discord.DMChannel):
-            await ctx.send("Please use that command in DM.")
+            
+            try:
+                await ctx.message.delete()
+            except discord.errors.Forbidden:
+                pass
+            
+            await ctx.send(_("Please use that command in DM.n"
+                          "Since users probably saw your token, it is recommanded to reset it right now"
+                          "https://discordapp.com/developers/applications/me/{}".format(self.bot.user.id)
+                          """Select "Reveal token" then "Generate a new token?"."""))
             return
+        
         await ctx.bot.db.token.set(token)
         await ctx.send("Token set. Restart me.")
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -574,6 +574,16 @@ class Core:
                 await ctx.send(_("You have been set as owner."))
             else:
                 await ctx.send(_("Invalid token."))
+                
+    @_set.command()
+    @checks.is_owner()
+    async def token(self, ctx, token: str):
+        """Change bot token."""
+        if not token:
+            await ctx.send_help()
+            return
+        await ctx.bot.db.token.set(token)
+        await ctx.send("Token set. Restart me.")
 
     @_set.command()
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -583,13 +583,14 @@ class Core:
             
             try:
                 await ctx.message.delete()
-            except discord.errors.Forbidden:
+            except discord.Forbidden:
                 pass
             
-            await ctx.send(_("Please use that command in DM.n"
-                          "Since users probably saw your token, it is recommanded to reset it right now"
-                          "https://discordapp.com/developers/applications/me/{}".format(self.bot.user.id)
-                          """Select "Reveal token" then "Generate a new token?"."""))
+            await ctx.send(
+                _("Please use that command in DM. Since users probably saw your token,"
+                  " it is recommended to reset it right now. Go to the following link and"
+                  " select `Reveal Token` and `Generate a new token?`."
+                  "\n\nhttps://discordapp.com/developers/applications/me/{}").format(self.bot.user.id))
             return
         
         await ctx.bot.db.token.set(token)

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -579,8 +579,8 @@ class Core:
     @checks.is_owner()
     async def token(self, ctx, token: str):
         """Change bot token."""
-        if not token:
-            await ctx.send_help()
+        if not not isinstance(ctx.channel, discord.DMChannel):
+            await ctx.send("Please use that command in DM.")
             return
         await ctx.bot.db.token.set(token)
         await ctx.send("Token set. Restart me.")


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

The `[p]set token` command from V2 is missing, and we are obligated to manually edit the `settings.json` file. That PR adds this command. This still needs testing (as I'm not home to do it) but, following the code from this file, this should work. I made it the same way as you made your commands in that file.