### PR TITLE
[V3 Audio] Local playback

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -844,9 +844,9 @@ class Audio:
         shuffle = await self.config.guild(ctx.guild).shuffle()
         if not self._player_check(ctx):
             try:
-                if not ctx.author.voice.channel.permissions_for(
-                    ctx.me
-                ).connect or self._userlimit(ctx.author.voice.channel):
+                if not ctx.author.voice.channel.permissions_for(ctx.me).connect or self._userlimit(
+                    ctx.author.voice.channel
+                ):
                     return await self._embed_msg(
                         ctx, "I don't have permission to connect to your channel."
                     )
@@ -1278,9 +1278,9 @@ class Audio:
                 return False
         if not self._player_check(ctx):
             try:
-                if not ctx.author.voice.channel.permissions_for(
-                    ctx.me
-                ).connect or self._userlimit(ctx.author.voice.channel):
+                if not ctx.author.voice.channel.permissions_for(ctx.me).connect or self._userlimit(
+                    ctx.author.voice.channel
+                ):
                     return await self._embed_msg(
                         ctx, "I don't have permission to connect to your channel."
                     )
@@ -1638,9 +1638,9 @@ class Audio:
 
         if not self._player_check(ctx):
             try:
-                if not ctx.author.voice.channel.permissions_for(
-                    ctx.me
-                ).connect or self._userlimit(ctx.author.voice.channel):
+                if not ctx.author.voice.channel.permissions_for(ctx.me).connect or self._userlimit(
+                    ctx.author.voice.channel
+                ):
                     return await self._embed_msg(
                         ctx, "I don't have permission to connect to your channel."
                     )

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -1367,6 +1367,7 @@ class Audio:
     @commands.guild_only()
     async def queue(self, ctx, *, page="1"):
         """Lists the queue.
+
         Use [p]queue search <search terms> to search the queue."""
         if not self._player_check(ctx):
             return await self._embed_msg(ctx, "There's nothing in the queue.")

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -490,13 +490,9 @@ class Audio:
         """Play a local track."""
         if not await self._localtracks_check(ctx):
             return
-
-        localtracks_folders = [
-            f
-            for f in os.listdir(os.getcwd() + "/localtracks/")
-            if not os.path.isfile(os.getcwd() + "/localtracks/" + f)
-        ]
-
+        localtracks_folders = await self._localtracks_folders(ctx)
+        if not localtracks_folders:
+            return await self._embed_msg(ctx, "No album folders found.")
         len_folder_pages = math.ceil(len(localtracks_folders) / 5)
         folder_page_list = []
         for page_num in range(1, len_folder_pages + 1):
@@ -540,11 +536,9 @@ class Audio:
         """Search for songs across all localtracks folders."""
         if not await self._localtracks_check(ctx):
             return
-        localtracks_folders = [
-            f
-            for f in os.listdir(os.getcwd() + "/localtracks/")
-            if not os.path.isfile(os.getcwd() + "/localtracks/" + f)
-        ]
+        localtracks_folders = await self._localtracks_folders(ctx)
+        if not localtracks_folders:
+            return await self._embed_msg(ctx, "No album folders found.")
         all_tracks = []
         for local_folder in localtracks_folders:
             folder_tracks = await self._folder_list(ctx, local_folder)
@@ -2347,6 +2341,16 @@ class Audio:
             return len([player for p in lavalink.players if p.is_playing])
         else:
             return 0
+
+    async def _localtracks_folders(self, ctx):
+        if not await self._localtracks_check(ctx):
+            return
+        localtracks_folders = [
+            f
+            for f in os.listdir(os.getcwd() + "/localtracks/")
+            if not os.path.isfile(os.getcwd() + "/localtracks/" + f)
+        ]
+        return localtracks_folders
 
     @staticmethod
     def _match_url(url):

--- a/redbot/cogs/audio/data/application.yml
+++ b/redbot/cogs/audio/data/application.yml
@@ -14,7 +14,7 @@ lavalink:
       vimeo: true
       mixer: true
       http: true
-      local: false
+      local: true
     sentryDsn: ""
     bufferDurationMs: 400
     youtubePlaylistLoadLimit: 10000


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes
This builds on top of #2077 and could be used in favor of it.

Filetype support: .mp3, .flac, .ogg

Local tracks can be queued a few ways:

- `[p]play localtracks/foldername/song_to_play.mp3`
- `[p]local play` (interactive)
- `[p]local folder` (interactive, queues an entire localtracks folder)
- `[p]local search` (interactive, queues the user-picked track via menu)

Informational display will favor ID3 tag information, but if it's not available, it'll use the file name.

If you're looking to test this as an existing user:

- You must be using an internal lavalink server, or your jar should live in the audio data folder if it's external.

- Tracks should go in a localtracks folder under the audio data directory. Place tracks inside an additional subfolder. You can have as many subfolders under localtracks as you want, however audio only looks one folder deep for tracks.

For example:

data_directory/cogs/Audio/localtracks/Album Folder Name/Artist - Track.mp3

data_directory/cogs/Audio/localtracks/Another Great Album/Another Artist - Another Track.mp3

are both valid paths for tracks.

- Replace the lavalink.jar in your audio data directory with build no. 584 (https://ci.fredboat.com/repository/download/Lavalink_Build/4825:id/Lavalink.jar?guest=1)
- Change `local: false` in the application.yml file in audio's data path to `true`.
- If your files return "Nothing found.", check your error.log or the lavalink.log in the data directory to see if it was an encoding error.

General error reporting in Discord is disabled for local tracks. Lavalink is not best-suited for local track playback and can complain at the end of every mp3 file but play the entire thing, for example.

Something to be considered before merging: There should be a way to determine if someone has an existing lavalink.jar and application.yml and be able to overwrite them both, or set them to download & overwrite by default on the release this is included in.