### PR TITLE
[V3 Mod/Modlog] prevent self-casing the bot + feedback for heirarchy

### DIFF
--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -317,7 +317,7 @@ class Mod:
             )
             return
         elif ctx.guild.me.top_role <= user.top_role or user == ctx.guild.owner:
-            await ctx.send(_("I cannot do that due to discord heirarchy rules"))
+            await ctx.send(_("I cannot do that due to discord hierarchy rules"))
             return
         audit_reason = get_audit_reason(author, reason)
         try:
@@ -373,7 +373,7 @@ class Mod:
             )
             return
         elif ctx.guild.me.top_role <= user.top_role or user == ctx.guild.owner:
-            await ctx.send(_("I cannot do that due to discord heirarchy rules"))
+            await ctx.send(_("I cannot do that due to discord hierarchy rules"))
             return
 
         if days:

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -316,6 +316,9 @@ class Mod:
                 )
             )
             return
+        elif ctx.guild.me.top_role <= user.top_role or user == ctx.guild.owner:
+            await ctx.send(_("I cannot do that due to discord heirarchy rules"))
+            return
         audit_reason = get_audit_reason(author, reason)
         try:
             await guild.kick(user, reason=audit_reason)
@@ -368,6 +371,9 @@ class Mod:
                     "hierarchy."
                 )
             )
+            return
+        elif ctx.guild.me.top_role <= user.top_role or user == ctx.guild.owner:
+            await ctx.send(_("I cannot do that due to discord heirarchy rules"))
             return
 
         if days:

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -461,7 +461,7 @@ async def create_case(
     if not await case_type.is_enabled():
         return None
 
-    if user == guild.me:
+    if user == bot.user:
         return None
 
     next_case_number = int(await get_next_case_number(guild))

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -461,6 +461,9 @@ async def create_case(
     if not await case_type.is_enabled():
         return None
 
+    if user == guild.me:
+        return None
+
     next_case_number = int(await get_next_case_number(guild))
 
     case = Case(


### PR DESCRIPTION
### Type

- [X] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

* Prevent the bot from making cases where it is the target

* Prevents the mod cog from attempting to self-ban or kick the bot through a hierarchy check, which doubles as extra user facing feedback for an unexpected reason a kick or ban may fail.

see #1775 