### PR TITLE
[V3] subgroup help fix

### DIFF
--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -182,7 +182,9 @@ class Alias:
         """
         Manage global aliases.
         """
-        if ctx.invoked_subcommand is None or isinstance(ctx.invoked_subcommand, commands.Group):
+        if ctx.invoked_subcommand is None or isinstance(
+            ctx.invoked_subcommand, discord.ext.commands.Group
+        ):
             await ctx.send_help()
 
     @checks.mod_or_permissions(manage_guild=True)

--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -166,7 +166,9 @@ class CustomCommands:
 
         {server}    message.guild
         """
-        if not ctx.invoked_subcommand or isinstance(ctx.invoked_subcommand, commands.Group):
+        if not ctx.invoked_subcommand or isinstance(
+            ctx.invoked_subcommand, discord.ext.commands.Group
+        ):
             await ctx.send_help()
 
     @cc_add.command(name="random")

--- a/redbot/cogs/downloader/checks.py
+++ b/redbot/cogs/downloader/checks.py
@@ -23,7 +23,9 @@ def install_agreement():
             return True
         elif downloader.already_agreed:
             return True
-        elif ctx.invoked_subcommand is None or isinstance(ctx.invoked_subcommand, commands.Group):
+        elif ctx.invoked_subcommand is None or isinstance(
+            ctx.invoked_subcommand, discord.ext.commands.Group
+        ):
             return True
 
         def does_agree(msg: discord.Message):


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

This fixes help for command subgroups which use an `isinstance` to determine they are the last thing in the chain. A more robust fix for this would require more extensive modifications to `redbot.core.commands`
