### PR TITLE
[V3] rpc close removed

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -164,7 +164,6 @@ def main():
         sentry_log.critical("Fatal Exception", exc_info=e)
         loop.run_until_complete(red.logout())
     finally:
-        red.rpc.close()
         if cleanup_tasks:
             pending = asyncio.Task.all_tasks(loop=red.loop)
             gathered = asyncio.gather(*pending, loop=red.loop, return_exceptions=True)


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
red no longer has an rpc.close method, removing it from the finally in main