### PR TITLE
[V3 Core] Fix display of whitelist and blacklist members

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1257,7 +1257,7 @@ class Core(CoreLogic):
 
         msg = _("Whitelisted Users:")
         for user in curr_list:
-            msg.append("\n\t- {}".format(user))
+            msg += "\n\t- {}".format(user)
 
         for page in pagify(msg):
             await ctx.send(box(page))
@@ -1320,7 +1320,7 @@ class Core(CoreLogic):
 
         msg = _("blacklisted Users:")
         for user in curr_list:
-            msg.append("\n\t- {}".format(user))
+            msg += "\n\t- {}".format(user)
 
         for page in pagify(msg):
             await ctx.send(box(page))


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
`[p]whitelist list` and `[p]blacklist list` fail because strings don't have `.append`.