### PR TITLE
[V3] Update trivia version and allow installing in develop mode

### DIFF
--- a/redbot/cogs/trivia/trivia.py
+++ b/redbot/cogs/trivia/trivia.py
@@ -3,7 +3,7 @@ from collections import Counter
 import yaml
 import discord
 from discord.ext import commands
-import redbot.trivia
+from redbot.ext import trivia as ext_trivia
 from redbot.core import Config, checks
 from redbot.core.data_manager import cog_data_path
 from redbot.core.utils.chat_formatting import box, pagify
@@ -482,7 +482,7 @@ class Trivia:
         personal_lists = tuple(p.resolve()
                                for p in cog_data_path(self).glob("*.yaml"))
 
-        return personal_lists + tuple(redbot.trivia.lists())
+        return personal_lists + tuple(ext_trivia.lists())
 
     def __unload(self):
         for session in self.trivia_sessions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ raven==6.5.0
 colorama==0.3.9
 aiohttp-json-rpc==0.8.7
 pyyaml==3.12
-Red-Trivia>=1.1.0
+Red-Trivia>=1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ raven==6.5.0
 colorama==0.3.9
 aiohttp-json-rpc==0.8.7
 pyyaml==3.12
-Red-Trivia<1.1.0
+Red-Trivia>=1.1.0


### PR DESCRIPTION
### Type

- Enhancement

### Description of the changes
Alright. This *officially* fixes our namespace issue with the trivia package, which means we can now safely pip install the redbot package in develop mode. Yay!