### PR TITLE
[V3 Cleanup] Cleanup Before command

### DIFF
--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -248,6 +248,42 @@ class Cleanup:
 
     @cleanup.command()
     @commands.guild_only()
+    async def before(
+        self, ctx: commands.Context, message_id: int, number: int, delete_pinned: bool = False
+    ):
+        """Deletes X messages before specified message.
+
+        To get a message id, enable developer mode in Discord's
+        settings, 'appearance' tab. Then right click a message
+        and copy its id.
+
+        This command only works on bots running as bot accounts.
+        """
+
+        channel = ctx.channel
+        if not channel.permissions_for(ctx.guild.me).manage_messages:
+            await ctx.send("I need the Manage Messages permission to do this.")
+            return
+        author = ctx.author
+
+        try:
+            before = await channel.get_message(message_id)
+        except discord.NotFound:
+            return await ctx.send(_("Message not found."))
+
+        to_delete = await self.get_messages_for_deletion(
+            channel=channel, number=number, before=before, delete_pinned=delete_pinned
+        )
+
+        reason = "{}({}) deleted {} messages in channel {}.".format(
+            author.name, author.id, len(to_delete), channel.name
+        )
+        log.info(reason)
+
+        await mass_purge(to_delete, channel)
+
+    @cleanup.command()
+    @commands.guild_only()
     async def messages(self, ctx: commands.Context, number: int, delete_pinned: bool = False):
         """Deletes last X messages.
 

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -220,8 +220,6 @@ class Cleanup:
         To get a message id, enable developer mode in Discord's
         settings, 'appearance' tab. Then right click a message
         and copy its id.
-
-        This command only works on bots running as bot accounts.
         """
 
         channel = ctx.channel
@@ -256,8 +254,6 @@ class Cleanup:
         To get a message id, enable developer mode in Discord's
         settings, 'appearance' tab. Then right click a message
         and copy its id.
-
-        This command only works on bots running as bot accounts.
         """
 
         channel = ctx.channel


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes

Adds the ability to cleanup before a specified message id. Requires passing a number of messages to delete to keep with syntax of `cleanup self/user`