### PR TITLE
Ignore fuzzywuzzy slow sequence matcher warning

### DIFF
--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -1,6 +1,7 @@
 import sys
+import warnings
 import discord
-from colorama import init, Back
+from colorama import init
 
 init()
 # Let's do all the dumb version checking in one place.
@@ -12,3 +13,6 @@ if discord.version_info.major < 1:
         " >= 1.0.0."
     )
     sys.exit(1)
+
+# Filter fuzzywuzzy slow sequence matcher warning
+warnings.filterwarnings("ignore", module=r"fuzzywuzzy.*")

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -60,7 +60,7 @@ def init_loggers(cli_flags):
         os.environ["PYTHONASYNCIODEBUG"] = "1"
         logger.setLevel(logging.DEBUG)
     else:
-        logger.setLevel(logging.WARNING)
+        logger.setLevel(logging.INFO)
 
     from redbot.core.data_manager import core_data_path
 

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -170,6 +170,12 @@ def init_events(bot, cli_flags):
             print("\nInvite URL: {}\n".format(invite_url))
 
         bot.color = discord.Colour(await bot.db.color())
+        try:
+            import Levenshtein
+        except ImportError:
+            log.info(
+                "python-Levenshtein is not installed, fuzzy string matching will be a bit slower."
+            )
 
     @bot.event
     async def on_error(event_method, *args, **kwargs):


### PR DESCRIPTION
Many users who see this warning seem to panic and think it is worth reporting. I'd rather this just be hidden.