### PR TITLE
[v2 downloader] handle importerror in is_lib_installed()

### DIFF
--- a/cogs/downloader.py
+++ b/cogs/downloader.py
@@ -527,7 +527,10 @@ class Downloader:
         return git_name[:-4]
 
     def is_lib_installed(self, name):
-        return bool(find_spec(name))
+        try:
+            return bool(find_spec(name))
+        except ImportError:
+            return False
 
     def _do_first_run(self):
         save = False


### PR DESCRIPTION
### Type

- [x] Bugfix

### Description of the changes

Fixes #1926 by returning False when import of parent package fails.