### PR TITLE
[V3 Alias] Removed useless condition

### DIFF
--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -182,7 +182,7 @@ class Alias:
         """
         Manage global aliases.
         """
-        if ctx.invoked_subcommand is None or isinstance(ctx.invoked_subcommand, commands.Group):
+        if ctx.invoked_subcommand is None:
             await ctx.send_help()
 
     @checks.mod_or_permissions(manage_guild=True)


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

The condition `isinstance(ctx.invoked_subcommand, commands.Group)` is always `False`, so when a user type `[p]alias global`, nothing will be posted by the bot (= no help message).