### PR TITLE
[V3] --token and --no-instance flags

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -116,7 +116,7 @@ def main():
             "\033[0m"
         )
         cli_flags.instance_name = "temporary_red"
-        save_default_config()
+        create_temp_config()
     load_basic_configuration(cli_flags.instance_name)
     log, sentry_log = init_loggers(cli_flags)
     red = Red(cli_flags=cli_flags, description=description, pm_help=None)

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -6,7 +6,7 @@ import sys
 import discord
 from redbot.core.bot import Red, ExitCodes
 from redbot.core.cog_manager import CogManagerUI
-from redbot.core.data_manager import save_default_config, load_basic_configuration, config_file
+from redbot.core.data_manager import create_temp_config, load_basic_configuration, config_file
 from redbot.core.json_io import JsonIO
 from redbot.core.global_checks import init_global_checks
 from redbot.core.events import init_events

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -112,7 +112,7 @@ def main():
     if cli_flags.no_instance:
         print(
             "\033[1m"
-            "Warning: The data will be placed in a temporary folder and removed on next reboot."
+            "Warning: The data will be placed in a temporary folder and removed on next system reboot."
             "\033[0m"
         )
         cli_flags.instance_name = "temporary_red"

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -101,22 +101,20 @@ def list_instances():
 def main():
     description = "Red - Version {}".format(__version__)
     cli_flags = parse_cli_flags(sys.argv[1:])
-    token = os.environ.get("RED_TOKEN", tmp_data["token"])
-    if not token and cli_flags.token:
-        token = cli_flags.token
     if cli_flags.list_instances:
         list_instances()
     elif cli_flags.version:
         print(description)
         sys.exit(0)
-    elif not cli_flags.instance_name and not cli_flags.token:
+    elif not cli_flags.instance_name and not cli_flags.no_instance:
         print("Error: No instance name was provided!")
         sys.exit(1)
-    if token and not cli_flags.instance_name:
+    if cli_flags.no_instance:
         print(
-            "Running Red with a custom token. " "Data will be saved under 'temporary_red' folder."
+            "\033[1m"
+            "Warning: The data will be placed in a temporary folder and removed on next reboot."
+            "\033[0m"
         )
-        print("Warning: The data will be placed in a temporary folder and removed on next reboot.")
         cli_flags.instance_name = "temporary_red"
         save_default_config()
     load_basic_configuration(cli_flags.instance_name)
@@ -131,6 +129,9 @@ def main():
     loop = asyncio.get_event_loop()
     tmp_data = {}
     loop.run_until_complete(_get_prefix_and_token(red, tmp_data))
+    token = os.environ.get("RED_TOKEN", tmp_data["token"])
+    if cli_flags.token:
+        token = cli_flags.token
     prefix = cli_flags.prefix or tmp_data["prefix"]
     if not (token and prefix):
         if cli_flags.no_prompt is False:

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -6,7 +6,7 @@ import sys
 import discord
 from redbot.core.bot import Red, ExitCodes
 from redbot.core.cog_manager import CogManagerUI
-from redbot.core.data_manager import load_basic_configuration, config_file
+from redbot.core.data_manager import save_default_config, load_basic_configuration, config_file
 from redbot.core.json_io import JsonIO
 from redbot.core.global_checks import init_global_checks
 from redbot.core.events import init_events
@@ -101,14 +101,24 @@ def list_instances():
 def main():
     description = "Red - Version {}".format(__version__)
     cli_flags = parse_cli_flags(sys.argv[1:])
+    token = os.environ.get("RED_TOKEN", tmp_data["token"])
+    if not token and cli_flags.token:
+        token = cli_flags.token
     if cli_flags.list_instances:
         list_instances()
     elif cli_flags.version:
         print(description)
         sys.exit(0)
-    elif not cli_flags.instance_name:
+    elif not cli_flags.instance_name and not cli_flags.token:
         print("Error: No instance name was provided!")
         sys.exit(1)
+    if token and not cli_flags.instance_name:
+        print(
+            "Running Red with a custom token. " "Data will be saved under 'temporary_red' folder."
+        )
+        print("Warning: The data will be placed in a temporary folder and removed on next reboot.")
+        cli_flags.instance_name = "temporary_red"
+        save_default_config()
     load_basic_configuration(cli_flags.instance_name)
     log, sentry_log = init_loggers(cli_flags)
     red = Red(cli_flags=cli_flags, description=description, pm_help=None)
@@ -121,7 +131,6 @@ def main():
     loop = asyncio.get_event_loop()
     tmp_data = {}
     loop.run_until_complete(_get_prefix_and_token(red, tmp_data))
-    token = os.environ.get("RED_TOKEN", tmp_data["token"])
     prefix = cli_flags.prefix or tmp_data["prefix"]
     if not (token and prefix):
         if cli_flags.no_prompt is False:

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -145,7 +145,7 @@ def parse_cli_flags(args):
         help=(
             "Run Red without any existing instance. "
             "The data will be saved under a temporary folder "
-            "and deleted on next restart."
+            "and deleted on next system restart."
         ),
     )
     parser.add_argument(

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -139,7 +139,15 @@ def parse_cli_flags(args):
         help="Enables the built-in RPC server. Please read the docs prior to enabling this!",
     )
     parser.add_argument(
-        "instance_name", nargs="?", help="Name of the bot instance created during `redbot-setup`."
+        "--token",
+        type=str,
+        help=(
+            "Run Red with the given token. The instance name is optional. "
+            "If it is not given, the data won't be saved."
+        ),
+    )
+    parser.add_argument(
+        "instance_name", help="Name of the bot instance created during `redbot-setup`."
     )
 
     args = parser.parse_args(args)

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -141,13 +141,19 @@ def parse_cli_flags(args):
     parser.add_argument(
         "--token",
         type=str,
-        help=(
-            "Run Red with the given token. The instance name is optional. "
-            "If it is not given, the data won't be saved."
-        ),
+        help="Run Red with the given token.",
     )
     parser.add_argument(
-        "instance_name", help="Name of the bot instance created during `redbot-setup`."
+        "--no-instance",
+        action="store_true",
+        help=(
+            "Run Red without any existing instance. "
+            "The data will be saved under a temporary folder "
+            "and deleted on next restart."
+        )
+    )
+    parser.add_argument(
+        "instance_name", nargs="?", help="Name of the bot instance created during `redbot-setup`."
     )
 
     args = parser.parse_args(args)

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -138,11 +138,7 @@ def parse_cli_flags(args):
         action="store_true",
         help="Enables the built-in RPC server. Please read the docs prior to enabling this!",
     )
-    parser.add_argument(
-        "--token",
-        type=str,
-        help="Run Red with the given token.",
-    )
+    parser.add_argument("--token", type=str, help="Run Red with the given token.")
     parser.add_argument(
         "--no-instance",
         action="store_true",
@@ -150,7 +146,7 @@ def parse_cli_flags(args):
             "Run Red without any existing instance. "
             "The data will be saved under a temporary folder "
             "and deleted on next restart."
-        )
+        ),
     )
     parser.add_argument(
         "instance_name", nargs="?", help="Name of the bot instance created during `redbot-setup`."

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -7,6 +7,7 @@ import shutil
 import logging
 
 import appdirs
+import tempfile
 
 from .json_io import JsonIO
 
@@ -37,6 +38,23 @@ if sys.platform == "linux":
 if not config_dir:
     config_dir = Path(appdir.user_config_dir)
 config_file = config_dir / "config.json"
+
+
+def save_default_config():
+    """
+    Creates a default instance for Red, so it can be ran
+    without creating an instance.
+    """
+    name = "temporary_red"
+
+    default_dirs = deepcopy(basic_config_default)
+    default_dirs["DATA_PATH"] = tempfile.mkdtemp()
+    default_dirs["STORAGE_TYPE"] = "JSON"
+    default_dirs["STORAGE_DETAILS"] = {}
+
+    config = JsonIO(config_file)._load_json()
+    config[name] = default_dirs
+    JsonIO(config_file)._save_json(config)
 
 
 def load_basic_configuration(instance_name_: str):

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -13,6 +13,7 @@ import tempfile
 from .json_io import JsonIO
 
 __all__ = [
+    "create_temp_config",
     "load_basic_configuration",
     "cog_data_path",
     "core_data_path",

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -41,10 +41,13 @@ if not config_dir:
 config_file = config_dir / "config.json"
 
 
-def save_default_config():
+def create_temp_config():
     """
     Creates a default instance for Red, so it can be ran
     without creating an instance.
+
+    .. warning:: The data of this instance will be removed
+        on next system restart.
     """
     name = "temporary_red"
 

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -2,6 +2,7 @@ import sys
 import os
 from pathlib import Path
 from typing import List
+from copy import deepcopy
 import hashlib
 import shutil
 import logging


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [x] New feature

### Description of the changes

This PR brings two new flags to `redbot`:

- The `--token` flag that will run Red with the given token instead of the saved one.
- The `--no-instance` flag that will run Red without any instance. The data will be saved under a `tmp` dir and removed on next restart.

These flags can be combined for testing on Travis CI for example : 

```
python3 -m redbot --no-instance --prefix ! --token $MY_PREFIX
```
That command will run Red without any setup, useful for online automated testing !