### PR TITLE
[V3 Info] Don't rely on redirect

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -72,7 +72,7 @@ class Core:
         owner = app_info.owner
 
         async with aiohttp.ClientSession() as session:
-            async with session.get("https://pypi.python.org/pypi/red-discordbot/json") as r:
+            async with session.get('{}/json'.format(red_pypi)) as r:
                 data = await r.json()
         outdated = StrictVersion(data["info"]["version"]) > StrictVersion(__version__)
         about = (

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -72,7 +72,7 @@ class Core:
         owner = app_info.owner
 
         async with aiohttp.ClientSession() as session:
-            async with session.get("http://pypi.python.org/pypi/red-discordbot/json") as r:
+            async with session.get("https://pypi.python.org/pypi/red-discordbot/json") as r:
                 data = await r.json()
         outdated = StrictVersion(data["info"]["version"]) > StrictVersion(__version__)
         about = (

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -110,7 +110,7 @@ def init_events(bot, cli_flags):
         INFO.append('{} cogs with {} commands'.format(len(bot.cogs), len(bot.commands)))
 
         async with aiohttp.ClientSession() as session:
-            async with session.get("http://pypi.python.org/pypi/red-discordbot/json") as r:
+            async with session.get("https://pypi.python.org/pypi/red-discordbot/json") as r:
                 data = await r.json()
         if StrictVersion(data["info"]["version"]) > StrictVersion(red_version):
             INFO.append(


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Fixes following trace:

```
Exception in command 'info'
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/discord/ext/commands/core.py", line 62, in wrapped
    ret = yield from coro(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/redbot/core/core_commands.py", line 76, in info
    data = await r.json()
  File "/usr/lib/python3.6/site-packages/aiohttp/client_reqrep.py", line 730, in json
    headers=self.headers)
aiohttp.client_exceptions.ClientResponseError: 0, message='Attempt to decode JSON with unexpected mimetype: text/plain; charset=utf-8'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/discord/ext/commands/bot.py", line 886, in invoke
    yield from ctx.command.invoke(ctx)
  File "/usr/lib/python3.6/site-packages/discord/ext/commands/core.py", line 514, in invoke
    yield from injected(*ctx.args, **ctx.kwargs)
  File "/usr/lib/python3.6/site-packages/discord/ext/commands/core.py", line 71, in wrapped
    raise CommandInvokeError(e) from e
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: ClientResponseError: 0, message='Attempt to decode JSON with unexpected mimetype: text/plain; charset=utf-8'
```