### PR TITLE
[V3] Use typing.TYPE_CHECKING instead of utils.TYPE_CHECKING

### DIFF
--- a/redbot/cogs/downloader/installable.py
+++ b/redbot/cogs/downloader/installable.py
@@ -3,9 +3,8 @@ import distutils.dir_util
 import shutil
 from enum import Enum
 from pathlib import Path
-from typing import MutableMapping, Any
+from typing import MutableMapping, Any, TYPE_CHECKING
 
-from redbot.core.utils import TYPE_CHECKING
 from .log import log
 from .json_mixins import RepoJSONMixin
 
@@ -25,7 +24,7 @@ class Installable(RepoJSONMixin):
      - Modules
      - Repo Libraries
      - Other stuff?
-     
+
     The attributes of this class will mostly come from the installation's
     info.json.
 

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -1,14 +1,12 @@
 import logging
 import collections
 from copy import deepcopy
-from typing import Union, Tuple
+from typing import Union, Tuple, TYPE_CHECKING
 
 import discord
 
 from .data_manager import cog_data_path, core_data_path
 from .drivers import get_driver
-
-from .utils import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .drivers.red_base import BaseDriver

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from random import SystemRandom
 from string import ascii_letters, digits
 from distutils.version import StrictVersion
+from typing import TYPE_CHECKING
 
 import aiohttp
 import discord
@@ -21,9 +22,7 @@ import pkg_resources
 from redbot.core import __version__
 from redbot.core import checks
 from redbot.core import i18n
-from redbot.core import rpc
 from redbot.core import commands
-from .utils import TYPE_CHECKING
 from .utils.chat_formatting import pagify, box, inline
 
 if TYPE_CHECKING:

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -9,10 +9,6 @@ import logging
 import appdirs
 
 from .json_io import JsonIO
-from .utils import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from . import Config
 
 __all__ = [
     "load_basic_configuration",

--- a/redbot/core/utils/__init__.py
+++ b/redbot/core/utils/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ["TYPE_CHECKING", "NewType", "safe_delete", "fuzzy_command_search"]
+__all__ = ["safe_delete", "fuzzy_command_search"]
 
 from pathlib import Path
 import os
@@ -6,18 +6,6 @@ import shutil
 from redbot.core import commands
 from fuzzywuzzy import process
 from .chat_formatting import box
-
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
-
-try:
-    from typing import NewType
-except ImportError:
-
-    def NewType(name, tp):
-        return type(name, (tp,), {})
 
 
 def safe_delete(pth: Path):


### PR DESCRIPTION
Not needed any more as we no longer support python<3.6.

This is a breaking change since it removes `redbot.core.utils.TYPE_CHECKING` and `redbot.core.utils.NewType`. Not sure if any cog creators are using it, but should really send out a warning regardless.