### PR TITLE
[V3 Launcher] append --user if the bot isn't in a venv

### DIFF
--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -27,7 +27,7 @@ if sys.platform == "linux":
 
 PYTHON_OK = sys.version_info >= (3, 6)
 INTERACTIVE_MODE = not len(sys.argv) > 1  # CLI flags = non-interactive
-if not INTERACTIVE_MODE and "--user" in sys.argv:
+if not len(sys.argv) > 2 and "--user" in sys.argv:
     # only --user CLI flag
     INTERACTIVE_MODE = True
 

--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -82,7 +82,7 @@ def parse_cli_args():
     return parser.parse_known_args()
 
 
-def update_red(dev=False, reinstall=False, voice=False, mongo=False, docs=False, test=False):
+def update_red(dev=False, voice=False, mongo=False, docs=False, test=False):
     interpreter = sys.executable
     print("Updating Red...")
     # If the user ran redbot-launcher.exe, updating with pip will fail
@@ -115,13 +115,20 @@ def update_red(dev=False, reinstall=False, voice=False, mongo=False, docs=False,
         package = "Red-DiscordBot"
         if egg_l:
             package += "[{}]".format(", ".join(egg_l))
-    arguments = [interpreter, "-m", "pip", "install", "-U", "--process-dependency-links"]
-    if reinstall:
-        arguments.extend(["-I", "--force-reinstall", "--no-cache-dir"])
-    arguments.append(package)
-    if args.user:
-        arguments.append("--user")
-    code = subprocess.call(arguments)
+    code = subprocess.call(
+        [
+            interpreter,
+            "-m",
+            "pip",
+            "install",
+            "-U",
+            "-I",
+            "--no-cache-dir",
+            "--force-reinstall",
+            "--process-dependency-links",
+            package,
+        ]
+    )
     if code == 0:
         print("Red has been updated")
     else:
@@ -319,7 +326,7 @@ def extras_selector():
     return selected
 
 
-def development_choice(reinstall=False, can_go_back=True):
+def development_choice(can_go_back=True):
     while True:
         print("\n")
         print("Do you want to install stable or development version?")
@@ -335,7 +342,6 @@ def development_choice(reinstall=False, can_go_back=True):
             selected = extras_selector()
             update_red(
                 dev=False,
-                reinstall=reinstall,
                 voice=True if "voice" in selected else False,
                 docs=True if "docs" in selected else False,
                 test=True if "test" in selected else False,
@@ -346,7 +352,6 @@ def development_choice(reinstall=False, can_go_back=True):
             selected = extras_selector()
             update_red(
                 dev=True,
-                reinstall=reinstall,
                 voice=True if "voice" in selected else False,
                 docs=True if "docs" in selected else False,
                 test=True if "test" in selected else False,
@@ -452,14 +457,14 @@ def main_menu():
                 print("0. Back")
                 choice = user_choice()
                 if choice == "1":
-                    if development_choice(reinstall=True):
+                    if development_choice():
                         wait()
                 elif choice == "2":
                     loop.run_until_complete(reset_red())
                     wait()
                 elif choice == "3":
                     loop.run_until_complete(reset_red())
-                    development_choice(reinstall=True, can_go_back=False)
+                    development_choice(can_go_back=False)
                     wait()
                 elif choice == "0":
                     break

--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -58,10 +58,14 @@ def parse_cli_args():
     parser.add_argument(
         "--update-dev", help="Updates Red from the Github repo", action="store_true"
     )
-    parser.add_argument("--voice", help="Installs extra 'voice' when updating", action="store_true")
+    parser.add_argument(
+        "--voice", help="Installs extra 'voice' when updating", action="store_true"
+    )
     parser.add_argument("--docs", help="Installs extra 'docs' when updating", action="store_true")
     parser.add_argument("--test", help="Installs extra 'test' when updating", action="store_true")
-    parser.add_argument("--mongo", help="Installs extra 'mongo' when updating", action="store_true")
+    parser.add_argument(
+        "--mongo", help="Installs extra 'mongo' when updating", action="store_true"
+    )
     parser.add_argument(
         "--debuginfo",
         help="Prints basic debug info that would be useful for support",
@@ -266,7 +270,8 @@ async def reset_red():
         return
     print("WARNING: You are about to remove ALL Red instances on this computer.")
     print(
-        "If you want to reset data of only one instance, " "please select option 5 in the launcher."
+        "If you want to reset data of only one instance, "
+        "please select option 5 in the launcher."
     )
     await asyncio.sleep(2)
     print("\nIf you continue you will remove these instanes.\n")

--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -37,6 +37,14 @@ IS_WINDOWS = os.name == "nt"
 IS_MAC = sys.platform == "darwin"
 
 
+def is_venv():
+    """Return True if the process is in a venv or in a virtualenv."""
+    # credit to @calebj
+    return hasattr(sys, "real_prefix") or (
+        hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix
+    )
+
+
 def parse_cli_args():
     parser = argparse.ArgumentParser(
         description="Red - Discord Bot's launcher (V3)", allow_abbrev=False
@@ -115,20 +123,21 @@ def update_red(dev=False, voice=False, mongo=False, docs=False, test=False):
         package = "Red-DiscordBot"
         if egg_l:
             package += "[{}]".format(", ".join(egg_l))
-    code = subprocess.call(
-        [
-            interpreter,
-            "-m",
-            "pip",
-            "install",
-            "-U",
-            "-I",
-            "--no-cache-dir",
-            "--force-reinstall",
-            "--process-dependency-links",
-            package,
-        ]
-    )
+    arguments = [
+        interpreter,
+        "-m",
+        "pip",
+        "install",
+        "-U",
+        "-I",
+        "--no-cache-dir",
+        "--force-reinstall",
+        "--process-dependency-links",
+        package,
+    ]
+    if not is_venv():
+        arguments.append("--user")
+    code = subprocess.call(arguments)
     if code == 0:
         print("Red has been updated")
     else:

--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -27,9 +27,6 @@ if sys.platform == "linux":
 
 PYTHON_OK = sys.version_info >= (3, 6)
 INTERACTIVE_MODE = not len(sys.argv) > 1  # CLI flags = non-interactive
-if not len(sys.argv) > 2 and "--user" in sys.argv:
-    # only --user CLI flag
-    INTERACTIVE_MODE = True
 
 INTRO = "==========================\nRed Discord Bot - Launcher\n==========================\n"
 
@@ -77,14 +74,6 @@ def parse_cli_args():
     parser.add_argument(
         "--debuginfo",
         help="Prints basic debug info that would be useful for support",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--user",
-        help=(
-            "Install packages in ~/.local/ or %APPDATA%\Python on Windows. "
-            "This doesn't require admin permissions when updating."
-        ),
         action="store_true",
     )
     return parser.parse_known_args()


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

This adds the `--user` flag to `redbot-launcher` which allow people to install and update their packages without admin permissions. This will basically add the `--user` flag to all `pip install` commands.