### PR TITLE
[V3 Downloader] Allow use of prefix in install message

### DIFF
--- a/docs/framework_downloader.rst
+++ b/docs/framework_downloader.rst
@@ -22,7 +22,7 @@ Keys common to both repo and cog info.json (case sensitive)
   is installed or a repo is added
   
   .. tip:: You can use the ``{prefix}`` key in your string to use the prefix
-    used for installing.
+      used for installing.
 
 - ``short`` (string) - A short description of the cog or repo. For cogs, this info 
   is displayed when a user executes ``!cog list``

--- a/docs/framework_downloader.rst
+++ b/docs/framework_downloader.rst
@@ -21,7 +21,7 @@ Keys common to both repo and cog info.json (case sensitive)
 - ``install_msg`` (string) - The message that gets displayed when a cog 
   is installed or a repo is added
   
-  .. tip:: You can use the ``{prefix}`` key in your string to use the prefix
+  .. tip:: You can use the ``[p]`` key in your string to use the prefix
       used for installing.
 
 - ``short`` (string) - A short description of the cog or repo. For cogs, this info 

--- a/docs/framework_downloader.rst
+++ b/docs/framework_downloader.rst
@@ -20,6 +20,9 @@ Keys common to both repo and cog info.json (case sensitive)
 
 - ``install_msg`` (string) - The message that gets displayed when a cog 
   is installed or a repo is added
+  
+  .. tip:: You can use the ``{prefix}`` key in your string to use the prefix
+    used for installing.
 
 - ``short`` (string) - A short description of the cog or repo. For cogs, this info 
   is displayed when a user executes ``!cog list``

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -234,7 +234,7 @@ class Downloader:
         else:
             await ctx.send(_("Repo `{}` successfully added.").format(name))
             if repo.install_msg is not None:
-                await ctx.send(repo.install_msg.format(prefix=ctx.prefix))
+                await ctx.send(repo.install_msg.replace("[p]", ctx.prefix))
 
     @repo.command(name="delete")
     async def _repo_del(self, ctx, repo_name: Repo):
@@ -319,7 +319,7 @@ class Downloader:
 
         await ctx.send(_("`{}` cog successfully installed.").format(cog_name))
         if cog.install_msg is not None:
-            await ctx.send(cog.install_msg.format(prefix=ctx.prefix))
+            await ctx.send(cog.install_msg.replace("[p]", ctx.prefix))
 
     @cog.command(name="uninstall")
     async def _cog_uninstall(self, ctx, cog_name: InstalledCog):

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -319,7 +319,7 @@ class Downloader:
 
         await ctx.send(_("`{}` cog successfully installed.").format(cog_name))
         if cog.install_msg is not None:
-            await ctx.send(cog.install_msg)
+            await ctx.send(cog.install_msg.format(prefix=ctx.prefix))
 
     @cog.command(name="uninstall")
     async def _cog_uninstall(self, ctx, cog_name: InstalledCog):

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -234,7 +234,7 @@ class Downloader:
         else:
             await ctx.send(_("Repo `{}` successfully added.").format(name))
             if repo.install_msg is not None:
-                await ctx.send(repo.install_msg)
+                await ctx.send(repo.install_msg.format(prefix=ctx.prefix))
 
     @repo.command(name="delete")
     async def _repo_del(self, ctx, repo_name: Repo):


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

With that feature, cog creators will be able to use the context prefix in their installation message, so they can use `{prefix}` which will become `!` or anything depending on the prefix used. It's better than using `[p]` anyway.