### PR TITLE
[V3 Instance setup] implement backup support for instances using Mongo

### DIFF
--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -378,10 +378,8 @@ async def remove_instance():
 
 def main():
     if args.delete:
-        try:
-            remove_instance()
-        except NotImplementedError as e:
-            print(str(e))
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(remove_instance())
     elif args.edit:
         loop = asyncio.get_event_loop()
         loop.run_until_complete(edit_instance())

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -16,8 +16,8 @@ from redbot.core.cli import confirm
 from redbot.core.data_manager import basic_config_default
 from redbot.core.json_io import JsonIO
 from redbot.core.utils import safe_delete
-from redbot.core.drivers.red_mongo import Mongo, get_config_details
 from redbot.core.drivers.red_json import JSON
+from redbot.core.drivers.red_mongo import get_config_details
 
 config_dir = None
 appdir = appdirs.AppDirs("Red-DiscordBot")
@@ -172,6 +172,7 @@ def basic_setup():
 
 
 async def json_to_mongo(current_data_dir: Path, storage_details: dict):
+    from redbot.core.drivers.red_mongo import Mongo
     core_data_file = list(current_data_dir.glob("core/settings.json"))[0]
     m = Mongo("Core", **storage_details)
     with core_data_file.open(mode="r") as f:
@@ -198,6 +199,7 @@ async def json_to_mongo(current_data_dir: Path, storage_details: dict):
 
 
 async def mongo_to_json(current_data_dir: Path, storage_details: dict):
+    from redbot.core.drivers.red_mongo import Mongo
     m = Mongo("Core", **storage_details)
     db = m.db
     collection_names = await db.collection_names(include_system_collections=False)

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -17,7 +17,6 @@ from redbot.core.data_manager import basic_config_default
 from redbot.core.json_io import JsonIO
 from redbot.core.utils import safe_delete
 from redbot.core.drivers.red_json import JSON
-from redbot.core.drivers.red_mongo import get_config_details
 
 config_dir = None
 appdir = appdirs.AppDirs("Red-DiscordBot")
@@ -268,6 +267,7 @@ async def edit_instance():
         }
         default_dirs["STORAGE_TYPE"] = storage_dict[storage]
         if storage_dict.get(storage, 1) == "MongoDB":
+            from redbot.core.drivers.red_mongo import get_config_details
             storage_details = get_config_details()
             default_dirs["STORAGE_DETAILS"] = storage_details
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Implement backup support for MongoDB instances. Previously not implemented but as a result of my working on storage backend switching, I now know what I needed to do to export to JSON for backup purposes.