### PR TITLE
[V3 Permissions] Don't rely on load order to be consistent

### DIFF
--- a/redbot/cogs/permissions/resolvers.py
+++ b/redbot/cogs/permissions/resolvers.py
@@ -12,20 +12,10 @@ async def val_if_check_is_valid(*, ctx: commands.Context, check: object, level: 
     Returns the value from a check if it is valid
     """
 
-    # Non staticmethods should not be run without their parent
-    # class, even if the parent class did not deregister them
-    if check.__module__ is None:
-        pass
-    elif isinstance(check, types.FunctionType):
-        if (
-            next(filter(lambda x: check.__module__ == x.__module__, ctx.bot.cogs.values()), None)
-            is None
-        ):
-            return None
-
     val = None
     # let's not spam the console with improperly made 3rd party checks
     try:
+        # pretty sure this is redunant, but if it is, it will short circuit at or
         if asyncio.iscoroutine(check) or asyncio.iscoroutinefunction(check):
             val = await check(ctx, level=level)
         else:

--- a/redbot/cogs/permissions/resolvers.py
+++ b/redbot/cogs/permissions/resolvers.py
@@ -15,8 +15,7 @@ async def val_if_check_is_valid(*, ctx: commands.Context, check: object, level: 
     val = None
     # let's not spam the console with improperly made 3rd party checks
     try:
-        # pretty sure this is redunant, but if it is, it will short circuit at or
-        if asyncio.iscoroutine(check) or asyncio.iscoroutinefunction(check):
+        if asyncio.iscoroutinefunction(check):
             val = await check(ctx, level=level)
         else:
             val = check(ctx, level=level)


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Modifies permissions re #1758

This is technically a breaking change for any 3rd party cogs which were hooking into permissions. As this API was not fully documented yet, I doubt the use is widespread of it, but there should be some level of informing on this. This is however, a relatively easy change to accommodate as a cog creator if anyone was using it.

This is tested and working as intended.
