### PR TITLE
[V3 Audio] Bump timeout connecting to Lavalink

### DIFF
--- a/redbot/cogs/audio/__init__.py
+++ b/redbot/cogs/audio/__init__.py
@@ -50,7 +50,6 @@ async def setup(bot: commands.Bot):
     await start_lavalink_server(bot.loop)
 
     async def _finish():
-        await asyncio.sleep(50)
         await cog.init_config()
         bot.add_cog(cog)
 

--- a/redbot/cogs/audio/__init__.py
+++ b/redbot/cogs/audio/__init__.py
@@ -50,7 +50,7 @@ async def setup(bot: commands.Bot):
     await start_lavalink_server(bot.loop)
 
     async def _finish():
-        await asyncio.sleep(10)
+        await asyncio.sleep(50)
         await cog.init_config()
         bot.add_cog(cog)
 

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -44,7 +44,7 @@ class Audio:
         ws_port = await self.config.ws_port()
 
         await lavalink.initialize(
-            bot=self.bot, host=host, password=password, rest_port=rest_port, ws_port=ws_port
+            bot=self.bot, host=host, password=password, rest_port=rest_port, ws_port=ws_port, timeout=60
         )
         lavalink.register_event_listener(self.event_handler)
 


### PR DESCRIPTION
### Type

- [X] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

Lavalink server can take 20-35 seconds to start, bumped to 50 seconds for good measure.