### PR TITLE
[V3 CI] Re-enable and fix linkcheck build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -190,6 +190,13 @@ texinfo_documents = [
 ]
 
 
+# -- Options for linkcheck builder ----------------------------------------
+
+# A list of regular expressions that match URIs that should not be
+# checked when doing a linkcheck build.
+linkcheck_ignore = [r"https://java.com*"]
+
+
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.6", None),

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -8,7 +8,7 @@ Installing Red on Windows
 Needed Software
 ---------------
 
-* `Python <https://python.org/downloads/>`_ - Red needs Python 3.6
+* `Python <https://www.python.org/downloads/>`_ - Red needs Python 3.6
 
 .. note:: Please make sure that the box to add Python to PATH is CHECKED, otherwise
           you may run into issues when trying to run Red

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ basepython = python3.6
 extras = voice, docs, mongo
 commands =
     sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out" -W -bhtml
-    # sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out" -W -blinkcheck
+    sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out" -W -blinkcheck
 
 [testenv:style]
 description = Stylecheck the code with black to see if anything needs changes.


### PR DESCRIPTION
### Type

- Bugfix

### Description of the changes
Resolves #1957.

Since java.com blocks requests from Travis's server, we can prevent the link checker from trying to check java.com links.

I also made a simple change to a python.org link to www.python.org, since it was a permanent redirect.