### PR TITLE
[V3] Make bot send typing whilst loading cogs

### DIFF
--- a/redbot/cogs/audio/__init__.py
+++ b/redbot/cogs/audio/__init__.py
@@ -9,7 +9,7 @@ from discord.ext import commands
 from redbot.core.data_manager import cog_data_path
 import redbot.core
 
-log = logging.getLogger('red.audio')
+log = logging.getLogger("red.audio")
 
 LAVALINK_DOWNLOAD_URL = (
     "https://github.com/Cog-Creators/Red-DiscordBot/" "releases/download/{}/Lavalink.jar"

--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -4,6 +4,9 @@ import asyncio
 from subprocess import Popen, DEVNULL, PIPE
 import os
 import logging
+from typing import Optional, Tuple
+
+_JavaVersion = Tuple[int, int]
 
 log = logging.getLogger("red.audio.manager")
 
@@ -36,16 +39,16 @@ async def monitor_lavalink_server(loop):
             )
 
 
-async def has_java(loop):
+async def has_java(loop) -> Tuple[bool, Optional[_JavaVersion]]:
     java_available = shutil.which("java") is not None
     if not java_available:
-        return False
+        return False, None
 
     version = await get_java_version(loop)
     return version >= (1, 8), version
 
 
-async def get_java_version(loop):
+async def get_java_version(loop) -> _JavaVersion:
     """
     This assumes we've already checked that java exists.
     """

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -337,22 +337,23 @@ class Core:
 
         if len(cogspecs) > 0:
             for spec, name in cogspecs:
-                try:
-                    await ctx.bot.load_extension(spec)
-                except Exception as e:
-                    log.exception("Package loading failed", exc_info=e)
+                async with ctx.typing():
+                    try:
+                        await ctx.bot.load_extension(spec)
+                    except Exception as e:
+                        log.exception("Package loading failed", exc_info=e)
 
-                    exception_log = "Exception in command '{}'\n" "".format(
-                        ctx.command.qualified_name
-                    )
-                    exception_log += "".join(
-                        traceback.format_exception(type(e), e, e.__traceback__)
-                    )
-                    self.bot._last_exception = exception_log
-                    failed_packages.append(inline(name))
-                else:
-                    await ctx.bot.add_loaded_package(name)
-                    loaded_packages.append(inline(name))
+                        exception_log = "Exception in command '{}'\n" "".format(
+                            ctx.command.qualified_name
+                        )
+                        exception_log += "".join(
+                            traceback.format_exception(type(e), e, e.__traceback__)
+                        )
+                        self.bot._last_exception = exception_log
+                        failed_packages.append(inline(name))
+                    else:
+                        await ctx.bot.add_loaded_package(name)
+                        loaded_packages.append(inline(name))
 
         if loaded_packages:
             fmt = "Loaded {packs}"
@@ -421,18 +422,19 @@ class Core:
                 notfound_packages.append(inline(c))
 
         for spec, name in cogspecs:
-            try:
-                self.cleanup_and_refresh_modules(spec.name)
-                await ctx.bot.load_extension(spec)
-                loaded_packages.append(inline(name))
-            except Exception as e:
-                log.exception("Package reloading failed", exc_info=e)
+            async with ctx.typing():
+                try:
+                    self.cleanup_and_refresh_modules(spec.name)
+                    await ctx.bot.load_extension(spec)
+                    loaded_packages.append(inline(name))
+                except Exception as e:
+                    log.exception("Package reloading failed", exc_info=e)
 
-                exception_log = "Exception in command '{}'\n" "".format(ctx.command.qualified_name)
-                exception_log += "".join(traceback.format_exception(type(e), e, e.__traceback__))
-                self.bot._last_exception = exception_log
+                    exception_log = "Exception in command '{}'\n" "".format(ctx.command.qualified_name)
+                    exception_log += "".join(traceback.format_exception(type(e), e, e.__traceback__))
+                    self.bot._last_exception = exception_log
 
-                failed_packages.append(inline(name))
+                    failed_packages.append(inline(name))
 
         if loaded_packages:
             fmt = "Package{plural} {packs} {other} reloaded."

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -430,8 +430,12 @@ class Core:
                 except Exception as e:
                     log.exception("Package reloading failed", exc_info=e)
 
-                    exception_log = "Exception in command '{}'\n" "".format(ctx.command.qualified_name)
-                    exception_log += "".join(traceback.format_exception(type(e), e, e.__traceback__))
+                    exception_log = "Exception in command '{}'\n" "".format(
+                        ctx.command.qualified_name
+                    )
+                    exception_log += "".join(
+                        traceback.format_exception(type(e), e, e.__traceback__)
+                    )
                     self.bot._last_exception = exception_log
 
                     failed_packages.append(inline(name))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -501,7 +501,8 @@ class Core(CoreLogic):
         """Loads packages"""
 
         cog_names = [c.strip() for c in cog_name.split(" ")]
-        loaded, failed, not_found = await self._load(cog_names)
+        async with ctx.typing():
+            loaded, failed, not_found = await self._load(cog_names)
 
         if loaded:
             fmt = "Loaded {packs}"
@@ -546,8 +547,8 @@ class Core(CoreLogic):
         """Reloads packages"""
 
         cog_names = [c.strip() for c in cog_name.split(" ")]
-
-        loaded, failed, not_found = await self._reload(cog_names)
+        async with ctx.typing():
+            loaded, failed, not_found = await self._reload(cog_names)
 
         if loaded:
             fmt = "Package{plural} {packs} {other} reloaded."
@@ -642,7 +643,7 @@ class Core(CoreLogic):
         """
         Toggle whether to use the bot owner-configured colour for embeds.
 
-        Default is to not use the bot's configured colour, in which case the 
+        Default is to not use the bot's configured colour, in which case the
         colour used will be the colour of the bot's top role.
         """
         current_setting = await ctx.bot.db.guild(ctx.guild).use_bot_color()
@@ -992,7 +993,7 @@ class Core(CoreLogic):
         """
         Set the tagline to be used.
 
-        This setting only applies to embedded help. If no tagline is 
+        This setting only applies to embedded help. If no tagline is
         specified, the default will be used instead.
         """
         if tagline is None:


### PR DESCRIPTION
This is for #1709 - at least whilst downloading the Lavalink.jar, the user knows the bot is still doing something since it's typing.

Not ideal since it doesn't exactly say "Downloading Lavalink.jar", but better than nothing given we can't really send a message without context.

It also fixes the other bug mentioned in #1709.