### PR TITLE
Fix compiler detection on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,13 +42,12 @@ def check_compiler_available():
     m = ccompiler.new_compiler()
 
     with tempfile.TemporaryDirectory() as tdir:
-        with tempfile.NamedTemporaryFile(prefix="dummy", suffix=".c", dir=tdir) as tfile:
-            tfile.write(b"int main(int argc, char** argv) {return 0;}")
-            tfile.seek(0)
-            try:
-                m.compile([tfile.name], output_dir=tdir)
-            except (CCompilerError, DistutilsPlatformError):
-                return False
+        with open(os.path.join(tdir, "dummy.c"), "w") as tfile:
+            tfile.write("int main(int argc, char** argv) {return 0;}")
+        try:
+            m.compile([tfile.name], output_dir=tdir)
+        except (CCompilerError, DistutilsPlatformError):
+            return False
     return True
 
 


### PR DESCRIPTION
Compiler detection failed previously on Windows, due to a FileNotFoundError being raised when trying to compile a dummy C file. This was likely to do with how tempfiles are created and destroyed on Windows, as it seemed to work fine on Linux.

What I've done to resolve this is simply compile an ordinary file, but remain within a temporary directory. This should does not appear to have any side effects from my testing on Windows (NTFS) and Ubuntu Bionic (Ext4).
