### PR TITLE
[V3 Core] Add [p]helpset

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -49,6 +49,8 @@ class RedBase(BotBase):
             enable_sentry=None,
             locale="en",
             embeds=True,
+            help__page_char_limit=1000,
+            help__max_pages_in_guild=2,
         )
 
         self.db.register_guild(

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -851,7 +851,7 @@ class Core:
         The default value is 1000 characters.
         """
         if limit <= 0:
-            await ctx.send(_("Error: You must give a positive value!"))
+            await ctx.send(_("You must give a positive value!"))
             return
 
         await ctx.bot.db.help.page_char_limit.set(limit)

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -852,6 +852,7 @@ class Core:
         """
         if limit <= 0:
             await ctx.send(_("Error: You must give a positive value!"))
+            return
 
         await ctx.bot.db.help.page_char_limit.set(limit)
         await ctx.send(_("Done. The character limit per page has been set to {}.").format(limit))
@@ -870,6 +871,7 @@ class Core:
         """
         if pages < 0:
             await ctx.send(_("You must give a value of zero or greater!"))
+            return
 
         await ctx.bot.db.help.max_pages_in_guild.set(pages)
         await ctx.send(_("Done. The page limit has been set to {}.").format(pages))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -831,6 +831,49 @@ class Core:
             ctx.bot.disable_sentry()
             await ctx.send(_("Done. Sentry logging is now disabled."))
 
+    @commands.group()
+    @checks.is_owner()
+    async def helpset(self, ctx: commands.Context):
+        """Manage settings for the help command."""
+        if ctx.invoked_subcommand is None:
+            await ctx.send_help()
+
+    @helpset.command(name="pagecharlimit")
+    async def helpset_pagecharlimt(self, ctx: commands.Context, limit: int):
+        """Set the character limit for each page in the help message.
+
+        This setting only applies to embedded help.
+
+        Please note that setting a relitavely small character limit may
+        mean some pages will exceed this limit. This is because categories
+        are never spread across multiple pages in the help message.
+
+        The default value is 1000 characters.
+        """
+        if limit <= 0:
+            await ctx.send(_("Error: You must give a positive value!"))
+
+        await ctx.bot.db.help.page_char_limit.set(limit)
+        await ctx.send(_("Done. The character limit per page has been set to {}.").format(limit))
+
+    @helpset.command(name="maxpages")
+    async def helpset_maxpages(self, ctx: commands.Context, pages: int):
+        """Set the maximum number of help pages sent in a server channel.
+
+        This setting only applies to embedded help.
+
+        If a help message contains more pages than this value, the help message will
+        be sent to the command author via DM. This is to help reduce spam in server
+        text channels.
+
+        The default value is 2 pages.
+        """
+        if pages < 0:
+            await ctx.send(_("You must give a value of zero or greater!"))
+
+        await ctx.bot.db.help.max_pages_in_guild.set(pages)
+        await ctx.send(_("Done. The page limit has been set to {}.").format(pages))
+
     @commands.command()
     @checks.is_owner()
     async def listlocales(self, ctx: commands.Context):

--- a/redbot/core/help_formatter.py
+++ b/redbot/core/help_formatter.py
@@ -236,7 +236,9 @@ class Help(formatter.HelpFormatter):
             emb["embed"]["title"] = "{0}".format(reason)
 
         ret = []
-        field_groups = self.group_fields(emb["fields"])
+
+        page_char_limit = await ctx.bot.db.help.page_char_limit()
+        field_groups = self.group_fields(emb["fields"], page_char_limit)
 
         for i, group in enumerate(field_groups, 1):
             embed = discord.Embed(color=self.color, **emb["embed"])
@@ -360,7 +362,8 @@ async def help(ctx, *cmds: str):
         else:
             embeds = await f.format_help_for(ctx, command)
 
-    if len(embeds) > 2:
+    max_pages_in_guild = await ctx.bot.db.help.max_pages_in_guild()
+    if len(embeds) > max_pages_in_guild:
         destination = ctx.author
 
     for embed in embeds:


### PR DESCRIPTION
### Type

- New Feature

### Description of the changes
Currently, `[p]helpset` can:
 - Set the maximum number of characters per page in help messages
 - Set the maximum number of pages sent to a server text channel before the message is sent via DM.

Resolves #1512 

Works towards #1605