### PR TITLE
[Launcher] Always force reinstall when updating

### DIFF
--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -71,7 +71,7 @@ def parse_cli_args():
     return parser.parse_known_args()
 
 
-def update_red(dev=False, reinstall=False, voice=False, mongo=False, docs=False, test=False):
+def update_red(dev=False, voice=False, mongo=False, docs=False, test=False):
     interpreter = sys.executable
     print("Updating Red...")
     # If the user ran redbot-launcher.exe, updating with pip will fail
@@ -104,25 +104,20 @@ def update_red(dev=False, reinstall=False, voice=False, mongo=False, docs=False,
         package = "Red-DiscordBot"
         if egg_l:
             package += "[{}]".format(", ".join(egg_l))
-    if reinstall:
-        code = subprocess.call(
-            [
-                interpreter,
-                "-m",
-                "pip",
-                "install",
-                "-U",
-                "-I",
-                "--force-reinstall",
-                "--no-cache-dir",
-                "--process-dependency-links",
-                package,
-            ]
-        )
-    else:
-        code = subprocess.call(
-            [interpreter, "-m", "pip", "install", "-U", "--process-dependency-links", package]
-        )
+    code = subprocess.call(
+        [
+            interpreter,
+            "-m",
+            "pip",
+            "install",
+            "-U",
+            "-I",
+            "--no-cache-dir",
+            "--force-reinstall",
+            "--process-dependency-links",
+            package,
+        ]
+    )
     if code == 0:
         print("Red has been updated")
     else:
@@ -320,7 +315,7 @@ def extras_selector():
     return selected
 
 
-def development_choice(reinstall=False, can_go_back=True):
+def development_choice(can_go_back=True):
     while True:
         print("\n")
         print("Do you want to install stable or development version?")
@@ -336,7 +331,6 @@ def development_choice(reinstall=False, can_go_back=True):
             selected = extras_selector()
             update_red(
                 dev=False,
-                reinstall=reinstall,
                 voice=True if "voice" in selected else False,
                 docs=True if "docs" in selected else False,
                 test=True if "test" in selected else False,
@@ -347,7 +341,6 @@ def development_choice(reinstall=False, can_go_back=True):
             selected = extras_selector()
             update_red(
                 dev=True,
-                reinstall=reinstall,
                 voice=True if "voice" in selected else False,
                 docs=True if "docs" in selected else False,
                 test=True if "test" in selected else False,
@@ -453,14 +446,14 @@ def main_menu():
                 print("0. Back")
                 choice = user_choice()
                 if choice == "1":
-                    if development_choice(reinstall=True):
+                    if development_choice():
                         wait()
                 elif choice == "2":
                     loop.run_until_complete(reset_red())
                     wait()
                 elif choice == "3":
                     loop.run_until_complete(reset_red())
-                    development_choice(reinstall=True, can_go_back=False)
+                    development_choice(can_go_back=False)
                     wait()
                 elif choice == "0":
                     break


### PR DESCRIPTION
In lieu of recent support issues involving users updating dependencies, it shows that dependency links are wasted when upgrading unless we force reinstall and ignore the cache. Only then, will pip install the up-to-date discord.py specified in the dependency link.