### PR TITLE
[V3] Fix role check in local blacklist/whitelist

### DIFF
--- a/redbot/core/global_checks.py
+++ b/redbot/core/global_checks.py
@@ -26,7 +26,7 @@ def init_global_checks(bot):
         local_blacklist = await guild_settings.blacklist()
         local_whitelist = await guild_settings.whitelist()
 
-        _ids = [r.id for r in ctx.author.roles if not r.is_default]
+        _ids = [r.id for r in ctx.author.roles if not r.is_default()]
         _ids.append(ctx.author.id)
         if local_whitelist:
             return any(i in local_whitelist for i in _ids)


### PR DESCRIPTION
fixes #2133 , 

`discord.Role.is_default` is a method, not a property.

### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
