### PR TITLE
[V3 Trivia] Lock trivia version to <1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ raven==6.5.0
 colorama==0.3.9
 aiohttp-json-rpc==0.8.7
 pyyaml==3.12
-Red-Trivia
+Red-Trivia<1.1.0


### PR DESCRIPTION
-- This PR is **blocking** Cog-Creators/Red-Trivia#21 --

Since Cog-Creators/Red-Trivia#21 introduces a breaking change, we need to lock the current trivia version should that PR be merged, until we make an update which accommodates for it.