### PR TITLE
[V3 core.commands] decorator inheritence fix

### DIFF
--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -53,6 +53,7 @@ class Command(commands.Command):
         the internal command list via :meth:`~.GroupMixin.add_command`.
         """
         cls = cls or self.__class__
+
         def decorator(func):
             result = command(*args, **kwargs)(func)
             self.add_command(result)
@@ -65,13 +66,14 @@ class Command(commands.Command):
         the internal command list via :meth:`~.GroupMixin.add_command`.
         """
         cls = None or Group
+
         def decorator(func):
             result = group(*args, **kwargs)(func)
             self.add_command(result)
             return result
 
-
         return decorator
+
 
 class Group(Command, commands.Group):
     """Group command class for Red.

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -48,6 +48,30 @@ class Command(commands.Command):
         # We don't want our help property to be overwritten, namely by super()
         pass
 
+    def command(self, cls=None, *args, **kwargs):
+        """A shortcut decorator that invokes :func:`.command` and adds it to
+        the internal command list via :meth:`~.GroupMixin.add_command`.
+        """
+        cls = cls or self.__class__
+        def decorator(func):
+            result = command(*args, **kwargs)(func)
+            self.add_command(result)
+            return result
+
+        return decorator
+
+    def group(self, cls=None, *args, **kwargs):
+        """A shortcut decorator that invokes :func:`.group` and adds it to
+        the internal command list via :meth:`~.GroupMixin.add_command`.
+        """
+        cls = None or Group
+        def decorator(func):
+            result = group(*args, **kwargs)(func)
+            self.add_command(result)
+            return result
+
+
+        return decorator
 
 class Group(Command, commands.Group):
     """Group command class for Red.


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Sub commands and subgroups will correctly inherit from redbot.core.commands