### PR TITLE
[V3] More mention filtering

### DIFF
--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -12,7 +12,7 @@ from .checks import mod_or_voice_permissions, admin_or_voice_permissions, bot_ha
 from redbot.core.utils.mod import is_mod_or_superior, is_allowed_by_hierarchy, get_audit_reason
 from .log import log
 
-from redbot.core.utils.common_filters import filter_invites
+from redbot.core.utils.common_filters import filter_invites, filter_various_mentions
 
 _ = Translator("Mod", __file__)
 
@@ -1323,9 +1323,11 @@ class Mod:
         if roles is not None:
             data.add_field(name=_("Roles"), value=roles, inline=False)
         if names:
+            # May need sanitizing later, but mentions do not ping in embeds currently
             val = filter_invites(", ".join(names))
             data.add_field(name=_("Previous Names"), value=val, inline=False)
         if nicks:
+            # May need sanitizing later, but mentions do not ping in embeds currently
             val = filter_invites(", ".join(nicks))
             data.add_field(name=_("Previous Nicknames"), value=val, inline=False)
         if voice_state and voice_state.channel:
@@ -1369,6 +1371,7 @@ class Mod:
             msg += "\n"
             msg += ", ".join(nicks)
         if msg:
+            msg = filter_various_mentions(msg)
             await ctx.send(msg)
         else:
             await ctx.send(_("That user doesn't have any recorded name or nickname change."))

--- a/redbot/core/utils/common_filters.py
+++ b/redbot/core/utils/common_filters.py
@@ -17,8 +17,7 @@ INVITE_URL_RE = re.compile(r"(discord.gg|discordapp.com/invite|discord.me)(\S+)"
 
 MASS_MENTION_RE = re.compile(r"(@)(?=everyone|here)")  # This only matches the @ for sanitizing
 
-# negative lookbehind used here to avoid canceling our own filter strategy.
-OTHER_MENTION_RE = re.compile(r"(?<!\\)(<(@?[!&]|#)\d+>)")
+OTHER_MENTION_RE = re.compile(r"(<)(@[!&]?|#)(\d+>)")
 
 # convenience wrappers
 def filter_urls(to_filter: str) -> str:
@@ -101,6 +100,4 @@ def filter_various_mentions(to_filter: str) -> str:
     str
         The sanitized string.
     """
-    # This matches with a negative lookbehind (see above) so this is a safe strategy
-    # for negating the mention, while retaining useful information.
-    return OTHER_MENTION_RE.sub(r"\\\0", to_filter)
+    return OTHER_MENTION_RE.sub(r"\1\\\2\3", to_filter)

--- a/redbot/core/utils/common_filters.py
+++ b/redbot/core/utils/common_filters.py
@@ -101,4 +101,6 @@ def filter_various_mentions(to_filter: str) -> str:
     str
         The sanitized string.
     """
+    # This matches with a negative lookbehind (see above) so this is a safe strategy
+    # for negating the mention, while retaining useful information.
     return OTHER_MENTION_RE.sub(r"\\\0", to_filter)

--- a/redbot/core/utils/common_filters.py
+++ b/redbot/core/utils/common_filters.py
@@ -18,7 +18,7 @@ INVITE_URL_RE = re.compile(r"(discord.gg|discordapp.com/invite|discord.me)(\S+)"
 MASS_MENTION_RE = re.compile(r"(@)(?=everyone|here)")  # This only matches the @ for sanitizing
 
 # negative lookbehind used here to avoid canceling our own filter strategy.
-OTHER_MENTION_RE = re.compile(r"(?<!\\)(<@?[!&]\d+>)")
+OTHER_MENTION_RE = re.compile(r"(?<!\\)(<(@?[!&]|#)\d+>)")
 
 # convenience wrappers
 def filter_urls(to_filter: str) -> str:

--- a/redbot/core/utils/common_filters.py
+++ b/redbot/core/utils/common_filters.py
@@ -7,6 +7,7 @@ __all__ = [
     "filter_urls",
     "filter_invites",
     "filter_mass_mentions",
+    "filter_various_mentions",
 ]
 
 # regexes
@@ -16,6 +17,8 @@ INVITE_URL_RE = re.compile(r"(discord.gg|discordapp.com/invite|discord.me)(\S+)"
 
 MASS_MENTION_RE = re.compile(r"(@)(?=everyone|here)")  # This only matches the @ for sanitizing
 
+# negative lookbehind used here to avoid canceling our own filter strategy.
+OTHER_MENTION_RE = re.compile(r"(?<!\\)(<@?[!&]\d+>)")
 
 # convenience wrappers
 def filter_urls(to_filter: str) -> str:
@@ -79,3 +82,23 @@ def filter_mass_mentions(to_filter: str) -> str:
 
     """
     return MASS_MENTION_RE.sub("@\u200b", to_filter)
+
+
+def filter_various_mentions(to_filter: str) -> str:
+    """
+    Get a string with role, user, and channel mentions sanitized.
+
+    This is mainly for use on user display names, not message content,
+    and should be applied sparingly.
+
+    Parameters
+    ----------
+    to_filter : str
+        The string to filter.
+
+    Returns
+    -------
+    str
+        The sanitized string.
+    """
+    return OTHER_MENTION_RE.sub(r"\\\0", to_filter)


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Escapes out bad mention content from usernames in the `[p]names` command. Notably, a user with any fake mention in their name or display name won't be rendered as such in output.