### PR TITLE
[V3] enforce commands as ours

### DIFF
--- a/docs/framework_commands.rst
+++ b/docs/framework_commands.rst
@@ -5,8 +5,9 @@ Commands Package
 ================
 
 This package acts almost identically to :doc:`discord.ext.commands <dpy:ext/commands/api>`; i.e.
-they both have the same attributes. Some of these attributes, however, have been slightly modified,
-as outlined below.
+all of the attributes from discord.py's are also in ours. 
+Some of these attributes, however, have been slightly modified, while others have been added to
+extend functionlities used throughout the bot, as outlined below.
 
 .. autofunction:: redbot.core.commands.command
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -300,7 +300,8 @@ class RedBase(BotBase, RPCMixin):
                     " is not using Red's command module, and cannot be added. "
                     "If this is your cog, please use from `redbot.core import commands`"
                     "in place of `from discord.ext import commands`. For more details on "
-                    "this requirement, see the documentation."
+                    "this requirement, see this page: "
+                    "http://red-discordbot.readthedocs.io/en/v3-develop/framework_commands.html"
                 )
         super().add_cog(cog)
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -296,7 +296,8 @@ class RedBase(BotBase, RPCMixin):
                 _attr, commands.Command
             ):
                 raise RuntimeError(
-                    f"{cog.__module__} is not using Red's command module, and cannot be added."
+                    f"{cog.__class__.__name} from {cog.__module__},"
+                    " is not using Red's command module, and cannot be added."
                 )
         super().add_cog(cog)
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -296,8 +296,11 @@ class RedBase(BotBase, RPCMixin):
                 _attr, commands.Command
             ):
                 raise RuntimeError(
-                    f"{cog.__class__.__name} from {cog.__module__},"
-                    " is not using Red's command module, and cannot be added."
+                    f"The {cog.__class__.__name__} cog in the {cog.__module__} package,"
+                    " is not using Red's command module, and cannot be added. "
+                    "If this is your cog, please use from `redbot.core import commands`"
+                    "in place of `from discord.ext import commands`. For more details on "
+                    "this requirement, see the documentation."
                 )
         super().add_cog(cog)
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -289,6 +289,17 @@ class RedBase(BotBase, RPCMixin):
             if pkg_name.startswith("redbot.cogs"):
                 del sys.modules["redbot.cogs"].__dict__[name]
 
+    def add_cog(self, cog):
+        for attr in dir(cog):
+            _attr = getattr(cog, attr)
+            if isinstance(_attr, discord.ext.commands.Command) and not isinstance(
+                _attr, commands.Command
+            ):
+                raise RuntimeError(
+                    f"{cog.__module__} is not using Red's command module, and cannot be added."
+                )
+        super().add_cog(cog)
+
 
 class Red(RedBase, discord.AutoShardedClient):
     """


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Prevents cogs not using our command module from being added (#1880)

### Why in cog load
Rather than do this at the command level, it makes more sense to do at the cog level to prevent the cog from even being partially added. 

