### PR TITLE
Set 3.6.6 as minimum python version on Windows

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Red's repository is configured to follow a particular development workflow, usin
 
 ### 4.1 Setting up your development environment
 The following requirements must be installed prior to setting up:
- - Python 3.6.2 or greater
+ - Python 3.6.2 or greater (3.6.6 or greater on Windows)
  - git
  - pip
  - pipenv

--- a/docs/guide_cog_creation.rst
+++ b/docs/guide_cog_creation.rst
@@ -17,8 +17,8 @@ you in the process.
 Getting started
 ---------------
 
-To start off, be sure that you have installed Python 3.6.2 or higher. Open a terminal or command prompt and type
-:code:`pip install --process-dependency-links -U git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=redbot[test]`
+To start off, be sure that you have installed Python 3.6.2 or higher (3.6.6 or higher on Windows).
+Open a terminal or command prompt and type :code:`pip install --process-dependency-links -U git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=redbot[test]`
 (note that if you get an error with this, try again but put :code:`python -m` in front of the command
 This will install the latest version of V3.
 

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -8,7 +8,7 @@ Installing Red on Windows
 Needed Software
 ---------------
 
-* `Python <https://www.python.org/downloads/>`_ - Red needs Python 3.6.2 or greater
+* `Python <https://www.python.org/downloads/>`_ - Red needs Python 3.6.6 or greater on Windows
 
 .. note:: Please make sure that the box to add Python to PATH is CHECKED, otherwise
           you may run into issues when trying to run Red

--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -1,18 +1,32 @@
 import sys
 import warnings
 import discord
-from colorama import init
+import colorama
 
-init()
 # Let's do all the dumb version checking in one place.
+if sys.platform == "win32":
+    # Due to issues with ProactorEventLoop prior to 3.6.6 (bpo-26819)
+    MIN_PYTHON_VERSION = (3, 6, 6)
+else:
+    MIN_PYTHON_VERSION = (3, 6, 2)
+
+if sys.version_info < MIN_PYTHON_VERSION:
+    print(
+        f"Python {'.'.join(map(str, MIN_PYTHON_VERSION))} is required to run Red, but you have "
+        f"{sys.version}! Please update Python."
+    )
+    sys.exit(1)
 
 if discord.version_info.major < 1:
     print(
         "You are not running the rewritten version of discord.py.\n\n"
-        "In order to use Red v3 you MUST be running d.py version"
-        " >= 1.0.0."
+        "In order to use Red V3 you MUST be running d.py version "
+        "1.0.0 or greater."
     )
     sys.exit(1)
+
+
+colorama.init()
 
 # Filter fuzzywuzzy slow sequence matcher warning
 warnings.filterwarnings("ignore", module=r"fuzzywuzzy.*")

--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -25,13 +25,20 @@ from redbot.core.cli import confirm
 if sys.platform == "linux":
     import distro
 
-PYTHON_OK = sys.version_info >= (3, 6, 2)
 INTERACTIVE_MODE = not len(sys.argv) > 1  # CLI flags = non-interactive
 
 INTRO = "==========================\nRed Discord Bot - Launcher\n==========================\n"
 
 IS_WINDOWS = os.name == "nt"
 IS_MAC = sys.platform == "darwin"
+
+if IS_WINDOWS:
+    # Due to issues with ProactorEventLoop prior to 3.6.6 (bpo-26819)
+    MIN_PYTHON_VERSION = (3, 6, 6)
+else:
+    MIN_PYTHON_VERSION = (3, 6, 2)
+
+PYTHON_OK = sys.version_info >= MIN_PYTHON_VERSION
 
 
 def is_venv():
@@ -461,9 +468,11 @@ def main_menu():
 
 def main():
     if not PYTHON_OK:
-        raise RuntimeError(
-            "Red requires Python 3.6.2 or greater. Please install the correct version!"
+        print(
+            f"Python {'.'.join(map(str, MIN_PYTHON_VERSION))} is required to run Red, but you "
+            f"have {sys.version}! Please update Python."
         )
+        sys.exit(1)
     if args.debuginfo:  # Check first since the function triggers an exit
         debug_info()
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ requirements = [
 
 python_requires = ">=3.6.2,<3.8"
 if os.name == "nt":
+    # Due to issues with ProactorEventLoop prior to 3.6.6 (bpo-26819)
     python_requires = ">=3.6.6,<3.8"
 
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,10 @@ requirements = [
     "yarl==1.2.6",
 ]
 
+python_requires = ">=3.6.2,<3.8"
+if os.name == "nt":
+    python_requires = ">=3.6.6,<3.8"
+
 
 def get_dependency_links():
     with open("dependency_links.txt") as file:
@@ -94,7 +98,7 @@ if __name__ == "__main__":
             ],
             "pytest11": ["red-discordbot = redbot.pytest"],
         },
-        python_requires=">=3.6.2,<3.8",
+        python_requires=python_requires,
         install_requires=requirements,
         dependency_links=get_dependency_links(),
         extras_require={


### PR DESCRIPTION
Due to a bug in ProactorEventLoop prior to 3.6.6, this is necessary, one user reported this last night straight after beta 21 was released.

Relevant bug: http://bugs.python.org/issue26819