### PR TITLE
 [V3] Stop `tmp` dir showing up

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def check_compiler_available():
             tfile.write(b"int main(int argc, char** argv) {return 0;}")
             tfile.seek(0)
             try:
-                m.compile([tfile.name])
+                m.compile([tfile.name], output_dir=tdir)
             except (CCompilerError, DistutilsPlatformError):
                 return False
     return True


### PR DESCRIPTION
### Type

- Bugfix

### Description of the changes
Compiled C files when setting up the bot keep getting written to the wrong folder. This makes sure they're put into the same folder which gets cleaned up.