### PR TITLE
[V3] Global data path

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -9,6 +9,7 @@ from redbot.core.cog_manager import CogManagerUI
 from redbot.core.data_manager import (
     create_temp_config,
     load_basic_configuration,
+    global_core_data_path,
     config_file,
     _convert_base_config,
 )
@@ -131,6 +132,7 @@ def main():
         )
         cli_flags.instance_name = "temporary_red"
         create_temp_config()
+    _convert_base_config()
     load_basic_configuration(cli_flags.instance_name)
     log, sentry_log = init_loggers(cli_flags)
     red = Red(cli_flags=cli_flags, description=description, pm_help=None)

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -6,7 +6,12 @@ import sys
 import discord
 from redbot.core.bot import Red, ExitCodes
 from redbot.core.cog_manager import CogManagerUI
-from redbot.core.data_manager import create_temp_config, load_basic_configuration, config_file
+from redbot.core.data_manager import (
+    create_temp_config,
+    load_basic_configuration,
+    config_file,
+    _convert_base_config,
+)
 from redbot.core.json_io import JsonIO
 from redbot.core.global_checks import init_global_checks
 from redbot.core.events import init_events

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -41,6 +41,7 @@ if sys.platform == "linux":
         config_dir = Path(appdir.site_data_dir)
 if not config_dir:
     config_dir = Path(appdir.user_config_dir)
+config_file = config_dir / basic_config_default["CORE_PATH_APPEND"] / "config.json"
 
 
 def _base_data_path() -> Path:
@@ -158,7 +159,7 @@ def global_core_data_path() -> Path:
         raise RuntimeError(
             "You must load the basic config before you can get the core data path."
         ) from e
-    global_core_path = base_global_data_path / basic_config["CORE_PATH_APPEND"]
+    global_core_path = base_global_data_path / basic_config_default["CORE_PATH_APPEND"]
     global_core_path.mkdir(exist_ok=True, parents=True)
 
     return global_core_path.resolve()
@@ -179,9 +180,9 @@ def create_temp_config():
     default_dirs["STORAGE_TYPE"] = "JSON"
     default_dirs["STORAGE_DETAILS"] = {}
 
-    config = JsonIO(global_core_data_path() / "config.json")._load_json()
+    config = JsonIO(config_file)._load_json()
     config[name] = default_dirs
-    JsonIO(global_core_data_path() / "config.json")._save_json(config)
+    JsonIO(config_file)._save_json(config)
 
 
 def load_basic_configuration(instance_name_: str):
@@ -202,7 +203,7 @@ def load_basic_configuration(instance_name_: str):
     global basic_config
     global instance_name
 
-    jsonio = JsonIO(global_core_data_path() / "config.json")
+    jsonio = JsonIO(config_file)
 
     instance_name = instance_name_
 
@@ -223,7 +224,7 @@ def _convert_base_config():
     """
     old_conf = config_dir / "config.json"
     if old_conf.exists():
-        shutil.move(str(old_conf.absolute()), str(global_core_data_path.absolute()))
+        shutil.move(str(old_conf.absolute()), str(config_file.absolute()))
 
 
 def _find_data_files(init_location: str) -> (Path, List[Path]):

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -17,8 +17,8 @@ __all__ = [
     "load_basic_configuration",
     "cog_data_path",
     "core_data_path",
-    "cog_global_data_path",
-    "core_global_data_path",
+    "global_cog_data_path",
+    "global_core_data_path",
     "load_bundled_data",
     "bundled_data_path",
     "storage_details",
@@ -179,9 +179,9 @@ def create_temp_config():
     default_dirs["STORAGE_TYPE"] = "JSON"
     default_dirs["STORAGE_DETAILS"] = {}
 
-    config = JsonIO(config_file)._load_json()
+    config = JsonIO(global_core_data_path() / "config.json")._load_json()
     config[name] = default_dirs
-    JsonIO(config_file)._save_json(config)
+    JsonIO(global_core_data_path() / "config.json")._save_json(config)
 
 
 def load_basic_configuration(instance_name_: str):
@@ -202,7 +202,7 @@ def load_basic_configuration(instance_name_: str):
     global basic_config
     global instance_name
 
-    jsonio = JsonIO(config_file)
+    jsonio = JsonIO(global_core_data_path() / "config.json")
 
     instance_name = instance_name_
 
@@ -215,6 +215,15 @@ def load_basic_configuration(instance_name_: str):
             " prior to running the bot."
         )
         sys.exit(1)
+
+
+def _convert_base_config():
+    """
+    Move ``./config.json`` to ``./core/config.json``.
+    """
+    old_conf = config_dir / "config.json"
+    if old_conf.exists():
+        shutil.move(str(old_conf.absolute()), str(global_core_data_path.absolute()))
 
 
 def _find_data_files(init_location: str) -> (Path, List[Path]):

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -41,60 +41,6 @@ if sys.platform == "linux":
         config_dir = Path(appdir.site_data_dir)
 if not config_dir:
     config_dir = Path(appdir.user_config_dir)
-config_file = config_dir / "config.json"
-
-
-def create_temp_config():
-    """
-    Creates a default instance for Red, so it can be ran
-    without creating an instance.
-
-    .. warning:: The data of this instance will be removed
-        on next system restart.
-    """
-    name = "temporary_red"
-
-    default_dirs = deepcopy(basic_config_default)
-    default_dirs["DATA_PATH"] = tempfile.mkdtemp()
-    default_dirs["STORAGE_TYPE"] = "JSON"
-    default_dirs["STORAGE_DETAILS"] = {}
-
-    config = JsonIO(config_file)._load_json()
-    config[name] = default_dirs
-    JsonIO(config_file)._save_json(config)
-
-
-def load_basic_configuration(instance_name_: str):
-    """Loads the basic bootstrap configuration necessary for `Config`
-    to know where to store or look for data.
-
-    .. important::
-        It is necessary to call this function BEFORE getting any `Config`
-        objects!
-
-    Parameters
-    ----------
-    instance_name_ : str
-        The instance name given by CLI argument and created during
-        redbot setup.
-    """
-    global jsonio
-    global basic_config
-    global instance_name
-
-    jsonio = JsonIO(config_file)
-
-    instance_name = instance_name_
-
-    try:
-        config = jsonio._load_json()
-        basic_config = config[instance_name]
-    except (FileNotFoundError, KeyError):
-        print(
-            "You need to configure the bot instance using `redbot-setup`"
-            " prior to running the bot."
-        )
-        sys.exit(1)
 
 
 def _base_data_path() -> Path:
@@ -161,19 +107,6 @@ def core_data_path() -> Path:
     return core_path.resolve()
 
 
-def global_core_data_path() -> Path:
-    try:
-        base_global_data_path = Path(_base_global_data_path())
-    except RuntimeError as e:
-        raise RuntimeError(
-            "You must load the basic config before you can get the core data path."
-        ) from e
-    global_core_path = base_global_data_path / basic_config["CORE_PATH_APPEND"]
-    global_core_path.mkdir(exist_ok=True, parents=True)
-
-    return global_core_path.resolve()
-
-
 def global_cog_data_path(cog_instance=None, raw_name: str = None) -> Path:
     """Gets the global cog data path. If you want to get the folder with
     which to store your own cog's data please pass in an instance
@@ -216,6 +149,72 @@ def global_cog_data_path(cog_instance=None, raw_name: str = None) -> Path:
     cog_path.mkdir(exist_ok=True, parents=True)
 
     return cog_path.resolve()
+
+
+def global_core_data_path() -> Path:
+    try:
+        base_global_data_path = Path(_base_global_data_path())
+    except RuntimeError as e:
+        raise RuntimeError(
+            "You must load the basic config before you can get the core data path."
+        ) from e
+    global_core_path = base_global_data_path / basic_config["CORE_PATH_APPEND"]
+    global_core_path.mkdir(exist_ok=True, parents=True)
+
+    return global_core_path.resolve()
+
+
+def create_temp_config():
+    """
+    Creates a default instance for Red, so it can be ran
+    without creating an instance.
+
+    .. warning:: The data of this instance will be removed
+        on next system restart.
+    """
+    name = "temporary_red"
+
+    default_dirs = deepcopy(basic_config_default)
+    default_dirs["DATA_PATH"] = tempfile.mkdtemp()
+    default_dirs["STORAGE_TYPE"] = "JSON"
+    default_dirs["STORAGE_DETAILS"] = {}
+
+    config = JsonIO(config_file)._load_json()
+    config[name] = default_dirs
+    JsonIO(config_file)._save_json(config)
+
+
+def load_basic_configuration(instance_name_: str):
+    """Loads the basic bootstrap configuration necessary for `Config`
+    to know where to store or look for data.
+
+    .. important::
+        It is necessary to call this function BEFORE getting any `Config`
+        objects!
+
+    Parameters
+    ----------
+    instance_name_ : str
+        The instance name given by CLI argument and created during
+        redbot setup.
+    """
+    global jsonio
+    global basic_config
+    global instance_name
+
+    jsonio = JsonIO(config_file)
+
+    instance_name = instance_name_
+
+    try:
+        config = jsonio._load_json()
+        basic_config = config[instance_name]
+    except (FileNotFoundError, KeyError):
+        print(
+            "You need to configure the bot instance using `redbot-setup`"
+            " prior to running the bot."
+        )
+        sys.exit(1)
 
 
 def _find_data_files(init_location: str) -> (Path, List[Path]):

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -17,6 +17,8 @@ __all__ = [
     "load_basic_configuration",
     "cog_data_path",
     "core_data_path",
+    "cog_global_data_path",
+    "core_global_data_path",
     "load_bundled_data",
     "bundled_data_path",
     "storage_details",
@@ -102,6 +104,12 @@ def _base_data_path() -> Path:
     return Path(path).resolve()
 
 
+def _base_global_data_path() -> Path:
+    if basic_config is None:
+        raise RuntimeError("You must load the basic config before you can get the base data path.")
+    return config_dir.resolve()
+
+
 def cog_data_path(cog_instance=None, raw_name: str = None) -> Path:
     """Gets the base cog data path. If you want to get the folder with
     which to store your own cog's data please pass in an instance
@@ -151,6 +159,63 @@ def core_data_path() -> Path:
     core_path.mkdir(exist_ok=True, parents=True)
 
     return core_path.resolve()
+
+
+def global_core_data_path() -> Path:
+    try:
+        base_global_data_path = Path(_base_global_data_path())
+    except RuntimeError as e:
+        raise RuntimeError(
+            "You must load the basic config before you can get the core data path."
+        ) from e
+    global_core_path = base_global_data_path / basic_config["CORE_PATH_APPEND"]
+    global_core_path.mkdir(exist_ok=True, parents=True)
+
+    return global_core_path.resolve()
+
+
+def global_cog_data_path(cog_instance=None, raw_name: str = None) -> Path:
+    """Gets the global cog data path. If you want to get the folder with
+    which to store your own cog's data please pass in an instance
+    of your cog class.
+
+    Instead of :py:func:`cog_data_path` which returns a folder in the
+    instance's files, this function returns a folder in Red's internal
+    files. **This means that the same folder will be returned for all
+    instance**. This can be useful for running a server or storing
+    huge files, but should not be used for values depending on the bot.
+
+    Either ``cog_instance`` or ``raw_name`` will be used, not both.
+
+    Parameters
+    ----------
+    cog_instance
+        The instance of the cog you wish to get a data path for.
+    raw_name : str
+        The name of the cog to get a data path for.
+
+    Returns
+    -------
+    pathlib.Path
+        If ``cog_instance`` is provided it will return a path to a folder
+        dedicated to a given cog. Otherwise it will return a path to the
+        folder that contains data for all cogs.
+    """
+    try:
+        base_global_data_path = Path(_base_global_data_path())
+    except RuntimeError as e:
+        raise RuntimeError(
+            "You must load the basic config before you can get the cog data path."
+        ) from e
+    cog_path = base_global_data_path / basic_config["COG_PATH_APPEND"]
+
+    if raw_name is not None:
+        cog_path = cog_path / raw_name
+    elif cog_instance is not None:
+        cog_path = cog_path / cog_instance.__class__.__name__
+    cog_path.mkdir(exist_ok=True, parents=True)
+
+    return cog_path.resolve()
 
 
 def _find_data_files(init_location: str) -> (Path, List[Path]):


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes

This will add two new functions to `redbot.core.dataconverter`: `global_cog_data_path` and `global_core_data_path`. These functions are similar to `cog_data_path` and `core_data_path`, except they will redirect to a folder common to all instances. This resolves #2039.

**Important:** I tested it quickly, the base functions are working, but this might need more deep testing since this modifies the main code from `__main__` (starting a bot and grabbing data).