### PR TITLE
[Downloader] Fix URL parsing for non-GitHub/GitLab links

### DIFF
--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -644,4 +644,4 @@ class RepoManager:
                 url = url[: tree_url_match.start("tree")]
                 if branch is None:
                     branch = tree_url_match["branch"]
-            return url, branch
+        return url, branch

--- a/tests/cogs/downloader/test_downloader.py
+++ b/tests/cogs/downloader/test_downloader.py
@@ -118,3 +118,19 @@ def test_tree_url_parse(repo_manager):
 
     for test_case in cases:
         assert test_case["expected"] == repo_manager._parse_url(*test_case["input"])
+
+
+def test_tree_url_non_github(repo_manager):
+    cases = [
+        {
+            "input": ("https://gitlab.com/Tobotimus/Tobo-Cogs", None),
+            "expected": ("https://gitlab.com/Tobotimus/Tobo-Cogs", None),
+        },
+        {
+            "input": ("https://my.usgs.gov/bitbucket/scm/Tobotimus/Tobo-Cogs", "V3"),
+            "expected": ("https://my.usgs.gov/bitbucket/scm/Tobotimus/Tobo-Cogs", "V3"),
+        },
+    ]
+
+    for test_case in cases:
+        assert test_case["expected"] == repo_manager._parse_url(*test_case["input"])


### PR DESCRIPTION
Bug slipped through #2119