### PR TITLE
[V3 Config] Support MongoDB URIs

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -89,6 +89,12 @@
             ],
             "version": "==1.3.0"
         },
+        "dnspython": {
+            "hashes": [
+                "sha256:861e6e58faa730f9845aaaa9c6c832851fbf89382ac52915a51f89c71accdd31"
+            ],
+            "version": "==1.15.0"
+        },
         "e1839a8": {
             "editable": true,
             "extras": [

--- a/redbot/core/drivers/red_mongo.py
+++ b/redbot/core/drivers/red_mongo.py
@@ -9,7 +9,7 @@ _conn = None
 
 
 def _initialize(**kwargs):
-    uri = kwargs["URI"]
+    kwargs.get("URI", "mongodb")
     host = kwargs["HOST"]
     port = kwargs["PORT"]
     admin_user = kwargs["USERNAME"]

--- a/redbot/core/drivers/red_mongo.py
+++ b/redbot/core/drivers/red_mongo.py
@@ -9,18 +9,24 @@ _conn = None
 
 
 def _initialize(**kwargs):
+    uri = kwargs["URI"]
     host = kwargs["HOST"]
     port = kwargs["PORT"]
     admin_user = kwargs["USERNAME"]
     admin_pass = kwargs["PASSWORD"]
     db_name = kwargs.get("DB_NAME", "default_db")
 
+    if port is 0:
+        ports = ""
+    else:
+        ports = ":{}".format(port)
+
     if admin_user is not None and admin_pass is not None:
-        url = "mongodb://{}:{}@{}:{}/{}".format(
-            quote_plus(admin_user), quote_plus(admin_pass), host, port, db_name
+        url = "{}://{}:{}@{}{}/{}".format(
+            uri, quote_plus(admin_user), quote_plus(admin_pass), host, ports, db_name
         )
     else:
-        url = "mongodb://{}:{}/{}".format(host, port, db_name)
+        url = "{}://{}{}/{}".format(uri, host, ports, db_name)
 
     global _conn
     _conn = motor.motor_asyncio.AsyncIOMotorClient(url)
@@ -111,8 +117,22 @@ class Mongo(BaseDriver):
 
 
 def get_config_details():
+    uri = None
+    while True:
+        uri = input("Enter URI scheme (mongodb or mongodb+srv): ")
+        if uri is "":
+            uri = "mongodb"
+
+        if uri in ["mongodb", "mongodb+srv"]:
+            break
+        else:
+            print("Invalid URI scheme")
+
     host = input("Enter host address: ")
-    port = int(input("Enter host port: "))
+    if uri is "mongodb":
+        port = int(input("Enter host port: "))
+    else:
+        port = 0
 
     admin_uname = input("Enter login username: ")
     admin_password = input("Enter login password: ")
@@ -128,5 +148,6 @@ def get_config_details():
         "USERNAME": admin_uname,
         "PASSWORD": admin_password,
         "DB_NAME": db_name,
+        "URI": uri,
     }
     return ret

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
                 "pytest-asyncio==0.9.0",
                 "six==1.11.0",
             ],
-            "mongo": ["motor==2.0.0", "pymongo==3.7.1"],
+            "mongo": ["motor==2.0.0", "pymongo==3.7.1", "dnspython==1.15.0"],
             "docs": [
                 "alabaster==0.7.11",
                 "babel==2.6.0",


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes

Allows the user to specify using mongodb or mongodb+srv. Specifically adds support for MongoDB Clusters through use of DNS SRV records. This does add an additional dependency of dnspython