### PR TITLE
[V3 Admin] Fix permission problems

### DIFF
--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -273,7 +273,7 @@ class Admin:
             guild = ctx.guild
         
         member = guild.get_member(ctx.author.id)    
-        if not (member.guild_permissions.administartor or \
+        if not (member.guild_permissions.administrator or \
             self.bot.is_owner(ctx.author)):
             await ctx.send("You are not allowed to do that on this guild!")
             return

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -271,6 +271,12 @@ class Admin:
         """
         if guild is None:
             guild = ctx.guild
+        
+        member = guild.get_member(ctx.author.id)    
+        if not (member.guild_permissions.administartor or \
+            self.bot.is_owner(ctx.author)):
+            await ctx.send("You are not allowed to do that on this guild!")
+            return
 
         ignored = await self.conf.guild(guild).announce_ignore()
         await self.conf.guild(guild).announce_ignore.set(not ignored)

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -40,6 +40,7 @@ RUNNING_ANNOUNCEMENT = (
 
 
 class Admin:
+
     def __init__(self, config=Config):
         self.conf = config.get_conf(self, 8237492837454039, force_registration=True)
 
@@ -271,10 +272,9 @@ class Admin:
         """
         if guild is None:
             guild = ctx.guild
-        
-        member = guild.get_member(ctx.author.id)    
-        if not (member.guild_permissions.administrator or \
-            self.bot.is_owner(ctx.author)):
+
+        member = guild.get_member(ctx.author.id)
+        if not (member.guild_permissions.administrator or self.bot.is_owner(ctx.author)):
             await ctx.send("You are not allowed to do that on this guild!")
             return
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Any owner could interact with an other guild without permissions using [p]announce ignore. Now it checks if the member has permissions on the selected guild.

This is not tested but should work.