### PR TITLE
[V3] Mark 3.7 as unsupported in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
             'redbot-launcher=redbot.launcher:main'
         ]
     },
-    python_requires='>=3.5',
+    python_requires='>=3.5,<3.7',
     setup_requires=get_requirements(),
     install_requires=get_requirements(),
     dependency_links=dep_links,


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
PRevents install on 3.7 where there are still isues RE: `async` keyword