### PR TITLE
[V3/Economy]

### DIFF
--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -167,7 +167,7 @@ class Economy:
         try:
             await bank.transfer_credits(from_, to, amount)
         except ValueError as e:
-            await ctx.send(str(e))
+            return await ctx.send(str(e))
 
         await ctx.send(
             _("{} transferred {} {} to {}").format(


### PR DESCRIPTION
Fixed an erroneous message when transferring credits while having insufficient funds.

### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This PR addresses the Economy transfer bug in  #1697