### PR TITLE
[V3 Core] local whitelist/blacklist

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1351,6 +1351,7 @@ class Core(CoreLogic):
         await ctx.send(_("blacklist has been cleared."))
 
     @commands.group()
+    @commands.guild_only()
     @checks.admin_or_permissions(administrator=True)
     async def localwhitelist(self, ctx):
         """

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1350,7 +1350,6 @@ class Core(CoreLogic):
         await ctx.bot.db.blacklist.set([])
         await ctx.send(_("blacklist has been cleared."))
 
-
     @commands.group()
     @checks.admin_or_permissions(administrator=True)
     async def localwhitelist(self, ctx):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1257,7 +1257,7 @@ class Core(CoreLogic):
 
         msg = _("Whitelisted Users:")
         for user in curr_list:
-            msg.append("\n\t- {}".format(user))
+            msg += "\n\t- {}".format(user)
 
         for page in pagify(msg):
             await ctx.send(box(page))
@@ -1320,7 +1320,7 @@ class Core(CoreLogic):
 
         msg = _("blacklisted Users:")
         for user in curr_list:
-            msg.append("\n\t- {}".format(user))
+            msg += "\n\t- {}".format(user)
 
         for page in pagify(msg):
             await ctx.send(box(page))
@@ -1389,7 +1389,7 @@ class Core(CoreLogic):
 
         msg = _("Whitelisted Users and roles:")
         for obj in curr_list:
-            msg.append("\n\t- {}".format(obj))
+            msg += "\n\t- {}".format(obj)
 
         for page in pagify(msg):
             await ctx.send(box(page))
@@ -1477,7 +1477,7 @@ class Core(CoreLogic):
 
         msg = _("blacklisted Users and Roles:")
         for obj in curr_list:
-            msg.append("\n\t- {}".format(obj))
+            msg +="\n\t- {}".format(obj)
 
         for page in pagify(msg):
             await ctx.send(box(page))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1350,6 +1350,177 @@ class Core(CoreLogic):
         await ctx.bot.db.blacklist.set([])
         await ctx.send(_("blacklist has been cleared."))
 
+
+    @commands.group()
+    @checks.admin_or_permissions(administrator=True)
+    async def localwhitelist(self, ctx):
+        """
+        Whitelist management commands.
+        """
+        if ctx.invoked_subcommand is None:
+            await ctx.send_help()
+
+    @localwhitelist.command(name="add")
+    async def localwhitelist_add(self, ctx, *, user_or_role: str):
+        """
+        Adds a user or role to the whitelist.
+        """
+        try:
+            obj = await commands.MemberConverter().convert(ctx, user_or_role)
+        except commands.BadArgument:
+            obj = await commands.RoleConverter().convert(ctx, user_or_role)
+            user = False
+        else:
+            user = True
+        async with ctx.bot.db.guild(ctx.guild).whitelist() as curr_list:
+            if obj.id not in curr_list:
+                curr_list.append(obj.id)
+
+        if user:
+            await ctx.send(_("User added to whitelist."))
+        else:
+            await ctx.send(_("Role added to whitelist."))
+
+    @localwhitelist.command(name="list")
+    async def localwhitelist_list(self, ctx):
+        """
+        Lists whitelisted users and roles.
+        """
+        curr_list = await ctx.bot.db.guild(ctx.guild).whitelist()
+
+        msg = _("Whitelisted Users and roles:")
+        for obj in curr_list:
+            msg.append("\n\t- {}".format(obj))
+
+        for page in pagify(msg):
+            await ctx.send(box(page))
+
+    @localwhitelist.command(name="remove")
+    async def localwhitelist_remove(self, ctx, *, user_or_role: str):
+        """
+        Removes user or role from whitelist.
+        """
+        try:
+            obj = await commands.MemberConverter().convert(ctx, user_or_role)
+        except commands.BadArgument:
+            obj = await commands.RoleConverter().convert(ctx, user_or_role)
+            user = False
+        else:
+            user = True
+
+        removed = False
+        async with ctx.bot.db.guild(ctx.guild).whitelist() as curr_list:
+            if obj.id in curr_list:
+                removed = True
+                curr_list.remove(obj.id)
+
+        if removed:
+            if user:
+                await ctx.send(_("User has been removed from whitelist."))
+            else:
+                await ctx.send(_("Role has been removed from whitelist."))
+        else:
+            if user:
+                await ctx.send(_("User was not in the whitelist."))
+            else:
+                await ctx.send(_("Role was not in the whitelist."))
+
+    @localwhitelist.command(name="clear")
+    async def localwhitelist_clear(self, ctx):
+        """
+        Clears the whitelist.
+        """
+        await ctx.bot.db.guild(ctx.guild).whitelist.set([])
+        await ctx.send(_("Whitelist has been cleared."))
+
+    @commands.group()
+    @commands.guild_only()
+    @checks.admin_or_permissions(administrator=True)
+    async def localblacklist(self, ctx):
+        """
+        blacklist management commands.
+        """
+        if ctx.invoked_subcommand is None:
+            await ctx.send_help()
+
+    @localblacklist.command(name="add")
+    async def localblacklist_add(self, ctx, *, user_or_role: str):
+        """
+        Adds a user or role to the blacklist.
+        """
+        try:
+            obj = await commands.MemberConverter().convert(ctx, user_or_role)
+        except commands.BadArgument:
+            obj = await commands.RoleConverter().convert(ctx, user_or_role)
+            user = False
+        else:
+            user = True
+
+        if user and await ctx.bot.is_owner(obj):
+            ctx.send(_("You cannot blacklist an owner!"))
+            return
+
+        async with ctx.bot.db.guild(ctx.guild).blacklist() as curr_list:
+            if obj.id not in curr_list:
+                curr_list.append(obj.id)
+
+        if user:
+            await ctx.send(_("User added to blacklist."))
+        else:
+            await ctx.send(_("Role added to blacklist."))
+
+    @localblacklist.command(name="list")
+    async def localblacklist_list(self, ctx):
+        """
+        Lists blacklisted users and roles.
+        """
+        curr_list = await ctx.bot.db.guild(ctx.guild).blacklist()
+
+        msg = _("blacklisted Users and Roles:")
+        for obj in curr_list:
+            msg.append("\n\t- {}".format(obj))
+
+        for page in pagify(msg):
+            await ctx.send(box(page))
+
+    @localblacklist.command(name="remove")
+    async def localblacklist_remove(self, ctx, *, user_or_role: str):
+        """
+        Removes user or role from blacklist.
+        """
+        removed = False
+        try:
+            obj = await commands.MemberConverter().convert(ctx, user_or_role)
+        except commands.BadArgument:
+            obj = await commands.RoleConverter().convert(ctx, user_or_role)
+            user = False
+        else:
+            user = True
+
+        async with ctx.bot.db.guild(ctx.guild).blacklist() as curr_list:
+            if obj.id in curr_list:
+                removed = True
+                curr_list.remove(obj.id)
+
+        if removed:
+            if user:
+                await ctx.send(_("User has been removed from blacklist."))
+            else:
+                await ctx.send(_("Role has been removed from blacklist."))
+        else:
+            if user:
+                await ctx.send(_("User was not in the blacklist."))
+            else:
+                await ctx.send(_("Role was not in the blacklist."))
+
+    @localblacklist.command(name="clear")
+    async def localblacklist_clear(self, ctx):
+        """
+        Clears the blacklist.
+        """
+        await ctx.bot.db.guild(ctx.guild).blacklist.set([])
+        await ctx.send(_("blacklist has been cleared."))
+
     # RPC handlers
     async def rpc_load(self, request):
         cog_name = request.params[0]

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1478,7 +1478,7 @@ class Core(CoreLogic):
 
         msg = _("blacklisted Users and Roles:")
         for obj in curr_list:
-            msg +="\n\t- {}".format(obj)
+            msg += "\n\t- {}".format(obj)
 
         for page in pagify(msg):
             await ctx.send(box(page))

--- a/redbot/core/global_checks.py
+++ b/redbot/core/global_checks.py
@@ -26,10 +26,12 @@ def init_global_checks(bot):
         local_blacklist = await guild_settings.blacklist()
         local_whitelist = await guild_settings.whitelist()
 
+        _ids = [r.id for r in ctx.author.roles if not r.is_default]
+        _ids.append(ctx.author.id)
         if local_whitelist:
-            return ctx.author.id in local_whitelist
+            return any(i in local_whitelist for i in _ids)
 
-        return ctx.author.id not in local_blacklist
+        return not any(i in local_blacklist for i in _ids)
 
     @bot.check
     async def bots(ctx):


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [x] New feature

### Description of the changes

implements local whitelist/blacklist which had unused bot.db settings and prior existing checks.

Modifies those checks to also allow role use in the lists for local lists. 

Why this is needed + use case:
Role blacklist (example: for punished roles) is not strictly covered by permissions without using the 3rd party check hooks, as it's entries are on a Cog or Command basis, not globally applies by role or user.

This is a simple enough feature with a large enough use case to be in core, whereas the override hooks in permissions are designed for people to have viable solutions for edge cases requiring overriding the rule order or creating more complex rule sets.