### PR TITLE
[V2 General] fixed lmgtfy when search term contains a plus

### DIFF
--- a/cogs/general.py
+++ b/cogs/general.py
@@ -154,7 +154,7 @@ class General:
     @commands.command()
     async def lmgtfy(self, *, search_terms : str):
         """Creates a lmgtfy link"""
-        search_terms = escape_mass_mentions(search_terms.replace(" ", "+"))
+        search_terms = escape_mass_mentions(search_terms.replace("+","%2B").replace(" ", "+"))
         await self.bot.say("https://lmgtfy.com/?q={}".format(search_terms))
 
     @commands.command(no_pm=True, hidden=True)


### PR DESCRIPTION
A plus in an equation is interpreted as a space by https://lmgtfy.com which breaks the equation. Fixed by escaping plus characters in the search terms.

### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Before spaces are replaced with pluses replace pluses with "%2B" (the URL escaped plus) to allow search terms containing a plus such as equations to be properly processed by the web page linked to.