### PR TITLE
[V3 Checks] Preserve backwards compatibility in deprecated functions

### DIFF
--- a/redbot/core/checks.py
+++ b/redbot/core/checks.py
@@ -57,7 +57,7 @@ def is_mod_or_superior(ctx: "Context") -> Awaitable[bool]:
         "release, please use `redbot.core.utils.mod.is_mod_or_superior` instead.",
         category=DeprecationWarning,
     )
-    return _is_mod_or_superior(ctx.bot, ctx.member)
+    return _is_mod_or_superior(ctx.bot, ctx.author)
 
 
 def is_admin_or_superior(ctx: "Context") -> Awaitable[bool]:
@@ -66,7 +66,7 @@ def is_admin_or_superior(ctx: "Context") -> Awaitable[bool]:
         "release, please use `redbot.core.utils.mod.is_admin_or_superior` instead.",
         category=DeprecationWarning,
     )
-    return _is_admin_or_superior(ctx.bot, ctx.member)
+    return _is_admin_or_superior(ctx.bot, ctx.author)
 
 
 def check_permissions(ctx: "Context", perms: Dict[str, bool]) -> Awaitable[bool]:

--- a/redbot/core/checks.py
+++ b/redbot/core/checks.py
@@ -51,22 +51,22 @@ def bot_in_a_guild():
     return _check_decorator(predicate)
 
 
-def is_mod_or_superior(bot: "Red", member: discord.Member) -> Awaitable[bool]:
+def is_mod_or_superior(ctx: "Context") -> Awaitable[bool]:
     warnings.warn(
         "`redbot.core.checks.is_mod_or_superior` is deprecated and will be removed in a future "
         "release, please use `redbot.core.utils.mod.is_mod_or_superior` instead.",
         category=DeprecationWarning,
     )
-    return _is_mod_or_superior(bot, member)
+    return _is_mod_or_superior(ctx.bot, ctx.member)
 
 
-def is_admin_or_superior(bot: "Red", member: discord.Member) -> Awaitable[bool]:
+def is_admin_or_superior(ctx: "Context") -> Awaitable[bool]:
     warnings.warn(
         "`redbot.core.checks.is_admin_or_superior` is deprecated and will be removed in a future "
         "release, please use `redbot.core.utils.mod.is_admin_or_superior` instead.",
         category=DeprecationWarning,
     )
-    return _is_admin_or_superior(bot, member)
+    return _is_admin_or_superior(ctx.bot, ctx.member)
 
 
 def check_permissions(ctx: "Context", perms: Dict[str, bool]) -> Awaitable[bool]:


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
#2149 changed the positional arguments of the non-decorator `checks` functions. This restores the singular Context argument.