### PR TITLE
[V3 Audio] More aggressive empty disconnect

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -1754,7 +1754,7 @@ class Audio:
                 if server.id not in stop_times:
                     stop_times[server.id] = None
 
-                if p.current is None and [self.bot.user] == p.channel.members:
+                if [self.bot.user] == p.channel.members:
                     if stop_times[server.id] is None:
                         stop_times[server.id] = int(time.time())
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
As requested by some users, empty disconnect now disconnects even if the bot is playing something - the only requirement for the disconnect once set is that the bot is alone in the voice channel.