### PR TITLE
[V3] Prevent cleanup infinite loop

### DIFF
--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -94,12 +94,12 @@ class Cleanup:
         channel = ctx.channel
         author = ctx.author
         is_bot = self.bot.user.bot
-        
+
         if number > 100:
             cont = await self.check_100_plus(ctx, number)
             if not cont:
                 return
-    
+
         def check(m):
             if text in m.content:
                 return True
@@ -134,7 +134,7 @@ class Cleanup:
         channel = ctx.channel
         author = ctx.author
         is_bot = self.bot.user.bot
-       
+
         if number > 100:
             cont = await self.check_100_plus(ctx, number)
             if not cont:
@@ -217,7 +217,7 @@ class Cleanup:
         author = ctx.author
 
         is_bot = self.bot.user.bot
-        
+
         if number > 100:
             cont = await self.check_100_plus(ctx, number)
             if not cont:
@@ -252,7 +252,7 @@ class Cleanup:
             if not cont:
                 return
 
-        prefixes = await self.bot.get_prefix(ctx.message) # This returns all server prefixes
+        prefixes = await self.bot.get_prefix(ctx.message)  # This returns all server prefixes
         if isinstance(prefixes, str):
             prefixes = [prefixes]
 

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -55,6 +55,7 @@ class Cleanup:
         too_old = False
 
         while not too_old and len(to_delete) - 1 < number:
+            message = None
             async for message in channel.history(limit=limit,
                                                  before=before,
                                                  after=after):
@@ -66,6 +67,9 @@ class Cleanup:
                     break
                 elif number and len(to_delete) >= number:
                     break
+            if message is None:
+                break
+            else:
                 before = message
         return to_delete
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

If passed `number` was greater than messages in channel, while loop would run infinitely
This fixes #1513 

Additionally, I unindented `before = message` from async for loop
I did not see a purpose to assign it within the for loop, but correct me if I'm wrong