### PR TITLE
[V3 Audio] fix zombie process on unload

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -92,4 +92,5 @@ def shutdown_lavalink_server():
     global proc
     if proc is not None:
         proc.terminate()
+        proc.wait()
         proc = None


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes an issue I discovered where unloading audio left a zombie process behind. 