### PR TITLE
[Audio] More robust startup and unload

### DIFF
--- a/redbot/cogs/audio/__init__.py
+++ b/redbot/cogs/audio/__init__.py
@@ -52,6 +52,6 @@ async def setup(bot: commands.Bot):
         await maybe_download_lavalink(bot.loop, cog)
         await start_lavalink_server(bot.loop)
 
+    await cog.initialize()
+
     bot.add_cog(cog)
-    bot.loop.create_task(cog.disconnect_timer())
-    bot.loop.create_task(cog.init_config())

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -666,3 +666,7 @@ class Streams:
     def __unload(self):
         if self.task:
             self.task.cancel()
+
+    def __del__(self):
+        if self.task:
+            self.task.cancel()

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -667,6 +667,4 @@ class Streams:
         if self.task:
             self.task.cancel()
 
-    def __del__(self):
-        if self.task:
-            self.task.cancel()
+    __del__ = __unload


### PR DESCRIPTION
Currently, Audio is loading before the Lavalink connection is properly established. This can cause problems if a user runs a command during the setup time.

Also, if Audio ever fails to load, the tasks and aiohttp sessions the cog created are destroyed whilst still pending/open. This causes an ugly traceback possibly other side-effects as well.

This change ensures the lavalink connection is established prior to load, and tasks are cancelled properly when audio is either deleted or unloaded.

This does the same for streams, which can have a similar cleanup problem to audio.