### PR TITLE
[V3 Docs] expand info.json docs

### DIFF
--- a/docs/framework_downloader.rst
+++ b/docs/framework_downloader.rst
@@ -6,21 +6,30 @@ Downloader Framework
 Info.json
 *********
 
-The info.json file may exist inside every package folder in the repo,
-it is optional however. This string describes the valid keys within
-an info file (and maybe how the Downloader cog uses them).
+The optional info.json file may exist inside every package folder in the repo, 
+as well as in the root of the repo. The following sections describe the valid 
+keys within an info file (and maybe how the Downloader cog uses them).
 
-KEYS (case sensitive):
+Keys common to both repo and cog info.json (case sensitive)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- ``author`` (list of strings) - list of names of authors of the cog
+- ``author`` (list of strings) - list of names of authors of the cog or repo.
+
+- ``description`` (string) - A long description of the cog or repo. For cogs, this 
+  is displayed when a user executes ``!cog info``.
+
+- ``install_msg`` (string) - The message that gets displayed when a cog 
+  is installed or a repo is added
+
+- ``short`` (string) - A short description of the cog or repo. For cogs, this info 
+  is displayed when a user executes ``!cog list``
+
+Keys specific to the cog info.json (case sensitive)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - ``bot_version`` (list of integer) - Min version number of Red in the format ``(MAJOR, MINOR, PATCH)``
 
-- ``description`` (string) - A long description of the cog that appears when a user executes ```!cog info``.
-
 - ``hidden`` (bool) - Determines if a cog is available for install.
-
-- ``install_msg`` (string) - The message that gets displayed when a cog is installed
 
 - ``required_cogs`` (map of cogname to repo URL) - A map of required cogs that this cog depends on.
   Downloader will not deal with this functionality but it may be useful for other cogs.
@@ -28,9 +37,6 @@ KEYS (case sensitive):
 - ``requirements`` (list of strings) - list of required libraries that are
   passed to pip on cog install. ``SHARED_LIBRARIES`` do NOT go in this
   list.
-
-- ``short`` (string) - A short description of the cog that appears when
-  a user executes `!cog list`
 
 - ``tags`` (list of strings) - A list of strings that are related to the
   functionality of the cog. Used to aid in searching.


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
#1688 

This should clear up what keys are available in the repo-level info.json (at the root of the repo) and what is available for the cog-level info.json (in each package)