### PR TITLE
[V3 Modlog] Make the case number optional

### DIFF
--- a/redbot/cogs/modlog/modlog.py
+++ b/redbot/cogs/modlog/modlog.py
@@ -99,12 +99,22 @@ class ModLog:
 
     @commands.command()
     @commands.guild_only()
-    async def reason(self, ctx: commands.Context, case: int, *, reason: str = ""):
+    async def reason(self, ctx: commands.Context, reason: str = ""):
         """Lets you specify a reason for mod-log's cases
+        
         Please note that you can only edit cases you are
-        the owner of unless you are a mod/admin or the server owner"""
+        the owner of unless you are a mod/admin or the server owner.
+        
+        If no number is specified, the latest case will be used."""
         author = ctx.author
         guild = ctx.guild
+        potential_case = reason.split()[0]
+        if potential_case.isnumeric():
+            case = int(potential_case)
+            reason.replace(potential_case, '')
+        else:
+            case = await modlog.get_next_case_number(guild) - 1
+            # latest case
         if not reason:
             await ctx.send_help()
             return

--- a/redbot/cogs/modlog/modlog.py
+++ b/redbot/cogs/modlog/modlog.py
@@ -97,7 +97,7 @@ class ModLog:
         else:
             await ctx.send(embed=await case.get_case_msg_content())
 
-    @commands.command()
+    @commands.command(usage="[case] <reason>")
     @commands.guild_only()
     async def reason(self, ctx: commands.Context, *, reason: str):
         """Lets you specify a reason for mod-log's cases

--- a/redbot/cogs/modlog/modlog.py
+++ b/redbot/cogs/modlog/modlog.py
@@ -99,7 +99,7 @@ class ModLog:
 
     @commands.command()
     @commands.guild_only()
-    async def reason(self, ctx: commands.Context, reason: str = ""):
+    async def reason(self, ctx: commands.Context, *, reason: str):
         """Lets you specify a reason for mod-log's cases
         
         Please note that you can only edit cases you are
@@ -111,13 +111,10 @@ class ModLog:
         potential_case = reason.split()[0]
         if potential_case.isnumeric():
             case = int(potential_case)
-            reason.replace(potential_case, '')
+            reason = reason.replace(potential_case, '')
         else:
-            case = await modlog.get_next_case_number(guild) - 1
+            case = str(int(await modlog.get_next_case_number(guild)) - 1)
             # latest case
-        if not reason:
-            await ctx.send_help()
-            return
         try:
             case_before = await modlog.get_case(case, guild, self.bot)
         except RuntimeError:

--- a/redbot/cogs/modlog/modlog.py
+++ b/redbot/cogs/modlog/modlog.py
@@ -111,7 +111,7 @@ class ModLog:
         potential_case = reason.split()[0]
         if potential_case.isnumeric():
             case = int(potential_case)
-            reason = reason.replace(potential_case, '')
+            reason = reason.replace(potential_case, "")
         else:
             case = str(int(await modlog.get_next_case_number(guild)) - 1)
             # latest case

--- a/redbot/cogs/modlog/modlog.py
+++ b/redbot/cogs/modlog/modlog.py
@@ -109,7 +109,7 @@ class ModLog:
         author = ctx.author
         guild = ctx.guild
         potential_case = reason.split()[0]
-        if potential_case.isnumeric():
+        if potential_case.isdigit():
             case = int(potential_case)
             reason = reason.replace(potential_case, "")
         else:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

Like on V2's modlog, the PR makes the case number optional and, if not provided, the latest case will be chosen.

### Examples

I have a modlog with 15 cases

```
[p]reason 13 This is my new magic reason
```
> This will edit the case number 13.

```
[p]reason I'm bored.
```
> This will edit the case number 15.