### PR TITLE
Unembed and send message on ping

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -59,8 +59,7 @@ class Core:
         """Pong."""
         if ctx.guild is None or ctx.channel.permissions_for(ctx.guild.me).add_reactions:
             await ctx.message.add_reaction("\U0001f3d3")  # ping pong paddle
-        else:
-            await ctx.maybe_send_embed("Pong.")
+            await ctx.send("Pong.") # Send a message as well because reacts are stupid.
 
     @commands.command()
     async def info(self, ctx: commands.Context):


### PR DESCRIPTION
### Type

- [ X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This removes the embed from ping along with sending a reaction and message when the command is run.
