### PR TITLE
[V3] Utilize shorten_by

### DIFF
--- a/redbot/cogs/trivia/trivia.py
+++ b/redbot/cogs/trivia/trivia.py
@@ -368,7 +368,7 @@ class Trivia:
             return
         leaderboard = self._get_leaderboard(data, key, top)
         ret = []
-        for page in pagify(leaderboard):
+        for page in pagify(leaderboard, shorten_by=10):
             ret.append(await ctx.send(box(page, lang="py")))
         return ret
 

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -70,7 +70,6 @@ class Warnings:
     @commands.guild_only()
     async def action_add(self, ctx: commands.Context, name: str, points: int):
         """Create an action to be taken at a specified point count
-
         Duplicate action names are not allowed
         """
         guild = ctx.guild
@@ -215,7 +214,6 @@ class Warnings:
     @checks.admin_or_permissions(ban_members=True)
     async def warn(self, ctx: commands.Context, user: discord.Member, reason: str):
         """Warn the user for the specified reason
-
         Reason must be a registered reason, or "custom" if custom reasons are allowed
         """
         if user == ctx.author:
@@ -296,7 +294,6 @@ class Warnings:
     @commands.guild_only()
     async def warnings(self, ctx: commands.Context, userid: int = None):
         """Show warnings for the specified user.
-
         If userid is None, show warnings for the person running the command
         Note that showing warnings for users other than yourself requires
         appropriate permissions
@@ -330,7 +327,9 @@ class Warnings:
                     msg += "{} point warning {} issued by {} for {}\n".format(
                         user_warnings[key]["points"], key, mod, user_warnings[key]["description"]
                     )
-                await ctx.send_interactive(pagify(msg, shorten_by=58), box_lang="Warnings for {}".format(user))
+                await ctx.send_interactive(
+                    pagify(msg, shorten_by=58), box_lang="Warnings for {}".format(user)
+                )
 
     @commands.command()
     @commands.guild_only()

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -330,7 +330,7 @@ class Warnings:
                     msg += "{} point warning {} issued by {} for {}\n".format(
                         user_warnings[key]["points"], key, mod, user_warnings[key]["description"]
                     )
-                await ctx.send_interactive(pagify(msg), box_lang="Warnings for {}".format(user))
+                await ctx.send_interactive(pagify(msg, shorten_by=58), box_lang="Warnings for {}".format(user))
 
     @commands.command()
     @commands.guild_only()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -422,7 +422,7 @@ class Core(CoreLogic):
             destination = ctx.channel
 
         if self.bot._last_exception:
-            for page in pagify(self.bot._last_exception):
+            for page in pagify(self.bot._last_exception, shorten_by=10):
                 await destination.send(box(page, lang="py"))
         else:
             await ctx.send("No exception has occurred yet")
@@ -1070,7 +1070,7 @@ class Core(CoreLogic):
             if not locale_list:
                 await ctx.send("No languages found.")
                 return
-            pages = pagify("\n".join(locale_list))
+            pages = pagify("\n".join(locale_list), shorten_by=26)
 
         await ctx.send_interactive(pages, box_lang="Available Locales:")
 


### PR DESCRIPTION
### Type

- [X] Bugfix

### Description of the changes

Various files failed to properly utilize pagify's `shorten_by` kwarg, meaning they could cause bad requests due to >2000 characters despite the use of pagify.