### PR TITLE
[V3 Core] fix some issues with [p]set and [p]set nickname

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -697,7 +697,7 @@ class Core:
     @_set.command(name="nickname")
     @checks.admin()
     @commands.guild_only()
-    async def _nickname(self, ctx, *, nickname: str):
+    async def _nickname(self, ctx, *, nickname: str=None):
         """Sets Red's nickname"""
         try:
             await ctx.guild.me.edit(nick=nickname)

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -700,7 +700,7 @@ class Core:
     async def _nickname(self, ctx, *, nickname: str):
         """Sets Red's nickname"""
         try:
-            await ctx.bot.user.edit(nick=nickname)
+            await ctx.guild.me.edit(nick=nickname)
         except discord.Forbidden:
             await ctx.send(_("I lack the permissions to change my own "
                              "nickname."))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -541,7 +541,8 @@ class Core:
                 "Locale: {}"
                 "".format(
                     ctx.bot.user.name, " ".join(prefixes),
-                    admin_role.name, mod_role.name, locale
+                    admin_role.name if admin_role else "Not set",
+                    mod_role.name if mod_role else "Not set", locale
                 )
             )
             await ctx.send(box(settings))


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #1493 

Fixes an `AttributeError` with `[p]set` when mod and/or admin roles are not set

Also makes `[p]set nickname` actually usable