### PR TITLE
[V3 Trivia] Append only takes one argument. This was silently failing

### DIFF
--- a/redbot/cogs/trivia/session.py
+++ b/redbot/cogs/trivia/session.py
@@ -311,9 +311,9 @@ def _parse_answers(answers):
     for answer in answers:
         if isinstance(answer, bool):
             if answer is True:
-                ret.append("True", "Yes")
+                ret.extend(["True", "Yes"])
             else:
-                ret.append("False", "No")
+                ret.extend(["False", "No"])
         else:
             ret.append(str(answer))
     # Uniquify list


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

This was incorrect syntax of `list.append` and was silently failing. Adjusted to use `list.extend`