### PR TITLE
[V3 Launcher] Use "python -m" for run_red

### DIFF
--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -140,9 +140,10 @@ def update_red(dev=False, voice=False, mongo=False, docs=False, test=False):
 
 
 def run_red(selected_instance, autorestart: bool = False, cliflags=None):
+    interpreter = sys.executable
     while True:
         print("Starting {}...".format(selected_instance))
-        cmd_list = ["redbot", selected_instance]
+        cmd_list = [interpreter, "-m", "redbot", selected_instance]
         if cliflags:
             cmd_list += cliflags
         status = subprocess.call(cmd_list)


### PR DESCRIPTION
### Type

- [X] Enhancement

### Description of the changes

Changes run_red to use "python -m redbot <instance>" (specifically "\<executable\> -m redbot \<instance\>").

This makes the launcher friendlier to virtual environments since it sticks with the python being used, same with the `pip` call in `update_red`, rather than depending on the path / environment to resolve it.