### PR TITLE
Fix typo in llset

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -1660,7 +1660,7 @@ class Audio:
     @llsetup.command()
     async def wsport(self, ctx, ws_port):
         """Set the lavalink websocket server port."""
-        await self.config.rest_port.set(ws_port)
+        await self.config.ws_port.set(ws_port)
         if await self._check_external():
             embed = discord.Embed(
                 colour=ctx.guild.me.top_role.colour,


### PR DESCRIPTION
🙃

### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

- Fixes typo in `llset` that causes issues for people using external LL servers; I didn't notice this in b13 because I had helped a user setup manually (via. the audio cogs settings.json, but a report in the #lavalink channel prompted me to look further.