### PR TITLE
[V3 Core commands] Message when loaded cog was not found

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -327,8 +327,8 @@ class Core:
                 cogspecs.append((spec, c))
             except RuntimeError:
                 notfound_packages.append(inline(c))
-                #await ctx.send(_("No module named '{}' was found in any"
-                #                 " cog path.").format(c))
+                await ctx.send(_("No module named '{}' was found in any"
+                                 " cog path.").format(c))
 
         if len(cogspecs) == 0:
             return


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

The line that says "No module named {} was found in any cog path" was somehow as a comment in the load command. While keeping that, the bot won't say anything if the cog you are trying to load doesn't exist