### PR TITLE
[v3] Sentry: use raven-aiohttp

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -295,6 +295,13 @@ class Red(RedBase, discord.AutoShardedClient):
     You're welcome Caleb.
     """
 
+    async def logout(self):
+        """Logs out of Discord and closes all connections."""
+        if self._sentry_mgr:
+            await self._sentry_mgr.close()
+
+        await super().logout()
+
     async def shutdown(self, *, restart: bool = False):
         """Gracefully quit Red.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyyaml==3.12
 fuzzywuzzy[speedup]<=0.16.0
 Red-Trivia>=1.1.1
 async-timeout<3.0.0
+raven-aiohttp==0.7.0


### PR DESCRIPTION
### Type
- [x] Enhancement

### Description of the changes
Switch to the nonblocking [raven-aiohttp](https://github.com/getsentry/raven-aiohttp/) transport for Sentry.

Added the logout function to the Red class to hook any async shutdown code, such as graceful shutdown of Raven's aiohttp session.