### PR TITLE
[V3 Docs] Add intersphinx link to discord.ext.commands api reference

### DIFF
--- a/docs/framework_commands.rst
+++ b/docs/framework_commands.rst
@@ -4,8 +4,9 @@
 Commands Package
 ================
 
-This package acts almost identically to ``discord.ext.commands``; i.e. they both have the same
-attributes. Some of these attributes, however, have been slightly modified, as outlined below.
+This package acts almost identically to :doc:`discord.ext.commands <dpy:ext/commands/api>`; i.e.
+they both have the same attributes. Some of these attributes, however, have been slightly modified,
+as outlined below.
 
 .. autofunction:: redbot.core.commands.command
 


### PR DESCRIPTION
This should make it clearer where to find the complete documentation for users, and not just our modifications.