### PR TITLE
[V3 Warnings] Send DM option

### DIFF
--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -294,7 +294,7 @@ class Warnings:
         else:
             if not await is_admin_or_superior(self.bot, ctx.author):
                 await ctx.send(
-                    warning(_("You are not allowed to check " "warnings for other users!"))
+                    warning(_("You are not allowed to check " "warnings for other users!")))
                 return
             else:
                 user = ctx.guild.get_member(userid)

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -3,8 +3,12 @@ from collections import namedtuple
 import discord
 import asyncio
 
-from redbot.cogs.warnings.helpers import warning_points_add_check, get_command_for_exceeded_points, \
-    get_command_for_dropping_points, warning_points_remove_check
+from redbot.cogs.warnings.helpers import (
+    warning_points_add_check,
+    get_command_for_exceeded_points,
+    get_command_for_dropping_points,
+    warning_points_remove_check,
+)
 from redbot.core import Config, modlog, checks, commands
 from redbot.core.bot import Red
 from redbot.core.i18n import Translator, cog_i18n
@@ -18,18 +22,9 @@ _ = Translator("Warnings", __file__)
 class Warnings:
     """A warning system for Red"""
 
-    default_guild = {
-        "actions": [],
-        "reasons": {},
-        "allow_custom_reasons": False,
-        "send_dm": False
-    }
+    default_guild = {"actions": [], "reasons": {}, "allow_custom_reasons": False}
 
-    default_member = {
-        "total_points": 0,
-        "status": "",
-        "warnings": {}
-    }
+    default_member = {"total_points": 0, "status": "", "warnings": {}}
 
     def __init__(self, bot: Red):
         self.config = Config.get_conf(self, identifier=5757575755)
@@ -42,9 +37,7 @@ class Warnings:
     @staticmethod
     async def register_warningtype():
         try:
-            await modlog.register_casetype(
-                "warning", True, "\N{WARNING SIGN}", "Warning", None
-            )
+            await modlog.register_casetype("warning", True, "\N{WARNING SIGN}", "Warning", None)
         except RuntimeError:
             pass
 
@@ -149,9 +142,7 @@ class Warnings:
                 registered_actions.remove(to_remove)
                 await ctx.tick()
             else:
-                await ctx.send(
-                    _("No action named {} exists!").format(action_name)
-                )
+                await ctx.send(_("No action named {} exists!").format(action_name))
 
     @commands.group()
     @commands.guild_only()
@@ -170,13 +161,8 @@ class Warnings:
         if name.lower() == "custom":
             await ctx.send("That cannot be used as a reason name!")
             return
-        to_add = {
-            "points": points,
-            "description": description
-        }
-        completed = {
-            name.lower(): to_add
-        }
+        to_add = {"points": points, "description": description}
+        completed = {name.lower(): to_add}
 
         guild_settings = self.config.guild(guild)
 
@@ -230,8 +216,7 @@ class Warnings:
                 msg_list.append(
                     "Name: {}\nPoints: {}\nExceed command: {}\n"
                     "Drop command: {}".format(
-                        r["action_name"], r["points"], r["exceed_command"],
-                        r["drop_command"]
+                        r["action_name"], r["points"], r["exceed_command"], r["drop_command"]
                     )
                 )
         if msg_list:
@@ -299,7 +284,7 @@ class Warnings:
 
     @commands.command()
     @commands.guild_only()
-    async def warnings(self, ctx: commands.Context, userid: int=None):
+    async def warnings(self, ctx: commands.Context, userid: int = None):
         """Show warnings for the specified user.
         If userid is None, show warnings for the person running the command
         Note that showing warnings for users other than yourself requires
@@ -309,11 +294,7 @@ class Warnings:
         else:
             if not await is_admin_or_superior(self.bot, ctx.author):
                 await ctx.send(
-                    warning(
-                        _("You are not allowed to check "
-                          "warnings for other users!")
-                    )
-                )
+                    warning(_("You are not allowed to check " "warnings for other users!"))
                 return
             else:
                 user = ctx.guild.get_member(userid)
@@ -329,22 +310,14 @@ class Warnings:
                     mod = ctx.guild.get_member(user_warnings[key]["mod"])
                     if mod is None:
                         mod = discord.utils.get(
-                            self.bot.get_all_members(),
-                            id=user_warnings[key]["mod"]
+                            self.bot.get_all_members(), id=user_warnings[key]["mod"]
                         )
                         if mod is None:
-                            mod = await self.bot.get_user_info(
-                                user_warnings[key]["mod"]
-                            )
+                            mod = await self.bot.get_user_info(user_warnings[key]["mod"])
                     msg += "{} point warning {} issued by {} for {}\n".format(
-                        user_warnings[key]["points"],
-                        key,
-                        mod,
-                        user_warnings[key]["description"]
+                        user_warnings[key]["points"], key, mod, user_warnings[key]["description"]
                     )
-                await ctx.send_interactive(
-                    pagify(msg), box_lang="Warnings for {}".format(user)
-                )
+                await ctx.send_interactive(pagify(msg), box_lang="Warnings for {}".format(user))
 
     @commands.command()
     @commands.guild_only()
@@ -372,10 +345,7 @@ class Warnings:
     @staticmethod
     async def custom_warning_reason(ctx: commands.Context):
         """Handles getting description and points for custom reasons"""
-        to_add = {
-            "points": 0,
-            "description": ""
-        }
+        to_add = {"points": 0, "description": ""}
 
         def same_author_check(m):
             return m.author == ctx.author

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -22,7 +22,7 @@ _ = Translator("Warnings", __file__)
 class Warnings:
     """A warning system for Red"""
 
-    default_guild = {"actions": [], "reasons": {}, "allow_custom_reasons": False}
+    default_guild = {"actions": [], "reasons": {}, "allow_custom_reasons": False, "semd_dm": False}
 
     default_member = {"total_points": 0, "status": "", "warnings": {}}
 

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -65,9 +65,7 @@ class Warnings:
         """Allow or disable sending a message to the warned member"""
         guild = ctx.guild
         await self.config.guild(guild).send_dm.set(send)
-        await ctx.send(
-            _("Warn DMs have been {}").format(_("enabled") if send else _("disabled"))
-        )
+        await ctx.send(_("Warn DMs have been {}").format(_("enabled") if send else _("disabled")))
 
     @commands.group()
     @commands.guild_only()
@@ -109,7 +107,7 @@ class Warnings:
             "action_name": name,
             "points": points,
             "exceed_command": exceed_command,
-            "drop_command": drop_command
+            "drop_command": drop_command,
         }
 
         # Have all details for the action, now save the action
@@ -258,7 +256,7 @@ class Warnings:
             str(ctx.message.id): {
                 "points": reason_type["points"],
                 "description": reason_type["description"],
-                "mod": ctx.author.id
+                "mod": ctx.author.id,
             }
         }
         async with member_settings.warnings() as user_warnings:

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -294,7 +294,8 @@ class Warnings:
         else:
             if not await is_admin_or_superior(self.bot, ctx.author):
                 await ctx.send(
-                    warning(_("You are not allowed to check " "warnings for other users!")))
+                    warning(_("You are not allowed to check " "warnings for other users!"))
+                )
                 return
             else:
                 user = ctx.guild.get_member(userid)

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -237,9 +237,7 @@ class Warnings:
                     _(
                         "Custom reasons are not allowed! Please see {} for "
                         "a complete list of valid reasons"
-                    ).format(
-                        "`{}reasonlist`".format(ctx.prefix)
-                    )
+                    ).format("`{}reasonlist`".format(ctx.prefix))
                 )
                 return
             reason_type = await self.custom_warning_reason(ctx)


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

This option will make the bot send a DM with the warn reason when the command is used. I know you guys don't like the DMed reasons but this is something a lot of servers are using, so I though this would be cool to add.