### PR TITLE
[Downloader] Parse tree URLs when cloning repos

### DIFF
--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -491,6 +491,7 @@ class Repo(RepoJSONMixin):
 
 class RepoManager:
 
+    GITHUB_OR_GITLAB_RE = re.compile("https?://git(?:hub)|(?:lab)\.com/")
     TREE_URL_RE = re.compile(r"(?P<tree>/tree)/(?P<branch>\S+)$")
 
     def __init__(self):
@@ -637,9 +638,10 @@ class RepoManager:
         return ret
 
     def _parse_url(self, url: str, branch: Optional[str]) -> Tuple[str, Optional[str]]:
-        tree_url_match = self.TREE_URL_RE.search(url)
-        if tree_url_match:
-            url = url[: tree_url_match.start("tree")]
-            if branch is None:
-                branch = tree_url_match["branch"]
-        return url, branch
+        if self.GITHUB_OR_GITLAB_RE.match(url):
+            tree_url_match = self.TREE_URL_RE.search(url)
+            if tree_url_match:
+                url = url[: tree_url_match.start("tree")]
+                if branch is None:
+                    branch = tree_url_match["branch"]
+            return url, branch

--- a/tests/cogs/downloader/test_downloader.py
+++ b/tests/cogs/downloader/test_downloader.py
@@ -94,3 +94,27 @@ async def test_existing_repo(repo_manager):
         await repo_manager.add_repo("http://test.com", "test")
 
     repo_manager.does_repo_exist.assert_called_once_with("test")
+
+
+def test_tree_url_parse(repo_manager):
+    cases = [
+        {
+            "input": ("https://github.com/Tobotimus/Tobo-Cogs", None),
+            "expected": ("https://github.com/Tobotimus/Tobo-Cogs", None),
+        },
+        {
+            "input": ("https://github.com/Tobotimus/Tobo-Cogs", "V3"),
+            "expected": ("https://github.com/Tobotimus/Tobo-Cogs", "V3"),
+        },
+        {
+            "input": ("https://github.com/Tobotimus/Tobo-Cogs/tree/V3", None),
+            "expected": ("https://github.com/Tobotimus/Tobo-Cogs", "V3"),
+        },
+        {
+            "input": ("https://github.com/Tobotimus/Tobo-Cogs/tree/V3", "V4"),
+            "expected": ("https://github.com/Tobotimus/Tobo-Cogs", "V4"),
+        },
+    ]
+
+    for test_case in cases:
+        assert test_case["expected"] == repo_manager._parse_url(*test_case["input"])


### PR DESCRIPTION
This addition handles a seemingly common misuse of `[p]repo add`, where users include the trailing `/tree/branch` part of a repo URL. The intended behaviour of how these are parsed should be explained by the supplied test case.