### PR TITLE
[V3 CLI] CLI prefix args correctly display in the on_ready print

### DIFF
--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -96,7 +96,7 @@ def init_events(bot, cli_flags):
             else:
                 invite_url = None
 
-        prefixes = await bot.db.prefix()
+        prefixes = cli_flags.prefix or (await bot.db.prefix())
         lang = await bot.db.locale()
         red_version = __version__
         red_pkg = pkg_resources.get_distribution("Red-DiscordBot")
@@ -118,24 +118,24 @@ def init_events(bot, cli_flags):
 
         INFO.append("{} cogs with {} commands".format(len(bot.cogs), len(bot.commands)))
 
-        async with aiohttp.ClientSession() as session:
-            async with session.get("https://pypi.python.org/pypi/red-discordbot/json") as r:
-                data = await r.json()
-        if StrictVersion(data["info"]["version"]) > StrictVersion(red_version):
-            INFO.append(
-                "Outdated version! {} is available "
-                "but you're using {}".format(data["info"]["version"], red_version)
-            )
-            owner = discord.utils.get(bot.get_all_members(), id=bot.owner_id)
-            try:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get("https://pypi.python.org/pypi/red-discordbot/json") as r:
+                    data = await r.json()
+            if StrictVersion(data["info"]["version"]) > StrictVersion(red_version):
+                INFO.append(
+                    "Outdated version! {} is available "
+                    "but you're using {}".format(data["info"]["version"], red_version)
+                )
+                owner = discord.utils.get(bot.get_all_members(), id=bot.owner_id)
                 await owner.send(
                     "Your Red instance is out of date! {} is the current "
                     "version, however you are using {}!".format(
                         data["info"]["version"], red_version
                     )
                 )
-            except:
-                pass
+        except:
+            pass
         INFO2 = []
 
         sentry = await bot.db.enable_sentry()


### PR DESCRIPTION
fixes #1477, 

This also includes a fix which prevents the CLI from dumping a traceback if it can't detect versions by modifying the scope of the preexisting try/except block slightly. This was necessary to actually test this currently, but there's no obvious downside to keeping it as this is directly related to what was previously in the block (a conditional attempt to message the owner on outdated launch)

This would also fix #1742 
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
