### PR TITLE
[V3/report] patch issue with attatchment grabbing

### DIFF
--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -1439,7 +1439,13 @@ class Mod:
                     return True
         return False
 
-    async def on_command(self, ctx: commands.Context):
+    async def on_command_completion(self, ctx: commands.Context):
+        await self._delete_delay(ctx)
+    
+    async def on_command_error(self, ctx: commands.Context, error):
+        await self._delete_delay(ctx)
+
+    async def _delete_delay(self, ctx: commands.Context):
         """Currently used for:
             * delete delay"""
         guild = ctx.guild

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -1441,7 +1441,7 @@ class Mod:
 
     async def on_command_completion(self, ctx: commands.Context):
         await self._delete_delay(ctx)
-    
+
     async def on_command_error(self, ctx: commands.Context, error):
         await self._delete_delay(ctx)
 

--- a/redbot/cogs/reports/reports.py
+++ b/redbot/cogs/reports/reports.py
@@ -212,15 +212,18 @@ class Reports:
             guild = await self.discover_guild(
                 author, prompt=_("Select a server to make a report in by number.")
             )
+            delete_later = False
         else:
-            try:
-                await ctx.message.delete()
-            except discord.Forbidden:
-                pass
+            delete_later = True
         if guild is None:
             return
         g_active = await self.config.guild(guild).active()
         if not g_active:
+            if delete_later:
+                try:
+                    await ctx.message.delete()
+                except discord.Forbidden:
+                    pass
             return await author.send(_("Reporting has not been enabled for this server"))
         if guild.id not in self.antispam:
             self.antispam[guild.id] = {}
@@ -236,15 +239,15 @@ class Reports:
             )
 
         if author.id in self.user_cache:
+            if delete_later:
+                try:
+                    await ctx.message.delete()
+                except discord.Forbidden:
+                    pass
             return await author.send(
                 _("Please finish making your prior report before making an additional one")
             )
 
-        if ctx.guild:
-            try:
-                await ctx.message.delete()
-            except (discord.Forbidden, discord.HTTPException):
-                pass
         self.user_cache.append(author.id)
 
         if _report:
@@ -263,6 +266,11 @@ class Reports:
             except discord.Forbidden:
                 await ctx.send(_("This requires DMs enabled."))
                 self.user_cache.remove(author.id)
+                if delete_later:
+                    try:
+                        await ctx.message.delete()
+                    except discord.Forbidden:
+                        pass
                 return
 
             def pred(m):
@@ -283,6 +291,11 @@ class Reports:
         self.antispam[guild.id][author.id].stamp()
 
         self.user_cache.remove(author.id)
+        if delete_later:
+            try:
+                await ctx.message.delete()
+            except discord.Forbidden:
+                pass
 
     async def on_raw_reaction_add(self, payload):
         """


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

This makes 2 changes: both aimed at fixing #1816 
The first in report's logic to ensure the attachment is grabbed prior to message deletion
The second in mod's logic to move the delete delay to trigger on command completion or command error instead of on_command. This prevents past issues like #1652 (fixed in an alternate way) as well as any future issues in which the message object has to be interacted with in the command.