### PR TITLE
[V3] Pin lavalink to 0.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ setup(
         "test": ["pytest>3", "pytest-asyncio"],
         "mongo": ["motor"],
         "docs": ["sphinx>=1.7", "sphinxcontrib-asyncio", "sphinx_rtd_theme"],
-        "voice": ["red-lavalink>=0.0.4"],
+        "voice": ["red-lavalink==0.1.0"],
         "style": ["black==18.5b1"],
     },
 )


### PR DESCRIPTION
Just gonna merge this into beta 19 so we can safely release the breaking red-lavalink 0.1.1