### PR TITLE
[V3 Streams] Fixed issue with making YT Stream Embed 

### DIFF
--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -180,7 +180,7 @@ class YoutubeStream(Stream):
         video_url = "https://youtube.com/watch?v={}".format(vid_data["id"])
         title = vid_data["snippet"]["title"]
         thumbnail = vid_data["snippet"]["thumbnails"]["default"]["url"]
-        channel_title = data["snippet"]["channelTitle"]
+        channel_title = vid_data["snippet"]["channelTitle"]
         embed = discord.Embed(title=title, url=video_url)
         embed.set_author(name=channel_title)
         embed.set_image(url=rnd(thumbnail))


### PR DESCRIPTION
fixed error not allowing bot to make yt stream embed

### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
changed data to vid_data to allow the bot to create and post an embed of a YouTube stream