### PR TITLE
[V3] Fix help's help

### DIFF
--- a/redbot/core/help_formatter.py
+++ b/redbot/core/help_formatter.py
@@ -280,6 +280,7 @@ class Help(formatter.HelpFormatter):
 @commands.command()
 async def help(ctx, *cmds: str):
     """Shows help documentation.
+
     [p]**help**: Shows the help manual.
     [p]**help** command: Show help for a command
     [p]**help** Category: Show commands and description for a category"""


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

`[p]help help` looked terrible

This follows the format of double space after first line for commands