### PR TITLE
[V3 CustomCommands] Parameters helptext

### DIFF
--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -412,13 +412,18 @@ class CustomCommands:
                         index + low, fin[index].annotation.__name__, anno.__name__
                     )
                 )
-            name = "{}_{}".format(
-                "text" if anno is Parameter.empty else anno.__name__.lower(),
-                index if index < high else "final",
-            )
-            fin[index] = fin[index].replace(name=name, annotation=anno)
+            if anno is not Parameter.empty:
+                fin[index] = fin[index].replace(annotation=anno)
         # consume rest
         fin[-1] = fin[-1].replace(kind=Parameter.KEYWORD_ONLY)
+        # name the parameters for the help text
+        for i, param in enumerate(fin):
+            anno = param.annotation
+            name = "{}_{}".format(
+                "text" if anno is Parameter.empty else anno.__name__.lower(),
+                i if i < high else "final",
+            )
+            fin[i] = fin[i].replace(name=name)
         # insert ctx parameter for discord.py parsing
         fin = default + [(p.name, p) for p in fin]
         return OrderedDict(fin)


### PR DESCRIPTION
### Type

- [x] Bugfix

### Description of the changes

Fixes a minor helptext error.
https://gyazo.com/7d4f5a60e058f7884038187fca79519a
The above should say `role_final` rather than `text_final`.

This bug only happened when using implied colon notation (since the parser remembers the colon notation for each argument), but since it impacted how it appears in the helptext (showing `text` rather than the accepted type), I considered it worth fixing.