### PR TITLE
[V3 Launcher] cli_flags when no instance (2)

### DIFF
--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -416,14 +416,14 @@ def main_menu():
         choice = user_choice()
         if choice == "1":
             instance = instance_menu()
-            cli_flags = cli_flag_getter()
             if instance:
+                cli_flags = cli_flag_getter()
                 run_red(instance, autorestart=True, cliflags=cli_flags)
             wait()
         elif choice == "2":
             instance = instance_menu()
-            cli_flags = cli_flag_getter()
             if instance:
+                cli_flags = cli_flag_getter()
                 run_red(instance, autorestart=False, cliflags=cli_flags)
             wait()
         elif choice == "3":


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
![image](https://user-images.githubusercontent.com/955640/45898983-a29b2780-bda9-11e8-8c7f-4300b3f251c8.png)

Same fix as #1497 , unsure why it was reverted.
Don't ask for cli_flags if no instance is found.