### PR TITLE
[V3/General] Fix lmgtfy when using the + symbol in the search

### DIFF
--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -163,7 +163,9 @@ class General:
     @commands.command()
     async def lmgtfy(self, ctx, *, search_terms: str):
         """Creates a lmgtfy link"""
-        search_terms = escape(search_terms.replace(" ", "+"), mass_mentions=True)
+        search_terms = escape(
+            search_terms.replace("+", "%2B").replace(" ", "+"), mass_mentions=True
+        )
         await ctx.send("https://lmgtfy.com/?q={}".format(search_terms))
 
     @commands.command(hidden=True)


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes a problem that occurs when using `+` in your search. 

Steps to reproduce:
>lmgtfy add 2+2

>>> result: add 2 2

This is a carry over of the fix proposed for V2 in PR #1868 