### PR TITLE
[V3 Audio] External lavalink server settings, playlist saving & recall, bugfixes

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -9,7 +9,7 @@ from redbot.core import Config, checks, bank
 
 from .manager import shutdown_lavalink_server
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"
 __author__ = ["aikaterna", "billy/bollo/ati"]
 
 
@@ -957,28 +957,72 @@ class Audio:
             await ctx.send_help()
 
     @llsetup.command()
+    async def external(self, ctx):
+        """Toggles using external lavalink servers."""
+        external = await self.config.use_external_lavalink()
+        await self.config.use_external_lavalink.set(not external)
+        if external:
+            await self.config.host.set('localhost')
+            await self.config.password.set('youshallnotpass')
+            await self.config.rest_port.set(2333)
+            await self.config.ws_port.set(2332)
+            embed = discord.Embed(colour=ctx.guild.me.top_role.colour, title='External lavalink server: {}.'.format(not external))
+            embed.set_footer(text='Defaults reset.')
+            return await ctx.send(embed=embed)
+        else:
+            await self._embed_msg(ctx, 'External lavalink server: {}.'.format(not external))
+
+    @llsetup.command()
     async def host(self, ctx, host):
         """Set the lavalink server host."""
         await self.config.host.set(host)
-        await self._embed_msg(ctx, 'Host set to {}.'.format(host))
+        if await self._check_external():
+            embed = discord.Embed(colour=ctx.guild.me.top_role.colour, title='Host set to {}.'.format(host))
+            embed.set_footer(text='External lavalink server set to True.')
+            await ctx.send(embed=embed)
+        else:
+            await self._embed_msg(ctx, 'Host set to {}.'.format(host))
 
     @llsetup.command()
-    async def password(self, ctx, passw):
+    async def password(self, ctx, password):
         """Set the lavalink server password."""
-        await self.config.passw.set(str(passw))
-        await self._embed_msg(ctx, 'Server password set to {}.'.format(passw))
+        await self.config.password.set(str(password))
+        if await self._check_external():
+            embed = discord.Embed(colour=ctx.guild.me.top_role.colour, title='Server password set to {}.'.format(password))
+            embed.set_footer(text='External lavalink server set to True.')
+            await ctx.send(embed=embed)
+        else:
+            await self._embed_msg(ctx, 'Server password set to {}.'.format(password))
 
     @llsetup.command()
     async def restport(self, ctx, rest_port):
         """Set the lavalink REST server port."""
-        await self.config.rest_port.set(str(rest_port))
-        await self._embed_msg(ctx, 'REST port set to {}.'.format(rest_port))
+        await self.config.rest_port.set(rest_port)
+        if await self._check_external():
+            embed = discord.Embed(colour=ctx.guild.me.top_role.colour, title='REST port set to {}.'.format(rest_port))
+            embed.set_footer(text='External lavalink server set to True.')
+            await ctx.send(embed=embed)
+        else:
+            await self._embed_msg(ctx, 'REST port set to {}.'.format(rest_port))
 
     @llsetup.command()
-    async def wsport(self, ctx, rest_port):
+    async def wsport(self, ctx, ws_port):
         """Set the lavalink websocket server port."""
-        await self.config.ws_port.set(str(ws_port))
-        await self._embed_msg(ctx, 'Websocket port set to {}.'.format(ws_port))
+        await self.config.rest_port.set(ws_port)
+        if await self._check_external():
+            embed = discord.Embed(colour=ctx.guild.me.top_role.colour, title='Websocket port set to {}.'.format(ws_port))
+            embed.set_footer(text='External lavalink server set to True.')
+            await ctx.send(embed=embed)
+        else:
+            await self._embed_msg(ctx, 'Websocket port set to {}.'.format(ws_port))
+
+    async def _check_external(self):
+        external = await self.config.use_external_lavalink()
+        if not external:
+            await self.config.use_external_lavalink.set(True)
+            return True
+        else:
+            return False
 
     @staticmethod
     async def _clear_react(message):

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -483,7 +483,8 @@ class Audio:
         player.store('channel', ctx.channel.id)
         player.store('guild', ctx.guild.id)
         await self._data_check(ctx)
-        if (ctx.author.voice.channel != player.channel and not await self._can_instaskip(ctx, ctx.author)):
+        if ((not ctx.author.voice or ctx.author.voice.channel != player.channel) and not
+            await self._can_instaskip(ctx, ctx.author)):
             return await self._embed_msg(ctx, 'You must be in the voice channel to use the play command.')
         if not await self._currency_check(ctx, jukebox_price):
             return
@@ -652,7 +653,8 @@ class Audio:
         player = lavalink.get_player(ctx.guild.id)
         player.store('channel', ctx.channel.id)
         player.store('guild', ctx.guild.id)
-        if (ctx.author.voice.channel != player.channel and not await self._can_instaskip(ctx, ctx.author)):
+        if ((not ctx.author.voice or ctx.author.voice.channel != player.channel) and not
+            await self._can_instaskip(ctx, ctx.author)):
             await self._embed_msg(ctx, 'You must be in the voice channel to use the playlist command.')
             return False
         if not await self._currency_check(ctx, jukebox_price):

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -181,16 +181,16 @@ class Audio:
         notify = await self.config.guild(ctx.guild).notify()
         await self.config.guild(ctx.guild).notify.set(not notify)
         await self._embed_msg(ctx, 'Verbose mode on: {}.'.format(not notify))
-
     @audioset.command()
     async def settings(self, ctx):
         """Show the current settings."""
         data = await self.config.guild(ctx.guild).all()
+        global_data = await self.config.all()
         dj_role_obj = discord.utils.get(ctx.guild.roles, id=data['dj_role'])
         dj_enabled = data['dj_enabled']
         jukebox = data['jukebox']
         jukebox_price = data['jukebox_price']
-        status = await self.config.status()
+
         vote_percent = data['vote_percent']
         msg = ('```ini\n'
                '----Guild Settings----\n')
@@ -202,12 +202,13 @@ class Audio:
         msg += ('Repeat:           [{repeat}]\n'
                 'Shuffle:          [{shuffle}]\n'
                 'Song notify msgs: [{notify}]\n'
-                'Songs as status:  [{0}]\n'.format(status, **data))
+                'Songs as status:  [{status}]\n'.format(**global_data, **data))
         if vote_percent > 0:
             msg += ('Vote skip:        [{vote_enabled}]\n'
                     'Skip percentage:  [{vote_percent}%]\n').format(**data)
         msg += ('---Lavalink Settings---\n'
-                'Cog version: {}\n```'.format(__version__))
+                'Cog version:      [{}]\n'
+                'External server:  [{use_external_lavalink}]```').format(__version__, **global_data)
 
         embed = discord.Embed(colour=ctx.guild.me.top_role.colour, description=msg)
         return await ctx.send(embed=embed)

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -461,7 +461,7 @@ class Audio:
                               description=queue_user_list)
         await ctx.send(embed=embed)
 
-    @commands.command(aliases=['p'])
+    @commands.command()
     async def play(self, ctx, *, query):
         """Play a URL or search for a song."""
         dj_enabled = await self.config.guild(ctx.guild).dj_enabled()

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -527,7 +527,7 @@ class Audio:
         player = lavalink.get_player(ctx.guild.id)
         shuffle = await self.config.guild(ctx.guild).shuffle()
         if dj_enabled:
-            if not await self._can_instaskip(ctx, ctx.author):
+            if not await self._can_instaskip(ctx, ctx.author) and not await self._is_alone(ctx, ctx.author):
                 return await self._embed_msg(ctx, 'You need the DJ role to skip songs.')
         if ((not ctx.author.voice or ctx.author.voice.channel != player.channel) and not
             await self._can_instaskip(ctx, ctx.author)):
@@ -705,7 +705,7 @@ class Audio:
             message = await ctx.send(embed=embed)
             dj_enabled = await self.config.guild(ctx.guild).dj_enabled()
             if dj_enabled:
-                if not await self._can_instaskip(ctx, ctx.author) and not await self._is_alone(ctx, ctx.author):
+                if not await self._can_instaskip(ctx, ctx.author):
                     return
 
             def check(r, u):

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -531,11 +531,13 @@ class Audio:
     @playlist.command(name='delete')
     async def _playlist_delete(self, ctx, playlist_name):
         """Delete a saved playlist."""
-        try:
-            async with self.config.guild(ctx.guild).playlists() as playlists:
+        async with self.config.guild(ctx.guild).playlists() as playlists:
+            try:
+                if playlists[playlist_name]['author'] != ctx.author.id and not await self._can_instaskip(ctx, ctx.author):
+                    return await self._embed_msg(ctx, 'You are not the author of that playlist.')
                 del playlists[playlist_name]
-        except KeyError:
-            return await self._embed_msg(ctx, 'No playlist with that name.')
+            except KeyError:
+                return await self._embed_msg(ctx, 'No playlist with that name.')
         await self._embed_msg(ctx, '{} playlist removed.'.format(playlist_name))
 
     @playlist.command(name='list')

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -538,7 +538,7 @@ class Audio:
             return await self._embed_msg(ctx, 'No previous track.')
         else:
             last_track = await player.get_tracks(player.fetch('prev_song'))
-            player.add(player.fetch('prev_requester').id, last_track[0])
+            player.add(player.fetch('prev_requester'), last_track[0])
             queue_len = len(player.queue)
             bump_song = player.queue[-1]
             player.queue.insert(0, bump_song)

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -497,6 +497,7 @@ class Audio:
 
         queue_duration = await self._queue_duration(ctx)
         queue_total_duration = lavalink.utils.format_time(queue_duration)
+        before_queue_length = len(player.queue) + 1
 
         if 'list' in query and 'ytsearch:' not in query:
             for track in tracks:
@@ -504,7 +505,7 @@ class Audio:
             embed = discord.Embed(colour=ctx.guild.me.top_role.colour, title='Playlist Enqueued',
                                   description='Added {} tracks to the queue.'.format(len(tracks)))
             if not shuffle and queue_duration > 0:
-                embed.set_footer(text='{} until start of playlist playback'.format(queue_total_duration))
+                embed.set_footer(text='{} until start of playlist playback: starts at #{} in queue'.format(queue_total_duration, before_queue_length))
             if not player.current:
                 await player.play()
         else:
@@ -513,7 +514,7 @@ class Audio:
             embed = discord.Embed(colour=ctx.guild.me.top_role.colour, title='Track Enqueued',
                                   description='**[{}]({})**'.format(single_track.title, single_track.uri))
             if not shuffle and queue_duration > 0:
-                embed.set_footer(text='{} until track playback'.format(queue_total_duration))
+                embed.set_footer(text='{} until track playback: #{} in queue'.format(queue_total_duration, before_queue_length))
             if not player.current:
                 await player.play()
         await ctx.send(embed=embed)
@@ -730,7 +731,7 @@ class Audio:
             queue_duration = await self._queue_duration(ctx)
             queue_total_duration = lavalink.utils.format_time(queue_duration)
             if not shuffle and queue_duration > 0:
-                songembed.set_footer(text='{} until start of search playback'.format(queue_total_duration))
+                songembed.set_footer(text='{} until start of search playback: starts at #{} in queue'.format(queue_total_duration, (len(player.queue) + 1)))
             for track in tracks:
                 player.add(ctx.author, track)
                 if not player.current:
@@ -750,7 +751,7 @@ class Audio:
         queue_duration = await self._queue_duration(ctx)
         queue_total_duration = lavalink.utils.format_time(queue_duration)
         if not shuffle and queue_duration > 0:
-            embed.set_footer(text='{} until track playback'.format(queue_total_duration))
+            embed.set_footer(text='{} until track playback: #{} in queue'.format(queue_total_duration, (len(player.queue) + 1)))
         player.add(ctx.author, search_choice)
         if not player.current:
             await player.play()

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -116,6 +116,17 @@ class Audio:
                 await self.bot.change_presence(activity=discord.Activity(name='music in {} servers'.format(playing_servers),
                                                type=discord.ActivityType.playing))
 
+        if event_type == lavalink.LavalinkEvents.TRACK_EXCEPTION:
+            message_channel = player.fetch('channel')
+            if message_channel:
+                message_channel = self.bot.get_channel(message_channel)
+                embed = discord.Embed(colour=message_channel.guild.me.top_role.colour, title='Track Error',
+                                      description='{}\n**[{}]({})**'.format(extra, player.current.title,
+                                      player.current.uri))
+                embed.set_footer(text='Skipping...')
+                await message_channel.send(embed=embed)
+                await player.skip()
+
     @commands.group()
     @commands.guild_only()
     async def audioset(self, ctx):

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -540,6 +540,33 @@ class Audio:
                 return await self._embed_msg(ctx, 'No playlist with that name.')
         await self._embed_msg(ctx, '{} playlist removed.'.format(playlist_name))
 
+    @playlist.command(name='info')
+    async def _playlist_info(self, ctx, playlist_name):
+        """Retrieve information from a saved playlist."""
+        playlists = await self.config.guild(ctx.guild).playlists.get_raw()
+        try:
+            author_id = playlists[playlist_name]['author']
+        except KeyError:
+            return await self._embed_msg(ctx, 'No playlist with that name.')
+        author_obj = self.bot.get_user(author_id)
+        playlist_url = playlists[playlist_name]['playlist_url']
+        try:
+            track_len = len(playlists[playlist_name]['tracks'])
+        except TypeError:
+            track_len = 1
+        if playlist_url is None:
+            playlist_url = '**Not generated from a URL.**'
+        else:
+            playlist_url = 'URL: <{}>'.format(playlist_url)
+        embed = discord.Embed(colour=ctx.guild.me.top_role.colour, title='Playlist info for {}:'.format(playlist_name),
+                              description='Author: **{}**\n{}'.format(author_obj, 
+                              playlist_url))
+        if track_len > 1:
+            embed.set_footer(text='{} tracks'.format(track_len))
+        if track_len == 1:
+            embed.set_footer(text='{} track'.format(track_len))
+        await ctx.send(embed=embed)
+
     @playlist.command(name='list')
     async def _playlist_list(self, ctx):
         """List saved playlists."""


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes
Simple error handling, will skip bad tracks with a small amount of info printed to the channel
External lavalink server settings added
Basic playlist handling: save urls, save out the queue to a playlist, load, list, and delete playlists
Various bugfixes: user name instead of id on prev track requeueing, jukebox mode: when user was outside of channel, they were charged the jukebox price before error was shown, DJ mode: pleb user could use play outside of voice channel