### PR TITLE
Update build

### DIFF
--- a/redbot/cogs/audio/__init__.py
+++ b/redbot/cogs/audio/__init__.py
@@ -8,7 +8,7 @@ from .manager import start_lavalink_server
 from discord.ext import commands
 from redbot.core.data_manager import cog_data_path
 
-LAVALINK_BUILD = 3065
+LAVALINK_BUILD = 3112
 LAVALINK_BUILD_URL = (
     "https://ci.fredboat.com/repository/download/"
     "Lavalink_Build/{}:id/Lavalink.jar?guest=1"


### PR DESCRIPTION


### Type

- [X] Bugfix
- [] Enhancement
- [] New feature

### Description of the changes
The current Lavalink build you are using has a shiny 404 on it, causing Red to use up an abnormal amount of resources trying to start Lavalink. Please update it to the current build