### PR TITLE
[V3] fix dm help set

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -605,6 +605,7 @@ class Core(CoreLogic):
                 guild_settings = f"Admin role: {admin_role}\nMod role: {mod_role}\n"
             else:
                 guild_settings = ""
+                prefixes = None  # This is correct. The below can happen in a guild.
             if not prefixes:
                 prefixes = await ctx.bot.db.prefix()
             locale = await ctx.bot.db.locale()


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Correctly handle lack of prefixes in `help set` when used in DM