### PR TITLE
[V3 Config] Add Group.clear_raw method

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -238,6 +238,29 @@ class Group(Value):
         else:
             return Value(identifiers=new_identifiers, default_value=None, driver=self.driver)
 
+    async def clear_raw(self, *nested_path: str):
+        """
+        Allows a developer to clear data as if it was stored in a standard
+        Python dictionary.
+
+        For example::
+
+            await conf.clear_raw("foo", "bar")
+
+            # is equivalent to
+
+            data = {"foo": {"bar": None}}
+            del data["foo"]["bar"]
+
+        Parameters
+        ----------
+        nested_path : str
+            Multiple arguments that mirror the arguments passed in for nested
+            dict access.
+        """
+        path = [str(p) for p in nested_path]
+        await self.driver.clear(*self.identifiers, *path)
+
     def is_group(self, item: str) -> bool:
         """A helper method for `__getattr__`. Most developers will have no need
         to use this.

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -225,6 +225,15 @@ async def test_set_dynamic_attr(config):
 
 
 @pytest.mark.asyncio
+async def test_clear_dynamic_attr(config):
+    await config.foo.set(True)
+    await config.clear_raw("foo")
+
+    with pytest.raises(KeyError):
+        await config.get_raw("foo")
+
+
+@pytest.mark.asyncio
 async def test_get_dynamic_attr(config):
     assert await config.get_raw("foobaz", default=True) is True
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [X] New feature

### Description of the changes
Adds a `clear_raw` method to Group objects, similar to the existing `get_raw` and `set_raw` methods.
Documentation included.