### PR TITLE
Data backend migration

### DIFF
--- a/docs/framework_config.rst
+++ b/docs/framework_config.rst
@@ -371,18 +371,3 @@ Driver Reference
 
 .. automodule:: redbot.core.drivers
     :members:
-
-Base Driver
-^^^^^^^^^^^
-.. autoclass:: redbot.core.drivers.red_base.BaseDriver
-    :members:
-
-JSON Driver
-^^^^^^^^^^^
-.. autoclass:: redbot.core.drivers.red_json.JSON
-    :members:
-
-Mongo Driver
-^^^^^^^^^^^^
-.. autoclass:: redbot.core.drivers.red_mongo.Mongo
-    :members:

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -9,7 +9,7 @@ from .data_manager import cog_data_path, core_data_path
 from .drivers import get_driver
 
 if TYPE_CHECKING:
-    from .drivers.red_base import BaseDriver
+    from .drivers import BaseDriver
 
 log = logging.getLogger("red.config")
 
@@ -63,7 +63,7 @@ class Value:
         element from a json document.
     default
         The default value for the data element that `identifiers` points at.
-    driver : `redbot.core.drivers.red_base.BaseDriver`
+    driver : `redbot.core.drivers.BaseDriver`
         A reference to `Config.driver`.
 
     """
@@ -171,7 +171,7 @@ class Group(Value):
         All registered default values for this Group.
     force_registration : `bool`
         Same as `Config.force_registration`.
-    driver : `redbot.core.drivers.red_base.BaseDriver`
+    driver : `redbot.core.drivers.BaseDriver`
         A reference to `Config.driver`.
 
     """
@@ -452,7 +452,7 @@ class Config:
         Unique identifier provided to differentiate cog data when name
         conflicts occur.
     driver
-        An instance of a driver that implements `redbot.core.drivers.red_base.BaseDriver`.
+        An instance of a driver that implements `redbot.core.drivers.BaseDriver`.
     force_registration : `bool`
         Determines if Config should throw an error if a cog attempts to access
         an attribute which has not been previously registered.

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1079,13 +1079,10 @@ class Core(CoreLogic):
     async def backup(self, ctx, backup_path: str = None):
         """Creates a backup of all data for the instance."""
         from redbot.core.data_manager import basic_config, instance_name
-        from redbot.core.drivers.red_json import JSON
 
         data_dir = Path(basic_config["DATA_PATH"])
         if basic_config["STORAGE_TYPE"] == "MongoDB":
-            from redbot.core.drivers.red_mongo import Mongo
-
-            m = Mongo("Core", **basic_config["STORAGE_DETAILS"])
+            m = drivers.Mongo("Core", **basic_config["STORAGE_DETAILS"])
             db = m.db
             collection_names = await db.collection_names(include_system_collections=False)
             for c_name in collection_names:
@@ -1098,7 +1095,7 @@ class Core(CoreLogic):
                 for item in docs:
                     item_id = str(item.pop("_id"))
                     output[item_id] = item
-                target = JSON(c_name, data_path_override=c_data_path)
+                target = drivers.JSON(c_name, data_path_override=c_data_path)
                 await target.jsonIO._threadsafe_save_json(output)
         backup_filename = "redv3-{}-{}.tar.gz".format(
             instance_name, ctx.message.created_at.strftime("%Y-%m-%d %H-%M-%S")

--- a/redbot/core/drivers/__init__.py
+++ b/redbot/core/drivers/__init__.py
@@ -1,11 +1,11 @@
 from typing import Type as _Type
 
-from .red_base import *
-from .red_json import *
-from .red_mongo import *
+from .red_base import BaseDriver
+from .red_json import JSON
+from .red_mongo import Mongo
 
 
-__all__ = ["BaseDriver", "JSON", "Mongo", "get_driver", "get_driver_cls"]
+__all__ = ["get_driver", "get_driver_cls", "BaseDriver", "JSON", "Mongo"]
 
 _DRIVER_CLASSES = {"json": JSON, "mongo": Mongo}
 

--- a/redbot/core/drivers/__init__.py
+++ b/redbot/core/drivers/__init__.py
@@ -1,34 +1,56 @@
+from typing import Type as _Type
+
 from .red_base import *
 from .red_json import *
 from .red_mongo import *
 
 
-__all__ = ["BaseDriver", "JSON", "Mongo", "get_driver"]
+__all__ = ["BaseDriver", "JSON", "Mongo", "get_driver", "get_driver_cls"]
+
+_DRIVER_CLASSES = {"json": JSON, "mongo": Mongo}
 
 
-def get_driver(type, *args, **kwargs):
-    """
-    Selectively import/load driver classes based on the selected type. This
-    is required so that dependencies can differ between installs (e.g. so that
-    you don't need to install a mongo dependency if you will just be running a
-    json data backend).
+def get_driver(storage_type: str, *args, **kwargs) -> BaseDriver:
+    """Get a new driver instance.
 
     .. note::
 
-        See the respective classes for information on what ``args`` and ``kwargs``
-        should be.
+        See the respective classes for information on what ``args``
+        and ``kwargs`` should be.
 
-    :param str type:
-        One of: json, mongo
-    :param args:
-        Dependent on driver type.
-    :param kwargs:
-        Dependent on driver type.
-    :return:
-        Subclass of :py:class:`.red_base.BaseDriver`.
+    Parameters
+    ----------
+    storage_type : str
+        The type of storage backend being used.
+    *args
+        Positional arguments passed to driver constructor.
+    **kwargs
+        Keyword arguments passed to driver constructor.
+
+    Returns
+    -------
+    BaseDriver
+        A new driver instance.
+
     """
-    if type == "JSON":
-        return JSON(*args, **kwargs)
-    elif type == "MongoDB":
-        return Mongo(*args, **kwargs)
-    raise RuntimeError("Invalid driver type: '{}'".format(type))
+    return get_driver_cls(storage_type)(*args, **kwargs)
+
+
+def get_driver_cls(storage_type: str) -> _Type[BaseDriver]:
+    """Get the class for the driver used by the given storage type.
+
+    Parameters
+    ----------
+    storage_type : str
+        The type of storage backend being used.
+
+    Returns
+    -------
+    Type[BaseDriver]
+        A class which subclasses `BaseDriver`.
+
+    """
+    try:
+        return _DRIVER_CLASSES[storage_type.lower()]
+    except KeyError:
+        raise RuntimeError(f"Invalid driver type: '{storage_type}'")

--- a/redbot/core/drivers/__init__.py
+++ b/redbot/core/drivers/__init__.py
@@ -1,4 +1,9 @@
-__all__ = ["get_driver"]
+from .red_base import *
+from .red_json import *
+from .red_mongo import *
+
+
+__all__ = ["BaseDriver", "JSON", "Mongo", "get_driver"]
 
 
 def get_driver(type, *args, **kwargs):
@@ -23,11 +28,7 @@ def get_driver(type, *args, **kwargs):
         Subclass of :py:class:`.red_base.BaseDriver`.
     """
     if type == "JSON":
-        from .red_json import JSON
-
         return JSON(*args, **kwargs)
     elif type == "MongoDB":
-        from .red_mongo import Mongo
-
         return Mongo(*args, **kwargs)
     raise RuntimeError("Invalid driver type: '{}'".format(type))

--- a/redbot/core/drivers/red_base.py
+++ b/redbot/core/drivers/red_base.py
@@ -1,8 +1,16 @@
+from typing import Any
+
 __all__ = ["BaseDriver"]
 
 
 class BaseDriver:
-    def __init__(self, cog_name, identifier):
+    """Abstract base class for drivers.
+
+    Storage backend drivers must implement all of this class's
+    methods.
+    """
+
+    def __init__(self, cog_name: str, identifier: str):
         self.cog_name = cog_name
         self.unique_cog_identifier = identifier
 
@@ -20,7 +28,7 @@ class BaseDriver:
         """
         raise NotImplementedError
 
-    async def get(self, *identifiers: str):
+    async def get(self, *identifiers: str) -> Any:
         """
         Finds the value indicate by the given identifiers.
 
@@ -37,7 +45,7 @@ class BaseDriver:
         """
         raise NotImplementedError
 
-    async def set(self, *identifiers: str, value=None):
+    async def set(self, *identifiers: str, value=None) -> None:
         """
         Sets the value of the key indicated by the given identifiers.
 
@@ -51,7 +59,7 @@ class BaseDriver:
         """
         raise NotImplementedError
 
-    async def clear(self, *identifiers: str):
+    async def clear(self, *identifiers: str) -> None:
         """
         Clears out the value specified by the given identifiers.
 

--- a/redbot/core/drivers/red_base.py
+++ b/redbot/core/drivers/red_base.py
@@ -7,7 +7,7 @@ class BaseDriver:
         self.unique_cog_identifier = identifier
 
     @staticmethod
-    def get_config_details():
+    def get_config_details() -> dict:
         """
         Asks users for additional configuration information necessary
         to use this config driver.
@@ -16,6 +16,7 @@ class BaseDriver:
         -------
         dict
             Dict of configuration details.
+
         """
         raise NotImplementedError
 
@@ -25,13 +26,14 @@ class BaseDriver:
 
         Parameters
         ----------
-        identifiers
+        *identifiers : str
             A list of identifiers that correspond to nested dict accesses.
 
         Returns
         -------
         Any
             Stored value.
+
         """
         raise NotImplementedError
 
@@ -41,10 +43,11 @@ class BaseDriver:
 
         Parameters
         ----------
-        identifiers
+        *identifiers : str
             A list of identifiers that correspond to nested dict accesses.
         value
             Any JSON serializable python object.
+
         """
         raise NotImplementedError
 
@@ -56,7 +59,8 @@ class BaseDriver:
 
         Parameters
         ----------
-        identifiers
+        *identifiers
             A list of identifiers that correspond to nested dict accesses.
+
         """
         raise NotImplementedError

--- a/redbot/core/drivers/red_base.py
+++ b/redbot/core/drivers/red_base.py
@@ -6,6 +6,19 @@ class BaseDriver:
         self.cog_name = cog_name
         self.unique_cog_identifier = identifier
 
+    @staticmethod
+    def get_config_details():
+        """
+        Asks users for additional configuration information necessary
+        to use this config driver.
+
+        Returns
+        -------
+        dict
+            Dict of configuration details.
+        """
+        raise NotImplementedError
+
     async def get(self, *identifiers: str):
         """
         Finds the value indicate by the given identifiers.
@@ -19,17 +32,6 @@ class BaseDriver:
         -------
         Any
             Stored value.
-        """
-        raise NotImplementedError
-
-    def get_config_details(self):
-        """
-        Asks users for additional configuration information necessary
-        to use this config driver.
-
-        Returns
-        -------
-            Dict of configuration details.
         """
         raise NotImplementedError
 

--- a/redbot/core/drivers/red_json.py
+++ b/redbot/core/drivers/red_json.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, Optional
 import copy
 import weakref
 import logging
@@ -34,24 +34,43 @@ def finalize_driver(cog_name):
 
 
 class JSON(BaseDriver):
-    """
-    Subclass of :py:class:`.red_base.BaseDriver`.
+    """JSON driver implementation.
 
-    .. py:attribute:: file_name
+    This backend is the easiest to set up, and suitable for most small
+    bots, however one should consider switching to a database backend
+    should their config files start to significantly grow in size
+    (e.g. if a single JSON grows larger than multiple MB), or the
+    access frequency greatly increases.
 
+    Parameters
+    ----------
+    cog_name : str
+        The name of the cog class. This will be the same as the name
+        of the folder containing the JSON file.
+    identifier : str
+        A unique identifier which will be the first key in the JSON
+        dict, to avoid any possible naming conflicts with other cogs.
+    data_path_override : Optional[pathlib.Path]
+        Where the JSON file will be saved.
+    file_name_override : str
+        The name of the JSON file, including the extension. defaults
+        to _settings.json_.
+
+    Attributes
+    ----------
+    file_name : str
         The name of the file in which to store JSON data.
+    data_path : pathlib.Path
+        The path in which to store the file indicated by `file_name`.
 
-    .. py:attribute:: data_path
-
-        The path in which to store the file indicated by :py:attr:`file_name`.
     """
 
     def __init__(
         self,
-        cog_name,
-        identifier,
+        cog_name: str,
+        identifier: str,
         *,
-        data_path_override: Path = None,
+        data_path_override: Optional[Path] = None,
         file_name_override: str = "settings.json"
     ):
         super().__init__(cog_name, identifier)
@@ -78,8 +97,8 @@ class JSON(BaseDriver):
         _shared_datastore[self.cog_name] = value
 
     @staticmethod
-    def get_config_details():
-        return
+    def get_config_details() -> dict:
+        return {}
 
     def _load_data(self):
         if self.cog_name not in _driver_counts:

--- a/redbot/core/drivers/red_json.py
+++ b/redbot/core/drivers/red_json.py
@@ -68,6 +68,7 @@ class JSON(BaseDriver):
         self.jsonIO = JsonIO(self.data_path)
 
         self._load_data()
+
     @property
     def data(self):
         return _shared_datastore.get(self.cog_name)

--- a/redbot/core/drivers/red_json.py
+++ b/redbot/core/drivers/red_json.py
@@ -68,7 +68,6 @@ class JSON(BaseDriver):
         self.jsonIO = JsonIO(self.data_path)
 
         self._load_data()
-
     @property
     def data(self):
         return _shared_datastore.get(self.cog_name)
@@ -76,6 +75,10 @@ class JSON(BaseDriver):
     @data.setter
     def data(self, value):
         _shared_datastore[self.cog_name] = value
+
+    @staticmethod
+    def get_config_details():
+        return
 
     def _load_data(self):
         if self.cog_name not in _driver_counts:
@@ -122,6 +125,3 @@ class JSON(BaseDriver):
             pass
         else:
             await self.jsonIO._threadsafe_save_json(self.data)
-
-    def get_config_details(self):
-        return

--- a/redbot/core/drivers/red_mongo.py
+++ b/redbot/core/drivers/red_mongo.py
@@ -15,6 +15,7 @@ _conn = None
 
 class MotorUnavailable(Exception):
     """Required dependencies for Mongo storage are unavailable."""
+
     pass
 
 

--- a/redbot/core/drivers/red_mongo.py
+++ b/redbot/core/drivers/red_mongo.py
@@ -41,9 +41,7 @@ def _initialize(**kwargs):
 
 
 class Mongo(BaseDriver):
-    """
-    Subclass of :py:class:`.red_base.BaseDriver`.
-    """
+    """MongoDB storage driver."""
 
     def __init__(self, cog_name, identifier, **kwargs):
         super().__init__(cog_name, identifier)
@@ -53,8 +51,7 @@ class Mongo(BaseDriver):
 
     @property
     def db(self) -> "motor.core.Database":
-        """
-        Gets the mongo database for this cog's name.
+        """motor.core.Database : The mongo database for this cog's name.
 
         .. warning::
 
@@ -62,13 +59,11 @@ class Mongo(BaseDriver):
             database is accessed. We will want to create a connection pool down the
             line to limit the number of connections.
 
-        :return:
-            PyMongo Database object.
         """
         return _conn.get_database()
 
     @staticmethod
-    def get_config_details():
+    def get_config_details() -> dict:
         host = input("Enter host address: ")
         port = int(input("Enter host port: "))
 
@@ -96,9 +91,11 @@ class Mongo(BaseDriver):
         Unless you are doing custom stuff ``collection_name`` should be one of the class
         attributes of :py:class:`core.config.Config`.
 
-        :param str collection_name:
-        :return:
-            PyMongo collection object.
+        Returns
+        -------
+        motor.core.Collection
+            The collection for this cog's data.
+
         """
         return self.db[self.cog_name]
 

--- a/redbot/migrate.py
+++ b/redbot/migrate.py
@@ -1,0 +1,124 @@
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from typing import Sequence, Optional, Any, Dict, List, Tuple, Awaitable, Callable
+
+from redbot.core import data_manager
+from redbot.core import drivers
+
+log = logging.getLogger(__name__)
+
+
+async def load_json_data():
+    core_data, cog_data = {}, {}
+    core_data_path = data_manager.core_data_path()
+    json_path = core_data_path / "settings.json"
+    if json_path.is_file():
+        with json_path.open() as file:
+            core_data = json.load(file)
+    else:
+        log.warning("Core settings.json seems to be missing, it should be at %s", json_path)
+
+    cog_data_path = data_manager.cog_data_path()
+    for path in cog_data_path.iterdir():
+        if not path.is_dir():
+            log.info("Skipping %s as it is not a directory", path)
+            continue
+        json_path = path / "settings.json"
+        if not json_path.is_file():
+            log.info("Skipping directory %s as it does not contain a settings.json.", path)
+            continue
+
+        with json_path.open() as file:
+            cog_data[path.stem] = json.load(file)
+
+    return core_data, cog_data
+
+
+class BaseDumper:
+    DriverCls: type
+
+    def __init__(self, core_data: Dict[str, Any], cog_data: Dict[str, Any]):
+        self.core_data: Dict[str, Any] = core_data
+        self.cog_data: Dict[str, Any] = cog_data
+        # noinspection PyUnresolvedReferences
+        storage_details = self.DriverCls.get_config_details()
+        self._core_driver: drivers.BaseDriver = self.DriverCls(
+            "Core", "0", data_path_override=data_manager.core_data_path(), **storage_details
+        )
+        self._cog_drivers: List[drivers.BaseDriver] = []
+        for cog_name, data in cog_data.items():
+            for identifier, cog_data in data.items():
+                self._cog_drivers.append(
+                    self.DriverCls(
+                        cog_name,
+                        identifier,
+                        data_path_override=data_manager.cog_data_path(raw_name=cog_name),
+                        **storage_details,
+                    )
+                )
+
+    async def _dump(self):
+        inner_core_data = self.core_data.get("0", {})
+        for key, value in inner_core_data.items():
+            await self._core_driver.set(key, value=value)
+        for cog_driver in self._cog_drivers:
+            cog_data = self.cog_data[cog_driver.cog_name][cog_driver.unique_cog_identifier]
+            for key, value in cog_data.items():
+                await cog_driver.set(key, value=value)
+
+    def __await__(self):
+        return self._dump().__await__()
+
+
+class MongoDumper(BaseDumper):
+    DriverCls = drivers.Mongo
+
+
+class JSONDumper(BaseDumper):
+    DriverCls = drivers.JSON
+
+
+LOADERS: Dict[str, Callable[[], Awaitable[Tuple[Dict, Dict]]]] = {"JSON": load_json_data}
+
+
+DUMPERS: Dict[str, Callable[[Dict, Dict], Awaitable[None]]] = {
+    "Mongo": MongoDumper,
+    "JSON": JSONDumper,
+}
+
+
+async def _migrate(load, dump):
+    await dump(*(await load()))
+
+
+def main(args: Optional[Sequence[str]] = None):
+    if args is None:
+        args = sys.argv[1:]
+
+    options = parse_cli_args(args)
+
+    data_manager.load_basic_configuration(options.instance)
+    cur_storage_type = data_manager.storage_type()
+    load = LOADERS[cur_storage_type]
+    dump = DUMPERS[options.migrate_to]
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(_migrate(load, dump))
+    print(
+        "Migration complete. You may now set up a new instance using redbot-setup "
+        "which utilises the migrated data."
+    )
+    return 0
+
+
+def parse_cli_args(args: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("instance")
+    parser.add_argument("migrate_to")
+    return parser.parse_args(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/redbot/migrate.py
+++ b/redbot/migrate.py
@@ -91,9 +91,7 @@ class MongoDumper(BaseDumper):
 
 LOADERS: Dict[str, Callable[[], Awaitable[Tuple[Dict, Dict]]]] = {"JSON": load_json_data}
 
-DUMPERS: Dict[str, Callable[[Dict, Dict], Awaitable[None]]] = {
-    "Mongo": MongoDumper,
-}
+DUMPERS: Dict[str, Callable[[Dict, Dict], Awaitable[None]]] = {"Mongo": MongoDumper}
 
 AVAILABLE_LOADERS_STR = ", ".join(LOADERS)
 AVAILABLE_DUMPERS_STR = ", ".join(DUMPERS)
@@ -120,7 +118,7 @@ def _parse_cli_args(args: Sequence[str]) -> argparse.Namespace:
         help=(
             "The name of the storage backend to migrate to. Valid backends: "
             + AVAILABLE_DUMPERS_STR
-        )
+        ),
     )
     return parser.parse_args(args)
 

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -20,7 +20,7 @@ from redbot.core.data_manager import (
 )
 from redbot.core.json_io import JsonIO
 from redbot.core.utils import safe_delete
-from redbot.core.drivers.red_json import JSON
+from redbot.core.drivers import JSON, Mongo
 
 config_dir = None
 appdir = appdirs.AppDirs("Red-DiscordBot")
@@ -158,9 +158,7 @@ def basic_setup():
     default_dirs["STORAGE_TYPE"] = storage_dict.get(storage, 1)
 
     if storage_dict.get(storage, 1) == "MongoDB":
-        from redbot.core.drivers.red_mongo import get_config_details
-
-        default_dirs["STORAGE_DETAILS"] = get_config_details()
+        default_dirs["STORAGE_DETAILS"] = Mongo.get_config_details()
     else:
         default_dirs["STORAGE_DETAILS"] = {}
 
@@ -175,8 +173,6 @@ def basic_setup():
 
 
 async def json_to_mongo(current_data_dir: Path, storage_details: dict):
-    from redbot.core.drivers.red_mongo import Mongo
-
     core_data_file = list(current_data_dir.glob("core/settings.json"))[0]
     m = Mongo("Core", "0", **storage_details)
     with core_data_file.open(mode="r") as f:
@@ -200,8 +196,6 @@ async def json_to_mongo(current_data_dir: Path, storage_details: dict):
 
 
 async def mongo_to_json(current_data_dir: Path, storage_details: dict):
-    from redbot.core.drivers.red_mongo import Mongo
-
     m = Mongo("Core", "0", **storage_details)
     db = m.db
     collection_names = await db.collection_names(include_system_collections=False)
@@ -268,9 +262,7 @@ async def edit_instance():
         storage_dict = {1: "JSON", 2: "MongoDB"}
         default_dirs["STORAGE_TYPE"] = storage_dict[storage]
         if storage_dict.get(storage, 1) == "MongoDB":
-            from redbot.core.drivers.red_mongo import get_config_details
-
-            storage_details = get_config_details()
+            storage_details = Mongo.get_config_details()
             default_dirs["STORAGE_DETAILS"] = storage_details
 
             if instance_data["STORAGE_TYPE"] == "JSON":
@@ -336,8 +328,6 @@ async def create_backup(selected, instance_data):
 
 async def remove_instance(selected, instance_data):
     if instance_data["STORAGE_TYPE"] == "MongoDB":
-        from redbot.core.drivers.red_mongo import Mongo
-
         m = Mongo("Core", **instance_data["STORAGE_DETAILS"])
         db = m.db
         collections = await db.collection_names(include_system_collections=False)

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -155,12 +155,8 @@ def basic_setup():
     storage = get_storage_type()
 
     storage_dict = {1: "JSON", 2: "MongoDB"}
-    default_dirs["STORAGE_TYPE"] = storage_dict.get(storage, 1)
-
-    if storage_dict.get(storage, 1) == "MongoDB":
-        default_dirs["STORAGE_DETAILS"] = Mongo.get_config_details()
-    else:
-        default_dirs["STORAGE_DETAILS"] = {}
+    default_dirs["STORAGE_TYPE"] = storage_type = storage_dict.get(storage, 1)
+    default_dirs["STORAGE_DETAILS"] = Mongo.get_config_details()
 
     name = get_name()
     save_config(name, default_dirs)

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ if __name__ == "__main__":
                 "redbot=redbot.__main__:main",
                 "redbot-setup=redbot.setup:main",
                 "redbot-launcher=redbot.launcher:main",
+                "redbot-migrate=redbot.migrate:main",
             ],
             "pytest11": ["red-discordbot = redbot.pytest"],
         },


### PR DESCRIPTION
This adds a fairly small script for migrating data from JSON to Mongo, and can be extended in the future for other backends if required. The script has a console entry point, `redbot-migrate`.

It operates by loading all of the data from an instance given its name, and dumping it to the destination storage backend. Users can then create a new instance which uses the new backend, and reference specify wherever they dumped the migrated data.

I've also cleaned up some other usage of the `redbot.core.drivers` package throughout the bot - no more lazy loading, driver classes are accessible at the top of the `redbot.core.drivers` package (it makes no sense to have to access a single class through a submodule as well) and some more documentation has been added.

This could also be used (although slightly cumbersome) to restore backed up JSON data to a mongo instance.