### PR TITLE
[V3 Economy] Payday leaderboard clarification

### DIFF
--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -251,7 +251,7 @@ class Economy:
                     _(
                         "{0.mention} Here, take some {1}. Enjoy! (+{2} {1}!)\n\n"
                         "You currently have {3} {1}.\n\n"
-                        "You are currently #{4} on the leaderboard!"
+                        "You are currently #{4} on the global leaderboard!"
                     ).format(
                         author,
                         credits_name,


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

When [p]payday is used with a global bank, the number place shown on the message is relative to the global leaderboard. Since [p]leaderboard shows the server leaderboard by default, this can be confusing on a global bank as payday will most likely report a different place number than the user's server leaderboard does.