### PR TITLE
[V3/Bank] Change withdraw to accept 0.

### DIFF
--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -191,7 +191,7 @@ async def set_balance(member: discord.Member, amount: int) -> int:
 
 
 def _invalid_amount(amount: int) -> bool:
-    return amount <= 0
+    return amount < 0
 
 
 async def withdraw_credits(member: discord.Member, amount: int) -> int:
@@ -217,7 +217,7 @@ async def withdraw_credits(member: discord.Member, amount: int) -> int:
 
     """
     if _invalid_amount(amount):
-        raise ValueError("Invalid withdrawal amount {} <= 0".format(amount))
+        raise ValueError("Invalid withdrawal amount {} < 0".format(amount))
 
     bal = await get_balance(member)
     if amount > bal:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This change makes it so `withdraw_credits` will accept 0 for the amount. It currently raises a `ValueError`. When a cog requires credits to be used for some functionality an additional check has to be added for 0 (Essentially when someone wants to make it free). For example:
```py
if amount == 0:
    return True

 try:
    await bank.withdraw_credits(member, amount)
except ValueError:
    return False
else:
    return True
```

This change will eliminate that leading if statement. This won't adversely effect someone's balance, because under the operation is only subtracting `0`. Zero is the identity element in subtraction. 