### PR TITLE
Fixed Json driver not being to save ints

### DIFF
--- a/redbot/core/json_io.py
+++ b/redbot/core/json_io.py
@@ -11,8 +11,8 @@ from pathlib import Path
 
 log = logging.getLogger("red")
 
-PRETTY = {"indent": 4, "sort_keys": True, "separators": (",", " : ")}
-MINIFIED = {"sort_keys": True, "separators": (",", ":")}
+PRETTY = {"indent": 4, "sort_keys": False, "separators": (",", " : ")}
+MINIFIED = {"sort_keys": False, "separators": (",", ":")}
 
 
 class JsonIO:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Fixes the following traceback:
https://gist.github.com/Kowlin/9a3cd1fe04d85bdfc524c8a046bf3e91
