### PR TITLE
Show ping's response time

### DIFF
--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -51,7 +51,10 @@ class General:
     @commands.command(hidden=True)
     async def ping(self, ctx):
         """Pong."""
-        await ctx.send("Pong.")
+        pingtime = time.time()
+        pingmsg = await ctx.send("Pinging...")
+        pingresponse = (time.time() - pingtime) * 1000
+        await ctx.Message.edit(pingmsg, "Pong! :ping_pong:  My response time is `%dms`" % pingresponse)
 
     @commands.command()
     async def choose(self, ctx, *choices):


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Doesn't just confirm connection to the bot but also prints its response time. Useful to see if the server is under heavy load or to see how fast (or slow) the bot's connection is.