### PR TITLE
[V3 Audio] Check if player is playing when pausing

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -747,6 +747,8 @@ class Audio:
                 return await self._embed_msg(ctx, "You need the DJ role to pause songs.")
 
         command = ctx.invoked_with
+        if not player.current:
+            return await self._embed_msg(ctx, "Nothing playing.")
         if "localtracks/" in player.current.uri:
             description = "**{}**\n{}".format(
                 player.current.title, player.current.uri.replace("localtracks/", "")


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Audio errors out if someone uses pause/resume when the player is stopped, this resolves that issue.