### PR TITLE
[i18n] Update and extract all user-facing strings

### DIFF
--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -1,11 +1,10 @@
+import logging
 from typing import Tuple
 
 import discord
 
 from redbot.core import Config, checks, commands
-
-import logging
-
+from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils.chat_formatting import box
 from .announcer import Announcer
 from .converters import MemberDefaultAuthor, SelfRole

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -12,32 +12,35 @@ from .converters import MemberDefaultAuthor, SelfRole
 
 log = logging.getLogger("red.admin")
 
-GENERIC_FORBIDDEN = (
+_ = Translator("Admin", __file__)
+
+GENERIC_FORBIDDEN = _(
     "I attempted to do something that Discord denied me permissions for."
     " Your command failed to successfully complete."
 )
 
-HIERARCHY_ISSUE = (
+HIERARCHY_ISSUE = _(
     "I tried to add {role.name} to {member.display_name} but that role"
     " is higher than my highest role in the Discord hierarchy so I was"
     " unable to successfully add it. Please give me a higher role and "
     "try again."
 )
 
-USER_HIERARCHY_ISSUE = (
+USER_HIERARCHY_ISSUE = _(
     "I tried to add {role.name} to {member.display_name} but that role"
     " is higher than your highest role in the Discord hierarchy so I was"
     " unable to successfully add it. Please get a higher role and "
     "try again."
 )
 
-RUNNING_ANNOUNCEMENT = (
+RUNNING_ANNOUNCEMENT = _(
     "I am already announcing something. If you would like to make a"
     " different announcement please use `{prefix}announce cancel`"
     " first."
 )
 
 
+@cog_i18n(_)
 class Admin(commands.Cog):
     def __init__(self, config=Config):
         super().__init__()
@@ -103,8 +106,9 @@ class Admin(commands.Cog):
                 await self.complain(ctx, GENERIC_FORBIDDEN)
         else:
             await ctx.send(
-                "I successfully added {role.name} to"
-                " {member.display_name}".format(role=role, member=member)
+                _("I successfully added {role.name} to {member.display_name}").format(
+                    role=role, member=member
+                )
             )
 
     async def _removerole(self, ctx: commands.Context, member: discord.Member, role: discord.Role):
@@ -117,8 +121,9 @@ class Admin(commands.Cog):
                 await self.complain(ctx, GENERIC_FORBIDDEN)
         else:
             await ctx.send(
-                "I successfully removed {role.name} from"
-                " {member.display_name}".format(role=role, member=member)
+                _("I successfully removed {role.name} from {member.display_name}").format(
+                    role=role, member=member
+                )
             )
 
     @commands.command()
@@ -189,7 +194,7 @@ class Admin(commands.Cog):
             await self.complain(ctx, GENERIC_FORBIDDEN)
         else:
             log.info(reason)
-            await ctx.send("Done.")
+            await ctx.send(_("Done."))
 
     @editrole.command(name="name")
     @checks.admin_or_permissions(administrator=True)
@@ -215,7 +220,7 @@ class Admin(commands.Cog):
             await self.complain(ctx, GENERIC_FORBIDDEN)
         else:
             log.info(reason)
-            await ctx.send("Done.")
+            await ctx.send(_("Done."))
 
     @commands.group(invoke_without_command=True)
     @checks.is_owner()
@@ -229,7 +234,7 @@ class Admin(commands.Cog):
 
             self.__current_announcer = announcer
 
-            await ctx.send("The announcement has begun.")
+            await ctx.send(_("The announcement has begun."))
         else:
             prefix = ctx.prefix
             await self.complain(ctx, RUNNING_ANNOUNCEMENT, prefix=prefix)
@@ -245,7 +250,7 @@ class Admin(commands.Cog):
         except AttributeError:
             pass
 
-        await ctx.send("The current announcement has been cancelled.")
+        await ctx.send(_("The current announcement has been cancelled."))
 
     @announce.command(name="channel")
     @commands.guild_only()
@@ -258,7 +263,9 @@ class Admin(commands.Cog):
             channel = ctx.channel
         await self.conf.guild(ctx.guild).announce_channel.set(channel.id)
 
-        await ctx.send("The announcement channel has been set to {}".format(channel.mention))
+        await ctx.send(
+            _("The announcement channel has been set to {channel.mention}").format(channel=channel)
+        )
 
     @announce.command(name="ignore")
     @commands.guild_only()
@@ -270,9 +277,16 @@ class Admin(commands.Cog):
         ignored = await self.conf.guild(ctx.guild).announce_ignore()
         await self.conf.guild(ctx.guild).announce_ignore.set(not ignored)
 
-        verb = "will" if ignored else "will not"
-
-        await ctx.send(f"The server {ctx.guild.name} {verb} receive announcements.")
+        if ignored:  # Keeping original logic....
+            await ctx.send(
+                _("The server {guild.name} will receive announcements.").format(guild=ctx.guild)
+            )
+        else:
+            await ctx.send(
+                _("The server {guild.name} will not receive announcements.").format(
+                    guild=ctx.guild
+                )
+            )
 
     async def _valid_selfroles(self, guild: discord.Guild) -> Tuple[discord.Role]:
         """
@@ -325,7 +339,7 @@ class Admin(commands.Cog):
             if role.id not in curr_selfroles:
                 curr_selfroles.append(role.id)
 
-        await ctx.send("The selfroles list has been successfully modified.")
+        await ctx.send(_("The selfroles list has been successfully modified."))
 
     @selfrole.command(name="delete")
     @checks.admin_or_permissions(manage_roles=True)
@@ -338,7 +352,7 @@ class Admin(commands.Cog):
         async with self.conf.guild(ctx.guild).selfroles() as curr_selfroles:
             curr_selfroles.remove(role.id)
 
-        await ctx.send("The selfroles list has been successfully modified.")
+        await ctx.send(_("The selfroles list has been successfully modified."))
 
     @selfrole.command(name="list")
     async def selfrole_list(self, ctx: commands.Context):
@@ -348,7 +362,7 @@ class Admin(commands.Cog):
         selfroles = await self._valid_selfroles(ctx.guild)
         fmt_selfroles = "\n".join(["+ " + r.name for r in selfroles])
 
-        msg = "Available Selfroles:\n{}".format(fmt_selfroles)
+        msg = _("Available Selfroles:\n{selfroles}").format(selfroles=fmt_selfroles)
         await ctx.send(box(msg, "diff"))
 
     async def _serverlock_check(self, guild: discord.Guild) -> bool:
@@ -371,9 +385,10 @@ class Admin(commands.Cog):
         serverlocked = await self.conf.serverlocked()
         await self.conf.serverlocked.set(not serverlocked)
 
-        verb = "is now" if not serverlocked else "is no longer"
-
-        await ctx.send("The bot {} serverlocked.".format(verb))
+        if serverlocked:  # again with original logic I'm not sure of
+            await ctx.send(_("The bot is no longer serverlocked."))
+        else:
+            await ctx.send(_("The bot is now serverlocked."))
 
     # region Event Handlers
     async def on_guild_join(self, guild: discord.Guild):

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -14,26 +14,30 @@ log = logging.getLogger("red.admin")
 
 _ = Translator("Admin", __file__)
 
-GENERIC_FORBIDDEN = _(
+# The following are all lambdas to allow us to fetch the translation
+# during runtime, without having to copy the large strings everywhere
+# in the code.
+
+generic_forbidden = lambda: _(
     "I attempted to do something that Discord denied me permissions for."
     " Your command failed to successfully complete."
 )
 
-HIERARCHY_ISSUE = _(
+hierarchy_issue = lambda: _(
     "I tried to add {role.name} to {member.display_name} but that role"
     " is higher than my highest role in the Discord hierarchy so I was"
     " unable to successfully add it. Please give me a higher role and "
     "try again."
 )
 
-USER_HIERARCHY_ISSUE = _(
+user_hierarchy_issue = lambda: _(
     "I tried to add {role.name} to {member.display_name} but that role"
     " is higher than your highest role in the Discord hierarchy so I was"
     " unable to successfully add it. Please get a higher role and "
     "try again."
 )
 
-RUNNING_ANNOUNCEMENT = _(
+running_announcement = lambda: _(
     "I am already announcing something. If you would like to make a"
     " different announcement please use `{prefix}announce cancel`"
     " first."
@@ -42,6 +46,7 @@ RUNNING_ANNOUNCEMENT = _(
 
 @cog_i18n(_)
 class Admin(commands.Cog):
+    """A collection of server administration utilities."""
     def __init__(self, config=Config):
         super().__init__()
         self.conf = config.get_conf(self, 8237492837454039, force_registration=True)
@@ -101,9 +106,9 @@ class Admin(commands.Cog):
             await member.add_roles(role)
         except discord.Forbidden:
             if not self.pass_hierarchy_check(ctx, role):
-                await self.complain(ctx, HIERARCHY_ISSUE, role=role, member=member)
+                await self.complain(ctx, hierarchy_issue(), role=role, member=member)
             else:
-                await self.complain(ctx, GENERIC_FORBIDDEN)
+                await self.complain(ctx, generic_forbidden())
         else:
             await ctx.send(
                 _("I successfully added {role.name} to {member.display_name}").format(
@@ -116,9 +121,9 @@ class Admin(commands.Cog):
             await member.remove_roles(role)
         except discord.Forbidden:
             if not self.pass_hierarchy_check(ctx, role):
-                await self.complain(ctx, HIERARCHY_ISSUE, role=role, member=member)
+                await self.complain(ctx, hierarchy_issue(), role=role, member=member)
             else:
-                await self.complain(ctx, GENERIC_FORBIDDEN)
+                await self.complain(ctx, generic_forbidden())
         else:
             await ctx.send(
                 _("I successfully removed {role.name} from {member.display_name}").format(
@@ -132,8 +137,8 @@ class Admin(commands.Cog):
     async def addrole(
         self, ctx: commands.Context, rolename: discord.Role, *, user: MemberDefaultAuthor = None
     ):
-        """
-        Adds a role to a user.
+        """Add a role to a user.
+
         If user is left blank it defaults to the author of the command.
         """
         if user is None:
@@ -142,7 +147,7 @@ class Admin(commands.Cog):
             # noinspection PyTypeChecker
             await self._addrole(ctx, user, rolename)
         else:
-            await self.complain(ctx, USER_HIERARCHY_ISSUE, member=ctx.author, role=rolename)
+            await self.complain(ctx, user_hierarchy_issue(), member=ctx.author, role=rolename)
 
     @commands.command()
     @commands.guild_only()
@@ -150,8 +155,8 @@ class Admin(commands.Cog):
     async def removerole(
         self, ctx: commands.Context, rolename: discord.Role, *, user: MemberDefaultAuthor = None
     ):
-        """
-        Removes a role from a user.
+        """Remove a role from a user.
+
         If user is left blank it defaults to the author of the command.
         """
         if user is None:
@@ -160,38 +165,40 @@ class Admin(commands.Cog):
             # noinspection PyTypeChecker
             await self._removerole(ctx, user, rolename)
         else:
-            await self.complain(ctx, USER_HIERARCHY_ISSUE)
+            await self.complain(ctx, user_hierarchy_issue())
 
     @commands.group()
     @commands.guild_only()
     @checks.admin_or_permissions(manage_roles=True)
     async def editrole(self, ctx: commands.Context):
-        """Edits roles settings"""
+        """Edit role settings."""
         pass
 
     @editrole.command(name="colour", aliases=["color"])
     async def editrole_colour(
         self, ctx: commands.Context, role: discord.Role, value: discord.Colour
     ):
-        """Edits a role's colour
+        """Edit a role's colour.
 
         Use double quotes if the role contains spaces.
         Colour must be in hexadecimal format.
-        \"http://www.w3schools.com/colors/colors_picker.asp\"
+        [Online colour picker](http://www.w3schools.com/colors/colors_picker.asp)
+
         Examples:
-        !editrole colour \"The Transistor\" #ff0000
-        !editrole colour Test #ff9900"""
+            `[p]editrole colour "The Transistor" #ff0000`
+            `[p]editrole colour Test #ff9900`
+        """
         author = ctx.author
         reason = "{}({}) changed the colour of role '{}'".format(author.name, author.id, role.name)
 
         if not self.pass_user_hierarchy_check(ctx, role):
-            await self.complain(ctx, USER_HIERARCHY_ISSUE)
+            await self.complain(ctx, user_hierarchy_issue())
             return
 
         try:
             await role.edit(reason=reason, color=value)
         except discord.Forbidden:
-            await self.complain(ctx, GENERIC_FORBIDDEN)
+            await self.complain(ctx, generic_forbidden())
         else:
             log.info(reason)
             await ctx.send(_("Done."))
@@ -199,11 +206,13 @@ class Admin(commands.Cog):
     @editrole.command(name="name")
     @checks.admin_or_permissions(administrator=True)
     async def edit_role_name(self, ctx: commands.Context, role: discord.Role, *, name: str):
-        """Edits a role's name
+        """Edit a role's name.
 
         Use double quotes if the role or the name contain spaces.
+
         Examples:
-        !editrole name \"The Transistor\" Test"""
+            `[p]editrole name \"The Transistor\" Test`
+        """
         author = ctx.message.author
         old_name = role.name
         reason = "{}({}) changed the name of role '{}' to '{}'".format(
@@ -211,13 +220,13 @@ class Admin(commands.Cog):
         )
 
         if not self.pass_user_hierarchy_check(ctx, role):
-            await self.complain(ctx, USER_HIERARCHY_ISSUE)
+            await self.complain(ctx, user_hierarchy_issue())
             return
 
         try:
             await role.edit(reason=reason, name=name)
         except discord.Forbidden:
-            await self.complain(ctx, GENERIC_FORBIDDEN)
+            await self.complain(ctx, generic_forbidden())
         else:
             log.info(reason)
             await ctx.send(_("Done."))
@@ -225,9 +234,7 @@ class Admin(commands.Cog):
     @commands.group(invoke_without_command=True)
     @checks.is_owner()
     async def announce(self, ctx: commands.Context, *, message: str):
-        """
-        Announces a message to all servers the bot is in.
-        """
+        """Announce a message to all servers the bot is in."""
         if not self.is_announcing():
             announcer = Announcer(ctx, message, config=self.conf)
             announcer.start()
@@ -237,14 +244,12 @@ class Admin(commands.Cog):
             await ctx.send(_("The announcement has begun."))
         else:
             prefix = ctx.prefix
-            await self.complain(ctx, RUNNING_ANNOUNCEMENT, prefix=prefix)
+            await self.complain(ctx, running_announcement(), prefix=prefix)
 
     @announce.command(name="cancel")
     @checks.is_owner()
     async def announce_cancel(self, ctx):
-        """
-        Cancels a running announce.
-        """
+        """Cancel a running announce."""
         try:
             self.__current_announcer.cancel()
         except AttributeError:
@@ -256,9 +261,7 @@ class Admin(commands.Cog):
     @commands.guild_only()
     @checks.guildowner_or_permissions(administrator=True)
     async def announce_channel(self, ctx, *, channel: discord.TextChannel = None):
-        """
-        Changes the channel on which the bot makes announcements.
-        """
+        """Change the channel to which the bot makes announcements."""
         if channel is None:
             channel = ctx.channel
         await self.conf.guild(ctx.guild).announce_channel.set(channel.id)
@@ -271,9 +274,7 @@ class Admin(commands.Cog):
     @commands.guild_only()
     @checks.guildowner_or_permissions(administrator=True)
     async def announce_ignore(self, ctx):
-        """
-        Toggles whether the announcements will ignore the current server.
-        """
+        """Toggle announcements being enabled this server."""
         ignored = await self.conf.guild(ctx.guild).announce_ignore()
         await self.conf.guild(ctx.guild).announce_ignore.set(not ignored)
 
@@ -309,8 +310,9 @@ class Admin(commands.Cog):
     @commands.guild_only()
     @commands.group(invoke_without_command=True)
     async def selfrole(self, ctx: commands.Context, *, selfrole: SelfRole):
-        """
-        Add a role to yourself that server admins have configured as user settable.
+        """Add a role to yourself.
+
+        Server admins must have configured the role as user settable.
 
         NOTE: The role is case sensitive!
         """
@@ -319,8 +321,7 @@ class Admin(commands.Cog):
 
     @selfrole.command(name="remove")
     async def selfrole_remove(self, ctx: commands.Context, *, selfrole: SelfRole):
-        """
-        Removes a selfrole from yourself.
+        """Remove a selfrole from yourself.
 
         NOTE: The role is case sensitive!
         """
@@ -330,8 +331,7 @@ class Admin(commands.Cog):
     @selfrole.command(name="add")
     @checks.admin_or_permissions(manage_roles=True)
     async def selfrole_add(self, ctx: commands.Context, *, role: discord.Role):
-        """
-        Add a role to the list of available selfroles.
+        """Add a role to the list of available selfroles.
 
         NOTE: The role is case sensitive!
         """
@@ -344,8 +344,7 @@ class Admin(commands.Cog):
     @selfrole.command(name="delete")
     @checks.admin_or_permissions(manage_roles=True)
     async def selfrole_delete(self, ctx: commands.Context, *, role: SelfRole):
-        """
-        Removes a role from the list of available selfroles.
+        """Remove a role from the list of available selfroles.
 
         NOTE: The role is case sensitive!
         """
@@ -362,7 +361,7 @@ class Admin(commands.Cog):
         selfroles = await self._valid_selfroles(ctx.guild)
         fmt_selfroles = "\n".join(["+ " + r.name for r in selfroles])
 
-        msg = _("Available Selfroles:\n{selfroles}").format(selfroles=fmt_selfroles)
+        msg = _("Available Selfroles: {selfroles}").format(selfroles=fmt_selfroles)
         await ctx.send(box(msg, "diff"))
 
     async def _serverlock_check(self, guild: discord.Guild) -> bool:
@@ -379,9 +378,7 @@ class Admin(commands.Cog):
     @commands.command()
     @checks.is_owner()
     async def serverlock(self, ctx: commands.Context):
-        """
-        Locks a bot to its current servers only.
-        """
+        """Lock a bot to its current servers only."""
         serverlocked = await self.conf.serverlocked()
         await self.conf.serverlocked.set(not serverlocked)
 

--- a/redbot/cogs/admin/announcer.py
+++ b/redbot/cogs/admin/announcer.py
@@ -2,6 +2,9 @@ import asyncio
 
 import discord
 from redbot.core import commands
+from redbot.core.i18n import Translator
+
+_ = Translator("Announcer", __file__)
 
 
 class Announcer:
@@ -63,7 +66,9 @@ class Announcer:
             try:
                 await channel.send(self.message)
             except discord.Forbidden:
-                await bot_owner.send("I could not announce to server: {}".format(g.id))
+                await bot_owner.send(
+                    _("I could not announce to server: {server.id}").format(server=g)
+                )
             await asyncio.sleep(0.5)
 
         self.active = False

--- a/redbot/cogs/admin/converters.py
+++ b/redbot/cogs/admin/converters.py
@@ -1,5 +1,8 @@
 import discord
 from redbot.core import commands
+from redbot.core.i18n import Translator
+
+_ = Translator("AdminConverters", __file__)
 
 
 class MemberDefaultAuthor(commands.Converter):
@@ -19,7 +22,7 @@ class SelfRole(commands.Converter):
     async def convert(self, ctx: commands.Context, arg: str) -> discord.Role:
         admin = ctx.command.instance
         if admin is None:
-            raise commands.BadArgument("Admin is not loaded.")
+            raise commands.BadArgument(_("The Admin cog is not loaded."))
 
         conf = admin.conf
         selfroles = await conf.guild(ctx.guild).selfroles()
@@ -28,5 +31,5 @@ class SelfRole(commands.Converter):
         role = await role_converter.convert(ctx, arg)
 
         if role.id not in selfroles:
-            raise commands.BadArgument("The provided role is not a valid selfrole.")
+            raise commands.BadArgument(_("The provided role is not a valid selfrole."))
         return role

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -113,8 +113,9 @@ class Alias(commands.Cog):
         return False
 
     async def get_prefix(self, message: discord.Message) -> str:
-        """Tries to determine what prefix is used in a message object.
-        Looks to identify from longest prefix to smallest.
+        """
+        Tries to determine what prefix is used in a message object.
+            Looks to identify from longest prefix to smallest.
 
             Will raise ValueError if no prefix is found.
         :param message: Message object
@@ -175,7 +176,7 @@ class Alias(commands.Cog):
     @commands.group()
     @commands.guild_only()
     async def alias(self, ctx: commands.Context):
-        """Manage per-server aliases for commands."""
+        """Manage command aliases."""
         pass
 
     @alias.group(name="global")

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -15,15 +15,14 @@ _ = Translator("Alias", __file__)
 
 @cog_i18n(_)
 class Alias(commands.Cog):
-    """
-    Alias
-    
-    Aliases are per server shortcuts for commands. They
-        can act as both a lambda (storing arguments for repeated use)
-        or as simply a shortcut to saying "x y z".
-    
+    """Create aliases for commands.
+
+    Aliases are alternative names shortcuts for commands. They
+    can act as both a lambda (storing arguments for repeated use)
+    or as simply a shortcut to saying "x y z".
+
     When run, aliases will accept any additional arguments
-        and append them to the stored alias
+    and append them to the stored alias.
     """
 
     default_global_settings = {"entries": []}
@@ -114,9 +113,8 @@ class Alias(commands.Cog):
         return False
 
     async def get_prefix(self, message: discord.Message) -> str:
-        """
-        Tries to determine what prefix is used in a message object.
-            Looks to identify from longest prefix to smallest.
+        """Tries to determine what prefix is used in a message object.
+        Looks to identify from longest prefix to smallest.
 
             Will raise ValueError if no prefix is found.
         :param message: Message object
@@ -177,23 +175,19 @@ class Alias(commands.Cog):
     @commands.group()
     @commands.guild_only()
     async def alias(self, ctx: commands.Context):
-        """Manage per-server aliases for commands"""
+        """Manage per-server aliases for commands."""
         pass
 
     @alias.group(name="global")
     async def global_(self, ctx: commands.Context):
-        """
-        Manage global aliases.
-        """
+        """Manage global aliases."""
         pass
 
     @checks.mod_or_permissions(manage_guild=True)
     @alias.command(name="add")
     @commands.guild_only()
     async def _add_alias(self, ctx: commands.Context, alias_name: str, *, command):
-        """
-        Add an alias for a command.
-        """
+        """Add an alias for a command."""
         # region Alias Add Validity Checking
         is_command = self.is_command(alias_name)
         if is_command:
@@ -242,9 +236,7 @@ class Alias(commands.Cog):
     @checks.is_owner()
     @global_.command(name="add")
     async def _add_global_alias(self, ctx: commands.Context, alias_name: str, *, command):
-        """
-        Add a global alias for a command.
-        """
+        """Add a global alias for a command."""
         # region Alias Add Validity Checking
         is_command = self.is_command(alias_name)
         if is_command:
@@ -292,7 +284,7 @@ class Alias(commands.Cog):
     @alias.command(name="help")
     @commands.guild_only()
     async def _help_alias(self, ctx: commands.Context, alias_name: str):
-        """Tries to execute help for the base command of the alias"""
+        """Try to execute help for the base command of the alias."""
         is_alias, alias = await self.is_alias(ctx.guild, alias_name=alias_name)
         if is_alias:
             base_cmd = alias.command[0]
@@ -308,7 +300,7 @@ class Alias(commands.Cog):
     @alias.command(name="show")
     @commands.guild_only()
     async def _show_alias(self, ctx: commands.Context, alias_name: str):
-        """Shows what command the alias executes."""
+        """Show what command the alias executes."""
         is_alias, alias = await self.is_alias(ctx.guild, alias_name)
 
         if is_alias:
@@ -324,14 +316,12 @@ class Alias(commands.Cog):
     @alias.command(name="del")
     @commands.guild_only()
     async def _del_alias(self, ctx: commands.Context, alias_name: str):
-        """
-        Deletes an existing alias on this server.
-        """
+        """Delete an existing alias on this server."""
         aliases = await self.unloaded_aliases(ctx.guild)
         try:
             next(aliases)
         except StopIteration:
-            await ctx.send(_("There are no aliases on this guild."))
+            await ctx.send(_("There are no aliases on this server."))
             return
 
         if await self.delete_alias(ctx, alias_name):
@@ -344,9 +334,7 @@ class Alias(commands.Cog):
     @checks.is_owner()
     @global_.command(name="del")
     async def _del_global_alias(self, ctx: commands.Context, alias_name: str):
-        """
-        Deletes an existing global alias.
-        """
+        """Delete an existing global alias."""
         aliases = await self.unloaded_global_aliases()
         try:
             next(aliases)
@@ -364,9 +352,7 @@ class Alias(commands.Cog):
     @alias.command(name="list")
     @commands.guild_only()
     async def _list_alias(self, ctx: commands.Context):
-        """
-        Lists the available aliases on this server.
-        """
+        """List the available aliases on this server."""
         names = [_("Aliases:")] + sorted(
             ["+ " + a.name for a in (await self.unloaded_aliases(ctx.guild))]
         )
@@ -377,9 +363,7 @@ class Alias(commands.Cog):
 
     @global_.command(name="list")
     async def _list_global_alias(self, ctx: commands.Context):
-        """
-        Lists the available global aliases on this bot.
-        """
+        """List the available global aliases on this bot."""
         names = [_("Aliases:")] + sorted(
             ["+ " + a.name for a in await self.unloaded_global_aliases()]
         )

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -200,9 +200,9 @@ class Alias(commands.Cog):
             await ctx.send(
                 _(
                     "You attempted to create a new alias"
-                    " with the name {} but that"
+                    " with the name {name} but that"
                     " name is already a command on this bot."
-                ).format(alias_name)
+                ).format(name=alias_name)
             )
             return
 
@@ -211,9 +211,9 @@ class Alias(commands.Cog):
             await ctx.send(
                 _(
                     "You attempted to create a new alias"
-                    " with the name {} but that"
+                    " with the name {name} but that"
                     " alias already exists on this server."
-                ).format(alias_name)
+                ).format(name=alias_name)
             )
             return
 
@@ -222,10 +222,10 @@ class Alias(commands.Cog):
             await ctx.send(
                 _(
                     "You attempted to create a new alias"
-                    " with the name {} but that"
+                    " with the name {name} but that"
                     " name is an invalid alias name. Alias"
                     " names may not contain spaces."
-                ).format(alias_name)
+                ).format(name=alias_name)
             )
             return
         # endregion
@@ -235,7 +235,9 @@ class Alias(commands.Cog):
 
         await self.add_alias(ctx, alias_name, command)
 
-        await ctx.send(_("A new alias with the trigger `{}` has been created.").format(alias_name))
+        await ctx.send(
+            _("A new alias with the trigger `{name}` has been created.").format(name=alias_name)
+        )
 
     @checks.is_owner()
     @global_.command(name="add")
@@ -249,9 +251,9 @@ class Alias(commands.Cog):
             await ctx.send(
                 _(
                     "You attempted to create a new global alias"
-                    " with the name {} but that"
+                    " with the name {name} but that"
                     " name is already a command on this bot."
-                ).format(alias_name)
+                ).format(name=alias_name)
             )
             return
 
@@ -260,9 +262,9 @@ class Alias(commands.Cog):
             await ctx.send(
                 _(
                     "You attempted to create a new global alias"
-                    " with the name {} but that"
+                    " with the name {name} but that"
                     " alias already exists on this server."
-                ).format(alias_name)
+                ).format(name=alias_name)
             )
             return
 
@@ -271,10 +273,10 @@ class Alias(commands.Cog):
             await ctx.send(
                 _(
                     "You attempted to create a new global alias"
-                    " with the name {} but that"
+                    " with the name {name} but that"
                     " name is an invalid alias name. Alias"
                     " names may not contain spaces."
-                ).format(alias_name)
+                ).format(name=alias_name)
             )
             return
         # endregion
@@ -282,7 +284,9 @@ class Alias(commands.Cog):
         await self.add_alias(ctx, alias_name, command, global_=True)
 
         await ctx.send(
-            _("A new global alias with the trigger `{}` has been created.").format(alias_name)
+            _("A new global alias with the trigger `{name}` has been created.").format(
+                name=alias_name
+            )
         )
 
     @alias.command(name="help")
@@ -294,10 +298,12 @@ class Alias(commands.Cog):
             base_cmd = alias.command[0]
 
             new_msg = copy(ctx.message)
-            new_msg.content = "{}help {}".format(ctx.prefix, base_cmd)
+            new_msg.content = _("{prefix}help {command}").format(
+                prefix=ctx.prefix, command=base_cmd
+            )
             await self.bot.process_commands(new_msg)
         else:
-            ctx.send(_("No such alias exists."))
+            await ctx.send(_("No such alias exists."))
 
     @alias.command(name="show")
     @commands.guild_only()
@@ -307,10 +313,12 @@ class Alias(commands.Cog):
 
         if is_alias:
             await ctx.send(
-                _("The `{}` alias will execute the command `{}`").format(alias_name, alias.command)
+                _("The `{alias_name}` alias will execute the command `{command}`").format(
+                    alias_name=alias_name, command=alias.command
+                )
             )
         else:
-            await ctx.send(_("There is no alias with the name `{}`").format(alias_name))
+            await ctx.send(_("There is no alias with the name `{name}`").format(name=alias_name))
 
     @checks.mod_or_permissions(manage_guild=True)
     @alias.command(name="del")
@@ -328,10 +336,10 @@ class Alias(commands.Cog):
 
         if await self.delete_alias(ctx, alias_name):
             await ctx.send(
-                _("Alias with the name `{}` was successfully deleted.").format(alias_name)
+                _("Alias with the name `{name}` was successfully deleted.").format(name=alias_name)
             )
         else:
-            await ctx.send(_("Alias with name `{}` was not found.").format(alias_name))
+            await ctx.send(_("Alias with name `{name}` was not found.").format(name=alias_name))
 
     @checks.is_owner()
     @global_.command(name="del")
@@ -348,10 +356,10 @@ class Alias(commands.Cog):
 
         if await self.delete_alias(ctx, alias_name, global_=True):
             await ctx.send(
-                _("Alias with the name `{}` was successfully deleted.").format(alias_name)
+                _("Alias with the name `{name}` was successfully deleted.").format(name=alias_name)
             )
         else:
-            await ctx.send(_("Alias with name `{}` was not found.").format(alias_name))
+            await ctx.send(_("Alias with name `{name}` was not found.").format(name=alias_name))
 
     @alias.command(name="list")
     @commands.guild_only()

--- a/redbot/cogs/bank/bank.py
+++ b/redbot/cogs/bank/bank.py
@@ -67,7 +67,7 @@ class Bank(commands.Cog):
     @checks.guildowner_or_permissions(administrator=True)
     @commands.group(autohelp=True)
     async def bankset(self, ctx: commands.Context):
-        """Base command for bank settings"""
+        """Base command for bank settings."""
         if ctx.invoked_subcommand is None:
             if await bank.is_global():
                 bank_name = await bank._conf.bank_name()
@@ -91,9 +91,11 @@ class Bank(commands.Cog):
     @bankset.command(name="toggleglobal")
     @checks.is_owner()
     async def bankset_toggleglobal(self, ctx: commands.Context, confirm: bool = False):
-        """Toggles whether the bank is global or not
-        If the bank is global, it will become per-server
-        If the bank is per-server, it will become global"""
+        """Toggle whether the bank is global or not.
+
+        If the bank is global, it will become per-server.
+        If the bank is per-server, it will become global.
+        """
         cur_setting = await bank.is_global()
 
         word = _("per-server") if cur_setting else _("global")
@@ -111,14 +113,14 @@ class Bank(commands.Cog):
     @bankset.command(name="bankname")
     @check_global_setting_guildowner()
     async def bankset_bankname(self, ctx: commands.Context, *, name: str):
-        """Set the bank's name"""
+        """Set the bank's name."""
         await bank.set_bank_name(name, ctx.guild)
         await ctx.send(_("Bank name has been set to: {name}").format(name=name))
 
     @bankset.command(name="creditsname")
     @check_global_setting_guildowner()
     async def bankset_creditsname(self, ctx: commands.Context, *, name: str):
-        """Set the name for the bank's currency"""
+        """Set the name for the bank's currency."""
         await bank.set_currency_name(name, ctx.guild)
         await ctx.send(_("Currency name has been set to: {name}").format(name=name))
 

--- a/redbot/cogs/bank/bank.py
+++ b/redbot/cogs/bank/bank.py
@@ -81,8 +81,11 @@ class Bank(commands.Cog):
                 default_balance = await bank._conf.guild(ctx.guild).default_balance()
 
             settings = _(
-                "Bank settings:\n\nBank name: {}\nCurrency: {}\nDefault balance: {}"
-            ).format(bank_name, currency_name, default_balance)
+                "Bank settings:\n\nBank name: {bank_name}\nCurrency: {currency_name}\n"
+                "Default balance: {default_balance}"
+            ).format(
+                bank_name=bank_name, currency_name=currency_name, default_balance=default_balance
+            )
             await ctx.send(box(settings))
 
     @bankset.command(name="toggleglobal")
@@ -97,26 +100,26 @@ class Bank(commands.Cog):
         if confirm is False:
             await ctx.send(
                 _(
-                    "This will toggle the bank to be {}, deleting all accounts "
-                    "in the process! If you're sure, type `{}`"
-                ).format(word, "{}bankset toggleglobal yes".format(ctx.prefix))
+                    "This will toggle the bank to be {banktype}, deleting all accounts "
+                    "in the process! If you're sure, type `{command}`"
+                ).format(banktype=word, command="{}bankset toggleglobal yes".format(ctx.prefix))
             )
         else:
             await bank.set_global(not cur_setting)
-            await ctx.send(_("The bank is now {}.").format(word))
+            await ctx.send(_("The bank is now {banktype}.").format(banktype=word))
 
     @bankset.command(name="bankname")
     @check_global_setting_guildowner()
     async def bankset_bankname(self, ctx: commands.Context, *, name: str):
         """Set the bank's name"""
         await bank.set_bank_name(name, ctx.guild)
-        await ctx.send(_("Bank's name has been set to {}").format(name))
+        await ctx.send(_("Bank name has been set to: {name}").format(name=name))
 
     @bankset.command(name="creditsname")
     @check_global_setting_guildowner()
     async def bankset_creditsname(self, ctx: commands.Context, *, name: str):
         """Set the name for the bank's currency"""
         await bank.set_currency_name(name, ctx.guild)
-        await ctx.send(_("Currency name has been set to {}").format(name))
+        await ctx.send(_("Currency name has been set to: {name}").format(name=name))
 
     # ENDSECTION

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -16,7 +16,7 @@ _ = Translator("Cleanup", __file__)
 
 @cog_i18n(_)
 class Cleanup(commands.Cog):
-    """Commands for cleaning messages."""
+    """Commands for cleaning up messages."""
 
     def __init__(self, bot: Red):
         super().__init__()
@@ -41,7 +41,7 @@ class Cleanup(commands.Cog):
             await prompt.delete()
             try:
                 await response.delete()
-            except:
+            except discord.HTTPException:
                 pass
             return True
         else:
@@ -109,6 +109,7 @@ class Cleanup(commands.Cog):
 
     @cleanup.command()
     @commands.guild_only()
+    @commands.bot_has_permissions(manage_messages=True)
     async def text(
         self, ctx: commands.Context, text: str, number: int, delete_pinned: bool = False
     ):
@@ -121,9 +122,6 @@ class Cleanup(commands.Cog):
         """
 
         channel = ctx.channel
-        if not channel.permissions_for(ctx.guild.me).manage_messages:
-            await ctx.send(_("I need the Manage Messages permission to do this."))
-            return
 
         author = ctx.author
 
@@ -157,6 +155,7 @@ class Cleanup(commands.Cog):
 
     @cleanup.command()
     @commands.guild_only()
+    @commands.bot_has_permissions(manage_messages=True)
     async def user(
         self, ctx: commands.Context, user: str, number: int, delete_pinned: bool = False
     ):
@@ -167,9 +166,6 @@ class Cleanup(commands.Cog):
             `[p]cleanup user Red 6`
         """
         channel = ctx.channel
-        if not channel.permissions_for(ctx.guild.me).manage_messages:
-            await ctx.send(_("I need the Manage Messages permission to do this."))
-            return
 
         member = None
         try:
@@ -215,6 +211,7 @@ class Cleanup(commands.Cog):
 
     @cleanup.command()
     @commands.guild_only()
+    @commands.bot_has_permissions(manage_messages=True)
     async def after(self, ctx: commands.Context, message_id: int, delete_pinned: bool = False):
         """Delete all messages after a specified message.
 
@@ -224,9 +221,6 @@ class Cleanup(commands.Cog):
         """
 
         channel = ctx.channel
-        if not channel.permissions_for(ctx.guild.me).manage_messages:
-            await ctx.send(_("I need the Manage Messages permission to do this."))
-            return
         author = ctx.author
 
         try:
@@ -247,6 +241,7 @@ class Cleanup(commands.Cog):
 
     @cleanup.command()
     @commands.guild_only()
+    @commands.bot_has_permissions(manage_messages=True)
     async def before(
         self, ctx: commands.Context, message_id: int, number: int, delete_pinned: bool = False
     ):
@@ -258,9 +253,6 @@ class Cleanup(commands.Cog):
         """
 
         channel = ctx.channel
-        if not channel.permissions_for(ctx.guild.me).manage_messages:
-            await ctx.send("I need the Manage Messages permission to do this.")
-            return
         author = ctx.author
 
         try:
@@ -281,6 +273,7 @@ class Cleanup(commands.Cog):
 
     @cleanup.command()
     @commands.guild_only()
+    @commands.bot_has_permissions(manage_messages=True)
     async def messages(self, ctx: commands.Context, number: int, delete_pinned: bool = False):
         """Delete the last X messages.
 
@@ -289,9 +282,6 @@ class Cleanup(commands.Cog):
         """
 
         channel = ctx.channel
-        if not channel.permissions_for(ctx.guild.me).manage_messages:
-            await ctx.send(_("I need the Manage Messages permission to do this."))
-            return
         author = ctx.author
 
         if number > 100:
@@ -313,13 +303,11 @@ class Cleanup(commands.Cog):
 
     @cleanup.command(name="bot")
     @commands.guild_only()
+    @commands.bot_has_permissions(manage_messages=True)
     async def cleanup_bot(self, ctx: commands.Context, number: int, delete_pinned: bool = False):
         """Clean up command messages and messages from the bot."""
 
         channel = ctx.channel
-        if not channel.permissions_for(ctx.guild.me).manage_messages:
-            await ctx.send(_("I need the Manage Messages permission to do this."))
-            return
         author = ctx.message.author
 
         if number > 100:

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -16,7 +16,7 @@ _ = Translator("Cleanup", __file__)
 
 @cog_i18n(_)
 class Cleanup(commands.Cog):
-    """Commands for cleaning messages"""
+    """Commands for cleaning messages."""
 
     def __init__(self, bot: Red):
         super().__init__()
@@ -104,7 +104,7 @@ class Cleanup(commands.Cog):
     @commands.group()
     @checks.mod_or_permissions(manage_messages=True)
     async def cleanup(self, ctx: commands.Context):
-        """Deletes messages."""
+        """Delete messages."""
         pass
 
     @cleanup.command()
@@ -112,16 +112,17 @@ class Cleanup(commands.Cog):
     async def text(
         self, ctx: commands.Context, text: str, number: int, delete_pinned: bool = False
     ):
-        """Deletes last X messages matching the specified text.
+        """Delete the last X messages matching the specified text.
 
         Example:
-        cleanup text \"test\" 5
+            `[p]cleanup text "test" 5`
 
-        Remember to use double quotes."""
+        Remember to use double quotes.
+        """
 
         channel = ctx.channel
         if not channel.permissions_for(ctx.guild.me).manage_messages:
-            await ctx.send("I need the Manage Messages permission to do this.")
+            await ctx.send(_("I need the Manage Messages permission to do this."))
             return
 
         author = ctx.author
@@ -159,14 +160,15 @@ class Cleanup(commands.Cog):
     async def user(
         self, ctx: commands.Context, user: str, number: int, delete_pinned: bool = False
     ):
-        """Deletes last X messages from specified user.
+        """Delete the last X messages from a specified user.
 
         Examples:
-        cleanup user @\u200bTwentysix 2
-        cleanup user Red 6"""
+            `[p]cleanup user @\u200bTwentysix 2`
+            `[p]cleanup user Red 6`
+        """
         channel = ctx.channel
         if not channel.permissions_for(ctx.guild.me).manage_messages:
-            await ctx.send("I need the Manage Messages permission to do this.")
+            await ctx.send(_("I need the Manage Messages permission to do this."))
             return
 
         member = None
@@ -214,7 +216,7 @@ class Cleanup(commands.Cog):
     @cleanup.command()
     @commands.guild_only()
     async def after(self, ctx: commands.Context, message_id: int, delete_pinned: bool = False):
-        """Deletes all messages after specified message.
+        """Delete all messages after a specified message.
 
         To get a message id, enable developer mode in Discord's
         settings, 'appearance' tab. Then right click a message
@@ -223,7 +225,7 @@ class Cleanup(commands.Cog):
 
         channel = ctx.channel
         if not channel.permissions_for(ctx.guild.me).manage_messages:
-            await ctx.send("I need the Manage Messages permission to do this.")
+            await ctx.send(_("I need the Manage Messages permission to do this."))
             return
         author = ctx.author
 
@@ -280,14 +282,15 @@ class Cleanup(commands.Cog):
     @cleanup.command()
     @commands.guild_only()
     async def messages(self, ctx: commands.Context, number: int, delete_pinned: bool = False):
-        """Deletes last X messages.
+        """Delete the last X messages.
 
         Example:
-        cleanup messages 26"""
+            `[p]cleanup messages 26`
+        """
 
         channel = ctx.channel
         if not channel.permissions_for(ctx.guild.me).manage_messages:
-            await ctx.send("I need the Manage Messages permission to do this.")
+            await ctx.send(_("I need the Manage Messages permission to do this."))
             return
         author = ctx.author
 
@@ -311,11 +314,11 @@ class Cleanup(commands.Cog):
     @cleanup.command(name="bot")
     @commands.guild_only()
     async def cleanup_bot(self, ctx: commands.Context, number: int, delete_pinned: bool = False):
-        """Cleans up command messages and messages from the bot."""
+        """Clean up command messages and messages from the bot."""
 
         channel = ctx.channel
         if not channel.permissions_for(ctx.guild.me).manage_messages:
-            await ctx.send("I need the Manage Messages permission to do this.")
+            await ctx.send(_("I need the Manage Messages permission to do this."))
             return
         author = ctx.message.author
 
@@ -369,7 +372,7 @@ class Cleanup(commands.Cog):
         match_pattern: str = None,
         delete_pinned: bool = False,
     ):
-        """Cleans up messages owned by the bot.
+        """Clean up messages owned by the bot.
 
         By default, all messages are cleaned. If a third argument is specified,
         it is used for pattern matching: If it begins with r( and ends with ),

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -33,7 +33,7 @@ class Cleanup(commands.Cog):
         """
 
         prompt = await ctx.send(
-            _("Are you sure you want to delete {} messages? (y/n)").format(number)
+            _("Are you sure you want to delete {number} messages? (y/n)").format(number=number)
         )
         response = await ctx.bot.wait_for("message", check=MessagePredicate.same_context(ctx))
 

--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -52,11 +52,11 @@ class CommandObj:
 
     async def get_responses(self, ctx):
         intro = _(
-            "Welcome to the interactive random {} maker!\n"
+            "Welcome to the interactive random {cc} maker!\n"
             "Every message you send will be added as one of the random "
             "responses to choose from once this {} is "
-            "triggered. To exit this interactive menu, type `{}`"
-        ).format("customcommand", "customcommand", "exit()")
+            "triggered. To exit this interactive menu, type `{quit}`"
+        ).format(cc="customcommand", quit="exit()")
         await ctx.send(intro)
 
         responses = []
@@ -226,8 +226,8 @@ class CustomCommands(commands.Cog):
             await ctx.send(_("Custom command successfully added."))
         except AlreadyExists:
             await ctx.send(
-                _("This command already exists. Use `{}` to edit it.").format(
-                    "{}customcom edit".format(ctx.prefix)
+                _("This command already exists. Use `{command}` to edit it.").format(
+                    command="{}customcom edit".format(ctx.prefix)
                 )
             )
 
@@ -249,8 +249,8 @@ class CustomCommands(commands.Cog):
             await ctx.send(_("Custom command successfully added."))
         except AlreadyExists:
             await ctx.send(
-                _("This command already exists. Use `{}` to edit it.").format(
-                    "{}customcom edit".format(ctx.prefix)
+                _("This command already exists. Use `{command}` to edit it.").format(
+                    command="{}customcom edit".format(ctx.prefix)
                 )
             )
         except ArgParseError as e:
@@ -293,8 +293,8 @@ class CustomCommands(commands.Cog):
             await ctx.send(_("Custom command cooldown successfully edited."))
         except NotFound:
             await ctx.send(
-                _("That command doesn't exist. Use `{}` to add it.").format(
-                    "{}customcom add".format(ctx.prefix)
+                _("That command doesn't exist. Use `{command}` to add it.").format(
+                    command="{}customcom add".format(ctx.prefix)
                 )
             )
 
@@ -341,8 +341,8 @@ class CustomCommands(commands.Cog):
             await ctx.send(
                 _(
                     "There are no custom commands in this server."
-                    " Use `{}` to start adding some."
-                ).format("{}customcom add".format(ctx.prefix))
+                    " Use `{command}` to start adding some."
+                ).format(command="{}customcom add".format(ctx.prefix))
             )
             return
 

--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -54,7 +54,7 @@ class CommandObj:
         intro = _(
             "Welcome to the interactive random {cc} maker!\n"
             "Every message you send will be added as one of the random "
-            "responses to choose from once this {} is "
+            "responses to choose from once this {cc} is "
             "triggered. To exit this interactive menu, type `{quit}`"
         ).format(cc="customcommand", quit="exit()")
         await ctx.send(intro)
@@ -196,30 +196,26 @@ class CustomCommands(commands.Cog):
     @commands.group(aliases=["cc"])
     @commands.guild_only()
     async def customcom(self, ctx: commands.Context):
-        """Custom commands management"""
+        """Custom commands management."""
         pass
 
-    @customcom.group(name="add")
+    @customcom.group(name="create", aliases=["add"])
     @checks.mod_or_permissions(administrator=True)
-    async def cc_add(self, ctx: commands.Context):
-        """
-        Adds a new custom command
+    async def cc_create(self, ctx: commands.Context):
+        """Create custom commands.
 
-        CCs can be enhanced with arguments:
-        https://red-discordbot.readthedocs.io/en/v3-develop/cog_customcom.html
+        CCs can be enhanced with arguments, see the guide
+        [here](https://red-discordbot.readthedocs.io/en/v3-develop/cog_customcom.html).
         """
         pass
 
-    @cc_add.command(name="random")
+    @cc_create.command(name="random")
     @checks.mod_or_permissions(administrator=True)
-    async def cc_add_random(self, ctx: commands.Context, command: str.lower):
-        """
-        Create a CC where it will randomly choose a response!
+    async def cc_create_random(self, ctx: commands.Context, command: str.lower):
+        """Create a CC where it will randomly choose a response!
 
-        Note: This is interactive
+        Note: This command is interactive.
         """
-        responses = []
-
         responses = await self.commandobj.get_responses(ctx=ctx)
         try:
             await self.commandobj.create(ctx=ctx, command=command, response=responses)
@@ -233,16 +229,16 @@ class CustomCommands(commands.Cog):
 
         # await ctx.send(str(responses))
 
-    @cc_add.command(name="simple")
+    @cc_create.command(name="simple")
     @checks.mod_or_permissions(administrator=True)
-    async def cc_add_simple(self, ctx, command: str.lower, *, text: str):
-        """Adds a simple custom command
+    async def cc_create_simple(self, ctx, command: str.lower, *, text: str):
+        """Add a simple custom command.
 
         Example:
-        [p]customcom add simple yourcommand Text you want
+        - `[p]customcom create simple yourcommand Text you want`
         """
         if command in self.bot.all_commands:
-            await ctx.send(_("That command is already a standard command."))
+            await ctx.send(_("There already exists a bot command with the same name."))
             return
         try:
             await self.commandobj.create(ctx=ctx, command=command, response=text)
@@ -261,13 +257,14 @@ class CustomCommands(commands.Cog):
     async def cc_cooldown(
         self, ctx, command: str.lower, cooldown: int = None, *, per: str.lower = "member"
     ):
-        """
-        Sets, edits, or views cooldowns for a custom command
+        """Set, edit, or view the cooldown for a custom command.
 
-        You may set cooldowns per member, channel, or guild.
-        Multiple cooldowns may be set. All cooldowns must be cooled to call the custom command.
+        You may set cooldowns per member, channel, or guild. Multiple
+        cooldowns may be set. All cooldowns must be cooled to call the
+        custom command.
+
         Example:
-        [p]customcom cooldown yourcommand 30
+        - `[p]customcom cooldown yourcommand 30`
         """
         if cooldown is None:
             try:
@@ -294,17 +291,18 @@ class CustomCommands(commands.Cog):
         except NotFound:
             await ctx.send(
                 _("That command doesn't exist. Use `{command}` to add it.").format(
-                    command="{}customcom add".format(ctx.prefix)
+                    command="{}customcom create".format(ctx.prefix)
                 )
             )
 
     @customcom.command(name="delete")
     @checks.mod_or_permissions(administrator=True)
     async def cc_delete(self, ctx, command: str.lower):
-        """Deletes a custom command
-
+        """Delete a custom command
+.
         Example:
-        [p]customcom delete yourcommand"""
+        - `[p]customcom delete yourcommand`
+        """
         try:
             await self.commandobj.delete(ctx=ctx, command=command)
             await ctx.send(_("Custom command successfully deleted."))
@@ -314,18 +312,20 @@ class CustomCommands(commands.Cog):
     @customcom.command(name="edit")
     @checks.mod_or_permissions(administrator=True)
     async def cc_edit(self, ctx, command: str.lower, *, text: str = None):
-        """Edits a custom command's response
+        """Edit a custom command.
 
         Example:
-        [p]customcom edit yourcommand Text you want
+        - `[p]customcom edit yourcommand Text you want`
         """
+        command = command.lower()
+
         try:
             await self.commandobj.edit(ctx=ctx, command=command, response=text)
             await ctx.send(_("Custom command successfully edited."))
         except NotFound:
             await ctx.send(
-                _("That command doesn't exist. Use `{}` to add it.").format(
-                    "{}customcom add".format(ctx.prefix)
+                _("That command doesn't exist. Use `{command}` to add it.").format(
+                    command="{}customcom create".format(ctx.prefix)
                 )
             )
         except ArgParseError as e:
@@ -333,7 +333,7 @@ class CustomCommands(commands.Cog):
 
     @customcom.command(name="list")
     async def cc_list(self, ctx):
-        """Shows custom commands list"""
+        """List all available custom commands."""
 
         response = await CommandObj.get_commands(self.config.guild(ctx.guild))
 
@@ -342,7 +342,7 @@ class CustomCommands(commands.Cog):
                 _(
                     "There are no custom commands in this server."
                     " Use `{command}` to start adding some."
-                ).format(command="{}customcom add".format(ctx.prefix))
+                ).format(command="{}customcom create".format(ctx.prefix))
             )
             return
 

--- a/redbot/cogs/dataconverter/dataconverter.py
+++ b/redbot/cogs/dataconverter/dataconverter.py
@@ -13,9 +13,7 @@ _ = Translator("DataConverter", __file__)
 
 @cog_i18n(_)
 class DataConverter(commands.Cog):
-    """
-    Cog for importing Red v2 Data
-    """
+    """Import Red V2 data to your V3 instance."""
 
     def __init__(self, bot: Red):
         super().__init__()
@@ -24,13 +22,10 @@ class DataConverter(commands.Cog):
     @checks.is_owner()
     @commands.command(name="convertdata")
     async def dataconversioncommand(self, ctx: commands.Context, v2path: str):
-        """
-        Interactive prompt for importing data from Red v2
+        """Interactive prompt for importing data from Red V2.
 
-        Takes the path where the v2 install is
-
-        Overwrites values which have entries in both v2 and v3,
-        use with caution.
+        Takes the path where the V2 install is, and overwrites
+        values which have entries in both V2 and v3; use with caution.
         """
         resolver = SpecResolver(Path(v2path.strip()))
 
@@ -54,7 +49,7 @@ class DataConverter(commands.Cog):
                     "message", check=MessagePredicate.same_context(ctx), timeout=60
                 )
             except asyncio.TimeoutError:
-                return await ctx.send(_("Try this again when you are more ready"))
+                return await ctx.send(_("Try this again when you are ready."))
             else:
                 if message.content.strip().lower() in ["quit", "exit", "-1", "q", "cancel"]:
                     return await ctx.tick()
@@ -72,7 +67,7 @@ class DataConverter(commands.Cog):
         else:
             return await ctx.send(
                 _(
-                    "There isn't anything else I know how to convert here."
-                    "\nThere might be more things I can convert in the future."
+                    "There isn't anything else I know how to convert here.\n"
+                    "There might be more things I can convert in the future."
                 )
             )

--- a/redbot/cogs/downloader/checks.py
+++ b/redbot/cogs/downloader/checks.py
@@ -1,11 +1,15 @@
 import asyncio
 
 from redbot.core import commands
+from redbot.core.i18n import Translator
 from redbot.core.utils.predicates import MessagePredicate
 
 __all__ = ["do_install_agreement"]
 
-REPO_INSTALL_MSG = (
+T_ = Translator("DownloaderChecks", __file__)
+
+_ = lambda s: s
+REPO_INSTALL_MSG = _(
     "You're about to add a 3rd party repository. The creator of Red"
     " and its community have no responsibility for any potential "
     "damage that the content of 3rd party repositories might cause."
@@ -14,6 +18,7 @@ REPO_INSTALL_MSG = (
     "shown again until the next reboot.\n\nYou have **30** seconds"
     " to reply to this message."
 )
+_ = T_
 
 
 async def do_install_agreement(ctx: commands.Context):
@@ -21,14 +26,14 @@ async def do_install_agreement(ctx: commands.Context):
     if downloader is None or downloader.already_agreed:
         return True
 
-    await ctx.send(REPO_INSTALL_MSG)
+    await ctx.send(T_(REPO_INSTALL_MSG))
 
     try:
         await ctx.bot.wait_for(
             "message", check=MessagePredicate.lower_equal_to("i agree", ctx), timeout=30
         )
     except asyncio.TimeoutError:
-        await ctx.send("Your response has timed out, please try again.")
+        await ctx.send(_("Your response has timed out, please try again."))
         return False
 
     downloader.already_agreed = True

--- a/redbot/cogs/downloader/converters.py
+++ b/redbot/cogs/downloader/converters.py
@@ -8,10 +8,10 @@ class InstalledCog(Installable):
     async def convert(cls, ctx: commands.Context, arg: str) -> Installable:
         downloader = ctx.bot.get_cog("Downloader")
         if downloader is None:
-            raise commands.CommandError("Downloader not loaded.")
+            raise commands.CommandError(_("No Downloader cog found."))
 
         cog = discord.utils.get(await downloader.installed_cogs(), name=arg)
         if cog is None:
-            raise commands.BadArgument("That cog is not installed")
+            raise commands.BadArgument(_("That cog is not installed"))
 
         return cog

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -8,7 +8,7 @@ from sys import path as syspath
 from typing import Tuple, Union, Iterable
 
 import discord
-from redbot.core import checks, commands, Config
+from redbot.core import checks, commands, Config, checks, commands
 from redbot.core.bot import Red
 from redbot.core.data_manager import cog_data_path
 from redbot.core.i18n import Translator, cog_i18n
@@ -193,9 +193,7 @@ class Downloader(commands.Cog):
     @commands.command()
     @checks.is_owner()
     async def pipinstall(self, ctx, *deps: str):
-        """
-        Installs a group of dependencies using pip.
-        """
+        """Install a group of dependencies using pip."""
         repo = Repo("", "", "", Path.cwd(), loop=ctx.bot.loop)
         success = await repo.install_raw_requirements(deps, self.LIB_PATH)
 
@@ -212,18 +210,15 @@ class Downloader(commands.Cog):
     @commands.group()
     @checks.is_owner()
     async def repo(self, ctx):
-        """
-        Command group for managing Downloader repos.
-        """
+        """Repo management commands."""
         pass
 
     @repo.command(name="add")
     async def _repo_add(self, ctx, name: str, repo_url: str, branch: str = None):
-        """
-        Add a new repo to Downloader.
+        """Add a new repo.
 
-        Name can only contain characters A-z, numbers and underscore
-        Branch will default to master if not specified
+        The name can only contain characters A-z, numbers and underscores.
+        The branch will default to master if not specified.
         """
         agreed = await do_install_agreement(ctx)
         if not agreed:
@@ -246,11 +241,9 @@ class Downloader(commands.Cog):
             if repo.install_msg is not None:
                 await ctx.send(repo.install_msg.replace("[p]", ctx.prefix))
 
-    @repo.command(name="delete")
+    @repo.command(name="delete", aliases=["remove"])
     async def _repo_del(self, ctx, repo_name: Repo):
-        """
-        Removes a repo from Downloader and its' files.
-        """
+        """Remove a repo and its files."""
         await self._repo_manager.delete_repo(repo_name.name)
 
         await ctx.send(
@@ -259,9 +252,7 @@ class Downloader(commands.Cog):
 
     @repo.command(name="list")
     async def _repo_list(self, ctx):
-        """
-        Lists all installed repos.
-        """
+        """List all installed repos."""
         repos = self._repo_manager.get_all_repo_names()
         repos = sorted(repos, key=str.lower)
         joined = _("Installed Repos:\n\n")
@@ -274,11 +265,9 @@ class Downloader(commands.Cog):
 
     @repo.command(name="info")
     async def _repo_info(self, ctx, repo_name: Repo):
-        """
-        Lists information about a single repo
-        """
+        """Show information about a repo."""
         if repo_name is None:
-            await ctx.send(_("There is no repo `{repo_name}`").format(repo_name=repo_name.name))
+            await ctx.send(_("Repo `{repo_name}` not found.").format(repo_name=repo_name.name))
             return
 
         msg = _("Information on {repo_name}:\n{description}").format(
@@ -289,28 +278,24 @@ class Downloader(commands.Cog):
     @commands.group()
     @checks.is_owner()
     async def cog(self, ctx):
-        """
-        Command group for managing installable Cogs.
-        """
+        """Cog installation management commands."""
         pass
 
     @cog.command(name="install")
     async def _cog_install(self, ctx, repo_name: Repo, cog_name: str):
-        """
-        Installs a cog from the given repo.
-        """
-        cog = discord.utils.get(repo_name.available_cogs, name=cog_name)  # type: Installable
+        """Install a cog from the given repo."""
+        cog: Installable = discord.utils.get(repo_name.available_cogs, name=cog_name)
         if cog is None:
             await ctx.send(
                 _(
-                    "Error, there is no cog by the name of `{cog_name}` in the `{repo_name}` repo."
+                    "Error: there is no cog by the name of `{cog_name}` in the `{repo_name}` repo."
                 ).format(cog_name=cog_name, repo_name=repo_name.name)
             )
             return
         elif cog.min_python_version > sys.version_info:
             await ctx.send(
-                _("This cog requires at least python version {}, aborting install.").format(
-                    ".".join([str(n) for n in cog.min_python_version])
+                _("This cog requires at least python version {version}, aborting install.").format(
+                    version=".".join([str(n) for n in cog.min_python_version])
                 )
             )
             return
@@ -329,15 +314,16 @@ class Downloader(commands.Cog):
 
         await repo_name.install_libraries(self.SHAREDLIB_PATH)
 
-        await ctx.send(_("`{cog_name}` cog successfully installed.").format(cog_name=cog_name))
+        await ctx.send(_("Cog `{cog_name}` successfully installed.").format(cog_name=cog_name))
         if cog.install_msg is not None:
             await ctx.send(cog.install_msg.replace("[p]", ctx.prefix))
 
     @cog.command(name="uninstall")
     async def _cog_uninstall(self, ctx, cog_name: InstalledCog):
-        """
-        Allows you to uninstall cogs that were previously installed
-            through Downloader.
+        """Uninstall a cog.
+
+        You may only uninstall cogs which were previously installed
+        by Downloader.
         """
         # noinspection PyUnresolvedReferences,PyProtectedMember
         real_name = cog_name.name
@@ -348,7 +334,7 @@ class Downloader(commands.Cog):
             # noinspection PyTypeChecker
             await self._remove_from_installed(cog_name)
             await ctx.send(
-                _("`{real_name}` was successfully removed.").format(real_name=real_name)
+                _("Cog `{cog_name}` was successfully uninstalled.").format(cog_name=real_name)
             )
         else:
             await ctx.send(
@@ -356,14 +342,14 @@ class Downloader(commands.Cog):
                     "That cog was installed but can no longer"
                     " be located. You may need to remove it's"
                     " files manually if it is still usable."
-                )
+                    " Also make sure you've unloaded the cog"
+                    " with `{prefix}unload {cog_name}`."
+                ).format(cog_name=real_name)
             )
 
     @cog.command(name="update")
     async def _cog_update(self, ctx, cog_name: InstalledCog = None):
-        """
-        Updates all cogs or one of your choosing.
-        """
+        """Update all cogs, or one of your choosing."""
         installed_cogs = set(await self.installed_cogs())
 
         async with ctx.typing():
@@ -426,9 +412,7 @@ class Downloader(commands.Cog):
 
     @cog.command(name="list")
     async def _cog_list(self, ctx, repo_name: Repo):
-        """
-        Lists all available cogs from a single repo.
-        """
+        """List all available cogs from a single repo."""
         installed = await self.installed_cogs()
         installed_str = ""
         if installed:
@@ -453,9 +437,7 @@ class Downloader(commands.Cog):
 
     @cog.command(name="info")
     async def _cog_info(self, ctx, repo_name: Repo, cog_name: str):
-        """
-        Lists information about a single cog.
-        """
+        """List information about a single cog."""
         cog = discord.utils.get(repo_name.available_cogs, name=cog_name)
         if cog is None:
             await ctx.send(
@@ -549,9 +531,9 @@ class Downloader(commands.Cog):
 
     @commands.command()
     async def findcog(self, ctx: commands.Context, command_name: str):
-        """
-        Figures out which cog a command comes from. Only works with loaded
-            cogs.
+        """Find which cog a command comes from.
+
+        This will only work with loaded cogs.
         """
         command = ctx.bot.all_commands.get(command_name)
 

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -242,7 +242,7 @@ class Downloader(commands.Cog):
                 exc_info=err,
             )
         else:
-            await ctx.send(_("Repo `{}` successfully added.").format(name))
+            await ctx.send(_("Repo `{name}` successfully added.").format(name=name))
             if repo.install_msg is not None:
                 await ctx.send(repo.install_msg.replace("[p]", ctx.prefix))
 
@@ -253,7 +253,9 @@ class Downloader(commands.Cog):
         """
         await self._repo_manager.delete_repo(repo_name.name)
 
-        await ctx.send(_("The repo `{}` has been deleted successfully.").format(repo_name.name))
+        await ctx.send(
+            _("The repo `{name}` has been deleted successfully.").format(name=repo_name.name)
+        )
 
     @repo.command(name="list")
     async def _repo_list(self, ctx):
@@ -276,10 +278,12 @@ class Downloader(commands.Cog):
         Lists information about a single repo
         """
         if repo_name is None:
-            await ctx.send(_("There is no repo `{}`").format(repo_name.name))
+            await ctx.send(_("There is no repo `{repo_name}`").format(repo_name=repo_name.name))
             return
 
-        msg = _("Information on {}:\n{}").format(repo_name.name, repo_name.description or "")
+        msg = _("Information on {repo_name}:\n{description}").format(
+            repo_name=repo_name.name, description=repo_name.description or ""
+        )
         await ctx.send(box(msg))
 
     @commands.group()
@@ -298,9 +302,9 @@ class Downloader(commands.Cog):
         cog = discord.utils.get(repo_name.available_cogs, name=cog_name)  # type: Installable
         if cog is None:
             await ctx.send(
-                _("Error, there is no cog by the name of `{}` in the `{}` repo.").format(
-                    cog_name, repo_name.name
-                )
+                _(
+                    "Error, there is no cog by the name of `{cog_name}` in the `{repo_name}` repo."
+                ).format(cog_name=cog_name, repo_name=repo_name.name)
             )
             return
         elif cog.min_python_version > sys.version_info:
@@ -313,9 +317,9 @@ class Downloader(commands.Cog):
 
         if not await repo_name.install_requirements(cog, self.LIB_PATH):
             await ctx.send(
-                _("Failed to install the required libraries for `{}`: `{}`").format(
-                    cog.name, cog.requirements
-                )
+                _(
+                    "Failed to install the required libraries for `{cog_name}`: `{libraries}`"
+                ).format(cog_name=cog.name, libraries=cog.requirements)
             )
             return
 
@@ -325,7 +329,7 @@ class Downloader(commands.Cog):
 
         await repo_name.install_libraries(self.SHAREDLIB_PATH)
 
-        await ctx.send(_("`{}` cog successfully installed.").format(cog_name))
+        await ctx.send(_("`{cog_name}` cog successfully installed.").format(cog_name=cog_name))
         if cog.install_msg is not None:
             await ctx.send(cog.install_msg.replace("[p]", ctx.prefix))
 
@@ -343,7 +347,9 @@ class Downloader(commands.Cog):
             await self._delete_cog(poss_installed_path)
             # noinspection PyTypeChecker
             await self._remove_from_installed(cog_name)
-            await ctx.send(_("`{}` was successfully removed.").format(real_name))
+            await ctx.send(
+                _("`{real_name}` was successfully removed.").format(real_name=real_name)
+            )
         else:
             await ctx.send(
                 _(
@@ -453,12 +459,18 @@ class Downloader(commands.Cog):
         cog = discord.utils.get(repo_name.available_cogs, name=cog_name)
         if cog is None:
             await ctx.send(
-                _("There is no cog `{}` in the repo `{}`").format(cog_name, repo_name.name)
+                _("There is no cog `{cog_name}` in the repo `{repo_name}`").format(
+                    cog_name=cog_name, repo_name=repo_name.name
+                )
             )
             return
 
-        msg = _("Information on {}:\n{}\n\nRequirements: {}").format(
-            cog.name, cog.description or "", ", ".join(cog.requirements) or "None"
+        msg = _(
+            "Information on {cog_name}:\n{description}\n\nRequirements: {requirements}"
+        ).format(
+            cog_name=cog.name,
+            description=cog.description or "",
+            requirements=", ".join(cog.requirements) or "None",
         )
         await ctx.send(box(msg))
 
@@ -512,9 +524,9 @@ class Downloader(commands.Cog):
             repo_url = "https://github.com/Cog-Creators/Red-DiscordBot"
             cog_name = cog_installable.__class__.__name__
 
-        msg = _("Command: {}\nMade by: {}\nRepo: {}\nCog name: {}")
+        msg = _("Command: {command}\nMade by: {author}\nRepo: {repo}\nCog name: {cog}")
 
-        return msg.format(command_name, made_by, repo_url, cog_name)
+        return msg.format(command=command_name, author=made_by, repo=repo_url, cog=cog_name)
 
     def cog_name_from_instance(self, instance: object) -> str:
         """Determines the cog name that Downloader knows from the cog instance.

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -12,10 +12,14 @@ from typing import Tuple, MutableMapping, Union, Optional
 
 from redbot.core import data_manager, commands
 from redbot.core.utils import safe_delete
+from redbot.core.i18n import Translator
+
 from . import errors
 from .installable import Installable, InstallableType
 from .json_mixins import RepoJSONMixin
 from .log import log
+
+_ = Translator("RepoManager", __file__)
 
 
 class Repo(RepoJSONMixin):
@@ -64,13 +68,15 @@ class Repo(RepoJSONMixin):
     async def convert(cls, ctx: commands.Context, argument: str):
         downloader_cog = ctx.bot.get_cog("Downloader")
         if downloader_cog is None:
-            raise commands.CommandError("No Downloader cog found.")
+            raise commands.CommandError(_("No Downloader cog found."))
 
         # noinspection PyProtectedMember
         repo_manager = downloader_cog._repo_manager
         poss_repo = repo_manager.get_repo(argument)
         if poss_repo is None:
-            raise commands.BadArgument("Repo by the name {} does not exist.".format(argument))
+            raise commands.BadArgument(
+                _('Repo by the name "{repo_name}" does not exist.').format(repo_name=argument)
+            )
         return poss_repo
 
     def _existing_git_repo(self) -> (bool, Path):

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -447,32 +447,30 @@ class Economy(commands.Cog):
         """Changes economy module settings"""
         guild = ctx.guild
         if ctx.invoked_subcommand is None:
+            fmt = {}
             if await bank.is_global():
-                slot_min = await self.config.SLOT_MIN()
-                slot_max = await self.config.SLOT_MAX()
-                slot_time = await self.config.SLOT_TIME()
-                payday_time = await self.config.PAYDAY_TIME()
-                payday_amount = await self.config.PAYDAY_CREDITS()
+                fmt["slot_min"] = await self.config.SLOT_MIN()
+                fmt["slot_max"] = await self.config.SLOT_MAX()
+                fmt["slot_time"] = await self.config.SLOT_TIME()
+                fmt["payday_time"] = await self.config.PAYDAY_TIME()
+                fmt["payday_amount"] = await self.config.PAYDAY_CREDITS()
             else:
-                slot_min = await self.config.guild(guild).SLOT_MIN()
-                slot_max = await self.config.guild(guild).SLOT_MAX()
-                slot_time = await self.config.guild(guild).SLOT_TIME()
-                payday_time = await self.config.guild(guild).PAYDAY_TIME()
-                payday_amount = await self.config.guild(guild).PAYDAY_CREDITS()
-            register_amount = await bank.get_default_balance(guild)
+                fmt["slot_min"] = await self.config.guild(guild).SLOT_MIN()
+                fmt["slot_max"] = await self.config.guild(guild).SLOT_MAX()
+                fmt["slot_time"] = await self.config.guild(guild).SLOT_TIME()
+                fmt["payday_time"] = await self.config.guild(guild).PAYDAY_TIME()
+                fmt["payday_amount"] = await self.config.guild(guild).PAYDAY_CREDITS()
+            fmt["register_amount"] = await bank.get_default_balance(guild)
             msg = box(
                 _(
-                    "Minimum slot bid: {}\n"
-                    "Maximum slot bid: {}\n"
-                    "Slot cooldown: {}\n"
-                    "Payday amount: {}\n"
-                    "Payday cooldown: {}\n"
-                    "Amount given at account registration: {}"
-                    ""
-                ).format(
-                    slot_min, slot_max, slot_time, payday_amount, payday_time, register_amount
-                ),
-                _("Current Economy settings:"),
+                    "Current Economy settings:"
+                    "Minimum slot bid: {slot_min}\n"
+                    "Maximum slot bid: {slot_max}\n"
+                    "Slot cooldown: {slot_time}\n"
+                    "Payday amount: {payday_amount}\n"
+                    "Payday cooldown: {payday_time}\n"
+                    "Amount given at account registration: {register_amount}"
+                ).format(**fmt)
             )
             await ctx.send(msg)
 
@@ -488,7 +486,9 @@ class Economy(commands.Cog):
         else:
             await self.config.guild(guild).SLOT_MIN.set(bid)
         credits_name = await bank.get_currency_name(guild)
-        await ctx.send(_("Minimum bid is now {} {}.").format(bid, credits_name))
+        await ctx.send(
+            _("Minimum bid is now {bid} {currency}.").format(bid=bid, currency=credits_name)
+        )
 
     @economyset.command()
     async def slotmax(self, ctx: commands.Context, bid: int):
@@ -503,7 +503,9 @@ class Economy(commands.Cog):
             await self.config.SLOT_MAX.set(bid)
         else:
             await self.config.guild(guild).SLOT_MAX.set(bid)
-        await ctx.send(_("Maximum bid is now {} {}.").format(bid, credits_name))
+        await ctx.send(
+            _("Maximum bid is now {bid} {currency}.").format(bid=bid, currency=credits_name)
+        )
 
     @economyset.command()
     async def slottime(self, ctx: commands.Context, seconds: int):
@@ -513,7 +515,7 @@ class Economy(commands.Cog):
             await self.config.SLOT_TIME.set(seconds)
         else:
             await self.config.guild(guild).SLOT_TIME.set(seconds)
-        await ctx.send(_("Cooldown is now {} seconds.").format(seconds))
+        await ctx.send(_("Cooldown is now {num} seconds.").format(num=seconds))
 
     @economyset.command()
     async def paydaytime(self, ctx: commands.Context, seconds: int):
@@ -524,7 +526,9 @@ class Economy(commands.Cog):
         else:
             await self.config.guild(guild).PAYDAY_TIME.set(seconds)
         await ctx.send(
-            _("Value modified. At least {} seconds must pass between each payday.").format(seconds)
+            _("Value modified. At least {num} seconds must pass between each payday.").format(
+                num=seconds
+            )
         )
 
     @economyset.command()
@@ -539,7 +543,11 @@ class Economy(commands.Cog):
             await self.config.PAYDAY_CREDITS.set(creds)
         else:
             await self.config.guild(guild).PAYDAY_CREDITS.set(creds)
-        await ctx.send(_("Every payday will now give {} {}.").format(creds, credits_name))
+        await ctx.send(
+            _("Every payday will now give {num} {currency}.").format(
+                num=creds, currency=credits_name
+            )
+        )
 
     @economyset.command()
     async def rolepaydayamount(self, ctx: commands.Context, role: discord.Role, creds: int):
@@ -551,9 +559,10 @@ class Economy(commands.Cog):
         else:
             await self.config.role(role).PAYDAY_CREDITS.set(creds)
             await ctx.send(
-                _("Every payday will now give {} {} to people with the role {}.").format(
-                    creds, credits_name, role.name
-                )
+                _(
+                    "Every payday will now give {num} {currency} "
+                    "to people with the role {role_name}."
+                ).format(num=creds, currency=credits_name, role_name=role.name)
             )
 
     @economyset.command()
@@ -565,7 +574,9 @@ class Economy(commands.Cog):
         credits_name = await bank.get_currency_name(guild)
         await bank.set_default_balance(creds, guild)
         await ctx.send(
-            _("Registering an account will now give {} {}.").format(creds, credits_name)
+            _("Registering an account will now give {num} {currency}.").format(
+                num=creds, currency=credits_name
+            )
         )
 
     # What would I ever do without stackoverflow?

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -3,6 +3,7 @@ import logging
 import random
 from collections import defaultdict, deque
 from enum import Enum
+from typing import cast, Iterable
 
 import discord
 
@@ -14,7 +15,7 @@ from redbot.core.utils.menus import menu, DEFAULT_CONTROLS
 
 from redbot.core.bot import Red
 
-_ = Translator("Economy", __file__)
+T_ = Translator("Economy", __file__)
 
 logger = logging.getLogger("red.economy")
 
@@ -34,6 +35,7 @@ class SMReel(Enum):
     snowflake = "\N{SNOWFLAKE}"
 
 
+_ = lambda s: s
 PAYOUTS = {
     (SMReel.two, SMReel.two, SMReel.six): {
         "payout": lambda x: x * 2500 + x,
@@ -72,6 +74,7 @@ SLOT_PAYOUTS_MSG = _(
     "Three symbols: +500\n"
     "Two symbols: Bet * 2"
 ).format(**SMReel.__dict__)
+_ = T_
 
 
 def guild_only_check():
@@ -106,9 +109,7 @@ class SetParser:
 
 @cog_i18n(_)
 class Economy(commands.Cog):
-    """Economy
-
-    Get rich and have fun with imaginary currency!"""
+    """Get rich and have fun with imaginary currency!"""
 
     default_guild_settings = {
         "PAYDAY_TIME": 300,
@@ -142,12 +143,12 @@ class Economy(commands.Cog):
     @guild_only_check()
     @commands.group(name="bank")
     async def _bank(self, ctx: commands.Context):
-        """Bank operations"""
+        """Manage the bank."""
         pass
 
     @_bank.command()
     async def balance(self, ctx: commands.Context, user: discord.Member = None):
-        """Shows balance of user.
+        """Show the user's account balance.
 
         Defaults to yours."""
         if user is None:
@@ -156,11 +157,15 @@ class Economy(commands.Cog):
         bal = await bank.get_balance(user)
         currency = await bank.get_currency_name(ctx.guild)
 
-        await ctx.send(_("{}'s balance is {} {}").format(user.display_name, bal, currency))
+        await ctx.send(
+            _("{user}'s balance is {num} {currency}").format(
+                user=user.display_name, num=bal, currency=currency
+            )
+        )
 
     @_bank.command()
     async def transfer(self, ctx: commands.Context, to: discord.Member, amount: int):
-        """Transfer currency to other users"""
+        """Transfer currency to other users."""
         from_ = ctx.author
         currency = await bank.get_currency_name(ctx.guild)
 
@@ -170,72 +175,83 @@ class Economy(commands.Cog):
             return await ctx.send(str(e))
 
         await ctx.send(
-            _("{} transferred {} {} to {}").format(
-                from_.display_name, amount, currency, to.display_name
+            _("{user} transferred {num} {currency} to {other_user}").format(
+                user=from_.display_name, num=amount, currency=currency, other_user=to.display_name
             )
         )
 
     @_bank.command(name="set")
     @check_global_setting_admin()
     async def _set(self, ctx: commands.Context, to: discord.Member, creds: SetParser):
-        """Sets balance of user's bank account. See help for more operations
+        """Set the balance of user's bank account.
 
-        Passing positive and negative values will add/remove currency instead
+        Passing positive and negative values will add/remove currency instead.
 
         Examples:
-            bank set @Twentysix 26 - Sets balance to 26
-            bank set @Twentysix +2 - Increases balance by 2
-            bank set @Twentysix -6 - Decreases balance by 6"""
+        - `[p]bank set @Twentysix 26` - Sets balance to 26
+        - `[p]bank set @Twentysix +2` - Increases balance by 2
+        - `[p]bank set @Twentysix -6` - Decreases balance by 6
+        """
         author = ctx.author
         currency = await bank.get_currency_name(ctx.guild)
 
         if creds.operation == "deposit":
             await bank.deposit_credits(to, creds.sum)
             await ctx.send(
-                _("{} added {} {} to {}'s account.").format(
-                    author.display_name, creds.sum, currency, to.display_name
+                _("{author} added {num} {currency} to {user}'s account.").format(
+                    author=author.display_name,
+                    num=creds.sum,
+                    currency=currency,
+                    user=to.display_name,
                 )
             )
         elif creds.operation == "withdraw":
             await bank.withdraw_credits(to, creds.sum)
             await ctx.send(
-                _("{} removed {} {} from {}'s account.").format(
-                    author.display_name, creds.sum, currency, to.display_name
+                _("{author} removed {num} {currency} from {user}'s account.").format(
+                    author=author.display_name,
+                    num=creds.sum,
+                    currency=currency,
+                    user=to.display_name,
                 )
             )
         else:
             await bank.set_balance(to, creds.sum)
             await ctx.send(
-                _("{} set {}'s account to {} {}.").format(
-                    author.display_name, to.display_name, creds.sum, currency
+                _("{author} set {users}'s account balance to {num} {currency}.").format(
+                    author=author.display_name,
+                    num=creds.sum,
+                    currency=currency,
+                    user=to.display_name,
                 )
             )
 
     @_bank.command()
     @check_global_setting_guildowner()
     async def reset(self, ctx, confirmation: bool = False):
-        """Deletes bank accounts"""
+        """Delete all bank accounts."""
         if confirmation is False:
             await ctx.send(
                 _(
-                    "This will delete all bank accounts for {}.\nIf you're sure, type "
-                    "`{}bank reset yes`"
+                    "This will delete all bank accounts for {scope}.\nIf you're sure, type "
+                    "`{prefix}bank reset yes`"
                 ).format(
-                    self.bot.user.name if await bank.is_global() else "this server", ctx.prefix
+                    scope=self.bot.user.name if await bank.is_global() else _("this server"),
+                    prefix=ctx.prefix,
                 )
             )
         else:
-            await bank.wipe_bank()
+            await bank.wipe_bank(guild=ctx.guild)
             await ctx.send(
-                _("All bank accounts for {} have been deleted.").format(
-                    self.bot.user.name if await bank.is_global() else "this server"
+                _("All bank accounts for {scope} have been deleted.").format(
+                    scope=self.bot.user.name if await bank.is_global() else _("this server")
                 )
             )
 
     @guild_only_check()
     @commands.command()
     async def payday(self, ctx: commands.Context):
-        """Get some free currency"""
+        """Get some free currency."""
         author = ctx.author
         guild = ctx.guild
 
@@ -251,24 +267,25 @@ class Economy(commands.Cog):
                 pos = await bank.get_leaderboard_position(author)
                 await ctx.send(
                     _(
-                        "{0.mention} Here, take some {1}. Enjoy! (+{2} {1}!)\n\n"
-                        "You currently have {3} {1}.\n\n"
-                        "You are currently #{4} on the global leaderboard!"
+                        "{author.mention} Here, take some {currency}. "
+                        "Enjoy! (+{amount} {new_balance}!)\n\n"
+                        "You currently have {new_balance} {currency}.\n\n"
+                        "You are currently #{pos} on the global leaderboard!"
                     ).format(
-                        author,
-                        credits_name,
-                        str(await self.config.PAYDAY_CREDITS()),
-                        str(await bank.get_balance(author)),
-                        pos,
+                        author=author,
+                        currency=credits_name,
+                        amount=await self.config.PAYDAY_CREDITS(),
+                        new_balance=await bank.get_balance(author),
+                        pos=pos,
                     )
                 )
 
             else:
                 dtime = self.display_time(next_payday - cur_time)
                 await ctx.send(
-                    _("{} Too soon. For your next payday you have to wait {}.").format(
-                        author.mention, dtime
-                    )
+                    _(
+                        "{author.mention} Too soon. For your next payday you have to wait {time}."
+                    ).format(author=author, time=dtime)
                 )
         else:
             next_payday = await self.config.member(author).next_payday()
@@ -286,31 +303,33 @@ class Economy(commands.Cog):
                 pos = await bank.get_leaderboard_position(author)
                 await ctx.send(
                     _(
-                        "{0.mention} Here, take some {1}. Enjoy! (+{2} {1}!)\n\n"
-                        "You currently have {3} {1}.\n\n"
-                        "You are currently #{4} on the leaderboard!"
+                        "{author.mention} Here, take some {currency}. "
+                        "Enjoy! (+{amount} {new_balance}!)\n\n"
+                        "You currently have {new_balance} {currency}.\n\n"
+                        "You are currently #{pos} on the global leaderboard!"
                     ).format(
-                        author,
-                        credits_name,
-                        credit_amount,
-                        str(await bank.get_balance(author)),
-                        pos,
+                        author=author,
+                        currency=credits_name,
+                        amount=credit_amount,
+                        new_balance=await bank.get_balance(author),
+                        pos=pos,
                     )
                 )
             else:
                 dtime = self.display_time(next_payday - cur_time)
                 await ctx.send(
-                    _("{} Too soon. For your next payday you have to wait {}.").format(
-                        author.mention, dtime
-                    )
+                    _(
+                        "{author.mention} Too soon. For your next payday you have to wait {time}."
+                    ).format(author=author, time=dtime)
                 )
 
     @commands.command()
     @guild_only_check()
     async def leaderboard(self, ctx: commands.Context, top: int = 10, show_global: bool = False):
-        """Prints out the leaderboard
+        """Print the leaderboard.
 
-        Defaults to top 10"""
+        Defaults to top 10.
+        """
         guild = ctx.guild
         author = ctx.author
         if top < 1:
@@ -320,9 +339,9 @@ class Economy(commands.Cog):
         ):  # show_global is only applicable if bank is global
             guild = None
         bank_sorted = await bank.get_leaderboard(positions=top, guild=guild)
-        if len(bank_sorted) < top:
-            top = len(bank_sorted)
-        header = f"{f'#':4}{f'Name':36}{f'Score':2}\n"
+        header = "{pound:4}{name:36}{score:2}\n".format(
+            pound="#", name=_("Name"), score=_("Score")
+        )
         highscores = [
             (
                 f"{f'{pos}.': <{3 if pos < 10 else 2}} {acc[1]['name']: <{35}s} "
@@ -347,13 +366,13 @@ class Economy(commands.Cog):
     @commands.command()
     @guild_only_check()
     async def payouts(self, ctx: commands.Context):
-        """Shows slot machine payouts"""
-        await ctx.author.send(SLOT_PAYOUTS_MSG)
+        """Show the payouts for the slot machine."""
+        await ctx.author.send(SLOT_PAYOUTS_MSG())
 
     @commands.command()
     @guild_only_check()
     async def slot(self, ctx: commands.Context, bid: int):
-        """Play the slot machine"""
+        """Use the slot machine."""
         author = ctx.author
         guild = ctx.guild
         channel = ctx.channel
@@ -386,8 +405,9 @@ class Economy(commands.Cog):
             await self.config.member(author).last_slot.set(now)
         await self.slot_machine(author, channel, bid)
 
-    async def slot_machine(self, author, channel, bid):
-        default_reel = deque(SMReel)
+    @staticmethod
+    async def slot_machine(author, channel, bid):
+        default_reel = deque(cast(Iterable, SMReel))
         reels = []
         for i in range(3):
             default_reel.rotate(random.randint(-999, 999))  # weeeeee
@@ -425,58 +445,62 @@ class Economy(commands.Cog):
             pay = payout["payout"](bid)
             now = then - bid + pay
             await bank.set_balance(author, now)
-            await channel.send(
-                _("{}\n{} {}\n\nYour bid: {}\n{} → {}!").format(
-                    slot, author.mention, payout["phrase"], bid, then, now
-                )
-            )
+            phrase = T_(payout["phrase"])
         else:
             then = await bank.get_balance(author)
             await bank.withdraw_credits(author, bid)
             now = then - bid
-            await channel.send(
-                _("{}\n{} Nothing!\nYour bid: {}\n{} → {}!").format(
-                    slot, author.mention, bid, then, now
-                )
+            phrase = _("Nothing!")
+        await channel.send(
+            (
+                "{slot}\n{author.mention} {phrase}\n\n"
+                + _("Your bid: {amount}")
+                + "\n{old_balance} → {new_balance}!"
+            ).format(
+                slot=slot,
+                author=author,
+                phrase=phrase,
+                amount=bid,
+                old_balance=then,
+                new_balance=now,
             )
+        )
 
     @commands.group()
     @guild_only_check()
     @check_global_setting_admin()
     async def economyset(self, ctx: commands.Context):
-        """Changes economy module settings"""
+        """Manage Economy settings."""
         guild = ctx.guild
         if ctx.invoked_subcommand is None:
-            fmt = {}
             if await bank.is_global():
-                fmt["slot_min"] = await self.config.SLOT_MIN()
-                fmt["slot_max"] = await self.config.SLOT_MAX()
-                fmt["slot_time"] = await self.config.SLOT_TIME()
-                fmt["payday_time"] = await self.config.PAYDAY_TIME()
-                fmt["payday_amount"] = await self.config.PAYDAY_CREDITS()
+                conf = self.config
             else:
-                fmt["slot_min"] = await self.config.guild(guild).SLOT_MIN()
-                fmt["slot_max"] = await self.config.guild(guild).SLOT_MAX()
-                fmt["slot_time"] = await self.config.guild(guild).SLOT_TIME()
-                fmt["payday_time"] = await self.config.guild(guild).PAYDAY_TIME()
-                fmt["payday_amount"] = await self.config.guild(guild).PAYDAY_CREDITS()
-            fmt["register_amount"] = await bank.get_default_balance(guild)
-            msg = box(
-                _(
-                    "Current Economy settings:"
-                    "Minimum slot bid: {slot_min}\n"
-                    "Maximum slot bid: {slot_max}\n"
-                    "Slot cooldown: {slot_time}\n"
-                    "Payday amount: {payday_amount}\n"
-                    "Payday cooldown: {payday_time}\n"
-                    "Amount given at account registration: {register_amount}"
-                ).format(**fmt)
+                conf = self.config.guild(ctx.guild)
+            await ctx.send(
+                box(
+                    _(
+                        "----Economy Settings---\n"
+                        "Minimum slot bid: {slot_min}\n"
+                        "Maximum slot bid: {slot_max}\n"
+                        "Slot cooldown: {slot_time}\n"
+                        "Payday amount: {payday_amount}\n"
+                        "Payday cooldown: {payday_time}\n"
+                        "Amount given at account registration: {register_amount}"
+                    ).format(
+                        slot_min=await conf.SLOT_MIN(),
+                        slot_max=await conf.SLOT_MAX(),
+                        slot_time=await conf.SLOT_TIME(),
+                        payday_time=await conf.PAYDAY_TIME(),
+                        payday_amount=await conf.PAYDAY_CREDITS(),
+                        register_amount=await bank.get_default_balance(guild),
+                    )
+                )
             )
-            await ctx.send(msg)
 
     @economyset.command()
     async def slotmin(self, ctx: commands.Context, bid: int):
-        """Minimum slot machine bid"""
+        """Set the minimum slot machine bid."""
         if bid < 1:
             await ctx.send(_("Invalid min bid amount."))
             return
@@ -492,10 +516,12 @@ class Economy(commands.Cog):
 
     @economyset.command()
     async def slotmax(self, ctx: commands.Context, bid: int):
-        """Maximum slot machine bid"""
+        """Set the maximum slot machine bid."""
         slot_min = await self.config.SLOT_MIN()
         if bid < 1 or bid < slot_min:
-            await ctx.send(_("Invalid slotmax bid amount. Must be greater than slotmin."))
+            await ctx.send(
+                _("Invalid maximum bid amount. Must be greater than the minimum amount.")
+            )
             return
         guild = ctx.guild
         credits_name = await bank.get_currency_name(guild)
@@ -509,7 +535,7 @@ class Economy(commands.Cog):
 
     @economyset.command()
     async def slottime(self, ctx: commands.Context, seconds: int):
-        """Seconds between each slots use"""
+        """Set the cooldown for the slot machine."""
         guild = ctx.guild
         if await bank.is_global():
             await self.config.SLOT_TIME.set(seconds)
@@ -519,7 +545,7 @@ class Economy(commands.Cog):
 
     @economyset.command()
     async def paydaytime(self, ctx: commands.Context, seconds: int):
-        """Seconds between each payday"""
+        """Set the cooldown for payday."""
         guild = ctx.guild
         if await bank.is_global():
             await self.config.PAYDAY_TIME.set(seconds)
@@ -533,7 +559,7 @@ class Economy(commands.Cog):
 
     @economyset.command()
     async def paydayamount(self, ctx: commands.Context, creds: int):
-        """Amount earned each payday"""
+        """Set the amount earned each payday."""
         guild = ctx.guild
         credits_name = await bank.get_currency_name(guild)
         if creds <= 0:
@@ -551,11 +577,11 @@ class Economy(commands.Cog):
 
     @economyset.command()
     async def rolepaydayamount(self, ctx: commands.Context, role: discord.Role, creds: int):
-        """Amount earned each payday for a role"""
+        """Set the amount earned each payday for a role."""
         guild = ctx.guild
         credits_name = await bank.get_currency_name(guild)
         if await bank.is_global():
-            await ctx.send("The bank must be per-server for per-role paydays to work.")
+            await ctx.send(_("The bank must be per-server for per-role paydays to work."))
         else:
             await self.config.role(role).PAYDAY_CREDITS.set(creds)
             await ctx.send(
@@ -567,7 +593,7 @@ class Economy(commands.Cog):
 
     @economyset.command()
     async def registeramount(self, ctx: commands.Context, creds: int):
-        """Amount given on registering an account"""
+        """Set the initial balance for new bank accounts."""
         guild = ctx.guild
         if creds < 0:
             creds = 0
@@ -580,7 +606,8 @@ class Economy(commands.Cog):
         )
 
     # What would I ever do without stackoverflow?
-    def display_time(self, seconds, granularity=2):
+    @staticmethod
+    def display_time(seconds, granularity=2):
         intervals = (  # Source: http://stackoverflow.com/a/24542445
             (_("weeks"), 604800),  # 60 * 60 * 24 * 7
             (_("days"), 86400),  # 60 * 60 * 24

--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -131,11 +131,23 @@ class General(commands.Cog):
             outcome = cond[(player_choice, red_choice)]
 
         if outcome is True:
-            await ctx.send(_("{} You win {}!").format(red_choice.value, author.mention))
+            await ctx.send(
+                _("{choice} You win {author.mention}!").format(
+                    choice=red_choice.value, author=author
+                )
+            )
         elif outcome is False:
-            await ctx.send(_("{} You lose {}!").format(red_choice.value, author.mention))
+            await ctx.send(
+                _("{choice} You lose {author.mention}!").format(
+                    choice=red_choice.value, author=author
+                )
+            )
         else:
-            await ctx.send(_("{} We're square {}!").format(red_choice.value, author.mention))
+            await ctx.send(
+                _("{choice} We're square {author.mention}!").format(
+                    choice=red_choice.value, author=author
+                )
+            )
 
     @commands.command(name="8", aliases=["8ball"])
     async def _8ball(self, ctx, *, question: str):
@@ -198,12 +210,12 @@ class General(commands.Cog):
         text_channels = len(guild.text_channels)
         voice_channels = len(guild.voice_channels)
         passed = (ctx.message.created_at - guild.created_at).days
-        created_at = _("Since {}. That's over {} days ago!").format(
-            guild.created_at.strftime("%d %b %Y %H:%M"), passed
+        created_at = _("Since {date}. That's over {num} days ago!").format(
+            date=guild.created_at.strftime("%d %b %Y %H:%M"), num=passed
         )
         data = discord.Embed(description=created_at, colour=(await ctx.embed_colour()))
         data.add_field(name=_("Region"), value=str(guild.region))
-        data.add_field(name=_("Users"), value="{}/{}".format(online, total_users))
+        data.add_field(name=_("Users"), value=f"{online}/{total_users}")
         data.add_field(name=_("Text Channels"), value=str(text_channels))
         data.add_field(name=_("Voice Channels"), value=str(voice_channels))
         data.add_field(name=_("Roles"), value=str(len(guild.roles)))
@@ -223,7 +235,7 @@ class General(commands.Cog):
 
     @commands.command()
     async def urban(self, ctx, *, word):
-        """Searches urban dictionary entries using the unofficial api"""
+        """Searches urban dictionary entries using the unofficial API."""
 
         try:
             url = "https://api.urbandictionary.com/v0/define?term=" + str(word).lower()
@@ -236,8 +248,9 @@ class General(commands.Cog):
 
         except:
             await ctx.send(
-                _("No Urban dictionary entries were found or there was an error in the process")
+                _("No Urban dictionary entries were found, or there was an error in the process")
             )
+            return
 
         if data.get("error") != 404:
 
@@ -246,20 +259,20 @@ class General(commands.Cog):
                 embeds = []
                 for ud in data["list"]:
                     embed = discord.Embed()
-                    embed.title = _("{} by {}").format(ud["word"].capitalize(), ud["author"])
+                    embed.title = _("{word} by {author}").format(
+                        word=ud["word"].capitalize(), author=ud["author"]
+                    )
                     embed.url = ud["permalink"]
 
-                    description = "{} \n \n **Example : ** {}".format(
-                        ud["definition"], ud.get("example", "N/A")
-                    )
+                    description = _("{definition}\n\n**Example:** {example}").format(**ud)
                     if len(description) > 2048:
                         description = "{}...".format(description[:2045])
                     embed.description = description
 
                     embed.set_footer(
-                        text=_("{} Down / {} Up , Powered by urban dictionary").format(
-                            ud["thumbs_down"], ud["thumbs_up"]
-                        )
+                        text=_(
+                            "{thumbs_down} Down / {thumbs_up} Up, Powered by Urban Dictionary."
+                        ).format(**ud)
                     )
                     embeds.append(embed)
 
@@ -274,25 +287,17 @@ class General(commands.Cog):
                     )
             else:
                 messages = []
+                ud.set_default("example", "N/A")
                 for ud in data["list"]:
-                    description = _("{} \n \n **Example : ** {}").format(
-                        ud["definition"], ud.get("example", "N/A")
-                    )
+                    description = _("{definition}\n\n**Example:** {example}").format(**ud)
                     if len(description) > 2048:
                         description = "{}...".format(description[:2045])
                     description = description
 
                     message = _(
-                        "<{}> \n {} by {} \n \n {} \n \n {} Down / {} Up, Powered by urban "
-                        "dictionary"
-                    ).format(
-                        ud["permalink"],
-                        ud["word"].capitalize(),
-                        ud["author"],
-                        description,
-                        ud["thumbs_down"],
-                        ud["thumbs_up"],
-                    )
+                        "<{permalink}>\n {word} by {author}\n\n{description}\n\n"
+                        "{thumbs_down} Down / {thumbs_up} Up, Powered by urban dictionary"
+                    ).format(word=ud.pop("word").capitalize(), **ud)
                     messages.append(message)
 
                 if messages is not None and len(messages) > 0:
@@ -306,6 +311,6 @@ class General(commands.Cog):
                     )
         else:
             await ctx.send(
-                _("No Urban dictionary entries were found or there was an error in the process")
+                _("No Urban dictionary entries were found, or there was an error in the process.")
             )
             return

--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -2,15 +2,14 @@ import datetime
 import time
 from enum import Enum
 from random import randint, choice
-from urllib.parse import quote_plus
 import aiohttp
 import discord
 from redbot.core import commands
 from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils.menus import menu, DEFAULT_CONTROLS
-from redbot.core.utils.chat_formatting import escape, italics, pagify
+from redbot.core.utils.chat_formatting import escape, italics
 
-_ = Translator("General", __file__)
+_ = T_ = Translator("General", __file__)
 
 
 class RPS(Enum):
@@ -29,71 +28,78 @@ class RPSParser:
         elif argument == "scissors":
             self.choice = RPS.scissors
         else:
-            raise
+            raise ValueError
 
 
 @cog_i18n(_)
 class General(commands.Cog):
     """General commands."""
 
+    global _
+    _ = lambda s: s
+    ball = [
+        _("As I see it, yes"),
+        _("It is certain"),
+        _("It is decidedly so"),
+        _("Most likely"),
+        _("Outlook good"),
+        _("Signs point to yes"),
+        _("Without a doubt"),
+        _("Yes"),
+        _("Yes – definitely"),
+        _("You may rely on it"),
+        _("Reply hazy, try again"),
+        _("Ask again later"),
+        _("Better not tell you now"),
+        _("Cannot predict now"),
+        _("Concentrate and ask again"),
+        _("Don't count on it"),
+        _("My reply is no"),
+        _("My sources say no"),
+        _("Outlook not so good"),
+        _("Very doubtful"),
+    ]
+    _ = T_
+
     def __init__(self):
         super().__init__()
         self.stopwatches = {}
-        self.ball = [
-            _("As I see it, yes"),
-            _("It is certain"),
-            _("It is decidedly so"),
-            _("Most likely"),
-            _("Outlook good"),
-            _("Signs point to yes"),
-            _("Without a doubt"),
-            _("Yes"),
-            _("Yes – definitely"),
-            _("You may rely on it"),
-            _("Reply hazy, try again"),
-            _("Ask again later"),
-            _("Better not tell you now"),
-            _("Cannot predict now"),
-            _("Concentrate and ask again"),
-            _("Don't count on it"),
-            _("My reply is no"),
-            _("My sources say no"),
-            _("Outlook not so good"),
-            _("Very doubtful"),
-        ]
 
     @commands.command()
     async def choose(self, ctx, *choices):
-        """Chooses between multiple choices.
+        """Choose between multiple options.
 
-        To denote multiple choices, you should use double quotes.
+        To denote options which include whitespace, you should use
+        double quotes.
         """
         choices = [escape(c, mass_mentions=True) for c in choices]
         if len(choices) < 2:
-            await ctx.send(_("Not enough choices to pick from."))
+            await ctx.send(_("Not enough options to pick from."))
         else:
             await ctx.send(choice(choices))
 
     @commands.command()
     async def roll(self, ctx, number: int = 100):
-        """Rolls random number (between 1 and user choice)
+        """Roll a random number.
 
-        Defaults to 100.
+        The result will be between 1 and `<number>`.
+
+        `<number>` defaults to 100.
         """
         author = ctx.author
         if number > 1:
             n = randint(1, number)
-            await ctx.send(_("{} :game_die: {} :game_die:").format(author.mention, n))
+            await ctx.send("{author.mention} :game_die: {n} :game_die:".format(author=author, n=n))
         else:
-            await ctx.send(_("{} Maybe higher than 1? ;P").format(author.mention))
+            await ctx.send(_("{author.mention} Maybe higher than 1? ;P").format(author=author))
 
     @commands.command()
     async def flip(self, ctx, user: discord.Member = None):
-        """Flips a coin... or a user.
+        """Flip a coin... or a user.
 
-        Defaults to coin.
+        Defaults to a coin.
         """
-        if user != None:
+        if user is not None:
             msg = ""
             if user.id == ctx.bot.user.id:
                 user = ctx.author
@@ -112,7 +118,7 @@ class General(commands.Cog):
 
     @commands.command()
     async def rps(self, ctx, your_choice: RPSParser):
-        """Play rock paper scissors"""
+        """Play Rock Paper Scissors."""
         author = ctx.author
         player_choice = your_choice.choice
         red_choice = choice((RPS.rock, RPS.paper, RPS.scissors))
@@ -151,31 +157,33 @@ class General(commands.Cog):
 
     @commands.command(name="8", aliases=["8ball"])
     async def _8ball(self, ctx, *, question: str):
-        """Ask 8 ball a question
+        """Ask 8 ball a question.
 
         Question must end with a question mark.
         """
         if question.endswith("?") and question != "?":
-            await ctx.send("`" + choice(self.ball) + "`")
+            await ctx.send("`" + T_(choice(self.ball)) + "`")
         else:
             await ctx.send(_("That doesn't look like a question."))
 
     @commands.command(aliases=["sw"])
     async def stopwatch(self, ctx):
-        """Starts/stops stopwatch"""
+        """Start or stop the stopwatch."""
         author = ctx.author
-        if not author.id in self.stopwatches:
+        if author.id not in self.stopwatches:
             self.stopwatches[author.id] = int(time.perf_counter())
             await ctx.send(author.mention + _(" Stopwatch started!"))
         else:
             tmp = abs(self.stopwatches[author.id] - int(time.perf_counter()))
             tmp = str(datetime.timedelta(seconds=tmp))
-            await ctx.send(author.mention + _(" Stopwatch stopped! Time: **") + tmp + "**")
+            await ctx.send(
+                author.mention + _(" Stopwatch stopped! Time: **{seconds}**").format(seconds=tmp)
+            )
             self.stopwatches.pop(author.id, None)
 
     @commands.command()
     async def lmgtfy(self, ctx, *, search_terms: str):
-        """Creates a lmgtfy link"""
+        """Create a lmgtfy link."""
         search_terms = escape(
             search_terms.replace("+", "%2B").replace(" ", "+"), mass_mentions=True
         )
@@ -184,9 +192,10 @@ class General(commands.Cog):
     @commands.command(hidden=True)
     @commands.guild_only()
     async def hug(self, ctx, user: discord.Member, intensity: int = 1):
-        """Because everyone likes hugs
+        """Because everyone likes hugs!
 
-        Up to 10 intensity levels."""
+        Up to 10 intensity levels.
+        """
         name = italics(user.display_name)
         if intensity <= 0:
             msg = "(っ˘̩╭╮˘̩)っ" + name
@@ -198,12 +207,15 @@ class General(commands.Cog):
             msg = "(つ≧▽≦)つ" + name
         elif intensity >= 10:
             msg = "(づ￣ ³￣)づ{} ⊂(´・ω・｀⊂)".format(name)
+        else:
+            # For the purposes of "msg might not be defined" linter errors
+            raise RuntimeError
         await ctx.send(msg)
 
     @commands.command()
     @commands.guild_only()
     async def serverinfo(self, ctx):
-        """Shows server's informations"""
+        """Show server information."""
         guild = ctx.guild
         online = len([m.status for m in guild.members if m.status != discord.Status.offline])
         total_users = len(guild.members)
@@ -230,12 +242,15 @@ class General(commands.Cog):
 
         try:
             await ctx.send(embed=data)
-        except discord.HTTPException:
+        except discord.Forbidden:
             await ctx.send(_("I need the `Embed links` permission to send this."))
 
     @commands.command()
     async def urban(self, ctx, *, word):
-        """Searches urban dictionary entries using the unofficial API."""
+        """Search the Urban Dictionary.
+
+        This uses the unofficial Urban Dictionary API.
+        """
 
         try:
             url = "https://api.urbandictionary.com/v0/define?term=" + str(word).lower()
@@ -246,7 +261,7 @@ class General(commands.Cog):
                 async with session.get(url, headers=headers) as response:
                     data = await response.json()
 
-        except:
+        except aiohttp.ClientError:
             await ctx.send(
                 _("No Urban dictionary entries were found, or there was an error in the process")
             )
@@ -287,17 +302,16 @@ class General(commands.Cog):
                     )
             else:
                 messages = []
-                ud.set_default("example", "N/A")
                 for ud in data["list"]:
+                    ud.set_default("example", "N/A")
                     description = _("{definition}\n\n**Example:** {example}").format(**ud)
                     if len(description) > 2048:
                         description = "{}...".format(description[:2045])
-                    description = description
 
                     message = _(
                         "<{permalink}>\n {word} by {author}\n\n{description}\n\n"
                         "{thumbs_down} Down / {thumbs_up} Up, Powered by urban dictionary"
-                    ).format(word=ud.pop("word").capitalize(), **ud)
+                    ).format(word=ud.pop("word").capitalize(), description=description, **ud)
                     messages.append(message)
 
                 if messages is not None and len(messages) > 0:

--- a/redbot/cogs/image/image.py
+++ b/redbot/cogs/image/image.py
@@ -29,23 +29,26 @@ class Image(commands.Cog):
 
     @commands.group(name="imgur")
     async def _imgur(self, ctx):
-        """Retrieves pictures from imgur
+        """Retrieve pictures from Imgur.
 
-        Make sure to set the client ID using
-        [p]imgurcreds"""
+        Make sure to set the Client ID using `[p]imgurcreds`.
+        """
         pass
 
     @_imgur.command(name="search")
     async def imgur_search(self, ctx, *, term: str):
-        """Searches Imgur for the specified term and returns up to 3 results"""
+        """Search Imgur for the specified term.
+
+        Returns up to 3 results.
+        """
         url = self.imgur_base_url + "gallery/search/time/all/0"
         params = {"q": term}
         imgur_client_id = await self.settings.imgur_client_id()
         if not imgur_client_id:
             await ctx.send(
-                _("A client ID has not been set! Please set one with {}.").format(
-                    "`{}imgurcreds`".format(ctx.prefix)
-                )
+                _(
+                    "A Client ID has not been set! Please set one with `{prefix}imgurcreds`."
+                ).format(prefix=ctx.prefix)
             )
             return
         headers = {"Authorization": "Client-ID {}".format(imgur_client_id)}
@@ -64,37 +67,41 @@ class Image(commands.Cog):
                 msg += "\n"
             await ctx.send(msg)
         else:
-            await ctx.send(_("Something went wrong. Error code is {}.").format(data["status"]))
+            await ctx.send(
+                _("Something went wrong. Error code is {code}.").format(code=data["status"])
+            )
 
     @_imgur.command(name="subreddit")
     async def imgur_subreddit(
         self, ctx, subreddit: str, sort_type: str = "top", window: str = "day"
     ):
-        """Gets images from the specified subreddit section
+        """Get images from a subreddit.
 
-        Sort types: new, top
-        Time windows: day, week, month, year, all"""
+        You can customize the search with the following options:
+        - `<sort_type>`: new, top
+        - `<window>`: day, week, month, year, all
+        """
         sort_type = sort_type.lower()
         window = window.lower()
-
-        if sort_type not in ("new", "top"):
-            await ctx.send(_("Only 'new' and 'top' are a valid sort type."))
-            return
-        elif window not in ("day", "week", "month", "year", "all"):
-            await ctx.send_help()
-            return
 
         if sort_type == "new":
             sort = "time"
         elif sort_type == "top":
             sort = "top"
+        else:
+            await ctx.send(_("Only 'new' and 'top' are a valid sort type."))
+            return
+
+        if window not in ("day", "week", "month", "year", "all"):
+            await ctx.send_help()
+            return
 
         imgur_client_id = await self.settings.imgur_client_id()
         if not imgur_client_id:
             await ctx.send(
-                _("A client ID has not been set! Please set one with {}.").format(
-                    "`{}imgurcreds`".format(ctx.prefix)
-                )
+                _(
+                    "A Client ID has not been set! Please set one with `{prefix}imgurcreds`."
+                ).format(prefix=ctx.prefix)
             )
             return
 
@@ -117,29 +124,33 @@ class Image(commands.Cog):
             else:
                 await ctx.send(_("No results found."))
         else:
-            await ctx.send(_("Something went wrong. Error code is {}.").format(data["status"]))
+            await ctx.send(
+                _("Something went wrong. Error code is {code}.").format(code=data["status"])
+            )
 
     @checks.is_owner()
     @commands.command()
     async def imgurcreds(self, ctx, imgur_client_id: str):
-        """Sets the imgur client id
+        """Set the Imgur Client ID.
 
-        You will need an account on Imgur to get this
-
-        You can get these by visiting https://api.imgur.com/oauth2/addclient
-        and filling out the form. Enter a name for the application, select
-        'Anonymous usage without user authorization' for the auth type,
-        set the authorization callback url to 'https://localhost'
-        leave the app website blank, enter a valid email address, and
-        enter a description. Check the box for the captcha, then click Next.
-        Your client ID will be on the page that loads."""
+        To get an Imgur Client ID:
+        1. Login to an Imgur account.
+        2. Visit [this](https://api.imgur.com/oauth2/addclient) page
+        3. Enter a name for your application
+        4. Select *Anonymous usage without user authorization* for the auth type
+        5. Set the authorization callback URL to `https://localhost`
+        6. Leave the app website blank
+        7. Enter a valid email address and a description
+        8. Check the captcha box and click next
+        9. Your Client ID will be on the next page.
+        """
         await self.settings.imgur_client_id.set(imgur_client_id)
-        await ctx.send(_("Set the imgur client id!"))
+        await ctx.send(_("The Imgur Client ID has been set!"))
 
     @commands.guild_only()
     @commands.command()
     async def gif(self, ctx, *keywords):
-        """Retrieves first search result from giphy"""
+        """Retrieve the first search result from Giphy."""
         if keywords:
             keywords = "+".join(keywords)
         else:
@@ -158,12 +169,12 @@ class Image(commands.Cog):
                 else:
                     await ctx.send(_("No results found."))
             else:
-                await ctx.send(_("Error contacting the API."))
+                await ctx.send(_("Error contacting the Giphy API."))
 
     @commands.guild_only()
     @commands.command()
     async def gifr(self, ctx, *keywords):
-        """Retrieves a random gif from a giphy search"""
+        """Retrieve a random GIF from a Giphy search."""
         if keywords:
             keywords = "+".join(keywords)
         else:

--- a/redbot/cogs/mod/checks.py
+++ b/redbot/cogs/mod/checks.py
@@ -1,5 +1,4 @@
 from redbot.core import commands
-import discord
 
 
 def mod_or_voice_permissions(**perms):

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -386,7 +386,7 @@ class Mod(commands.Cog):
     async def ban(
         self, ctx: commands.Context, user: discord.Member, days: str = None, *, reason: str = None
     ):
-        """Ban a user from the current server.
+        """Ban a user from this server.
 
         Deletes `<days>` worth of messages.
 
@@ -469,7 +469,7 @@ class Mod(commands.Cog):
     @commands.bot_has_permissions(ban_members=True)
     @checks.admin_or_permissions(ban_members=True)
     async def hackban(self, ctx: commands.Context, user_id: int, *, reason: str = None):
-        """Pre-emptively ban a user from the current server.
+        """Pre-emptively ban a user from this server.
 
         A user ID needs to be provided in order to ban
         using this command.
@@ -531,7 +531,7 @@ class Mod(commands.Cog):
     async def tempban(
         self, ctx: commands.Context, user: discord.Member, days: int = 1, *, reason: str = None
     ):
-        """Temporarily ban a user from the current server."""
+        """Temporarily ban a user from this server."""
         guild = ctx.guild
         author = ctx.author
         days_delta = timedelta(days=int(days))
@@ -672,7 +672,7 @@ class Mod(commands.Cog):
     @commands.bot_has_permissions(ban_members=True)
     @checks.admin_or_permissions(ban_members=True)
     async def unban(self, ctx: commands.Context, user_id: int, *, reason: str = None):
-        """Unban a user from the current server.
+        """Unban a user from this server.
 
         Requires specifying the target user's ID. To find this, you may either:
          1. Copy it from the mod log case (if one was created), or
@@ -1104,7 +1104,7 @@ class Mod(commands.Cog):
     async def unmute_channel(
         self, ctx: commands.Context, user: discord.Member, *, reason: str = None
     ):
-        """Unmute a user in the current channel."""
+        """Unmute a user in this channel."""
         channel = ctx.channel
         author = ctx.author
         guild = ctx.guild
@@ -1137,7 +1137,7 @@ class Mod(commands.Cog):
     async def unmute_guild(
         self, ctx: commands.Context, user: discord.Member, *, reason: str = None
     ):
-        """Unmute a user in the current server."""
+        """Unmute a user in this server."""
         guild = ctx.guild
         author = ctx.author
 
@@ -1236,7 +1236,7 @@ class Mod(commands.Cog):
     @ignore.command(name="server", aliases=["guild"])
     @checks.admin_or_permissions(manage_guild=True)
     async def ignore_guild(self, ctx: commands.Context):
-        """Ignore commands in the current server."""
+        """Ignore commands in this server."""
         guild = ctx.guild
         if not await self.settings.guild(guild).ignored():
             await self.settings.guild(guild).ignored.set(True)
@@ -1270,7 +1270,7 @@ class Mod(commands.Cog):
     @unignore.command(name="server", aliases=["guild"])
     @checks.admin_or_permissions(manage_guild=True)
     async def unignore_guild(self, ctx: commands.Context):
-        """Remove the current server from the ignore list."""
+        """Remove this server from the ignore list."""
         guild = ctx.message.guild
         if await self.settings.guild(guild).ignored():
             await self.settings.guild(guild).ignored.set(False)

--- a/redbot/cogs/modlog/modlog.py
+++ b/redbot/cogs/modlog/modlog.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import discord
 
 from redbot.core import checks, modlog, commands
@@ -10,7 +12,7 @@ _ = Translator("ModLog", __file__)
 
 @cog_i18n(_)
 class ModLog(commands.Cog):
-    """Log for mod actions"""
+    """Manage log channels for moderation actions."""
 
     def __init__(self, bot: Red):
         super().__init__()
@@ -19,23 +21,28 @@ class ModLog(commands.Cog):
     @commands.group()
     @checks.guildowner_or_permissions(administrator=True)
     async def modlogset(self, ctx: commands.Context):
-        """Settings for the mod log"""
+        """Manage modlog settings."""
         pass
 
     @modlogset.command()
     @commands.guild_only()
     async def modlog(self, ctx: commands.Context, channel: discord.TextChannel = None):
-        """Sets a channel as mod log
+        """Set a channel as the modlog.
 
-        Leaving the channel parameter empty will deactivate it"""
+        Omit `<channel>` to disable the modlog.
+        """
         guild = ctx.guild
         if channel:
             if channel.permissions_for(guild.me).send_messages:
                 await modlog.set_modlog_channel(guild, channel)
-                await ctx.send(_("Mod events will be sent to {}").format(channel.mention))
+                await ctx.send(
+                    _("Mod events will be sent to {channel}").format(channel=channel.mention)
+                )
             else:
                 await ctx.send(
-                    _("I do not have permissions to send messages in {}!").format(channel.mention)
+                    _("I do not have permissions to send messages in {channel}!").format(
+                        channel=channel.mention
+                    )
                 )
         else:
             try:
@@ -49,39 +56,36 @@ class ModLog(commands.Cog):
     @modlogset.command(name="cases")
     @commands.guild_only()
     async def set_cases(self, ctx: commands.Context, action: str = None):
-        """Enables or disables case creation for each type of mod action"""
+        """Enable or disable case creation for a mod action."""
         guild = ctx.guild
 
         if action is None:  # No args given
             casetypes = await modlog.get_all_casetypes(guild)
             await ctx.send_help()
-            title = _("Current settings:")
-            msg = ""
+            lines = []
             for ct in casetypes:
-                enabled = await ct.is_enabled()
-                value = "enabled" if enabled else "disabled"
-                msg += "%s : %s\n" % (ct.name, value)
+                enabled = "enabled" if await ct.is_enabled() else "disabled"
+                lines.append(f"{ct.name} : {enabled}")
 
-            msg = title + "\n" + box(msg)
-            await ctx.send(msg)
+            await ctx.send(_("Current settings:\n") + box("\n".join(lines)))
             return
+
         casetype = await modlog.get_casetype(action, guild)
         if not casetype:
             await ctx.send(_("That action is not registered"))
         else:
-
             enabled = await casetype.is_enabled()
-            await casetype.set_enabled(True if not enabled else False)
-
-            msg = _("Case creation for {} actions is now {}.").format(
-                action, "enabled" if not enabled else "disabled"
+            await casetype.set_enabled(not enabled)
+            await ctx.send(
+                _("Case creation for {action_name} actions is now {enabled}.").format(
+                    action_name=action, enabled="enabled" if not enabled else "disabled"
+                )
             )
-            await ctx.send(msg)
 
     @modlogset.command()
     @commands.guild_only()
     async def resetcases(self, ctx: commands.Context):
-        """Resets modlog's cases"""
+        """Reset all modlog cases in this server."""
         guild = ctx.guild
         await modlog.reset_cases(guild)
         await ctx.send(_("Cases have been reset."))
@@ -89,7 +93,7 @@ class ModLog(commands.Cog):
     @commands.command()
     @commands.guild_only()
     async def case(self, ctx: commands.Context, number: int):
-        """Shows the specified case"""
+        """Show the specified case."""
         try:
             case = await modlog.get_case(number, ctx.guild, self.bot)
         except RuntimeError:
@@ -101,24 +105,21 @@ class ModLog(commands.Cog):
             else:
                 await ctx.send(await case.message_content(embed=False))
 
-    @commands.command(usage="[case] <reason>")
+    @commands.command()
     @commands.guild_only()
-    async def reason(self, ctx: commands.Context, *, reason: str):
-        """Lets you specify a reason for mod-log's cases
-        
+    async def reason(self, ctx: commands.Context, case: Optional[int], *, reason: str):
+        """Specify a reason for a modlog case.
+
         Please note that you can only edit cases you are
-        the owner of unless you are a mod/admin or the server owner.
-        
-        If no number is specified, the latest case will be used."""
+        the owner of unless you are a mod, admin or server owner.
+
+        If no case number is specified, the latest case will be used.
+        """
         author = ctx.author
         guild = ctx.guild
-        potential_case = reason.split()[0]
-        if potential_case.isdigit():
-            case = int(potential_case)
-            reason = reason.replace(potential_case, "")
-        else:
-            case = str(int(await modlog.get_next_case_number(guild)) - 1)
-            # latest case
+        if case is None:
+            # get the latest case
+            case = int(await modlog.get_next_case_number(guild)) - 1
         try:
             case_before = await modlog.get_case(case, guild, self.bot)
         except RuntimeError:

--- a/redbot/cogs/permissions/converters.py
+++ b/redbot/cogs/permissions/converters.py
@@ -1,5 +1,9 @@
-from typing import NamedTuple, Union, Optional
+from typing import NamedTuple, Union, Optional, cast, Type
+
 from redbot.core import commands
+from redbot.core.i18n import Translator
+
+_ = Translator("PermissionsConverters", __file__)
 
 
 class CogOrCommand(NamedTuple):
@@ -18,39 +22,34 @@ class CogOrCommand(NamedTuple):
             return cls(type="COMMAND", name=cmd.qualified_name, obj=cmd)
 
         raise commands.BadArgument(
-            'Cog or command "{arg}" not found. Please note that this is case sensitive.'
-            "".format(arg=arg)
+            _(
+                'Cog or command "{name}" not found. Please note that this is case sensitive.'
+            ).format(name=arg)
         )
 
 
-class RuleType:
+def RuleType(arg: str) -> bool:
+    if arg.lower() in ("allow", "whitelist", "allowed"):
+        return True
+    if arg.lower() in ("deny", "blacklist", "denied"):
+        return False
 
-    # noinspection PyUnusedLocal
-    @classmethod
-    async def convert(cls, ctx: commands.Context, arg: str) -> bool:
-        if arg.lower() in ("allow", "whitelist", "allowed"):
-            return True
-        if arg.lower() in ("deny", "blacklist", "denied"):
-            return False
-
-        raise commands.BadArgument(
-            '"{arg}" is not a valid rule. Valid rules are "allow" or "deny"'.format(arg=arg)
-        )
+    raise commands.BadArgument(
+        _('"{arg}" is not a valid rule. Valid rules are "allow" or "deny"').format(arg=arg)
+    )
 
 
-class ClearableRuleType:
+def ClearableRuleType(arg: str) -> Optional[bool]:
+    if arg.lower() in ("allow", "whitelist", "allowed"):
+        return True
+    if arg.lower() in ("deny", "blacklist", "denied"):
+        return False
+    if arg.lower() in ("clear", "reset"):
+        return None
 
-    # noinspection PyUnusedLocal
-    @classmethod
-    async def convert(cls, ctx: commands.Context, arg: str) -> Optional[bool]:
-        if arg.lower() in ("allow", "whitelist", "allowed"):
-            return True
-        if arg.lower() in ("deny", "blacklist", "denied"):
-            return False
-        if arg.lower() in ("clear", "reset"):
-            return None
-
-        raise commands.BadArgument(
+    raise commands.BadArgument(
+        _(
             '"{arg}" is not a valid rule. Valid rules are "allow" or "deny", or "clear" to '
-            "remove the rule".format(arg=arg)
-        )
+            "remove the rule"
+        ).format(arg=arg)
+    )

--- a/redbot/cogs/permissions/permissions.py
+++ b/redbot/cogs/permissions/permissions.py
@@ -2,7 +2,7 @@ import asyncio
 import io
 import textwrap
 from copy import copy
-from typing import Union, Optional, Dict, List, Tuple, Any, Iterator, ItemsView
+from typing import Union, Optional, Dict, List, Tuple, Any, Iterator, ItemsView, cast
 
 import discord
 import yaml
@@ -287,9 +287,11 @@ class Permissions(commands.Cog):
         `<who_or_what>` is the user, channel, role or server the rule
         is for.
         """
-        # noinspection PyTypeChecker
         await self._add_rule(
-            rule=allow_or_deny, cog_or_cmd=cog_or_command, model_id=who_or_what.id, guild_id=0
+            rule=cast(bool, allow_or_deny),
+            cog_or_cmd=cog_or_command,
+            model_id=who_or_what.id,
+            guild_id=0,
         )
         await ctx.send(_("Rule added."))
 
@@ -312,9 +314,8 @@ class Permissions(commands.Cog):
 
         `<who_or_what>` is the user, channel or role the rule is for.
         """
-        # noinspection PyTypeChecker
         await self._add_rule(
-            rule=allow_or_deny,
+            rule=cast(bool, allow_or_deny),
             cog_or_cmd=cog_or_command,
             model_id=who_or_what.id,
             guild_id=ctx.guild.id,
@@ -381,9 +382,10 @@ class Permissions(commands.Cog):
         `<cog_or_command>` is the cog or command to set the default
         rule for. This is case sensitive.
         """
-        # noinspection PyTypeChecker
         await self._set_default_rule(
-            rule=allow_or_deny, cog_or_cmd=cog_or_command, guild_id=ctx.guild.id
+            rule=cast(Optional[bool], allow_or_deny),
+            cog_or_cmd=cog_or_command,
+            guild_id=ctx.guild.id,
         )
         await ctx.send(_("Default set."))
 
@@ -403,9 +405,8 @@ class Permissions(commands.Cog):
         `<cog_or_command>` is the cog or command to set the default
         rule for. This is case sensitive.
         """
-        # noinspection PyTypeChecker
         await self._set_default_rule(
-            rule=allow_or_deny, cog_or_cmd=cog_or_command, guild_id=GLOBAL
+            rule=cast(Optional[bool], allow_or_deny), cog_or_cmd=cog_or_command, guild_id=GLOBAL
         )
         await ctx.send(_("Default set."))
 

--- a/redbot/cogs/trivia/session.py
+++ b/redbot/cogs/trivia/session.py
@@ -4,20 +4,30 @@ import time
 import random
 from collections import Counter
 import discord
-from redbot.core.bank import deposit_credits
-from redbot.core.utils.chat_formatting import box
+from redbot.core import bank
+from redbot.core.i18n import Translator
+from redbot.core.utils.chat_formatting import box, bold, humanize_list
 from redbot.core.utils.common_filters import normalize_smartquotes
 from .log import LOG
 
 __all__ = ["TriviaSession"]
 
-_REVEAL_MESSAGES = ("I know this one! {}!", "Easy: {}.", "Oh really? It's {} of course.")
-_FAIL_MESSAGES = (
-    "To the next one I guess...",
-    "Moving on...",
-    "I'm sure you'll know the answer of the next one.",
-    "\N{PENSIVE FACE} Next one.",
+T_ = Translator("TriviaSession", __file__)
+
+
+_ = lambda s: s
+_REVEAL_MESSAGES = (
+    _("I know this one! {answer}!"),
+    _("Easy: {answer}."),
+    _("Oh really? It's {answer} of course."),
 )
+_FAIL_MESSAGES = (
+    _("To the next one I guess..."),
+    _("Moving on..."),
+    _("I'm sure you'll know the answer of the next one."),
+    _("\N{PENSIVE FACE} Next one."),
+)
+_ = T_
 
 
 class TriviaSession:
@@ -104,7 +114,7 @@ class TriviaSession:
             async with self.ctx.typing():
                 await asyncio.sleep(3)
             self.count += 1
-            msg = "**Question number {}!**\n\n{}".format(self.count, question)
+            msg = bold(_("**Question number {num}!").format(num=self.count)) + "\n\n" + question
             await self.ctx.send(msg)
             continue_ = await self.wait_for_answer(answers, delay, timeout)
             if continue_ is False:
@@ -113,7 +123,7 @@ class TriviaSession:
                 await self.end_game()
                 break
         else:
-            await self.ctx.send("There are no more questions!")
+            await self.ctx.send(_("There are no more questions!"))
             await self.end_game()
 
     async def _send_startup_msg(self):
@@ -121,20 +131,13 @@ class TriviaSession:
         for idx, tup in enumerate(self.settings["lists"].items()):
             name, author = tup
             if author:
-                title = "{} (by {})".format(name, author)
+                title = _("{trivia_list} (by {author})").format(trivia_list=name, author=author)
             else:
                 title = name
             list_names.append(title)
-        num_lists = len(list_names)
-        if num_lists > 2:
-            # at least 3 lists, join all but last with comma
-            msg = ", ".join(list_names[: num_lists - 1])
-            # join onto last with "and"
-            msg = " and ".join((msg, list_names[num_lists - 1]))
-        else:
-            # either 1 or 2 lists, join together with "and"
-            msg = " and ".join(list_names)
-        await self.ctx.send("Starting Trivia: " + msg)
+        await self.ctx.send(
+            _("Starting Trivia: {list_names}").format(list_names=humanize_list(list_names))
+        )
 
     def _iter_questions(self):
         """Iterate over questions and answers for this session.
@@ -179,20 +182,20 @@ class TriviaSession:
             )
         except asyncio.TimeoutError:
             if time.time() - self._last_response >= timeout:
-                await self.ctx.send("Guys...? Well, I guess I'll stop then.")
+                await self.ctx.send(_("Guys...? Well, I guess I'll stop then."))
                 self.stop()
                 return False
             if self.settings["reveal_answer"]:
-                reply = random.choice(_REVEAL_MESSAGES).format(answers[0])
+                reply = T_(random.choice(_REVEAL_MESSAGES)).format(answer=answers[0])
             else:
-                reply = random.choice(_FAIL_MESSAGES)
+                reply = T_(random.choice(_FAIL_MESSAGES))
             if self.settings["bot_plays"]:
-                reply += " **+1** for me!"
+                reply += _(" **+1** for me!")
                 self.scores[self.ctx.guild.me] += 1
             await self.ctx.send(reply)
         else:
             self.scores[message.author] += 1
-            reply = "You got it {}! **+1** to you!".format(message.author.display_name)
+            reply = _("You got it {user}! **+1** to you!").format(user=message.author.display_name)
             await self.ctx.send(reply)
         return True
 
@@ -282,10 +285,16 @@ class TriviaSession:
                 amount = int(multiplier * score)
                 if amount > 0:
                     LOG.debug("Paying trivia winner: %d credits --> %s", amount, str(winner))
-                    await deposit_credits(winner, int(multiplier * score))
+                    await bank.deposit_credits(winner, int(multiplier * score))
                     await self.ctx.send(
-                        "Congratulations, {0}, you have received {1} credits"
-                        " for coming first.".format(winner.display_name, amount)
+                        _(
+                            "Congratulations, {user}, you have received {num} {currency}"
+                            " for coming first."
+                        ).format(
+                            user=winner.display_name,
+                            num=amount,
+                            currency=await bank.get_currency_name(self.ctx.guild),
+                        )
                     )
 
 
@@ -313,9 +322,9 @@ def _parse_answers(answers):
     for answer in answers:
         if isinstance(answer, bool):
             if answer is True:
-                ret.extend(["True", "Yes"])
+                ret.extend(["True", "Yes", _("Yes")])
             else:
-                ret.extend(["False", "No"])
+                ret.extend(["False", "No", _("No")])
         else:
             ret.append(str(answer))
     # Uniquify list

--- a/redbot/cogs/trivia/trivia.py
+++ b/redbot/cogs/trivia/trivia.py
@@ -7,7 +7,8 @@ import discord
 from redbot.core import commands
 from redbot.core import Config, checks
 from redbot.core.data_manager import cog_data_path
-from redbot.core.utils.chat_formatting import box, pagify
+from redbot.core.i18n import Translator, cog_i18n
+from redbot.core.utils.chat_formatting import box, pagify, bold
 from redbot.cogs.bank import check_global_setting_admin
 from .log import LOG
 from .session import TriviaSession
@@ -16,6 +17,8 @@ __all__ = ["Trivia", "UNIQUE_ID", "get_core_lists"]
 
 UNIQUE_ID = 0xB3C0E453
 
+_ = Translator("Trivia", __file__)
+
 
 class InvalidListError(Exception):
     """A Trivia list file is in invalid format."""
@@ -23,6 +26,7 @@ class InvalidListError(Exception):
     pass
 
 
+@cog_i18n(_)
 class Trivia(commands.Cog):
     """Play trivia with friends!"""
 
@@ -47,20 +51,21 @@ class Trivia(commands.Cog):
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
     async def triviaset(self, ctx: commands.Context):
-        """Manage trivia settings."""
+        """Manage Trivia settings."""
         if ctx.invoked_subcommand is None:
             settings = self.conf.guild(ctx.guild)
             settings_dict = await settings.all()
             msg = box(
-                "**Current settings**\n"
-                "Bot gains points: {bot_plays}\n"
-                "Answer time limit: {delay} seconds\n"
-                "Lack of response timeout: {timeout} seconds\n"
-                "Points to win: {max_score}\n"
-                "Reveal answer on timeout: {reveal_answer}\n"
-                "Payout multiplier: {payout_multiplier}\n"
-                "Allow lists to override settings: {allow_override}"
-                "".format(**settings_dict),
+                _(
+                    "**Current settings**\n"
+                    "Bot gains points: {bot_plays}\n"
+                    "Answer time limit: {delay} seconds\n"
+                    "Lack of response timeout: {timeout} seconds\n"
+                    "Points to win: {max_score}\n"
+                    "Reveal answer on timeout: {reveal_answer}\n"
+                    "Payout multiplier: {payout_multiplier}\n"
+                    "Allow lists to override settings: {allow_override}"
+                ).format(**settings_dict),
                 lang="py",
             )
             await ctx.send(msg)
@@ -69,33 +74,34 @@ class Trivia(commands.Cog):
     async def triviaset_max_score(self, ctx: commands.Context, score: int):
         """Set the total points required to win."""
         if score < 0:
-            await ctx.send("Score must be greater than 0.")
+            await ctx.send(_("Score must be greater than 0."))
             return
         settings = self.conf.guild(ctx.guild)
         await settings.max_score.set(score)
-        await ctx.send("Done. Points required to win set to {}.".format(score))
+        await ctx.send(_("Done. Points required to win set to {num}.").format(num=score))
 
     @triviaset.command(name="timelimit")
     async def triviaset_timelimit(self, ctx: commands.Context, seconds: float):
         """Set the maximum seconds permitted to answer a question."""
         if seconds < 4.0:
-            await ctx.send("Must be at least 4 seconds.")
+            await ctx.send(_("Must be at least 4 seconds."))
             return
         settings = self.conf.guild(ctx.guild)
         await settings.delay.set(seconds)
-        await ctx.send("Done. Maximum seconds to answer set to {}.".format(seconds))
+        await ctx.send(_("Done. Maximum seconds to answer set to {num}.").format(num=seconds))
 
     @triviaset.command(name="stopafter")
     async def triviaset_stopafter(self, ctx: commands.Context, seconds: float):
         """Set how long until trivia stops due to no response."""
         settings = self.conf.guild(ctx.guild)
         if seconds < await settings.delay():
-            await ctx.send("Must be larger than the answer time limit.")
+            await ctx.send(_("Must be larger than the answer time limit."))
             return
         await settings.timeout.set(seconds)
         await ctx.send(
-            "Done. Trivia sessions will now time out after {}"
-            " seconds of no responses.".format(seconds)
+            _(
+                "Done. Trivia sessions will now time out after {num} seconds of no responses."
+            ).format(num=seconds)
         )
 
     @triviaset.command(name="override")
@@ -103,46 +109,46 @@ class Trivia(commands.Cog):
         """Allow/disallow trivia lists to override settings."""
         settings = self.conf.guild(ctx.guild)
         await settings.allow_override.set(enabled)
-        enabled = "now" if enabled else "no longer"
-        await ctx.send(
-            "Done. Trivia lists can {} override the trivia settings"
-            " for this server.".format(enabled)
-        )
+        if enabled:
+            await ctx.send(
+                _(
+                    "Done. Trivia lists can now override the trivia settings for this server."
+                ).format(now=enabled)
+            )
+        else:
+            await ctx.send(
+                _(
+                    "Done. Trivia lists can no longer override the trivia settings for this "
+                    "server."
+                ).format(now=enabled)
+            )
 
-    @triviaset.command(name="botplays")
-    async def trivaset_bot_plays(self, ctx: commands.Context, true_or_false: bool):
+    @triviaset.command(name="botplays", usage="<true_or_false>")
+    async def trivaset_bot_plays(self, ctx: commands.Context, enabled: bool):
         """Set whether or not the bot gains points.
 
         If enabled, the bot will gain a point if no one guesses correctly.
         """
         settings = self.conf.guild(ctx.guild)
-        await settings.bot_plays.set(true_or_false)
-        await ctx.send(
-            "Done. "
-            + (
-                "I'll gain a point if users don't answer in time."
-                if true_or_false
-                else "Alright, I won't embarass you at trivia anymore."
-            )
-        )
+        await settings.bot_plays.set(enabled)
+        if enabled:
+            await ctx.send(_("Done. I'll now gain a point if users don't answer in time."))
+        else:
+            await ctx.send(_("Alright, I won't embarass you at trivia anymore."))
 
-    @triviaset.command(name="revealanswer")
-    async def trivaset_reveal_answer(self, ctx: commands.Context, true_or_false: bool):
+    @triviaset.command(name="revealanswer", usage="<true_or_false>")
+    async def trivaset_reveal_answer(self, ctx: commands.Context, enabled: bool):
         """Set whether or not the answer is revealed.
 
         If enabled, the bot will reveal the answer if no one guesses correctly
         in time.
         """
         settings = self.conf.guild(ctx.guild)
-        await settings.reveal_answer.set(true_or_false)
-        await ctx.send(
-            "Done. "
-            + (
-                "I'll reveal the answer if no one knows it."
-                if true_or_false
-                else "I won't reveal the answer to the questions anymore."
-            )
-        )
+        await settings.reveal_answer.set(enabled)
+        if enabled:
+            await ctx.send(_("Done. I'll reveal the answer if no one knows it."))
+        else:
+            await ctx.send(_("Alright, I won't reveal the answer to the questions anymore."))
 
     @triviaset.command(name="payout")
     @check_global_setting_admin()
@@ -158,13 +164,13 @@ class Trivia(commands.Cog):
         """
         settings = self.conf.guild(ctx.guild)
         if multiplier < 0:
-            await ctx.send("Multiplier must be at least 0.")
+            await ctx.send(_("Multiplier must be at least 0."))
             return
         await settings.payout_multiplier.set(multiplier)
-        if not multiplier:
-            await ctx.send("Done. I will no longer reward the winner with a payout.")
-            return
-        await ctx.send("Done. Payout multiplier set to {}.".format(multiplier))
+        if multiplier:
+            await ctx.send(_("Done. Payout multiplier set to {num}.").format(num=multiplier))
+        else:
+            await ctx.send(_("Done. I will no longer reward the winner with a payout."))
 
     @commands.group(invoke_without_command=True)
     @commands.guild_only()
@@ -180,7 +186,7 @@ class Trivia(commands.Cog):
         categories = [c.lower() for c in categories]
         session = self._get_trivia_session(ctx.channel)
         if session is not None:
-            await ctx.send("There is already an ongoing trivia session in this channel.")
+            await ctx.send(_("There is already an ongoing trivia session in this channel."))
             return
         trivia_dict = {}
         authors = []
@@ -191,15 +197,17 @@ class Trivia(commands.Cog):
                 dict_ = self.get_trivia_list(category)
             except FileNotFoundError:
                 await ctx.send(
-                    "Invalid category `{0}`. See `{1}trivia list`"
-                    " for a list of trivia categories."
-                    "".format(category, ctx.prefix)
+                    _(
+                        "Invalid category `{name}`. See `{prefix}trivia list` for a list of "
+                        "trivia categories."
+                    ).format(name=category, prefix=ctx.prefix)
                 )
             except InvalidListError:
                 await ctx.send(
-                    "There was an error parsing the trivia list for"
-                    " the `{}` category. It may be formatted"
-                    " incorrectly.".format(category)
+                    _(
+                        "There was an error parsing the trivia list for the `{name}` category. It "
+                        "may be formatted incorrectly."
+                    ).format(name=category)
                 )
             else:
                 trivia_dict.update(dict_)
@@ -208,7 +216,7 @@ class Trivia(commands.Cog):
             return
         if not trivia_dict:
             await ctx.send(
-                "The trivia list was parsed successfully, however it appears to be empty!"
+                _("The trivia list was parsed successfully, however it appears to be empty!")
             )
             return
         settings = await self.conf.guild(ctx.guild).all()
@@ -225,7 +233,7 @@ class Trivia(commands.Cog):
         """Stop an ongoing trivia session."""
         session = self._get_trivia_session(ctx.channel)
         if session is None:
-            await ctx.send("There is no ongoing trivia session in this channel.")
+            await ctx.send(_("There is no ongoing trivia session in this channel."))
             return
         author = ctx.author
         auth_checks = (
@@ -238,20 +246,28 @@ class Trivia(commands.Cog):
         if any(auth_checks):
             await session.end_game()
             session.force_stop()
-            await ctx.send("Trivia stopped.")
+            await ctx.send(_("Trivia stopped."))
         else:
-            await ctx.send("You are not allowed to do that.")
+            await ctx.send(_("You are not allowed to do that."))
 
     @trivia.command(name="list")
     async def trivia_list(self, ctx: commands.Context):
         """List available trivia categories."""
         lists = set(p.stem for p in self._all_lists())
-
-        msg = box("**Available trivia lists**\n\n{}".format(", ".join(sorted(lists))))
-        if len(msg) > 1000:
-            await ctx.author.send(msg)
-            return
-        await ctx.send(msg)
+        if await ctx.embed_requested():
+            await ctx.send(
+                embed=discord.Embed(
+                    title=_("Available trivia lists"),
+                    colour=await ctx.embed_colour(),
+                    description=", ".join(sorted(lists)),
+                )
+            )
+        else:
+            msg = box(bold(_("Available trivia lists")) + "\n\n" + ", ".join(sorted(lists)))
+            if len(msg) > 1000:
+                await ctx.author.send(msg)
+            else:
+                await ctx.send(msg)
 
     @trivia.group(name="leaderboard", aliases=["lboard"], autohelp=False)
     async def trivia_leaderboard(self, ctx: commands.Context):
@@ -273,19 +289,21 @@ class Trivia(commands.Cog):
     ):
         """Leaderboard for this server.
 
-        <sort_by> can be any of the following fields:
-         - wins  : total wins
-         - avg   : average score
-         - total : total correct answers
+        `<sort_by>` can be any of the following fields:
+         - `wins`  : total wins
+         - `avg`   : average score
+         - `total` : total correct answers
+         - `games` : total games played
 
-        <top> is the number of ranks to show on the leaderboard.
+        `<top>` is the number of ranks to show on the leaderboard.
         """
         key = self._get_sort_key(sort_by)
         if key is None:
             await ctx.send(
-                "Unknown field `{}`, see `{}help trivia "
-                "leaderboard server` for valid fields to sort by."
-                "".format(sort_by, ctx.prefix)
+                _(
+                    "Unknown field `{field_name}`, see `{prefix}help trivia leaderboard server` "
+                    "for valid fields to sort by."
+                ).format(field_name=sort_by, prefix=ctx.prefix)
             )
             return
         guild = ctx.guild
@@ -300,20 +318,21 @@ class Trivia(commands.Cog):
     ):
         """Global trivia leaderboard.
 
-        <sort_by> can be any of the following fields:
-         - wins  : total wins
-         - avg   : average score
-         - total : total correct answers from all sessions
-         - games : total games played
+        `<sort_by>` can be any of the following fields:
+         - `wins`  : total wins
+         - `avg`   : average score
+         - `total` : total correct answers from all sessions
+         - `games` : total games played
 
-        <top> is the number of ranks to show on the leaderboard.
+        `<top>` is the number of ranks to show on the leaderboard.
         """
         key = self._get_sort_key(sort_by)
         if key is None:
             await ctx.send(
-                "Unknown field `{}`, see `{}help trivia "
-                "leaderboard global` for valid fields to sort by."
-                "".format(sort_by, ctx.prefix)
+                _(
+                    "Unknown field `{field_name}`, see `{prefix}help trivia leaderboard server` "
+                    "for valid fields to sort by."
+                ).format(field_name=sort_by, prefix=ctx.prefix)
             )
             return
         data = await self.conf.all_members()
@@ -365,7 +384,7 @@ class Trivia(commands.Cog):
 
         """
         if not data:
-            await ctx.send("There are no scores on record!")
+            await ctx.send(_("There are no scores on record!"))
             return
         leaderboard = self._get_leaderboard(data, key, top)
         ret = []
@@ -386,7 +405,7 @@ class Trivia(commands.Cog):
         try:
             priority.remove(key)
         except ValueError:
-            raise ValueError("{} is not a valid key.".format(key))
+            raise ValueError(f"{key} is not a valid key.")
         # Put key last in reverse priority
         priority.append(key)
         items = data.items()
@@ -395,16 +414,15 @@ class Trivia(commands.Cog):
         max_name_len = max(map(lambda m: len(str(m)), data.keys()))
         # Headers
         headers = (
-            "Rank",
-            "Member{}".format(" " * (max_name_len - 6)),
-            "Wins",
-            "Games Played",
-            "Total Score",
-            "Average Score",
+            _("Rank"),
+            _("Member") + " " * (max_name_len - 6),
+            _("Wins"),
+            _("Games Played"),
+            _("Total Score"),
+            _("Average Score"),
         )
-        lines = [" | ".join(headers)]
+        lines = [" | ".join(headers), " | ".join(("-" * len(h) for h in headers))]
         # Header underlines
-        lines.append(" | ".join(("-" * len(h) for h in headers)))
         for rank, tup in enumerate(items, 1):
             member, m_data = tup
             # Align fields to header width

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -22,7 +22,7 @@ _ = Translator("Warnings", __file__)
 
 @cog_i18n(_)
 class Warnings(commands.Cog):
-    """A warning system for Red"""
+    """Warn misbehaving users and take automated actions."""
 
     default_guild = {"actions": [], "reasons": {}, "allow_custom_reasons": False}
 
@@ -48,31 +48,42 @@ class Warnings(commands.Cog):
     @commands.guild_only()
     @checks.guildowner_or_permissions(administrator=True)
     async def warningset(self, ctx: commands.Context):
-        """Warning settings"""
+        """Manage settings for Warnings."""
         pass
 
     @warningset.command()
     @commands.guild_only()
     async def allowcustomreasons(self, ctx: commands.Context, allowed: bool):
-        """Enable or Disable custom reasons for a warning"""
+        """Enable or disable custom reasons for a warning."""
         guild = ctx.guild
         await self.config.guild(guild).allow_custom_reasons.set(allowed)
-        await ctx.send(
-            _("Custom reasons have been {}.").format(_("enabled") if allowed else _("disabled"))
-        )
+        if allowed:
+            await ctx.send(_("Custom reasons have been enabled."))
+        else:
+            await ctx.send(_("Custom reasons have been disabled."))
 
     @commands.group()
     @commands.guild_only()
     @checks.guildowner_or_permissions(administrator=True)
     async def warnaction(self, ctx: commands.Context):
-        """Action management"""
+        """Manage automated actions for Warnings.
+
+        Actions are essentially command macros. Any command can be run
+        when the action is initially triggered, and/or when the action
+        is lifted.
+
+        Actions must be given a name and a points threshold. When a
+        user is warned enough so that their points go over this
+        threshold, the action will be executed.
+        """
         pass
 
     @warnaction.command(name="add")
     @commands.guild_only()
     async def action_add(self, ctx: commands.Context, name: str, points: int):
-        """Create an action to be taken at a specified point count
-        Duplicate action names are not allowed
+        """Create an automated action.
+
+        Duplicate action names are not allowed.
         """
         guild = ctx.guild
 
@@ -103,7 +114,7 @@ class Warnings(commands.Cog):
     @warnaction.command(name="del")
     @commands.guild_only()
     async def action_del(self, ctx: commands.Context, action_name: str):
-        """Delete the point count action with the specified name"""
+        """Delete the action with the specified name."""
         guild = ctx.guild
         guild_settings = self.config.guild(guild)
         async with guild_settings.actions() as registered_actions:
@@ -116,23 +127,29 @@ class Warnings(commands.Cog):
                 registered_actions.remove(to_remove)
                 await ctx.tick()
             else:
-                await ctx.send(_("No action named {} exists!").format(action_name))
+                await ctx.send(_("No action named {name} exists!").format(name=action_name))
 
     @commands.group()
     @commands.guild_only()
     @checks.guildowner_or_permissions(administrator=True)
     async def warnreason(self, ctx: commands.Context):
-        """Add reasons for warnings"""
+        """Manage warning reasons.
+
+        Reasons must be given a name, description and points value. The
+        name of the reason must be given when a user is warned.
+        """
         pass
 
-    @warnreason.command(name="add")
+    @warnreason.command(name="create", aliases=["add"])
     @commands.guild_only()
-    async def reason_add(self, ctx: commands.Context, name: str, points: int, *, description: str):
-        """Add a reason to be available for warnings"""
+    async def reason_create(
+        self, ctx: commands.Context, name: str, points: int, *, description: str
+    ):
+        """Create a warning reason."""
         guild = ctx.guild
 
         if name.lower() == "custom":
-            await ctx.send("That cannot be used as a reason name!")
+            await ctx.send(_("*Custom* cannot be used as a reason name!"))
             return
         to_add = {"points": points, "description": description}
         completed = {name.lower(): to_add}
@@ -142,12 +159,12 @@ class Warnings(commands.Cog):
         async with guild_settings.reasons() as registered_reasons:
             registered_reasons.update(completed)
 
-        await ctx.send(_("That reason has been registered."))
+        await ctx.send(_("The new reason has been registered."))
 
-    @warnreason.command(name="del")
+    @warnreason.command(name="del", aliases=["remove"])
     @commands.guild_only()
     async def reason_del(self, ctx: commands.Context, reason_name: str):
-        """Delete the reason with the specified name"""
+        """Delete a warning reason."""
         guild = ctx.guild
         guild_settings = self.config.guild(guild)
         async with guild_settings.reasons() as registered_reasons:
@@ -160,7 +177,7 @@ class Warnings(commands.Cog):
     @commands.guild_only()
     @checks.admin_or_permissions(ban_members=True)
     async def reasonlist(self, ctx: commands.Context):
-        """List all configured reasons for warnings"""
+        """List all configured reasons for Warnings."""
         guild = ctx.guild
         guild_settings = self.config.guild(guild)
         msg_list = []
@@ -174,9 +191,9 @@ class Warnings(commands.Cog):
                     msg_list.append(em)
                 else:
                     msg_list.append(
-                        "Name: {}\nPoints: {}\nDescription: {}".format(
-                            r, v["points"], v["description"]
-                        )
+                        _(
+                            "Name: {reason_name}\nPoints: {points}\nDescription: {description}"
+                        ).format(reason_name=r, **v)
                     )
         if msg_list:
             await menu(ctx, msg_list, DEFAULT_CONTROLS)
@@ -187,7 +204,7 @@ class Warnings(commands.Cog):
     @commands.guild_only()
     @checks.admin_or_permissions(ban_members=True)
     async def actionlist(self, ctx: commands.Context):
-        """List the actions to be taken at specific point values"""
+        """List all configured automated actions for Warnings."""
         guild = ctx.guild
         guild_settings = self.config.guild(guild)
         msg_list = []
@@ -201,10 +218,10 @@ class Warnings(commands.Cog):
                     msg_list.append(em)
                 else:
                     msg_list.append(
-                        "Name: {}\nPoints: {}\nExceed command: {}\n"
-                        "Drop command: {}".format(
-                            r["action_name"], r["points"], r["exceed_command"], r["drop_command"]
-                        )
+                        _(
+                            "Name: {action_name}\nPoints: {points}\n"
+                            "Exceed command: {exceed_command}\nDrop command: {drop_command}"
+                        ).format(**r)
                     )
         if msg_list:
             await menu(ctx, msg_list, DEFAULT_CONTROLS)
@@ -215,8 +232,10 @@ class Warnings(commands.Cog):
     @commands.guild_only()
     @checks.admin_or_permissions(ban_members=True)
     async def warn(self, ctx: commands.Context, user: discord.Member, reason: str):
-        """Warn the user for the specified reason
-        Reason must be a registered reason, or "custom" if custom reasons are allowed
+        """Warn the user for the specified reason.
+
+        `<reason>` must be a registered reason name, or *custom* if
+        custom reasons are enabled.
         """
         if user == ctx.author:
             await ctx.send(_("You cannot warn yourself."))
@@ -226,9 +245,9 @@ class Warnings(commands.Cog):
             if not custom_allowed:
                 await ctx.send(
                     _(
-                        "Custom reasons are not allowed! Please see {} for "
+                        "Custom reasons are not allowed! Please see `{prefix}reasonlist` for "
                         "a complete list of valid reasons."
-                    ).format("`{}reasonlist`".format(ctx.prefix))
+                    ).format(prefix=ctx.prefix)
                 )
                 return
             reason_type = await self.custom_warning_reason(ctx)
@@ -272,9 +291,7 @@ class Warnings(commands.Cog):
         await warning_points_add_check(self.config, ctx, user, current_point_count)
         try:
             em = discord.Embed(
-                title=_("Warning from {mod_name}#{mod_discrim}").format(
-                    mod_name=ctx.author.display_name, mod_discrim=ctx.author.discriminator
-                ),
+                title=_("Warning from {user}").format(user=ctx.author),
                 description=reason_type["description"],
             )
             em.add_field(name=_("Points"), value=str(reason_type["points"]))
@@ -286,19 +303,17 @@ class Warnings(commands.Cog):
             )
         except discord.HTTPException:
             pass
-        await ctx.send(
-            _("User {user_name}#{user_discrim} has been warned.").format(
-                user_name=user.display_name, user_discrim=user.discriminator
-            )
-        )
+        await ctx.send(_("User {user} has been warned.").format(user=user))
 
     @commands.command()
     @commands.guild_only()
     async def warnings(self, ctx: commands.Context, userid: int = None):
-        """Show warnings for the specified user.
-        If userid is None, show warnings for the person running the command
+        """List the warnings for the specified user.
+
+        Emit `<userid>` to see your own warnings.
+
         Note that showing warnings for users other than yourself requires
-        appropriate permissions
+        appropriate permissions.
         """
         if userid is None:
             user = ctx.author
@@ -326,18 +341,24 @@ class Warnings(commands.Cog):
                         )
                         if mod is None:
                             mod = await self.bot.get_user_info(user_warnings[key]["mod"])
-                    msg += "{} point warning {} issued by {} for {}\n".format(
-                        user_warnings[key]["points"], key, mod, user_warnings[key]["description"]
+                    msg += _(
+                        "{num_points} point warning {reason_name} issued by {user} for "
+                        "{description}\n"
+                    ).format(
+                        num_points=user_warnings[key]["points"],
+                        reason_name=key,
+                        user=mod,
+                        description=user_warnings[key]["description"],
                     )
                 await ctx.send_interactive(
-                    pagify(msg, shorten_by=58), box_lang="Warnings for {}".format(user)
+                    pagify(msg, shorten_by=58), box_lang=_("Warnings for {user}").format(user=user)
                 )
 
     @commands.command()
     @commands.guild_only()
     @checks.admin_or_permissions(ban_members=True)
     async def unwarn(self, ctx: commands.Context, user_id: int, warn_id: str):
-        """Removes the specified warning from the user specified"""
+        """Remove a warning from a user."""
         if user_id == ctx.author.id:
             await ctx.send(_("You cannot remove warnings from yourself."))
             return
@@ -351,7 +372,7 @@ class Warnings(commands.Cog):
         await warning_points_remove_check(self.config, ctx, member, current_point_count)
         async with member_settings.warnings() as user_warnings:
             if warn_id not in user_warnings.keys():
-                await ctx.send("That warning doesn't exist!")
+                await ctx.send(_("That warning doesn't exist!"))
                 return
             else:
                 current_point_count -= user_warnings[warn_id]["points"]

--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -1,6 +1,6 @@
 import datetime
 import os
-from typing import Union, List
+from typing import Union, List, Optional
 
 import discord
 
@@ -296,12 +296,20 @@ async def transfer_credits(from_: discord.Member, to: discord.Member, amount: in
     return await deposit_credits(to, amount)
 
 
-async def wipe_bank():
-    """Delete all accounts from the bank."""
+async def wipe_bank(guild: Optional[discord.Guild] = None) -> None:
+    """Delete all accounts from the bank.
+
+    Parameters
+    ----------
+    guild : discord.Guild
+        The guild to clear accounts for. If unsupplied and the bank is
+        per-server, all accounts in every guild will be wiped.
+
+    """
     if await is_global():
         await _conf.clear_all_users()
     else:
-        await _conf.clear_all_members()
+        await _conf.clear_all_members(guild)
 
 
 async def get_leaderboard(positions: int = None, guild: discord.Guild = None) -> List[tuple]:

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -838,7 +838,7 @@ class Config:
         """
         return self._get_base_group(self.ROLE, role.id)
 
-    def user(self, user: discord.User) -> Group:
+    def user(self, user: discord.abc.User) -> Group:
         """Returns a `Group` for the given user.
 
         Parameters

--- a/redbot/core/i18n.py
+++ b/redbot/core/i18n.py
@@ -1,5 +1,7 @@
+import os
 import re
 from pathlib import Path
+from typing import Callable, Union
 
 from . import commands
 
@@ -113,9 +115,9 @@ def _normalize(string, remove_newline=False):
         ends_with_space = s[-1] in " \n\t\r"
         if remove_newline:
             newline_re = re.compile("[\r\n]+")
-            s = " ".join(filter(bool, newline_re.split(s)))
-        s = " ".join(filter(bool, s.split("\t")))
-        s = " ".join(filter(bool, s.split(" ")))
+            s = " ".join(filter(None, newline_re.split(s)))
+        s = " ".join(filter(None, s.split("\t")))
+        s = " ".join(filter(None, s.split(" ")))
         if starts_with_space:
             s = " " + s
         if ends_with_space:
@@ -149,10 +151,10 @@ def get_locale_path(cog_folder: Path, extension: str) -> Path:
     return cog_folder / "locales" / "{}.{}".format(get_locale(), extension)
 
 
-class Translator:
+class Translator(Callable[[str], str]):
     """Function to get translated strings at runtime."""
 
-    def __init__(self, name, file_location):
+    def __init__(self, name: str, file_location: Union[str, Path, os.PathLike]):
         """
         Initializes an internationalization object.
 
@@ -173,7 +175,7 @@ class Translator:
 
         self.load_translations()
 
-    def __call__(self, untranslated: str):
+    def __call__(self, untranslated: str) -> str:
         """Translate the given string.
 
         This will look for the string in the translator's :code:`.pot` file,

--- a/redbot/core/utils/tunnel.py
+++ b/redbot/core/utils/tunnel.py
@@ -4,7 +4,7 @@ from redbot.core.utils.chat_formatting import pagify
 import io
 import sys
 import weakref
-from typing import List
+from typing import List, Optional
 from .common_filters import filter_mass_mentions
 
 _instances = weakref.WeakValueDictionary({})
@@ -86,7 +86,11 @@ class Tunnel(metaclass=TunnelMeta):
 
     @staticmethod
     async def message_forwarder(
-        *, destination: discord.abc.Messageable, content: str = None, embed=None, files=[]
+        *,
+        destination: discord.abc.Messageable,
+        content: str = None,
+        embed=None,
+        files: Optional[List[discord.File]] = None
     ) -> List[discord.Message]:
         """
         This does the actual sending, use this instead of a full tunnel
@@ -95,19 +99,19 @@ class Tunnel(metaclass=TunnelMeta):
 
         Parameters
         ----------
-        destination: `discord.abc.Messageable`
+        destination: discord.abc.Messageable
             Where to send
-        content: `str`
+        content: str
             The message content
-        embed: `discord.Embed`
+        embed: discord.Embed
             The embed to send
-        files: `list` of `discord.File`
+        files: Optional[List[discord.File]]
             A list of files to send.
 
         Returns
         -------
-        list of `discord.Message`
-            The `discord.Message`\ (s) sent as a result
+        List[discord.Message]
+            The messages sent as a result.
 
         Raises
         ------
@@ -117,7 +121,6 @@ class Tunnel(metaclass=TunnelMeta):
             see `discord.abc.Messageable.send`
         """
         rets = []
-        files = files if files else None
         if content:
             for page in pagify(content):
                 rets.append(await destination.send(page, files=files, embed=embed))


### PR DESCRIPTION
### Aim
This PR aims to raise the standard to improve the coverage of extracted user-facing string literals and to make them less ambiguous for the translator, consequently improving the quality of translations.

### Rationale
A lot of our user-facing strings are either not being passed to gettext (they need the `_()` around them) or they're formatted strings being passed with ambiguous placeholders (see #1526).

#### Why a feature branch?
I've created a feature branch here to allow more people to contribute to the effort. It's quite a lot of work for just one person to do alone. FYI PR's you make to this branch will be squashed, however when this PR gets merged it will retain all individual commits, so you will get attributed for work you've done.

@mikeshardmind started us off with his work in #1795, so I've included those additions in here :)

#### Notes for contributing
Do not use f-strings when putting a string in gettext, they *must* be in the following format:
```py
_("Ping {time}ms").format(time=random.randint())
```

Notice the call to `.format()` being *outside* the call to `_()`.

This **will not** work either, as gettext will not find the string in question:
```py
f"{_('Ping {time}ms')}"
```

### Progress

#### Cog packages
- [x] admin
- [x] alias
- [x] audio
- [x] bank
- [x] cleanup
- [x] customcom
- [x] dataconverter
- [x] downloader
- [x] economy
- [x] filter
- [x] general
- [x] image
- [x] mod
- [x] modlog
- [x] permissions
- [x] reports
- [x] streams
- [x] trivia
- [x] warnings

#### Core modules

- [ ] commands (including discord.py converters)
- [ ] utils
- [ ] bank
- [ ] cog_manager
- [ ] core_commands
- [ ] dev_commands
- [ ] events
- [ ] help_formatter
- [ ] modlog
