### PR TITLE
[V3 Audio] Fix for using [p]now with thumbnail

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -459,8 +459,9 @@ class Audio:
         embed = discord.Embed(
             colour=(await ctx.embed_colour()), title="Now Playing", description=song
         )
-        if await self.config.guild(ctx.guild).thumbnail() and player.current.thumbnail:
-            embed.set_thumbnail(url=player.current.thumbnail)
+        if await self.config.guild(ctx.guild).thumbnail() and player.current:
+            if player.current.thumbnail:
+                embed.set_thumbnail(url=player.current.thumbnail)
         message = await ctx.send(embed=embed)
         player.store("np_message", message)
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Having the thumbnail toggle on and a connected but stopped player will result in an error when using [p]now, this checks for a playing song before attempting to place a thumbnail on the embed.