### PR TITLE
[V3 CogManager] Correctly separate core, install and other cog paths

### DIFF
--- a/redbot/core/cog_manager.py
+++ b/redbot/core/cog_manager.py
@@ -35,12 +35,13 @@ class CogManager:
     bot directory.
     """
 
+    CORE_PATH = Path(redbot.cogs.__path__[0])
+
     def __init__(self, paths: Tuple[str] = ()):
         self.conf = Config.get_conf(self, 2938473984732, True)
         tmp_cog_install_path = cog_data_path(self) / "cogs"
         tmp_cog_install_path.mkdir(parents=True, exist_ok=True)
         self.conf.register_global(paths=(), install_path=str(tmp_cog_install_path))
-        self.core_path = Path(redbot.cogs.__path__[0])
         self._paths = [Path(p) for p in paths]
 
     async def paths(self) -> Tuple[Path, ...]:
@@ -55,7 +56,7 @@ class CogManager:
         conf_paths = [Path(p) for p in await self.conf.paths()]
         other_paths = self._paths
 
-        all_paths = _deduplicate(list(conf_paths) + list(other_paths) + [self.core_path])
+        all_paths = _deduplicate(list(conf_paths) + list(other_paths) + [self.CORE_PATH])
 
         if self.install_path not in all_paths:
             all_paths.insert(0, await self.install_path())
@@ -150,7 +151,7 @@ class CogManager:
 
         if path == await self.install_path():
             raise ValueError("Cannot add the install path as an additional path.")
-        if path == self.core_path:
+        if path == self.CORE_PATH:
             raise ValueError("Cannot add the core path as an additional path.")
 
         async with self.conf.paths() as paths:
@@ -213,7 +214,7 @@ class CogManager:
         """
         resolved_paths = _deduplicate(await self.paths())
 
-        real_paths = [str(p) for p in resolved_paths if p != self.core_path]
+        real_paths = [str(p) for p in resolved_paths if p != self.CORE_PATH]
 
         for finder, module_name, _ in pkgutil.iter_modules(real_paths):
             if name == module_name:
@@ -324,7 +325,7 @@ class CogManagerUI:
         """
         cog_mgr = ctx.bot.cog_mgr
         install_path = await cog_mgr.install_path()
-        core_path = cog_mgr.core_path
+        core_path = cog_mgr.CORE_PATH
         cog_paths = await cog_mgr.paths()
         cog_paths = [p for p in cog_paths if p not in (install_path, core_path)]
 

--- a/redbot/core/cog_manager.py
+++ b/redbot/core/cog_manager.py
@@ -41,7 +41,7 @@ class CogManager:
         self.conf = Config.get_conf(self, 2938473984732, True)
         tmp_cog_install_path = cog_data_path(self) / "cogs"
         tmp_cog_install_path.mkdir(parents=True, exist_ok=True)
-        self.conf.register_global(paths=(), install_path=str(tmp_cog_install_path))
+        self.conf.register_global(paths=[], install_path=str(tmp_cog_install_path))
         self._paths = [Path(p) for p in paths]
 
     async def paths(self) -> Tuple[Path, ...]:

--- a/redbot/core/cog_manager.py
+++ b/redbot/core/cog_manager.py
@@ -212,9 +212,8 @@ class CogManager:
             When no matching spec can be found.
         """
         resolved_paths = _deduplicate(await self.paths())
-        core_paths = _deduplicate(await self.core_paths())
 
-        real_paths = [str(p) for p in resolved_paths if p not in core_paths]
+        real_paths = [str(p) for p in resolved_paths if p != self.core_path]
 
         for finder, module_name, _ in pkgutil.iter_modules(real_paths):
             if name == module_name:
@@ -227,7 +226,8 @@ class CogManager:
             " in any available path.".format(name)
         )
 
-    async def _find_core_cog(self, name: str) -> ModuleSpec:
+    @staticmethod
+    async def _find_core_cog(name: str) -> ModuleSpec:
         """
         Attempts to find a spec for a core cog.
 
@@ -309,7 +309,8 @@ _ = Translator("CogManagerUI", __file__)
 class CogManagerUI:
     """Commands to interface with Red's cog manager."""
 
-    async def visible_paths(self, ctx):
+    @staticmethod
+    async def visible_paths(ctx):
         install_path = await ctx.bot.cog_mgr.install_path()
         cog_paths = await ctx.bot.cog_mgr.paths()
         cog_paths = [p for p in cog_paths if p != install_path]
@@ -431,16 +432,16 @@ class CogManagerUI:
         """
         loaded = set(ctx.bot.extensions.keys())
 
-        all = set(await ctx.bot.cog_mgr.available_modules())
+        all_cogs = set(await ctx.bot.cog_mgr.available_modules())
 
-        unloaded = all - loaded
+        unloaded = all_cogs - loaded
 
         loaded = sorted(list(loaded), key=str.lower)
         unloaded = sorted(list(unloaded), key=str.lower)
 
         if await ctx.embed_requested():
-            loaded = ("**{} loaded:**\n").format(len(loaded)) + ", ".join(loaded)
-            unloaded = ("**{} unloaded:**\n").format(len(unloaded)) + ", ".join(unloaded)
+            loaded = _("**{} loaded:**\n").format(len(loaded)) + ", ".join(loaded)
+            unloaded = _("**{} unloaded:**\n").format(len(unloaded)) + ", ".join(unloaded)
 
             for page in pagify(loaded, delims=[", ", "\n"], page_length=1800):
                 e = discord.Embed(description=page, colour=discord.Colour.dark_green())
@@ -450,9 +451,9 @@ class CogManagerUI:
                 e = discord.Embed(description=page, colour=discord.Colour.dark_red())
                 await ctx.send(embed=e)
         else:
-            loaded_count = "**{} loaded:**\n".format(len(loaded))
+            loaded_count = _("**{} loaded:**\n").format(len(loaded))
             loaded = ", ".join(loaded)
-            unloaded_count = "**{} unloaded:**\n".format(len(unloaded))
+            unloaded_count = _("**{} unloaded:**\n").format(len(unloaded))
             unloaded = ", ".join(unloaded)
             loaded_count_sent = False
             unloaded_count_sent = False


### PR DESCRIPTION
### Type

 - Bugfix

### Description
Resolves #1982.

This also modifies `[p]paths` a bit so it displays the core cogs path separately from the other paths.

I will admit I cleaned up a few other things in this PR, I will go through and comment the rationale on the individual changes.

Minor breaking change:
 - `CogManager.core_paths()` has been changed to a static class attribute `CogManager.CORE_PATH`. This shouldn't really affect anyone since it's for internal use.