### PR TITLE
[V3 Downloader] Pip install to correct directory

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -192,7 +192,7 @@ class Downloader:
         Installs a group of dependencies using pip.
         """
         repo = Repo("", "", "", Path.cwd(), loop=ctx.bot.loop)
-        success = await repo.install_raw_requirements(deps, self.SHAREDLIB_PATH)
+        success = await repo.install_raw_requirements(deps, self.LIB_PATH)
 
         if success:
             await ctx.send(_("Libraries installed."))


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
`pipinstall` command needs to install to the `LIB_PATH`, not the `SHAREDLIB_PATH`.