### PR TITLE
[V3 Audio] Only allow audio commands in servers

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -1589,7 +1589,7 @@ class Audio:
         await ctx.send(embed=embed)
 
     @commands.group(aliases=["llset"])
-    @commands.guild_only()	
+    @commands.guild_only()
     @checks.is_owner()
     async def llsetup(self, ctx):
         """Lavalink server configuration options."""

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -302,6 +302,7 @@ class Audio:
         await self._embed_msg(ctx, "Song titles as status: {}.".format(not status))
 
     @commands.command()
+    @commands.guild_only()
     async def audiostats(self, ctx):
         """Audio stats."""
         server_num = len([p for p in lavalink.players if p.current is not None])
@@ -336,6 +337,7 @@ class Audio:
         await ctx.send(embed=embed)
 
     @commands.command()
+    @commands.guild_only()
     async def bump(self, ctx, index: int):
         """Bump a song number to the top of the queue."""
         dj_enabled = await self.config.guild(ctx.guild).dj_enabled()
@@ -361,6 +363,7 @@ class Audio:
         await self._embed_msg(ctx, "Moved {} to the top of the queue.".format(removed.title))
 
     @commands.command(aliases=["dc"])
+    @commands.guild_only()
     async def disconnect(self, ctx):
         """Disconnect from the voice channel."""
         dj_enabled = await self.config.guild(ctx.guild).dj_enabled()
@@ -377,6 +380,7 @@ class Audio:
                 return await lavalink.get_player(ctx.guild.id).disconnect()
 
     @commands.command(aliases=["np", "n", "song"])
+    @commands.guild_only()
     async def now(self, ctx):
         """Now playing."""
         if not self._player_check(ctx):
@@ -444,6 +448,7 @@ class Audio:
             await ctx.invoke(self.skip)
 
     @commands.command(aliases=["resume"])
+    @commands.guild_only()
     async def pause(self, ctx):
         """Pause and resume."""
         dj_enabled = await self.config.guild(ctx.guild).dj_enabled()
@@ -488,6 +493,7 @@ class Audio:
         await self._embed_msg(ctx, "Nothing playing.")
 
     @commands.command()
+    @commands.guild_only()
     async def percent(self, ctx):
         """Queue percentage."""
         if not self._player_check(ctx):
@@ -543,6 +549,7 @@ class Audio:
         await ctx.send(embed=embed)
 
     @commands.command()
+    @commands.guild_only()
     async def play(self, ctx, *, query):
         """Play a URL or search for a song."""
         dj_enabled = await self.config.guild(ctx.guild).dj_enabled()
@@ -997,6 +1004,7 @@ class Audio:
         return tracklist
 
     @commands.command()
+    @commands.guild_only()
     async def prev(self, ctx):
         """Skips to the start of the previously played track."""
         if not self._player_check(ctx):
@@ -1035,6 +1043,7 @@ class Audio:
             await ctx.send(embed=embed)
 
     @commands.command(aliases=["q"])
+    @commands.guild_only()
     async def queue(self, ctx, page: int = 1):
         """Lists the queue."""
         if not self._player_check(ctx):
@@ -1110,6 +1119,7 @@ class Audio:
         return embed
 
     @commands.command()
+    @commands.guild_only()
     async def repeat(self, ctx):
         """Toggles repeat."""
         dj_enabled = await self.config.guild(ctx.guild).dj_enabled()
@@ -1133,6 +1143,7 @@ class Audio:
         await self._embed_msg(ctx, "Repeat songs: {}.".format(repeat))
 
     @commands.command()
+    @commands.guild_only()
     async def remove(self, ctx, index: int):
         """Remove a specific song number from the queue."""
         dj_enabled = await self.config.guild(ctx.guild).dj_enabled()
@@ -1159,6 +1170,7 @@ class Audio:
         await self._embed_msg(ctx, "Removed {} from the queue.".format(removed.title))
 
     @commands.command()
+    @commands.guild_only()
     async def search(self, ctx, *, query):
         """Pick a song with a search.
         Use [p]search list <search term> to queue all songs found on YouTube.
@@ -1314,6 +1326,7 @@ class Audio:
         return embed
 
     @commands.command()
+    @commands.guild_only()
     async def seek(self, ctx, seconds: int = 30):
         """Seeks ahead or behind on a track by seconds."""
         dj_enabled = await self.config.guild(ctx.guild).dj_enabled()
@@ -1346,6 +1359,7 @@ class Audio:
             await self._embed_msg(ctx, "Nothing playing.")
 
     @commands.command()
+    @commands.guild_only()
     async def shuffle(self, ctx):
         """Toggles shuffle."""
         dj_enabled = await self.config.guild(ctx.guild).dj_enabled()
@@ -1367,6 +1381,7 @@ class Audio:
         await self._embed_msg(ctx, "Shuffle songs: {}.".format(shuffle))
 
     @commands.command(aliases=["forceskip", "fs"])
+    @commands.guild_only()
     async def skip(self, ctx):
         """Skips to the next track."""
         if not self._player_check(ctx):
@@ -1497,6 +1512,7 @@ class Audio:
         await player.skip()
 
     @commands.command(aliases=["s"])
+    @commands.guild_only()
     async def stop(self, ctx):
         """Stops playback and clears the queue."""
         dj_enabled = await self.config.guild(ctx.guild).dj_enabled()
@@ -1529,6 +1545,7 @@ class Audio:
             player.store("requester", None)
 
     @commands.command()
+    @commands.guild_only()
     async def volume(self, ctx, vol: int = None):
         """Sets the volume, 1% - 150%."""
         dj_enabled = await self.config.guild(ctx.guild).dj_enabled()
@@ -1572,6 +1589,7 @@ class Audio:
         await ctx.send(embed=embed)
 
     @commands.group(aliases=["llset"])
+    @commands.guild_only()	
     @checks.is_owner()
     async def llsetup(self, ctx):
         """Lavalink server configuration options."""


### PR DESCRIPTION
Fixes #1681

### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Only allow audio commands in servers. After audio is updated later to respect the embed/plaintext toggle in Red, [p]llsetup should be changed to allow that command in DMs.