### PR TITLE
[V3] Add requirements file for setting up dev environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ python:
 - 3.5.3
 - 3.6.1
 install:
-- echo "git+https://github.com/Rapptz/discord.py.git@rewrite#egg=discord.py[voice]" >> requirements.txt
-- pip install -r requirements.txt
-- pip install .[test]
+- pip install -r dev_install.txt
 script:
 - python -m compileall ./redbot/cogs
 - python -m pytest

--- a/dev_install.txt
+++ b/dev_install.txt
@@ -1,0 +1,11 @@
+# This is a pip requirements file used to quickly set up a development
+# environment for Red. Make sure you're using a virtual environment, and
+# simply run `pip install -r dev_install.txt` to get set up.
+#
+# Red will be installed in "editable" or "develop" mode, meaning that
+# the package installation itself is actually located here, in this
+# project directory, and each time you run Red, it will run directly
+# from these sources.
+
+git+https://github.com/Rapptz/discord.py#egg=discord.py[voice]
+-e .[test,docs,voice,mongo]

--- a/dev_install.txt
+++ b/dev_install.txt
@@ -7,5 +7,5 @@
 # project directory, and each time you run Red, it will run directly
 # from these sources.
 
-git+https://github.com/Rapptz/discord.py#egg=discord.py[voice]
+git+https://github.com/Rapptz/discord.py@rewrite#egg=discord.py[voice]
 -e .[test,docs,voice,mongo]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+discord.py>=1.0.0a0
 yarl==0.18.0
 aiohttp>=2.0.0,<2.3.0
 appdirs==1.4.3

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,9 @@ import sys
 
 from setuptools import find_packages
 
-IS_TRAVIS = 'TRAVIS' in os.environ
-IS_DEPLOYING = 'DEPLOYING' in os.environ
 IS_RTD = 'READTHEDOCS' in os.environ
 
 dep_links = ['https://github.com/Rapptz/discord.py/tarball/rewrite#egg=discord.py-1.0']
-if IS_TRAVIS:
-    dep_links = []
 
 
 def get_package_list():
@@ -24,15 +20,13 @@ def get_package_list():
 def get_requirements():
     with open('requirements.txt') as f:
         requirements = f.read().splitlines()
-    try:
-        requirements.remove('git+https://github.com/Rapptz/discord.py.git@rewrite#egg=discord.py[voice]')
-    except ValueError:
-        pass
 
-    if IS_DEPLOYING or not (IS_TRAVIS or IS_RTD):
-        requirements.append('discord.py>=1.0.0a0')
+    if IS_RTD:
+        requirements.remove('discord.py>=1.0.0a0')
+
     if sys.platform.startswith("linux"):
         requirements.append("distro")
+
     return requirements
 
 


### PR DESCRIPTION
Update: Superseded by #1642 

### Type

- Meta enhancement

### Description of the changes
This adds the `dev_install.txt` requirements file I've discussed in #1636. It makes setting up a development environment for Red as simple as `pip install -r dev_install.txt`.

I've also modified the Travis config to use this new requirements file for the installation phase.