### PR TITLE
[V3 Core] implement commands and settings for embeds

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -58,7 +58,8 @@ class RedBase(BotBase, RpcMethodMixin):
             whitelist=[],
             blacklist=[],
             enable_sentry=None,
-            locale='en'
+            locale='en',
+            embeds=True
         )
 
         self.db.register_guild(
@@ -66,7 +67,12 @@ class RedBase(BotBase, RpcMethodMixin):
             whitelist=[],
             blacklist=[],
             admin_role=None,
-            mod_role=None
+            mod_role=None,
+            embeds=None
+        )
+
+        self.db.register_user(
+            embeds=None
         )
 
         async def prefix_manager(bot, message):

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -142,6 +142,38 @@ class RedBase(BotBase, RpcMethodMixin):
         indict['owner_id'] = await self.db.owner()
         i18n.set_locale(await self.db.locale())
 
+    async def embed_requested(self, channel, user, command=None) -> bool:
+        """
+        Determine if an embed is requested for a response.
+
+        Parameters
+        ----------
+        channel : `discord.abc.GuildChannel` or `discord.abc.PrivateChannel`
+            The channel to check embed settings for.
+        user : `discord.abc.User`
+            The user to check embed settings for.
+        command
+            (Optional) the command ran.
+
+        Returns
+        -------
+        bool
+            :code:`True` if an embed is requested
+        """
+        if isinstance(channel, discord.abc.PrivateChannel) or (
+            command and command == self.get_command("help")
+        ):
+            user_setting = await self.db.user(user).embeds()
+            if user_setting is not None:
+                return user_setting
+        else:
+            guild_setting = await self.db.guild(channel.guild).embeds()
+            if command and command != self.get_command("help"):
+                if guild_setting is not None:
+                    return guild_setting
+        global_setting = await self.db.embeds()
+        return global_setting
+
     async def is_owner(self, user):
         if user.id in self._co_owners:
             return True

--- a/redbot/core/context.py
+++ b/redbot/core/context.py
@@ -124,24 +124,3 @@ class RedContext(commands.Context):
                         # or chanel is a DM
                         await query.delete()
         return ret
-
-    async def embed_requested(self) -> bool:
-        """Determine if an embed is requested for the command response.
-
-        Returns
-        -------
-        bool
-            :code:`True` if an embed is requested
-        """
-        if isinstance(self.channel, discord.abc.PrivateChannel) or\
-                self.command == self.bot.get_command("help"):
-            user_setting = await self.bot.db.user(self.author).embeds()
-            if user_setting is not None:
-                return user_setting
-        else:
-            guild_setting = await self.bot.db.guild(self.guild).embeds()
-            if self.command == self.bot.get_command("help"):
-                if guild_setting is not None:
-                    return guild_setting
-        global_setting = await self.bot.db.embeds()
-        return global_setting

--- a/redbot/core/context.py
+++ b/redbot/core/context.py
@@ -124,3 +124,16 @@ class RedContext(commands.Context):
                         # or chanel is a DM
                         await query.delete()
         return ret
+
+    async def embed_requested(self):
+        """
+        Simple helper to call bot.embed_requested
+
+        Returns
+        -------
+        bool:
+            :code:`True` if an embed is requested
+        """
+        return await self.bot.embed_requested(
+            self.channel, self.author, command=self.command
+        )

--- a/redbot/core/context.py
+++ b/redbot/core/context.py
@@ -124,3 +124,24 @@ class RedContext(commands.Context):
                         # or chanel is a DM
                         await query.delete()
         return ret
+
+    async def embed_requested(self) -> bool:
+        """Determine if an embed is requested for the command response.
+
+        Returns
+        -------
+        bool
+            :code:`True` if an embed is requested
+        """
+        if isinstance(self.channel, discord.abc.PrivateChannel) or\
+                self.command == self.bot.get_command("help"):
+            user_setting = await self.bot.db.user(self.author).embeds()
+            if user_setting is not None:
+                return user_setting
+        else:
+            guild_setting = await self.bot.db.guild(self.guild).embeds()
+            if self.command == self.bot.get_command("help"):
+                if guild_setting is not None:
+                    return guild_setting
+        global_setting = await self.bot.db.embeds()
+        return global_setting

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -131,6 +131,88 @@ class Core:
 
         return fmt.format(d=days, h=hours, m=minutes, s=seconds)
 
+    @commands.group()
+    async def embedset(self, ctx: RedContext):
+        """
+        Commands for toggling embeds on or off.
+
+        This setting determines whether or not to
+        use embeds as a response to a command (for
+        commands that support it). The default is to
+        use embeds.
+        """
+        if ctx.invoked_subcommand is None:
+            await ctx.send_help()
+
+    @embedset.command(name="global")
+    @checks.is_owner()
+    async def embedset_global(self, ctx: RedContext):
+        """
+        Toggle the global embed setting.
+
+        This is used as a fallback if the user
+        or guild hasn't set a preference. The
+        default is to use embeds.
+        """
+        current = await self.bot.db.embeds()
+        await self.bot.db.embeds.set(not current)
+        await ctx.send(
+            _("Embeds are now {} by default.").format(
+                "disabled" if current else "enabled"
+            )
+        )
+
+    @embedset.command(name="guild")
+    @checks.guildowner_or_permissions(administrator=True)
+    async def embedset_guild(self, ctx: RedContext, enabled: bool=None):
+        """
+        Toggle the guild's embed setting.
+
+        If enabled is None, the setting will be unset and
+        the global default will be used instead.
+
+        If set, this is used instead of the global default
+        to determine whether or not to use embeds. This is
+        used for all commands done in a guild channel except
+        for help commands.
+        """
+        await self.bot.db.guild(ctx.guild).embeds.set(enabled)
+        if enabled is None:
+            await ctx.send(
+                _("Embeds will now fall back to the global setting.")
+            )
+        else:
+            await ctx.send(
+                _("Embeds are now {} for this guild.").format(
+                    "enabled" if enabled else "disabled"
+                )
+            )
+
+    @embedset.command(name="user")
+    async def embedset_user(self, ctx: RedContext, enabled: bool=None):
+        """
+        Toggle the user's embed setting.
+
+        If enabled is None, the setting will be unset and
+        the global default will be used instead.
+
+        If set, this is used instead of the global default
+        to determine whether or not to use embeds. This is
+        used for all commands done in a DM with the bot, as
+        well as all help commands everywhere.
+        """
+        await self.bot.db.user(ctx.author).embeds.set(enabled)
+        if enabled is None:
+            await ctx.send(
+                _("Embeds will now fall back to the global setting.")
+            )
+        else:
+            await ctx.send(
+                _("Embeds are now {} for you.").format(
+                    "enabled" if enabled else "disabled"
+                )
+            )
+
     @commands.command()
     @checks.is_owner()
     async def traceback(self, ctx, public: bool=False):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -131,7 +131,7 @@ class Core:
 
         return fmt.format(d=days, h=hours, m=minutes, s=seconds)
 
-    @commands.group()
+    @commands.group(hidden=True)
     async def embedset(self, ctx: RedContext):
         """
         Commands for toggling embeds on or off.


### PR DESCRIPTION
This implements the necessary things for embeds to be toggled on or off

Specifically, we have 3 commands now that set 3 different settings for this.

One is bot-wide (which is also used as a fallback)
One is per-guild (applies to all commands done in a guild channel, except `[p]help`)
One is per-user (applies to all commands in DM as well as `[p]help` globally)

Also have implemented something in our context class to provide a way for commands to be able to find out if embeds should be used for a response or not.

This is the start of implementing #1436