### PR TITLE
[V3 Customcom] Removed spaces in the link

### DIFF
--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -179,7 +179,7 @@ class CustomCommands:
                      ctx: commands.Context):
         """
         CCs can be enhanced with arguments:
-        https: // twentysix26.github.io / Red - Docs / red_guide_command_args/
+        [Read the guide](https://twentysix26.github.io/Red-Docs/red_guide_command_args/)
         """
         if not ctx.invoked_subcommand or isinstance(ctx.invoked_subcommand,
                                                     commands.Group):


### PR DESCRIPTION

### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

The link wasn't clickable because there was spaces in it. Now it is with a hyperlink, since embeds supports it.