### PR TITLE
[V3] Correct minimum version

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Red's repository is configured to follow a particular development workflow, usin
 
 ### 4.1 Setting up your development environment
 The following requirements must be installed prior to setting up:
- - Python 3.6
+ - Python 3.6.2 or greater
  - git
  - pip
  - pipenv
@@ -79,7 +79,7 @@ Note: If you haven't used `pipenv` before but are comfortable with virtualenvs, 
 We've recently started using [tox](https://github.com/tox-dev/tox) to run all of our tests. It's extremely simple to use, and if you followed the previous section correctly, it is already installed to your virtual environment.
 
 Currently, tox does the following, creating its own virtual environments for each stage:
-- Runs all of our unit tests with [pytest](https://github.com/pytest-dev/pytest) on python 3.6 (test environment `py36`)
+- Runs all of our unit tests with [pytest](https://github.com/pytest-dev/pytest) on python 3.6 and 3.7 (test environments `py36` and `py37`)
 - Ensures documentation builds without warnings, and all hyperlinks have a valid destination (test environment `docs`)
 - Ensures that the code meets our style guide with [black](https://github.com/ambv/black) (test environment `style`)
 

--- a/docs/guide_cog_creation.rst
+++ b/docs/guide_cog_creation.rst
@@ -17,7 +17,7 @@ you in the process.
 Getting started
 ---------------
 
-To start off, be sure that you have installed Python 3.6 or higher. Open a terminal or command prompt and type
+To start off, be sure that you have installed Python 3.6.2 or higher. Open a terminal or command prompt and type
 :code:`pip install --process-dependency-links -U git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=redbot[test]`
 (note that if you get an error with this, try again but put :code:`python -m` in front of the command
 This will install the latest version of V3.

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -16,7 +16,7 @@ Installing the pre-requirements
 Please install the pre-requirements using the commands listed for your operating system.
 
 The pre-requirements are:
- - Python 3.6 or greater
+ - Python 3.6.2 or greater
  - pip 9.0 or greater
  - git
  - Java Runtime Environment 8 or later (for audio support)
@@ -108,7 +108,7 @@ Ubuntu 18.04 Bionic Beaver
 Ubuntu 16.04 Xenial Xerus
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-We recommend adding the ``deadsnakes`` apt repository to install Python 3.6 or greater:
+We recommend adding the ``deadsnakes`` apt repository to install Python 3.6.2 or greater:
 
 .. code-block:: none
 

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -8,7 +8,7 @@ Installing Red on Windows
 Needed Software
 ---------------
 
-* `Python <https://www.python.org/downloads/>`_ - Red needs Python 3.6
+* `Python <https://www.python.org/downloads/>`_ - Red needs Python 3.6.2 or greater
 
 .. note:: Please make sure that the box to add Python to PATH is CHECKED, otherwise
           you may run into issues when trying to run Red

--- a/docs/venv_guide.rst
+++ b/docs/venv_guide.rst
@@ -68,7 +68,7 @@ Using ``pyenv virtualenv``
 Using ``pyenv virtualenv`` saves you the headache of remembering where you installed your virtual
 environments. If you haven't already, install pyenv with `pyenv-installer`_.
 
-First, ensure your pyenv interpreter is set to python 3.6 or later with the following command::
+First, ensure your pyenv interpreter is set to python 3.6.2 or greater with the following command::
 
     pyenv version
 

--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -25,7 +25,7 @@ from redbot.core.cli import confirm
 if sys.platform == "linux":
     import distro
 
-PYTHON_OK = sys.version_info >= (3, 6)
+PYTHON_OK = sys.version_info >= (3, 6, 2)
 INTERACTIVE_MODE = not len(sys.argv) > 1  # CLI flags = non-interactive
 
 INTRO = "==========================\nRed Discord Bot - Launcher\n==========================\n"
@@ -462,7 +462,7 @@ def main_menu():
 def main():
     if not PYTHON_OK:
         raise RuntimeError(
-            "Red requires Python 3.6 or greater. Please install the correct version!"
+            "Red requires Python 3.6.2 or greater. Please install the correct version!"
         )
     if args.debuginfo:  # Check first since the function triggers an exit
         debug_info()

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ if __name__ == "__main__":
             ],
             "pytest11": ["red-discordbot = redbot.pytest"],
         },
-        python_requires=">=3.6,<3.8",
+        python_requires=">=3.6.2,<3.8",
         install_requires=requirements,
         dependency_links=get_dependency_links(),
         extras_require={


### PR DESCRIPTION
see #2092 

While this is needed because of an import just for typing, I see no reason not to bump the minimum version since this is a minor version difference since this is several minor version behind the latest 3.6, and there have been both security and performance improvements since.

That said, we need to be testing on our lowest supported version to ensure we don't have this happen again, right now our tests run on whatever Travis grabs for 3.6, which I assume is 3.6.6, but could be wrong.

### Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
