### PR TITLE
Use ProactorEventLoop on Windows

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -28,6 +28,9 @@ if sys.implementation.name == "cpython":
     else:
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+
 
 #
 #               Red - Discord Bot v3

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -29,7 +29,7 @@ if sys.implementation.name == "cpython":
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
 if sys.platform == "win32":
-    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+    asyncio.set_event_loop(asyncio.ProactorEventLoop())
 
 
 #


### PR DESCRIPTION
### Type

- Bugfix

### Description of the changes
The default event loop does not support asyncio subprocesses on Windows. This has caused issues on Windows with new changes such as #2035 and also apparently some Downloader issues. Changing to [asyncio.ProactorEventLoop](https://docs.python.org/3/library/asyncio-eventloops.html#asyncio.ProactorEventLoop) allows the use of these subprocesses, and also supports a larger set of asynchronous I/O operations and utilities.

A user in #v3-support who alerted me of these new issues has tested the changes on this branch, and it he has confirmed it resolved some issues with loading audio, and installing repos with downloader.