### PR TITLE
[V3 Downloader] Don't do 3rd party agreement without command args

### DIFF
--- a/redbot/cogs/downloader/checks.py
+++ b/redbot/cogs/downloader/checks.py
@@ -1,9 +1,9 @@
 import asyncio
 
 import discord
-from discord.ext import commands
+from redbot.core import commands
 
-__all__ = ["install_agreement"]
+__all__ = ["do_install_agreement"]
 
 REPO_INSTALL_MSG = (
     "You're about to add a 3rd party repository. The creator of Red"
@@ -16,32 +16,21 @@ REPO_INSTALL_MSG = (
 )
 
 
-def install_agreement():
-    async def pred(ctx: commands.Context):
-        downloader = ctx.command.instance
-        if downloader is None:
-            return True
-        elif downloader.already_agreed:
-            return True
-        elif ctx.invoked_subcommand is None or isinstance(ctx.invoked_subcommand, commands.Group):
-            return True
-
-        def does_agree(msg: discord.Message):
-            return (
-                ctx.author == msg.author
-                and ctx.channel == msg.channel
-                and msg.content == "I agree"
-            )
-
-        await ctx.send(REPO_INSTALL_MSG)
-
-        try:
-            await ctx.bot.wait_for("message", check=does_agree, timeout=30)
-        except asyncio.TimeoutError:
-            await ctx.send("Your response has timed out, please try again.")
-            return False
-
-        downloader.already_agreed = True
+async def do_install_agreement(ctx: commands.Context):
+    downloader = ctx.cog
+    if downloader is None or downloader.already_agreed:
         return True
 
-    return commands.check(pred)
+    def does_agree(msg: discord.Message):
+        return ctx.author == msg.author and ctx.channel == msg.channel and msg.content == "I agree"
+
+    await ctx.send(REPO_INSTALL_MSG)
+
+    try:
+        await ctx.bot.wait_for("message", check=does_agree, timeout=30)
+    except asyncio.TimeoutError:
+        await ctx.send("Your response has timed out, please try again.")
+        return False
+
+    downloader.already_agreed = True
+    return True

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -15,7 +15,7 @@ from redbot.core.utils.chat_formatting import box, pagify
 from redbot.core import commands
 
 from redbot.core.bot import Red
-from .checks import install_agreement
+from .checks import do_install_agreement
 from .converters import InstalledCog
 from .errors import CloningError, ExistingGitRepo
 from .installable import Installable
@@ -53,7 +53,7 @@ class Downloader:
 
     async def cog_install_path(self):
         """Get the current cog install path.
-        
+
         Returns
         -------
         pathlib.Path
@@ -64,7 +64,7 @@ class Downloader:
 
     async def installed_cogs(self) -> Tuple[Installable]:
         """Get info on installed cogs.
-        
+
         Returns
         -------
         `tuple` of `Installable`
@@ -77,7 +77,7 @@ class Downloader:
 
     async def _add_to_installed(self, cog: Installable):
         """Mark a cog as installed.
-        
+
         Parameters
         ----------
         cog : Installable
@@ -93,7 +93,7 @@ class Downloader:
 
     async def _remove_from_installed(self, cog: Installable):
         """Remove a cog from the saved list of installed cogs.
-        
+
         Parameters
         ----------
         cog : Installable
@@ -214,7 +214,6 @@ class Downloader:
             await ctx.send_help()
 
     @repo.command(name="add")
-    @install_agreement()
     async def _repo_add(self, ctx, name: str, repo_url: str, branch: str = None):
         """
         Add a new repo to Downloader.
@@ -222,6 +221,9 @@ class Downloader:
         Name can only contain characters A-z, numbers and underscore
         Branch will default to master if not specified
         """
+        agreed = await do_install_agreement(ctx)
+        if not agreed:
+            return
         try:
             # noinspection PyTypeChecker
             repo = await self._repo_manager.add_repo(name=name, url=repo_url, branch=branch)
@@ -436,7 +438,7 @@ class Downloader:
             Name of the command which belongs to the cog.
         cog_installable : `Installable` or `object`
             Can be an `Installable` instance or a Cog instance.
-            
+
         Returns
         -------
         str
@@ -461,12 +463,12 @@ class Downloader:
         """Determines the cog name that Downloader knows from the cog instance.
 
         Probably.
-        
+
         Parameters
         ----------
         instance : object
             The cog instance.
-            
+
         Returns
         -------
         str


### PR DESCRIPTION
### Type

- Bugfix

### Description of the changes
Resolves #1819.

This functionality is no longer contained in a check decorator because otherwise it gets called when it shouldn't.