### PR TITLE
[V3 ModLog] Fix error in command [p]case

### DIFF
--- a/redbot/cogs/modlog/modlog.py
+++ b/redbot/cogs/modlog/modlog.py
@@ -95,7 +95,10 @@ class ModLog:
             await ctx.send(_("That case does not exist for that server"))
             return
         else:
-            await ctx.send(embed=await case.get_case_msg_content())
+            if await ctx.embed_requested():
+                await ctx.send(embed=await case.message_content(embed=True))
+            else:
+                await ctx.send(await case.message_content(embed=False))
 
     @commands.command()
     @commands.guild_only()


### PR DESCRIPTION
Resolves #1978, which was caused by trying to call a nonexistent method `Case.get_case_msg_content()` -> The correct method is `Case.message_content()`

Also sends as plaintext (not embed) with respect to the optional embed setting.