### PR TITLE
[V3 commands] Introduction to Red's converters + TimeConverter

### DIFF
--- a/docs/framework_commands.rst
+++ b/docs/framework_commands.rst
@@ -26,5 +26,5 @@ extend functionlities used throughout the bot, as outlined below.
 Converters
 ----------
 
-.. autoclass:: redbot.core.commands.TimeConverter
+.. automodule:: redbot.core.commands.converters
     :members:

--- a/docs/framework_commands.rst
+++ b/docs/framework_commands.rst
@@ -21,3 +21,10 @@ extend functionlities used throughout the bot, as outlined below.
 
 .. autoclass:: redbot.core.commands.Context
     :members:
+
+----------
+Converters
+----------
+
+.. autoclass:: redbot.core.commands.Time
+    :members:

--- a/docs/framework_commands.rst
+++ b/docs/framework_commands.rst
@@ -26,5 +26,5 @@ extend functionlities used throughout the bot, as outlined below.
 Converters
 ----------
 
-.. autoclass:: redbot.core.commands.Time
+.. autoclass:: redbot.core.commands.TimeConverter
     :members:

--- a/redbot/core/commands/__init__.py
+++ b/redbot/core/commands/__init__.py
@@ -2,4 +2,5 @@
 from discord.ext.commands import *
 from .commands import *
 from .context import *
+from .converters import *
 from .errors import *

--- a/redbot/core/commands/converters.py
+++ b/redbot/core/commands/converters.py
@@ -1,0 +1,64 @@
+import re
+from datetime import timedelta
+from . import Converter, Context, BadArgument
+
+__all__ = ["Time"]
+
+
+class Time(Converter):
+    """
+    Convert to a :class:`datetime.timedelta` class.
+
+    The converter supports seconds, minutes, hours and days.
+
+    Time can be attached to the unit (only use the first letter) or not
+    (then use the full word).
+
+    .. admonition:: Example
+
+    *   `50s` = `50 seconds` -> :class:`datetime.timedelta(seconds=50)`
+    *   `12m` = `12 minutes` -> :class:`datetime.timedelta(seconds=720)`
+    *   `4h` = `4 hours` -> :class:`datetime.timedelta(seconds=14400)`
+    *   `1d` = `1 day` -> :class:`datetime.timedelta(days=1)`
+
+    Using the converter with a command:
+    .. code-block:: python3
+
+        @commands.command()
+        async def timer(self, ctx, time: commands.Time):
+            await self.start_timer(time)
+
+    Using the converter manually:
+    .. code-block:: python3
+
+        async def convert_time(ctx: RedContext, text: str) -> datetime.timedelta:
+            time = await commands.Time.convert(ctx, text)
+            return time
+
+    Arguments
+    ---------
+    ctx: Context
+        The context of the command.
+    argument: str
+        The string you want to convert.
+
+    Returns
+    -------
+    datetime.timedelta
+        The :class:`datetime.timedelta` object.
+
+    Raises
+    ------
+    """
+
+    async def convert(ctx: Context, argument: str) -> timedelta:
+        TIME_RE = re.compile(
+            r"((?P<days>\d+?)\s?(d(ays?)?))?\s?((?P<hours>\d+?)\s?(hours?|hrs|hr?))?\s?((?P<minutes>\d+?)\s?(minutes?|mins?|m))?\s?((?P<seconds>\d+?)\s?(seconds?|secs?|s))?\s?",
+            re.I,
+        )
+        matches = TIME_RE.match(argument)
+        params = {k: int(v) for k, v in matches.groupdict().items() if None not in (k, v)}
+        time = timedelta(**params)
+        if str(time) == "0:00:00":
+            raise BadArgument("No time could be found.")
+        return time

--- a/redbot/core/commands/converters.py
+++ b/redbot/core/commands/converters.py
@@ -2,10 +2,10 @@ import re
 from datetime import timedelta
 from . import Converter, Context, BadArgument
 
-__all__ = ["Time"]
+__all__ = ["TimeConverter"]
 
 
-class Time(Converter):
+class TimeConverter(Converter):
     """
     Convert to a :class:`datetime.timedelta` class.
 

--- a/redbot/core/commands/converters.py
+++ b/redbot/core/commands/converters.py
@@ -39,7 +39,7 @@ def timedelta_converter(argument: str) -> timedelta:
         .. code-block:: python3
 
             async def convert_time(ctx: Context, text: str) -> datetime.timedelta:
-                time = await commands.TimedeltaConverter().convert(ctx, text)
+                time = commands.TimedeltaConverter().convert(ctx, text)
                 return time
 
     Arguments

--- a/redbot/core/commands/converters.py
+++ b/redbot/core/commands/converters.py
@@ -13,7 +13,7 @@ TIME_RE = re.compile(
 )
 
 
-class TimedeltaConverter(Converter):
+def timedelta_converter(argument: str) -> timedelta:
     """
     Convert to a :class:`datetime.timedelta` class.
 
@@ -45,35 +45,26 @@ class TimedeltaConverter(Converter):
             async def convert_time(ctx: Context, text: str) -> datetime.timedelta:
                 time = await commands.TimedeltaConverter().convert(ctx, text)
                 return time
+
+    Arguments
+    ---------
+    argument: str
+        The string you want to convert.
+
+    Returns
+    -------
+    datetime.timedelta
+        The :class:`datetime.timedelta` object.
+
+    Raises
+    ------
+    ~discord.ext.commands.BadArgument
+        No time was found from the given string.
     """
 
-    async def convert(self, ctx: "Context", argument: str) -> timedelta:
-        """
-        Manually convert a string to a :class:`datetime.timedelta` class.
-
-        .. warning:: This should not be called as a command function annotation.
-            This is for manual calls.
-
-        Arguments
-        ---------
-        ctx: Context
-            The context of the command.
-        argument: str
-            The string you want to convert.
-
-        Returns
-        -------
-        datetime.timedelta
-            The :class:`datetime.timedelta` object.
-
-        Raises
-        ------
-        ~discord.ext.commands.BadArgument
-            No time was found from the given string.
-        """
-        matches = TIME_RE.match(argument)
-        params = {k: int(v) for k, v in matches.groupdict().items() if None not in (k, v)}
-        if not params:
-            raise BadArgument("No time could be found.")
-        time = timedelta(**params)
-        return time
+    matches = TIME_RE.match(argument)
+    params = {k: int(v) for k, v in matches.groupdict().items() if None not in (k, v)}
+    if not params:
+        raise BadArgument("No time could be found.")
+    time = timedelta(**params)
+    return time

--- a/redbot/core/commands/converters.py
+++ b/redbot/core/commands/converters.py
@@ -48,7 +48,7 @@ class TimedeltaConverter(Converter):
 
     async def convert(self, ctx: "Context", argument: str) -> timedelta:
         """
-        Convert manually a string to a :class:`datetime.timedelta` class.
+        Manually convert a string to a :class:`datetime.timedelta` class.
 
         .. warning:: This should not be called as a command function annotation.
             This is for manual calls.

--- a/redbot/core/commands/converters.py
+++ b/redbot/core/commands/converters.py
@@ -7,8 +7,6 @@ from redbot.core.commands import Converter, BadArgument
 if TYPE_CHECKING:
     from .commands import Context
 
-__all__ = ["TimedeltaConverter"]
-
 TIME_RE = re.compile(
     r"((?P<days>\d+?)\s?(d(ays?)?))?\s?((?P<hours>\d+?)\s?(hours?|hrs|hr?))?\s?((?P<minutes>\d+?)\s?(minutes?|mins?|m))?\s?((?P<seconds>\d+?)\s?(seconds?|secs?|s))?\s?",
     re.I,

--- a/redbot/core/commands/converters.py
+++ b/redbot/core/commands/converters.py
@@ -36,7 +36,7 @@ class TimedeltaConverter(Converter):
         .. code-block:: python3
 
             @commands.command()
-            async def timer(self, ctx, time: commands.Timedelta):
+            async def timer(self, ctx, time: commands.TimedeltaConverter):
                 await self.start_timer(time)
 
         Using the converter manually:
@@ -44,14 +44,14 @@ class TimedeltaConverter(Converter):
         .. code-block:: python3
 
             async def convert_time(ctx: Context, text: str) -> datetime.timedelta:
-                time = await commands.Timedelta.convert(ctx, text)
+                time = await commands.TimedeltaConverter().convert(ctx, text)
                 return time
     """
 
     async def convert(self, ctx: "Context", argument: str) -> timedelta:
         """
         Convert manually a string to a :class:`datetime.timedelta` class.
-        
+
         .. warning:: This should not be called as a command function annotation.
             This is for manual calls.
 

--- a/redbot/core/commands/converters.py
+++ b/redbot/core/commands/converters.py
@@ -1,8 +1,18 @@
 import re
 from datetime import timedelta
-from . import Converter, Context, BadArgument
+from typing import TYPE_CHECKING
+
+from redbot.core.commands import Converter, BadArgument
+
+if TYPE_CHECKING:
+    from .commands import Context
 
 __all__ = ["TimedeltaConverter"]
+
+TIME_RE = re.compile(
+    r"((?P<days>\d+?)\s?(d(ays?)?))?\s?((?P<hours>\d+?)\s?(hours?|hrs|hr?))?\s?((?P<minutes>\d+?)\s?(minutes?|mins?|m))?\s?((?P<seconds>\d+?)\s?(seconds?|secs?|s))?\s?",
+    re.I,
+)
 
 
 class TimedeltaConverter(Converter):
@@ -38,7 +48,7 @@ class TimedeltaConverter(Converter):
                 return time
     """
 
-    async def convert(ctx: Context, argument: str) -> timedelta:
+    async def convert(self, ctx: "Context", argument: str) -> timedelta:
         """
         Convert manually a string to a :class:`datetime.timedelta` class.
         
@@ -62,13 +72,9 @@ class TimedeltaConverter(Converter):
         ~discord.ext.commands.BadArgument
             No time was found from the given string.
         """
-        TIME_RE = re.compile(
-            r"((?P<days>\d+?)\s?(d(ays?)?))?\s?((?P<hours>\d+?)\s?(hours?|hrs|hr?))?\s?((?P<minutes>\d+?)\s?(minutes?|mins?|m))?\s?((?P<seconds>\d+?)\s?(seconds?|secs?|s))?\s?",
-            re.I,
-        )
         matches = TIME_RE.match(argument)
         params = {k: int(v) for k, v in matches.groupdict().items() if None not in (k, v)}
-        time = timedelta(**params)
-        if str(time) == "0:00:00":
+        if not params:
             raise BadArgument("No time could be found.")
+        time = timedelta(**params)
         return time

--- a/redbot/core/commands/converters.py
+++ b/redbot/core/commands/converters.py
@@ -39,7 +39,7 @@ def timedelta_converter(argument: str) -> timedelta:
         .. code-block:: python3
 
             async def convert_time(ctx: Context, text: str) -> datetime.timedelta:
-                time = await commands.timedelta_converter(text)
+                time = commands.timedelta_converter(text)
                 return time
 
     Arguments

--- a/redbot/core/commands/converters.py
+++ b/redbot/core/commands/converters.py
@@ -2,10 +2,10 @@ import re
 from datetime import timedelta
 from . import Converter, Context, BadArgument
 
-__all__ = ["TimeConverter"]
+__all__ = ["TimedeltaConverter"]
 
 
-class TimeConverter(Converter):
+class TimedeltaConverter(Converter):
     """
     Convert to a :class:`datetime.timedelta` class.
 
@@ -26,7 +26,7 @@ class TimeConverter(Converter):
         .. code-block:: python3
 
             @commands.command()
-            async def timer(self, ctx, time: commands.Time):
+            async def timer(self, ctx, time: commands.Timedelta):
                 await self.start_timer(time)
 
         Using the converter manually:
@@ -34,7 +34,7 @@ class TimeConverter(Converter):
         .. code-block:: python3
 
             async def convert_time(ctx: Context, text: str) -> datetime.timedelta:
-                time = await commands.Time.convert(ctx, text)
+                time = await commands.Timedelta.convert(ctx, text)
                 return time
     """
 

--- a/redbot/core/commands/converters.py
+++ b/redbot/core/commands/converters.py
@@ -1,11 +1,7 @@
 import re
 from datetime import timedelta
-from typing import TYPE_CHECKING
 
-from redbot.core.commands import Converter, BadArgument
-
-if TYPE_CHECKING:
-    from .commands import Context
+from redbot.core.commands import BadArgument
 
 TIME_RE = re.compile(
     r"((?P<days>\d+?)\s?(d(ays?)?))?\s?((?P<hours>\d+?)\s?(hours?|hrs|hr?))?\s?((?P<minutes>\d+?)\s?(minutes?|mins?|m))?\s?((?P<seconds>\d+?)\s?(seconds?|secs?|s))?\s?",

--- a/redbot/core/commands/converters.py
+++ b/redbot/core/commands/converters.py
@@ -35,7 +35,8 @@ class TimedeltaConverter(Converter):
 
             @commands.command()
             async def timer(self, ctx, time: commands.TimedeltaConverter):
-                await self.start_timer(time)
+                await asyncio.sleep(time.total_seconds())
+                await ctx.send("Time's up!")
 
         Using the converter manually:
 

--- a/redbot/core/commands/converters.py
+++ b/redbot/core/commands/converters.py
@@ -16,42 +16,52 @@ class Time(Converter):
 
     .. admonition:: Example
 
-    *   `50s` = `50 seconds` -> :class:`datetime.timedelta(seconds=50)`
-    *   `12m` = `12 minutes` -> :class:`datetime.timedelta(seconds=720)`
-    *   `4h` = `4 hours` -> :class:`datetime.timedelta(seconds=14400)`
-    *   `1d` = `1 day` -> :class:`datetime.timedelta(days=1)`
+        *   ``50s`` = ``50 seconds`` -> :class:`datetime.timedelta(seconds=50)`
+        *   ``12m`` = ``12 minutes`` -> :class:`datetime.timedelta(seconds=720)`
+        *   ``4h`` = ``4 hours`` -> :class:`datetime.timedelta(seconds=14400)`
+        *   ``1d`` = ``1 day`` -> :class:`datetime.timedelta(days=1)`
 
-    Using the converter with a command:
-    .. code-block:: python3
+        Using the converter with a command:
 
-        @commands.command()
-        async def timer(self, ctx, time: commands.Time):
-            await self.start_timer(time)
+        .. code-block:: python3
 
-    Using the converter manually:
-    .. code-block:: python3
+            @commands.command()
+            async def timer(self, ctx, time: commands.Time):
+                await self.start_timer(time)
 
-        async def convert_time(ctx: RedContext, text: str) -> datetime.timedelta:
-            time = await commands.Time.convert(ctx, text)
-            return time
+        Using the converter manually:
 
-    Arguments
-    ---------
-    ctx: Context
-        The context of the command.
-    argument: str
-        The string you want to convert.
+        .. code-block:: python3
 
-    Returns
-    -------
-    datetime.timedelta
-        The :class:`datetime.timedelta` object.
-
-    Raises
-    ------
+            async def convert_time(ctx: Context, text: str) -> datetime.timedelta:
+                time = await commands.Time.convert(ctx, text)
+                return time
     """
 
     async def convert(ctx: Context, argument: str) -> timedelta:
+        """
+        Convert manually a string to a :class:`datetime.timedelta` class.
+        
+        .. warning:: This should not be called as a command function annotation.
+            This is for manual calls.
+
+        Arguments
+        ---------
+        ctx: Context
+            The context of the command.
+        argument: str
+            The string you want to convert.
+
+        Returns
+        -------
+        datetime.timedelta
+            The :class:`datetime.timedelta` object.
+
+        Raises
+        ------
+        ~discord.ext.commands.BadArgument
+            No time was found from the given string.
+        """
         TIME_RE = re.compile(
             r"((?P<days>\d+?)\s?(d(ays?)?))?\s?((?P<hours>\d+?)\s?(hours?|hrs|hr?))?\s?((?P<minutes>\d+?)\s?(minutes?|mins?|m))?\s?((?P<seconds>\d+?)\s?(seconds?|secs?|s))?\s?",
             re.I,

--- a/redbot/core/commands/converters.py
+++ b/redbot/core/commands/converters.py
@@ -30,7 +30,7 @@ def timedelta_converter(argument: str) -> timedelta:
         .. code-block:: python3
 
             @commands.command()
-            async def timer(self, ctx, time: commands.TimedeltaConverter):
+            async def timer(self, ctx, time: commands.timedelta_converter):
                 await asyncio.sleep(time.total_seconds())
                 await ctx.send("Time's up!")
 
@@ -39,7 +39,7 @@ def timedelta_converter(argument: str) -> timedelta:
         .. code-block:: python3
 
             async def convert_time(ctx: Context, text: str) -> datetime.timedelta:
-                time = await commands.TimedeltaConverter().convert(ctx, text)
+                time = await commands.timedelta_converter(text)
                 return time
 
     Arguments


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes

This PR adds a `converters.py` file, following d.py's style. This comes with the `TimeConverter` converter, which converts a string to a `datetime.timedelta` unit. It can be called manually or be used as a function annotation, like other converters.

You can provide many types of strings and this will be converted to a valid class, thanks @mikeshardmind for the regex thing.

This PR will be needed for the future timed mute, that should be made by me if everything's alright.

### Example

- `5m` > `timedelta(seconds=300)`
- `10 minutes` > `timedelta(seconds=600)`
- `1 second` > `timedelta(seconds=1)`
- `5d` > `timedelta(days=5)`

### Documentation

![](https://screenshotscdn.firefoxusercontent.com/images/b26967b8-c820-4704-a30a-698bb16c8d89.png)