### PR TITLE
[V3] Predicate Utility

### DIFF
--- a/redbot/core/utils/predicates.py
+++ b/redbot/core/utils/predicates.py
@@ -1,0 +1,126 @@
+import discord
+from collections import Iterable
+
+
+class Predicate:
+    """A simple collection of predicates.
+
+    These predicates were made to help simplify checks in message events and
+    reduce boilerplate code.
+
+    For examples:
+    # valid yes or no response
+    `ctx.bot.wait_for('message', timeout=15.0, check=Predicate(ctx).confirm)`
+
+    # check if message content in under 2000 characters
+    `check = Predicate(ctx, length=2000).length_under
+     ctx.bot.wait_for('message', timeout=15.0, check=check)`
+
+
+    Attributes
+    ----------
+    sender : `discord.Member`
+        Used to verify the message content is coming from the desired sender.
+    collection : `Iterable`
+        Optional argument used for checking if the message content is inside the
+        declared collection.
+    length : `int`
+        Optional argument for comparing message lengths.
+    value
+         Optional argument that can be either a string, int, float, or object.
+         Used for comparison and equality.
+
+    Returns
+    -------
+        Boolean or it will raise a ValueError if you use a certain methods without an argument or
+        the value argument is set to an invalid type for a particular method.
+
+    """
+
+    def __init__(
+        self, sender: discord.Member, collection: Iterable = None, length: int = None, value=None
+    ):
+        self.sender = sender
+        self.collection = collection
+        self.length = length
+        self.value = value
+
+    def same(self, m):
+        """Checks if the author of the message is the same as the command issuer."""
+        return self.sender.author == m.author
+
+    def confirm(self, m):
+        """Checks if the author of the message is the same as the command issuer."""
+        return self.same(m) and m.content.lower() in ("yes", "no", "y", "n")
+
+    def valid_int(self, m):
+        """Returns true if the message content is an integer."""
+        return self.same(m) and m.content.isdigit()
+
+    def valid_float(self, m):
+        """Returns true if the message content is a float."""
+        try:
+            return self.same(m) and float(m.content) >= 1
+        except ValueError:
+            return False
+
+    def positive(self, m):
+        """Returns true if the message content is an integer and is positive"""
+        return self.same(m) and m.content.isdigit() and int(m.content) >= 0
+
+    def valid_role(self, m):
+        """Returns true if the message content is an existing role on the server."""
+        return (
+            self.same(m) and discord.utils.get(self.sender.guild.roles, name=m.content) is not None
+        )
+
+    def has_role(self, m):
+        """Returns true if the message content is a role the message sender has."""
+        return self.same(m) and discord.utils.get(self.sender.roles, name=m.content) is not None
+
+    def equal(self, m):
+        """Returns true if the message content is equal to the value set."""
+        return self.same(m) and m.content.lower() == self.value.lower()
+
+    def greater(self, m):
+        """Returns true if the message content is greater than the value set."""
+        try:
+            return self.valid_int(m) or self.valid_float(m) and float(m.content) > int(self.value)
+        except TypeError:
+            raise ValueError("Value argument in Predicate() must be an integer or float.")
+
+    def less(self, m):
+        """Returns true if the message content is less than the value set."""
+        try:
+            return self.valid_int(m) or self.valid_float(m) and float(m.content) < int(self.value)
+        except TypeError:
+            raise ValueError("Value argument in Predicate() must be an integer or float.")
+
+    def member(self, m):
+        """Returns true if the message content is the name of a member in the server."""
+        return (
+            self.same(m)
+            and discord.utils.get(self.sender.guild.members, name=m.content) is not None
+        )
+
+    def length_less(self, m):
+        """Returns true if the message content length is less than the provided length."""
+        try:
+            return self.same(m) and len(m.content) <= self.length
+        except TypeError:
+            raise ValueError("A length must be specified in Predicate().")
+
+    def length_greater(self, m):
+        """Returns true if the message content length is greater than or equal
+           to the provided length."""
+        try:
+            return self.same(m) and len(m.content) >= self.length
+        except TypeError:
+            raise ValueError("A length must be specified in Predicate().")
+
+    def contained(self, m):
+        """Returns true if the message content is a member of the provided collection."""
+        try:
+            return self.same(m) and m.content in self.collection
+        except TypeError:
+            raise ValueError("An iterable was not specified in Predicate().")


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

I often find myself and other cog creators having to write a bunch of boiler plate checks either through functions or lambdas for multiple cogs that need [waiting events](https://discordpy.readthedocs.io/en/rewrite/migrating.html#waiting-for-events). Specifically, for when you need to validate a response. Suppose the following scenario:

```py
# Common boilerplate check
def confirm(m):
    return m.author == ctx.author and m.content.lower() in ('yes', 'y', 'no', 'n')

try:
    response = await ctx.bot.wait_for('message', timeout=30, check=confirm)
except asyncio.TimeoutError:
    return await ctx.send('Response timed out')
```
Because `ctx` is often tightly coupled in these scenarios, you may find yourself writing simple predicates like the above `confirm` function or an equivalent lambda over and over across multiple commands or cogs.

Enter the new Predicates core utility module! This solves the problem with reusable predicates. Take the following example into consideration:

```py
from redbot.core import commands
from redbot.core.utils.predicates import Predicate

class CogExample:
    # setup code
    @commands.command()
    async def example(self, ctx):
        await ctx.send("Please set a new welcome message.")
        
        try:
            welcome_message = await self.handler(ctx)
        except asycnio.TimeoutError:
            await ctx.send("Response timed out.")
        except RuntimeError:
            await ctx.send("Cancelled setting a new welcome message.")
        # rest of your code

    async def handler(self, ctx):
        check = Predicate(ctx.author, length=2000)
        message = await ctx.bot.wait_for('message', timeout=30, check=check.length_under)
        await ctx.send("Are you sure you wish to change your message?")
        choice = await ctx.bot.wait_for('message', timeout=30, check=check.confirm)
        if choice.content.lower() in ('y', 'yes'):
            return message.content
        else:
            raise RuntimeError
```

In the above code, we bypass having to write **two** separate checks by using Predicate. The Predicate class comes with the following methods:

* same - sender and message author are the same
* confirm - message is `yes`, `y`, `no`, or `no`
* valid_int - message is an integer
* valid_float - message is a float
* positive - message is a positive integer
* valid_role - message is the same as a role on the server
* has_role - message is a role the name of a role the sender has
* equal - message is equal to a set value
* greater - message is a integer or float that is greater than a set value
* less - message is a integer or float that is less than a set value
* member - message is the name of a member on the server.
* length_less - message has a length that is less than the the predicate's set length
* length_greater - message has a length that is greater than the the predicate's set length
* contained - message is a part of the predicate's set collection.

Note: All methods require that the sender and the message author be the same.
