### PR TITLE
[V3 Docs] Move the install docs to install Python 3.6

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,8 @@ Welcome to Red - Discord Bot's documentation!
 
     install_windows
     install_mac
-    install_ubuntu
+    install_ubuntu_xenial
+    install_ubuntu_bionic
     install_debian
     install_centos
     install_arch

--- a/docs/install_centos.rst
+++ b/docs/install_centos.rst
@@ -15,7 +15,6 @@ Installing pre-requirements
     yum -y groupinstall development
     yum -y install https://centos7.iuscommunity.org/ius-release.rpm
     yum -y install yum-utils wget which python35u python35u-pip python35u-devel openssl-devel libffi-devel git java-1.8.0-openjdk
-    sh -c "$(wget https://gist.githubusercontent.com/mustafaturan/7053900/raw/27f4c8bad3ee2bb0027a1a52dc8501bf1e53b270/latest-ffmpeg-centos6.sh -O -)"
 
 --------------
 Installing Red

--- a/docs/install_centos.rst
+++ b/docs/install_centos.rst
@@ -14,7 +14,7 @@ Installing pre-requirements
 
     yum -y groupinstall development
     yum -y install https://centos7.iuscommunity.org/ius-release.rpm
-    yum -y install yum-utils wget which python35u python35u-pip python35u-devel openssl-devel libffi-devel git java-1.8.0-openjdk
+    yum -y install yum-utils wget which python36u python36u-pip python36u-devel openssl-devel libffi-devel git java-1.8.0-openjdk
 
 --------------
 Installing Red

--- a/docs/install_debian.rst
+++ b/docs/install_debian.rst
@@ -12,9 +12,18 @@ Installing pre-requirements
 
 .. code-block:: none
 
-    echo "deb http://httpredir.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list
-    apt-get update
-    apt-get install python3.5-dev python3-pip build-essential libssl-dev libffi-dev git unzip default-jre -y
+    sudo apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev git unzip default-jre
+    curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+
+After that last command, you may see a warning about 'pyenv' not being in the load path. Follow the instructions given to fix that, then close and reopen your shell
+
+Then run the following command:
+
+.. code-block:: none
+
+    CONFIGURE_OPTS=--enable-optimizations pyenv install 3.6.5 -v
+
+This may take a long time to complete.
 
 ------------------
 Installing the bot
@@ -22,7 +31,7 @@ Installing the bot
 
 To install without audio:
 
-:code:`pip3 install -U --process-dependency-links red-discordbot`
+:code:`pip3.6 install -U --process-dependency-links red-discordbot`
 
 To install with audio:
 

--- a/docs/install_debian.rst
+++ b/docs/install_debian.rst
@@ -25,6 +25,12 @@ Then run the following command:
 
 This may take a long time to complete.
 
+After that is finished, run:
+
+.. code-block:: none
+
+    pyenv global 3.6.5
+
 ------------------
 Installing the bot
 ------------------

--- a/docs/install_debian.rst
+++ b/docs/install_debian.rst
@@ -37,7 +37,7 @@ Installing the bot
 
 To install without audio:
 
-:code:`pip3.6 install -U --process-dependency-links red-discordbot`
+:code:`pip3 install -U --process-dependency-links red-discordbot`
 
 To install with audio:
 

--- a/docs/install_raspbian.rst
+++ b/docs/install_raspbian.rst
@@ -25,6 +25,11 @@ Then run the following command:
 
 This may take a long time to complete.
 
+After that is finished, run:
+
+.. code-block:: none
+
+    pyenv global 3.6.5
 
 --------------
 Installing Red

--- a/docs/install_ubuntu_bionic.rst
+++ b/docs/install_ubuntu_bionic.rst
@@ -1,40 +1,29 @@
-.. raspbian install guide
+.. ubuntu bionic install guide
 
-==================================
-Installing Red on Raspbian Stretch
-==================================
+==============================
+Installing Red on Ubuntu 18.04
+==============================
 
-.. warning:: For safety reasons, DO NOT install Red with a root user. Instead, `make a new one <https://www.raspberrypi.org/documentation/linux/usage/users.md>`_.
+.. warning:: For safety reasons, DO NOT install Red with a root user. Instead, `make a new one <http://manpages.ubuntu.com/manpages/artful/man8/adduser.8.html>`_.
 
----------------------------
-Installing pre-requirements
----------------------------
-
-.. code-block:: none
-
-    sudo apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev git unzip default-jre
-    curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
-
-After that last command, you may see a warning about 'pyenv' not being in the load path. Follow the instructions given to fix that, then close and reopen your shell
-
-Then run the following command:
+-------------------------------
+Installing the pre-requirements
+-------------------------------
 
 .. code-block:: none
 
-    CONFIGURE_OPTS=--enable-optimizations pyenv install 3.6.5 -v
-
-This may take a long time to complete.
+    sudo apt install python3.6-dev python3-pip build-essential libssl-dev libffi-dev git unzip default-jre -y
 
 
---------------
-Installing Red
---------------
+------------------
+Installing the bot
+------------------
 
-Without audio:
+To install without audio:
 
 :code:`pip3 install -U --process-dependency-links red-discordbot --user`
 
-With audio:
+To install with audio:
 
 :code:`pip3 install -U --process-dependency-links red-discordbot[voice] --user`
 
@@ -46,9 +35,9 @@ To install the development version (with audio):
 
 :code:`pip3 install -U --process-dependency-links git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot[voice] --user`
 
-----------------------
-Setting up an instance
-----------------------
+------------------------
+Setting up your instance
+------------------------
 
 Run :code:`redbot-setup` and follow the prompts. It will ask first for where you want to
 store the data (the default is :code:`~/.local/share/Red-DiscordBot`) and will then ask
@@ -63,5 +52,3 @@ Running Red
 
 Run :code:`redbot <your instance name>` and run through the initial setup. This will ask for
 your token and a prefix.
-
-.. warning:: Audio will not work on Raspberry Pi's **below** 2B. This is a CPU problem and *cannot* be fixed.

--- a/docs/install_ubuntu_xenial.rst
+++ b/docs/install_ubuntu_xenial.rst
@@ -11,6 +11,7 @@ Installing the pre-requirements
 -------------------------------
 
 .. code-block:: none
+
     sudo apt install software-properties-common
     sudo add-apt-repository ppa:deadsnakes/ppa
     sudo apt update

--- a/docs/install_ubuntu_xenial.rst
+++ b/docs/install_ubuntu_xenial.rst
@@ -1,4 +1,4 @@
-.. ubuntu install guide
+.. ubuntu xenial install guide
 
 ==============================
 Installing Red on Ubuntu 16.04
@@ -11,8 +11,12 @@ Installing the pre-requirements
 -------------------------------
 
 .. code-block:: none
-
-    sudo apt install python3.5-dev python3-pip build-essential libssl-dev libffi-dev git unzip default-jre -y
+    sudo apt install software-properties-common
+    sudo add-apt-repository ppa:deadsnakes/ppa
+    sudo apt update
+    sudo apt install python3.6-dev build-essential libssl-dev libffi-dev git unzip default-jre wget -y
+    wget https://bootstrap.pypa.io/get-pip.py
+    sudo python3.6 get-pip.py
 
 
 ------------------
@@ -21,19 +25,19 @@ Installing the bot
 
 To install without audio:
 
-:code:`pip3 install -U --process-dependency-links red-discordbot --user`
+:code:`pip3.6 install -U --process-dependency-links red-discordbot --user`
 
 To install with audio:
 
-:code:`pip3 install -U --process-dependency-links red-discordbot[voice] --user`
+:code:`pip3.6 install -U --process-dependency-links red-discordbot[voice] --user`
 
 To install the development version (without audio):
 
-:code:`pip3 install -U --process-dependency-links git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot --user`
+:code:`pip3.6 install -U --process-dependency-links git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot --user`
 
 To install the development version (with audio):
 
-:code:`pip3 install -U --process-dependency-links git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot[voice] --user`
+:code:`pip3.6 install -U --process-dependency-links git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=red-discordbot[voice] --user`
 
 ------------------------
 Setting up your instance

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -8,7 +8,7 @@ Installing Red on Windows
 Needed Software
 ---------------
 
-* `Python <https://python.org/downloads/>`_ - Red needs at least Python 3.5
+* `Python <https://python.org/downloads/>`_ - Red needs Python 3.6
 
 .. note:: Please make sure that the box to add Python to PATH is CHECKED, otherwise
           you may run into issues when trying to run Red


### PR DESCRIPTION
As a result of #1684 the docs need to be updated to have users install Python 3.6
