### PR TITLE
[V3] Correct error when using discord.ext.commands

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -300,7 +300,7 @@ class RedBase(BotBase, RPCMixin):
                 raise RuntimeError(
                     f"The {cog.__class__.__name__} cog in the {cog.__module__} package,"
                     " is not using Red's command module, and cannot be added. "
-                    "If this is your cog, please use from `redbot.core import commands`"
+                    "If this is your cog, please use `from redbot.core import commands`"
                     "in place of `from discord.ext import commands`. For more details on "
                     "this requirement, see this page: "
                     "http://red-discordbot.readthedocs.io/en/v3-develop/framework_commands.html"


### PR DESCRIPTION
resolves #2020

### Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Moves a backtick in a string to the correct location.