### PR TITLE
[V3] use uvloop if available

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -19,6 +19,14 @@ import logging.handlers
 import logging
 import os
 
+# Let's not force this dependency, but damn is uvloop fast.
+try:
+    import uvloop
+except ImportError:
+    pass
+else:
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
 
 #
 #               Red - Discord Bot v3

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -19,13 +19,14 @@ import logging.handlers
 import logging
 import os
 
-# Let's not force this dependency, but damn is uvloop fast.
-try:
-    import uvloop
-except ImportError:
-    pass
-else:
-    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+# Let's not force this dependency, uvloop is much faster on cpython
+if sys.implementation.name == "cpython":
+    try:
+        import uvloop
+    except ImportError:
+        pass
+    else:
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
 
 #


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [X] New feature

### Description of the changes

uvloop is a significantly faster event loop, and we should be able to just use it where available. Being a drop in replacement, simply checking availability, and using it if is available seems safe.

Note:
I've been using this particular modification on my own bots without issue prior to making this PR