### PR TITLE
[V3] fix not verifying checks first

### DIFF
--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -141,7 +141,6 @@ class Group(Command, commands.Group):
         super().__init__(*args, **kwargs)
 
     async def invoke(self, ctx):
-
         view = ctx.view
         previous = view.index
         view.skip_ws()
@@ -154,6 +153,7 @@ class Group(Command, commands.Group):
 
         if ctx.invoked_subcommand is None or self == ctx.invoked_subcommand:
             if self.autohelp and not self.invoke_without_command:
+                await self._verify_checks(ctx)
                 await ctx.send_help()
 
         await super().invoke(ctx)


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
While commands would never be invoked, help was being sent for command groups prior to where checks were being processed. (see #1881 )