### PR TITLE
[V3 Core Events] Check module existence in should_log_sentry

### DIFF
--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -43,7 +43,7 @@ def should_log_sentry(exception) -> bool:
         tb = tb.tb_next
 
     module = tb_frame.f_globals.get("__name__")
-    return module.startswith("redbot")
+    return module is not None and module.startswith("redbot")
 
 
 def init_events(bot, cli_flags):


### PR DESCRIPTION
### Type

- [X] Bugfix

### Description of the changes

Allows for a lack of module (which returns False) for `should_log_sentry`. This allows for, say, commands to be added by the Dev cog. ( ͡ಠ ʖ̯ ͡ಠ)