### PR TITLE
[V3 Admin] Announce ignore parameter modification

### DIFF
--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -264,20 +264,16 @@ class Admin:
     @announce.command(name="ignore")
     @commands.guild_only()
     @checks.guildowner_or_permissions(administrator=True)
-    async def announce_ignore(self, ctx, *, guild: discord.Guild = None):
+    async def announce_ignore(self, ctx):
         """
-        Toggles whether the announcements will ignore the given server.
-            Defaults to the current server if none is provided.
+        Toggles whether the announcements will ignore the current server.
         """
-        if guild is None:
-            guild = ctx.guild
-
-        ignored = await self.conf.guild(guild).announce_ignore()
-        await self.conf.guild(guild).announce_ignore.set(not ignored)
+        ignored = await self.conf.guild(ctx.guild).announce_ignore()
+        await self.conf.guild(ctx.guild).announce_ignore.set(not ignored)
 
         verb = "will" if ignored else "will not"
 
-        await ctx.send("The server {} {} receive announcements.".format(guild.name, verb))
+        await ctx.send(f"The server {ctx.guild.name} {verb} receive announcements.")
 
     async def _valid_selfroles(self, guild: discord.Guild) -> Tuple[discord.Role]:
         """


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
alt to #1774 

There isn't a converter for `discord.Guild` , so this will always resolve as the current guild when used. Rather than allow supplying a useless argument, just use `ctx.guild`