### PR TITLE
[Black] Don't normalize underscores in numeric literals

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -92,7 +92,7 @@ Your PR will not be merged until all of these tests pass.
 ### 4.3 Style
 Our style checker of choice, [black](https://github.com/ambv/black), actually happens to be an auto-formatter. The checking functionality simply detects whether or not it would try to reformat something in your code, should you run the formatter on it. For this reason, we recommend using this tool as a formatter, regardless of any disagreements you might have with the style it enforces.
 
-Use the command `black --help` to see how to use this tool. The full style guide is explained in detail on [black's GitHub repository](https://github.com/ambv/black). **There is one exception to this**, however, which is that we set the line length to 99, instead of black's default 88. When using `black` on the command line, simply use it like so: `black -l 99 <src>`.
+Use the command `black --help` to see how to use this tool. The full style guide is explained in detail on [black's GitHub repository](https://github.com/ambv/black). **There is one exception to this**, however, which is that we set the line length to 99, instead of black's default 88. When using `black` on the command line, simply use it like so: `black -l 99 -N <src>`.
 
 ### 4.4 Make
 You may have noticed we have a `Makefile` and a `make.bat` in the top-level directory. For now, you can do two things with them:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 reformat:
-	black -l 99 `git ls-files "*.py"`
+	black -l 99 -N `git ls-files "*.py"`
 stylecheck:
-	black --check -l 99 `git ls-files "*.py"`
+	black --check -l 99 -N `git ls-files "*.py"`
 gettext:
 	redgettext --command-docstrings --verbose --recursive redbot --exclude-files "redbot/pytest/**/*"
 	crowdin upload

--- a/make.bat
+++ b/make.bat
@@ -14,11 +14,11 @@ for /F "tokens=* USEBACKQ" %%A in (`git ls-files "*.py"`) do (
 goto %1
 
 :reformat
-black -l 99 !PYFILES!
+black -l 99 -N !PYFILES!
 exit /B %ERRORLEVEL%
 
 :stylecheck
-black -l 99 --check !PYFILES!
+black -l 99 -N --check !PYFILES!
 exit /B %ERRORLEVEL%
 
 :help


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Black's new version (the one after what we currently have pinned in the repository) has a [new feature](https://github.com/ambv/black/issues/467) that IMO is particularly annoying for us since it's reformatting all config's identifiers (and other stuff in mod.py, such as dates and IDs).  
This should probably be merged after the next version bump, if deemed necessary.