### PR TITLE
minor color fix

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -99,7 +99,7 @@ class RedBase(BotBase):
 
         self.counter = Counter()
         self.uptime = None
-        self.color = None
+        self.color = discord.Embed.Empty  # This is needed or color ends up 0x000000
 
         self.main_dir = bot_dir
 


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Minor fix for an unset color to be treated as unset rather than as `0x000000` due to how discord.py handles empty embed values