### PR TITLE
[V3 Streams] fix excessive writes to config

### DIFF
--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -508,6 +508,8 @@ class Streams:
             try:
                 embed = await stream.is_online()
             except OfflineStream:
+                if not stream._messages_cache:
+                    continue
                 for message in stream._messages_cache:
                     try:
                         autodelete = await self.db.guild(message.guild).autodelete()
@@ -558,6 +560,8 @@ class Streams:
                 print(_("The Community {} was not found!").format(community.name))
                 continue
             except OfflineCommunity:
+                if not community._messages_cache:
+                    continue
                 for message in community._messages_cache:
                     try:
                         autodelete = await self.db.guild(message.guild).autodelete()


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #2052. Turns out the issue was occurring because there was nothing telling both check_streams and check_communities that if the stream/community is offline and has nothing in the message cache that it should move on