### PR TITLE
[V3 Bank] Raise TypeError when passing a non-int transaction amount

### DIFF
--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -214,8 +214,12 @@ async def withdraw_credits(member: discord.Member, amount: int) -> int:
     ValueError
         If the withdrawal amount is invalid or if the account has insufficient
         funds.
+    TypeError
+        If the withdrawal amount is not an `int`.
 
     """
+    if not isinstance(amount, int):
+        raise TypeError("Withdrawal amount must be of type int, not {}".format(type(amount)))
     if _invalid_amount(amount):
         raise ValueError("Invalid withdrawal amount {} < 0".format(amount))
 
@@ -245,8 +249,12 @@ async def deposit_credits(member: discord.Member, amount: int) -> int:
     ------
     ValueError
         If the deposit amount is invalid.
+    TypeError
+        If the deposit amount is not an `int`.
 
     """
+    if not isinstance(amount, int):
+        raise TypeError("Deposit amount must be of type int, not {}".format(type(amount)))
     if _invalid_amount(amount):
         raise ValueError("Invalid deposit amount {} <= 0".format(amount))
 
@@ -269,14 +277,18 @@ async def transfer_credits(from_: discord.Member, to: discord.Member, amount: in
     Returns
     -------
     int
-        The new balance.
+        The new balance of the member gaining credits.
 
     Raises
     ------
     ValueError
         If the amount is invalid or if ``from_`` has insufficient funds.
+    TypeError
+        If the amount is not an `int`.
 
     """
+    if not isinstance(amount, int):
+        raise TypeError("Transfer amount must be of type int, not {}".format(type(amount)))
     if _invalid_amount(amount):
         raise ValueError("Invalid transfer amount {} <= 0".format(amount))
 

--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -219,7 +219,7 @@ async def withdraw_credits(member: discord.Member, amount: int) -> int:
 
     """
     if not isinstance(amount, int):
-        raise TypeError("Withdrawal amount must be of type int, not {}".format(type(amount)))
+        raise TypeError("Withdrawal amount must be of type int, not {}.".format(type(amount)))
     if _invalid_amount(amount):
         raise ValueError("Invalid withdrawal amount {} < 0".format(amount))
 
@@ -254,7 +254,7 @@ async def deposit_credits(member: discord.Member, amount: int) -> int:
 
     """
     if not isinstance(amount, int):
-        raise TypeError("Deposit amount must be of type int, not {}".format(type(amount)))
+        raise TypeError("Deposit amount must be of type int, not {}.".format(type(amount)))
     if _invalid_amount(amount):
         raise ValueError("Invalid deposit amount {} <= 0".format(amount))
 
@@ -288,7 +288,7 @@ async def transfer_credits(from_: discord.Member, to: discord.Member, amount: in
 
     """
     if not isinstance(amount, int):
-        raise TypeError("Transfer amount must be of type int, not {}".format(type(amount)))
+        raise TypeError("Transfer amount must be of type int, not {}.".format(type(amount)))
     if _invalid_amount(amount):
         raise ValueError("Invalid transfer amount {} <= 0".format(amount))
 

--- a/tests/cogs/test_economy.py
+++ b/tests/cogs/test_economy.py
@@ -69,3 +69,15 @@ async def test_set_default_balance(bank, guild_factory):
     await bank.set_default_balance(500, guild)
     default_bal = await bank.get_default_balance(guild)
     assert default_bal == 500
+
+
+@pytest.mark.asyncio
+async def test_nonint_transaction_amount(bank, member_factory):
+    mbr1 = member_factory.get()
+    mbr2 = member_factory.get()
+    with pytest.raises(TypeError):
+        await bank.deposit_credits(mbr1, 1.0)
+    with pytest.raises(TypeError):
+        await bank.withdraw_credits(mbr1, 1.0)
+    with pytest.raises(TypeError):
+        await bank.transfer_credits(mbr1, mbr2, 1.0)


### PR DESCRIPTION
Resolves #1975

Non-int transaction amounts don't really make any logical sense, so instead of naïvely putting them into Config, we should make sure the user is supplying the correct type.