### PR TITLE
Fixes #1931 (Permissions not able to override subcommands)

### DIFF
--- a/redbot/cogs/permissions/resolvers.py
+++ b/redbot/cogs/permissions/resolvers.py
@@ -48,7 +48,7 @@ def resolve_models(*, ctx: commands.Context, models: dict) -> bool:
     Resolves models in order.
     """
 
-    cmd_name = ctx.command.qualified_name
+    cmd_name = ctx._internal_view_use.qualified_name
     cog_name = ctx.cog.__class__.__name__
 
     resolved = None

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -20,6 +20,11 @@ class Context(commands.Context):
     This class inherits from `discord.ext.commands.Context`.
     """
 
+    def __init__(self, *args, **kwargs):
+        # This is used by permissions, avoids dynamic attribute issues
+        self._internal_view_use = None
+        super().__init__(*args, **kwargs)
+
     async def send_help(self) -> List[discord.Message]:
         """Send the command help message.
 


### PR DESCRIPTION
Fixes #1931 (Permissions not able to override subcommands)
Supercedes: #1961

Additionally, #1899 needs a new implementation and inclusion for the help formatter to correctly hide things.

### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

This adds an attribute to context allowing persistent storage of a fully consumed view object. This is needed because discord.py does not consume the view entirely at the point in time checks are run, and out model relies on knowing the command the user wants to run, not just each group, subgroup, and command in question individually.