### PR TITLE
[V3 Mod] Mute / Unmute enhancements

### DIFF
--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -118,13 +118,6 @@ class Mod(commands.Cog):
                 "audit_type": "member_update",
             },
             {
-                "name": "vmute",
-                "default_setting": False,
-                "image": "\N{SPEAKER WITH CANCELLATION STROKE}",
-                "case_str": "Voice Mute",
-                "audit_type": "overwrite_update",
-            },
-            {
                 "name": "cmute",
                 "default_setting": False,
                 "image": "\N{SPEAKER WITH CANCELLATION STROKE}",
@@ -143,13 +136,6 @@ class Mod(commands.Cog):
                 "default_setting": True,
                 "image": "\N{SPEAKER WITH CANCELLATION STROKE}",
                 "case_str": "Server Mute",
-                "audit_type": "overwrite_update",
-            },
-            {
-                "name": "vunmute",
-                "default_setting": False,
-                "image": "\N{SPEAKER}",
-                "case_str": "Voice Unmute",
                 "audit_type": "overwrite_update",
             },
             {
@@ -866,56 +852,6 @@ class Mod(commands.Cog):
         """Mutes user in the channel/server"""
         pass
 
-    @mute.command(name="voice")
-    @commands.guild_only()
-    @mod_or_voice_permissions(mute_members=True)
-    @bot_has_voice_permissions(mute_members=True)
-    async def voice_mute(
-        self,
-        ctx: commands.Context,
-        user: discord.Member,
-        channel: Optional[discord.VoiceChannel] = None,
-        *,
-        reason: str = None,
-    ):
-        """Mutes the user in a voice channel"""
-        if not channel:
-            user_voice_state = user.voice
-            if not user_voice_state:
-                await ctx.send(_("No voice state for the target!"))
-                return
-
-            channel = user_voice_state.channel
-            if not channel:
-                await ctx.send(_("That user is not in a voice channel right now!"))
-
-        author = ctx.author
-        guild = ctx.guild
-        audit_reason = get_audit_reason(author, reason)
-
-        success, message = await self.mute_user(guild, channel, author, user, audit_reason)
-
-        if success:
-            await ctx.send(
-                _("Muted {}#{} in channel {}").format(user.name, user.discriminator, channel.name)
-            )
-            try:
-                await modlog.create_case(
-                    self.bot,
-                    guild,
-                    ctx.message.created_at,
-                    "vmute",
-                    user,
-                    author,
-                    reason,
-                    until=None,
-                    channel=channel,
-                )
-            except RuntimeError as e:
-                await ctx.send(e)
-        else:
-            await ctx.send(_("Mute failed. Reason: {}").format(message))
-
     @checks.mod_or_permissions(administrator=True)
     @mute.command(name="channel")
     @commands.guild_only()
@@ -1097,58 +1033,6 @@ class Mod(commands.Cog):
 
         Defaults to channel"""
         pass
-
-    @unmute.command(name="voice")
-    @commands.guild_only()
-    @mod_or_voice_permissions(mute_members=True)
-    @bot_has_voice_permissions(mute_members=True)
-    async def voice_unmute(
-        self,
-        ctx: commands.Context,
-        user: discord.Member,
-        channel: Optional[discord.VoiceChannel] = None,
-        *,
-        reason: str = None,
-    ):
-        """Unmutes the user in a voice channel"""
-        if not channel:
-            user_voice_state = user.voice
-            if not user_voice_state:
-                await ctx.send(_("No voice state for the target!"))
-                return
-
-            channel = user_voice_state.channel
-            if not channel:
-                await ctx.send(_("That user is not in a voice channel right now!"))
-
-        author = ctx.author
-        guild = ctx.guild
-        audit_reason = get_audit_reason(author, reason)
-
-        success, message = await self.unmute_user(guild, channel, author, user, audit_reason)
-
-        if success:
-            await ctx.send(
-                _("Unmuted {}#{} in channel {}").format(
-                    user.name, user.discriminator, channel.name
-                )
-            )
-            try:
-                await modlog.create_case(
-                    self.bot,
-                    guild,
-                    ctx.message.created_at,
-                    "vunmute",
-                    user,
-                    author,
-                    reason,
-                    until=None,
-                    channel=channel,
-                )
-            except RuntimeError as e:
-                await ctx.send(e)
-        else:
-            await ctx.send(_("Unmute failed. Reason: {}").format(message))
 
     @checks.mod_or_permissions(administrator=True)
     @unmute.command(name="channel")
@@ -1800,12 +1684,15 @@ class Mod(commands.Cog):
 
 
 mute_unmute_issues = {
-    "already_muted": "That user is already muted in this channel.",
-    "already_unmuted": "That user isn't muted in this channel!",
-    "hierarchy_problem": "I cannot let you do that. You are not higher than "
-    "the user in the role hierarchy.",
-    "is_admin": "That user cannot be muted, as they have the Administrator permission.",
-    "permissions_issue": "Failed to mute user. I need the manage roles "
-    "permission and the user I'm muting must be "
-    "lower than myself in the role hierarchy.",
+    "already_muted": _("That user is already muted in this channel."),
+    "already_unmuted": _("That user isn't muted in this channel."),
+    "hierarchy_problem": _(
+        "I cannot let you do that. You are not higher than " "the user in the role hierarchy."
+    ),
+    "is_admin": _("That user cannot be muted, as they have the Administrator permission."),
+    "permissions_issue": _(
+        "Failed to mute user. I need the manage roles "
+        "permission and the user I'm muting must be "
+        "lower than myself in the role hierarchy."
+    ),
 }

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -1,6 +1,7 @@
 import asyncio
 from datetime import datetime, timedelta
 from collections import deque, defaultdict, namedtuple
+from typing import Optional
 
 import discord
 
@@ -131,6 +132,13 @@ class Mod(commands.Cog):
                 "audit_type": "overwrite_update",
             },
             {
+                "name": "catmute",
+                "default_setting": False,
+                "image": "\N{SPEAKER WITH CANCELLATION STROKE}",
+                "case_str": "Category Mute",
+                "audit_type": "overwrite_update",
+            },
+            {
                 "name": "smute",
                 "default_setting": True,
                 "image": "\N{SPEAKER WITH CANCELLATION STROKE}",
@@ -149,6 +157,13 @@ class Mod(commands.Cog):
                 "default_setting": False,
                 "image": "\N{SPEAKER}",
                 "case_str": "Channel Unmute",
+                "audit_type": "overwrite_update",
+            },
+            {
+                "name": "catunmute",
+                "default_setting": False,
+                "image": "\N{SPEAKER}",
+                "case_str": "Category Unmute",
                 "audit_type": "overwrite_update",
             },
             {
@@ -855,56 +870,52 @@ class Mod(commands.Cog):
     @commands.guild_only()
     @mod_or_voice_permissions(mute_members=True)
     @bot_has_voice_permissions(mute_members=True)
-    async def voice_mute(self, ctx: commands.Context, user: discord.Member, *, reason: str = None):
+    async def voice_mute(self, ctx: commands.Context, user: discord.Member, channel: Optional[discord.VoiceChannel] = None, *, reason: str = None):
         """Mutes the user in a voice channel"""
-        user_voice_state = user.voice
-        guild = ctx.guild
-        author = ctx.author
-        if user_voice_state:
+        if not channel:
+            user_voice_state = user.voice
+            if not user_voice_state:
+                await ctx.send(_("No voice state for the target!"))
+                return
+        
             channel = user_voice_state.channel
-            if channel and channel.permissions_for(user).speak:
-                overwrites = channel.overwrites_for(user)
-                overwrites.speak = False
-                audit_reason = get_audit_reason(ctx.author, reason)
-                await channel.set_permissions(user, overwrite=overwrites, reason=audit_reason)
-                await ctx.send(
-                    _("Muted {}#{} in channel {}").format(
-                        user.name, user.discriminator, channel.name
-                    )
-                )
-                try:
-                    await modlog.create_case(
-                        self.bot,
-                        guild,
-                        ctx.message.created_at,
-                        "boicemute",
-                        user,
-                        author,
-                        reason,
-                        until=None,
-                        channel=channel,
-                    )
-                except RuntimeError as e:
-                    await ctx.send(e)
-                return
-            elif channel.permissions_for(user).speak is False:
-                await ctx.send(_("That user is already muted in {}!").format(channel.name))
-                return
-            else:
+            if not channel:
                 await ctx.send(_("That user is not in a voice channel right now!"))
+
+        author = ctx.author
+        guild = ctx.guild
+        audit_reason = get_audit_reason(author, reason)
+
+        success, message = await self.mute_user(guild, channel, author, user, audit_reason)
+
+        if success:
+            await ctx.send(_("Muted {}#{} in channel {}").format(user.name, user.discriminator, channel.name))
+            try:
+                await modlog.create_case(
+                    self.bot,
+                    guild,
+                    ctx.message.created_at,
+                    "vmute",
+                    user,
+                    author,
+                    reason,
+                    until=None,
+                    channel=channel,
+                )
+            except RuntimeError as e:
+                await ctx.send(e)
         else:
-            await ctx.send(_("No voice state for the target!"))
-            return
+            await ctx.send(_("Mute failed. Reason: {}").format(message))
 
     @checks.mod_or_permissions(administrator=True)
     @mute.command(name="channel")
     @commands.guild_only()
     async def channel_mute(
-        self, ctx: commands.Context, user: discord.Member, *, reason: str = None
+        self, ctx: commands.Context, user: discord.Member, channel: Optional[discord.TextChannel] = None, *, reason: str = None
     ):
-        """Mutes user in the current channel"""
-        author = ctx.message.author
-        channel = ctx.message.channel
+        """Mutes user in the specified channel"""
+        author = ctx.author
+        channel = channel or ctx.channel
         guild = ctx.guild
 
         if reason is None:
@@ -917,7 +928,7 @@ class Mod(commands.Cog):
         success, issue = await self.mute_user(guild, channel, author, user, audit_reason)
 
         if success:
-            await channel.send(_("User has been muted in this channel."))
+            await ctx.send(_("User has been muted in this channel."))
             try:
                 await modlog.create_case(
                     self.bot,
@@ -933,7 +944,45 @@ class Mod(commands.Cog):
             except RuntimeError as e:
                 await ctx.send(e)
         else:
-            await channel.send(issue)
+            await ctx.send(_("Mute failed. Reason: {}").format(issue))
+
+    @checks.mod_or_permissions(administrator=True)
+    @mute.command(name="category")
+    @commands.guild_only()
+    async def category_mute(self, ctx: commands.Context, user: discord.Member, category: Optional[discord.CategoryChannel] = None, *, reason: str = None):
+        """Mutes user in the specified category"""
+        author = ctx.message.author
+        guild = ctx.guild
+        audit_reason = get_audit_reason(author, reason)
+
+        category = category or ctx.channel.category
+        if not category:
+            channels = [c for c in guild.channels if not c.category and not isinstance(c, discord.CategoryChannel)]
+        else:
+            channels = [category, *category.channels]
+        author = ctx.message.author
+        guild = ctx.guild
+        audit_reason = get_audit_reason(author, reason)
+
+        mute_success = []
+        for channel in channels:
+            mute_success.append(await self.mute_user(guild, channel, author, user, audit_reason))
+            await asyncio.sleep(0.1)
+        await ctx.send(_("User has been muted in {} / {} channels in this category.").format(len([a for a in mute_success if a[0]]), len(mute_success)))
+        try:
+            await modlog.create_case(
+                self.bot,
+                guild,
+                ctx.message.created_at,
+                "catmute",
+                user,
+                author,
+                reason,
+                until=None,
+                channel=category,
+            )
+        except RuntimeError as e:
+            await ctx.send(e)
 
     @checks.mod_or_permissions(administrator=True)
     @mute.command(name="server", aliases=["guild"])
@@ -942,27 +991,13 @@ class Mod(commands.Cog):
         """Mutes user in the server"""
         author = ctx.message.author
         guild = ctx.guild
-        user_voice_state = user.voice
-        if reason is None:
-            audit_reason = "server mute requested by {} (ID {})".format(author, author.id)
-        else:
-            audit_reason = "server mute requested by {} (ID {}). Reason: {}".format(
-                author, author.id, reason
-            )
+        audit_reason = get_audit_reason(author, reason)
 
         mute_success = []
         for channel in guild.channels:
-            if not isinstance(channel, discord.TextChannel):
-                if channel.permissions_for(user).speak:
-                    overwrites = channel.overwrites_for(user)
-                    overwrites.speak = False
-                    audit_reason = get_audit_reason(ctx.author, reason)
-                    await channel.set_permissions(user, overwrite=overwrites, reason=audit_reason)
-            else:
-                success, issue = await self.mute_user(guild, channel, author, user, audit_reason)
-                mute_success.append((success, issue))
+            mute_success.append(await self.mute_user(guild, channel, author, user, audit_reason))
             await asyncio.sleep(0.1)
-        await ctx.send(_("User has been muted in this server."))
+        await ctx.send(_("User has been muted in {} / {} channels in this server.").format(len([a for a in mute_success if a[0]]), len(mute_success)))
         try:
             await modlog.create_case(
                 self.bot,
@@ -981,7 +1016,7 @@ class Mod(commands.Cog):
     async def mute_user(
         self,
         guild: discord.Guild,
-        channel: discord.TextChannel,
+        channel: discord.abc.GuildChannel,
         author: discord.Member,
         user: discord.Member,
         reason: str,
@@ -989,25 +1024,30 @@ class Mod(commands.Cog):
         """Mutes the specified user in the specified channel"""
         overwrites = channel.overwrites_for(user)
         permissions = channel.permissions_for(user)
-        perms_cache = await self.settings.member(user).perms_cache()
+        new_overs = {}
 
-        if overwrites.send_messages is False or permissions.send_messages is False:
+        if not isinstance(channel, discord.TextChannel):
+            new_overs.update(speak=False)
+        if not isinstance(channel, discord.VoiceChannel):
+            new_overs.update(send_messages=False, add_reactions=False)
+
+        if permissions.administrator:
+            return False, mute_unmute_issues["is_admin"]
+
+        if all(getattr(permissions, p) is False for p in new_overs.keys()):
             return False, mute_unmute_issues["already_muted"]
 
         elif not await is_allowed_by_hierarchy(self.bot, self.settings, guild, author, user):
             return False, mute_unmute_issues["hierarchy_problem"]
 
-        perms_cache[str(channel.id)] = {
-            "send_messages": overwrites.send_messages,
-            "add_reactions": overwrites.add_reactions,
-        }
-        overwrites.update(send_messages=False, add_reactions=False)
+        old_overs = {k: getattr(overwrites, k) for k in new_overs}
+        overwrites.update(**new_overs)
         try:
             await channel.set_permissions(user, overwrite=overwrites, reason=reason)
         except discord.Forbidden:
             return False, mute_unmute_issues["permissions_issue"]
         else:
-            await self.settings.member(user).perms_cache.set(perms_cache)
+            await self.settings.member(user).set_raw("perms_cache", str(channel.id), value=old_overs)
             return True, None
 
     @commands.group()
@@ -1024,59 +1064,57 @@ class Mod(commands.Cog):
     @mod_or_voice_permissions(mute_members=True)
     @bot_has_voice_permissions(mute_members=True)
     async def voice_unmute(
-        self, ctx: commands.Context, user: discord.Member, *, reason: str = None
+        self, ctx: commands.Context, user: discord.Member, channel: Optional[discord.VoiceChannel] = None, *, reason: str = None
     ):
         """Unmutes the user in a voice channel"""
-        user_voice_state = user.voice
-        if user_voice_state:
-            channel = user_voice_state.channel
-            if channel and channel.permissions_for(user).speak is False:
-                overwrites = channel.overwrites_for(user)
-                overwrites.speak = None
-                audit_reason = get_audit_reason(ctx.author, reason)
-                await channel.set_permissions(user, overwrite=overwrites, reason=audit_reason)
-                author = ctx.author
-                guild = ctx.guild
-                await ctx.send(
-                    _("Unmuted {}#{} in channel {}").format(
-                        user.name, user.discriminator, channel.name
-                    )
-                )
-                try:
-                    await modlog.create_case(
-                        self.bot,
-                        guild,
-                        ctx.message.created_at,
-                        "voiceunmute",
-                        user,
-                        author,
-                        reason,
-                        until=None,
-                        channel=channel,
-                    )
-                except RuntimeError as e:
-                    await ctx.send(e)
-            elif channel.permissions_for(user).speak:
-                await ctx.send(_("That user is already unmuted in {}!").format(channel.name))
+        if not channel:
+            user_voice_state = user.voice
+            if not user_voice_state:
+                await ctx.send(_("No voice state for the target!"))
                 return
-            else:
+        
+            channel = user_voice_state.channel
+            if not channel:
                 await ctx.send(_("That user is not in a voice channel right now!"))
+
+        author = ctx.author
+        guild = ctx.guild
+        audit_reason = get_audit_reason(author, reason)
+
+        success, message = await self.unmute_user(guild, channel, author, user, audit_reason)
+
+        if success:
+            await ctx.send(_("Unmuted {}#{} in channel {}").format(user.name, user.discriminator, channel.name))
+            try:
+                await modlog.create_case(
+                    self.bot,
+                    guild,
+                    ctx.message.created_at,
+                    "vunmute",
+                    user,
+                    author,
+                    reason,
+                    until=None,
+                    channel=channel,
+                )
+            except RuntimeError as e:
+                await ctx.send(e)
         else:
-            await ctx.send(_("No voice state for the target!"))
-            return
+            await ctx.send(_("Unmute failed. Reason: {}").format(message))
 
     @checks.mod_or_permissions(administrator=True)
     @unmute.command(name="channel")
     @commands.guild_only()
     async def channel_unmute(
-        self, ctx: commands.Context, user: discord.Member, *, reason: str = None
+        self, ctx: commands.Context, user: discord.Member, channel: Optional[discord.TextChannel] = None, *, reason: str = None
     ):
         """Unmutes user in the current channel"""
-        channel = ctx.channel
+        channel = channel or ctx.channel
         author = ctx.author
         guild = ctx.guild
+        audit_reason = get_audit_reason(author, reason)
 
-        success, message = await self.unmute_user(guild, channel, author, user)
+        success, message = await self.unmute_user(guild, channel, author, user, audit_reason)
 
         if success:
             await ctx.send(_("User unmuted in this channel."))
@@ -1098,6 +1136,46 @@ class Mod(commands.Cog):
             await ctx.send(_("Unmute failed. Reason: {}").format(message))
 
     @checks.mod_or_permissions(administrator=True)
+    @unmute.command(name="category")
+    @commands.guild_only()
+    async def category_unmute(
+        self, ctx: commands.Context, user: discord.Member, category: Optional[discord.CategoryChannel] = None, *, reason: str = None
+    ):
+        """Unmutes user in the category"""
+        guild = ctx.guild
+        author = ctx.author
+        audit_reason = get_audit_reason(author, reason)
+
+        category = category or ctx.channel.category
+        if not category:
+            channels = [c for c in guild.channels if not c.category and not isinstance(c, discord.CategoryChannel)]
+        else:
+            channels = [category, *category.channels]
+        guild = ctx.guild
+        author = ctx.author
+        audit_reason = get_audit_reason(author, reason)
+
+        unmute_success = []
+        for channel in channels:
+            unmute_success.append(await self.unmute_user(guild, channel, author, user, audit_reason))
+            await asyncio.sleep(0.1)
+        await ctx.send(_("User has been unmuted in {} / {} channels in this category.").format(len([a for a in unmute_success if a[0]]), len(unmute_success)))
+        try:
+            await modlog.create_case(
+                self.bot,
+                guild,
+                ctx.message.created_at,
+                "catunmute",
+                user,
+                author,
+                reason,
+                until=None,
+                channel=category,
+            )
+        except RuntimeError as e:
+            await ctx.send(e)
+
+    @checks.mod_or_permissions(administrator=True)
     @unmute.command(name="server", aliases=["guild"])
     @commands.guild_only()
     async def guild_unmute(
@@ -1106,20 +1184,13 @@ class Mod(commands.Cog):
         """Unmutes user in the server"""
         guild = ctx.guild
         author = ctx.author
-        channel = ctx.channel
+        audit_reason = get_audit_reason(author, reason)
 
         unmute_success = []
         for channel in guild.channels:
-            if not isinstance(channel, discord.TextChannel):
-                if channel.permissions_for(user).speak is False:
-                    overwrites = channel.overwrites_for(user)
-                    overwrites.speak = None
-                    audit_reason = get_audit_reason(author, reason)
-                    await channel.set_permissions(user, overwrite=overwrites, reason=audit_reason)
-            success, message = await self.unmute_user(guild, channel, author, user)
-            unmute_success.append((success, message))
+            unmute_success.append(await self.unmute_user(guild, channel, author, user, audit_reason))
             await asyncio.sleep(0.1)
-        await ctx.send(_("User has been unmuted in this server."))
+        await ctx.send(_("User has been unmuted in {} / {} channels in this server.").format(len([a for a in unmute_success if a[0]]), len(unmute_success)))
         try:
             await modlog.create_case(
                 self.bot,
@@ -1130,6 +1201,7 @@ class Mod(commands.Cog):
                 author,
                 reason,
                 until=None,
+                channel=None,
             )
         except RuntimeError as e:
             await ctx.send(e)
@@ -1137,43 +1209,36 @@ class Mod(commands.Cog):
     async def unmute_user(
         self,
         guild: discord.Guild,
-        channel: discord.TextChannel,
+        channel: discord.abc.GuildChannel,
         author: discord.Member,
         user: discord.Member,
+        reason: str,
     ) -> (bool, str):
         overwrites = channel.overwrites_for(user)
-        permissions = channel.permissions_for(user)
         perms_cache = await self.settings.member(user).perms_cache()
 
-        if overwrites.send_messages or permissions.send_messages:
+        if channel.id in perms_cache:
+            old_values = perms_cache[channel.id]
+        else:
+            old_values = {"send_messages": None, "add_reactions": None, "speak": None}
+
+        if all(getattr(overwrites, k) == v for k, v in old_values.items()):
             return False, mute_unmute_issues["already_unmuted"]
 
         elif not await is_allowed_by_hierarchy(self.bot, self.settings, guild, author, user):
             return False, mute_unmute_issues["hierarchy_problem"]
 
-        if channel.id in perms_cache:
-            old_values = perms_cache[channel.id]
-        else:
-            old_values = {"send_messages": None, "add_reactions": None}
-        overwrites.update(
-            send_messages=old_values["send_messages"], add_reactions=old_values["add_reactions"]
-        )
-        is_empty = self.are_overwrites_empty(overwrites)
-
+        overwrites.update(**old_values)
         try:
-            if not is_empty:
-                await channel.set_permissions(user, overwrite=overwrites)
+            if overwrites.is_empty():
+                await channel.set_permissions(user, overwrite=None, reason=reason)
             else:
-                await channel.set_permissions(user, overwrite=None)
+                await channel.set_permissions(user, overwrite=overwrites, reason=reason)
         except discord.Forbidden:
             return False, mute_unmute_issues["permissions_issue"]
         else:
-            try:
-                del perms_cache[channel.id]
-            except KeyError:
-                pass
-            else:
-                await self.settings.member(user).perms_cache.set(perms_cache)
+            ids = (*self.settings.member(user).perms_cache.identifiers, str(channel.id))
+            await self.settings.driver.clear(*ids)
             return True, None
 
     @commands.group()
@@ -1653,18 +1718,13 @@ class Mod(commands.Cog):
                 while len(nick_list) > 20:
                     nick_list.pop(0)
 
-    @staticmethod
-    def are_overwrites_empty(overwrites):
-        """There is currently no cleaner way to check if a
-        PermissionOverwrite object is empty"""
-        return [p for p in iter(overwrites)] == [p for p in iter(discord.PermissionOverwrite())]
-
 
 mute_unmute_issues = {
     "already_muted": "That user can't send messages in this channel.",
     "already_unmuted": "That user isn't muted in this channel!",
     "hierarchy_problem": "I cannot let you do that. You are not higher than "
     "the user in the role hierarchy.",
+    "is_admin": "That user cannot be muted, as they have the Administrator permission.",
     "permissions_issue": "Failed to mute user. I need the manage roles "
     "permission and the user I'm muting must be "
     "lower than myself in the role hierarchy.",

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -946,9 +946,13 @@ class Mod(commands.Cog):
                 len([v for v in mute_success.values() if v[0]]), len(mute_success), category
             )
         )
-        log.info(
-            "\n".join(f"{k.name} ({k.id}): {v[1]}" for k, v in mute_success.items() if not v[0])
+
+        to_log = "\n".join(
+            f"{k.name} ({k.id}): {v[1]}" for k, v in mute_success.items() if not v[0]
         )
+        if to_log:
+            log.info(to_log)
+
         try:
             await modlog.create_case(
                 self.bot,
@@ -984,9 +988,13 @@ class Mod(commands.Cog):
                 len([v for v in mute_success.values() if v[0]]), len(mute_success)
             )
         )
-        log.info(
-            "\n".join(f"{k.name} ({k.id}): {v[1]}" for k, v in mute_success.items() if not v[0])
+
+        to_log = "\n".join(
+            f"{k.name} ({k.id}): {v[1]}" for k, v in mute_success.items() if not v[0]
         )
+        if to_log:
+            log.info(to_log)
+
         try:
             await modlog.create_case(
                 self.bot,
@@ -1144,9 +1152,13 @@ class Mod(commands.Cog):
                 len([v for v in unmute_success.values() if v[0]]), len(unmute_success), category
             )
         )
-        log.info(
-            "\n".join(f"{k.name} ({k.id}): {v[1]}" for k, v in unmute_success.items() if not v[0])
+
+        to_log = "\n".join(
+            f"{k.name} ({k.id}): {v[1]}" for k, v in unmute_success.items() if not v[0]
         )
+        if to_log:
+            log.info(to_log)
+
         try:
             await modlog.create_case(
                 self.bot,
@@ -1184,9 +1196,13 @@ class Mod(commands.Cog):
                 len([v for v in unmute_success.values() if v[0]]), len(unmute_success)
             )
         )
-        log.info(
-            "\n".join(f"{k.name} ({k.id}): {v[1]}" for k, v in unmute_success.items() if not v[0])
+
+        to_log = "\n".join(
+            f"{k.name} ({k.id}): {v[1]}" for k, v in unmute_success.items() if not v[0]
         )
+        if to_log:
+            log.info(to_log)
+
         try:
             await modlog.create_case(
                 self.bot,

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -872,7 +872,9 @@ class Mod(commands.Cog):
         success, issue = await self.mute_user(guild, channel, author, user, audit_reason)
 
         if success:
-            await ctx.send(_("User has been muted in this channel."))
+            await ctx.send(
+                _("Muted {}#{} in channel {}").format(user.name, user.discriminator, channel.name)
+            )
             try:
                 await modlog.create_case(
                     self.bot,
@@ -926,8 +928,8 @@ class Mod(commands.Cog):
             )
             await asyncio.sleep(0.1)
         await ctx.send(
-            _("User has been muted in {} / {} channels in this category.").format(
-                len([v for v in mute_success.values() if v[0]]), len(mute_success)
+            _("User has been muted in {} / {} channels in category {}.").format(
+                len([v for v in mute_success.values() if v[0]]), len(mute_success), category
             )
         )
         log.info(
@@ -1054,7 +1056,11 @@ class Mod(commands.Cog):
         success, message = await self.unmute_user(guild, channel, author, user, audit_reason)
 
         if success:
-            await ctx.send(_("User unmuted in this channel."))
+            await ctx.send(
+                _("Unmuted {}#{} in channel {}").format(
+                    user.name, user.discriminator, channel.name
+                )
+            )
             try:
                 await modlog.create_case(
                     self.bot,
@@ -1108,8 +1114,8 @@ class Mod(commands.Cog):
             )
             await asyncio.sleep(0.1)
         await ctx.send(
-            _("User has been unmuted in {} / {} channels in this category.").format(
-                len([v for v in unmute_success.values() if v[0]]), len(unmute_success)
+            _("User has been unmuted in {} / {} channels in category {}.").format(
+                len([v for v in unmute_success.values() if v[0]]), len(unmute_success), category
             )
         )
         log.info(

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -845,12 +845,22 @@ class Mod(commands.Cog):
                 _("I cannot do that, I lack the '{}' permission.").format("Manage Nicknames")
             )
 
-    @commands.group()
+    @checks.mod_or_permissions(administrator=True)
+    @commands.group(invoke_without_command=True)
     @commands.guild_only()
-    @checks.mod_or_permissions(manage_channel=True)
-    async def mute(self, ctx: commands.Context):
-        """Mutes user in the channel/server"""
-        pass
+    async def mute(
+        self,
+        ctx: commands.Context,
+        user: discord.Member,
+        channel: Optional[discord.TextChannel] = None,
+        *,
+        reason: str = None,
+    ):
+        """Mutes user in the channel/server
+        
+        Defaults to channel"""
+        if not ctx.invoked_subcommand:
+            await ctx.invoke(self.channel_mute, user=user, channel=channel, reason=reason)
 
     @checks.mod_or_permissions(administrator=True)
     @mute.command(name="channel")
@@ -1027,14 +1037,22 @@ class Mod(commands.Cog):
             )
             return True, None
 
-    @commands.group()
+    @checks.mod_or_permissions(administrator=True)
+    @commands.group(invoke_without_command=True)
     @commands.guild_only()
-    @checks.mod_or_permissions(manage_channel=True)
-    async def unmute(self, ctx: commands.Context):
+    async def unmute(
+        self,
+        ctx: commands.Context,
+        user: discord.Member,
+        channel: Optional[discord.TextChannel] = None,
+        *,
+        reason: str = None,
+    ):
         """Unmutes user in the channel/server
 
         Defaults to channel"""
-        pass
+        if not ctx.invoked_subcommand:
+            await ctx.invoke(self.channel_unmute, user=user, channel=channel, reason=reason)
 
     @checks.mod_or_permissions(administrator=True)
     @unmute.command(name="channel")

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -870,14 +870,21 @@ class Mod(commands.Cog):
     @commands.guild_only()
     @mod_or_voice_permissions(mute_members=True)
     @bot_has_voice_permissions(mute_members=True)
-    async def voice_mute(self, ctx: commands.Context, user: discord.Member, channel: Optional[discord.VoiceChannel] = None, *, reason: str = None):
+    async def voice_mute(
+        self,
+        ctx: commands.Context,
+        user: discord.Member,
+        channel: Optional[discord.VoiceChannel] = None,
+        *,
+        reason: str = None
+    ):
         """Mutes the user in a voice channel"""
         if not channel:
             user_voice_state = user.voice
             if not user_voice_state:
                 await ctx.send(_("No voice state for the target!"))
                 return
-        
+
             channel = user_voice_state.channel
             if not channel:
                 await ctx.send(_("That user is not in a voice channel right now!"))
@@ -889,7 +896,9 @@ class Mod(commands.Cog):
         success, message = await self.mute_user(guild, channel, author, user, audit_reason)
 
         if success:
-            await ctx.send(_("Muted {}#{} in channel {}").format(user.name, user.discriminator, channel.name))
+            await ctx.send(
+                _("Muted {}#{} in channel {}").format(user.name, user.discriminator, channel.name)
+            )
             try:
                 await modlog.create_case(
                     self.bot,
@@ -911,7 +920,12 @@ class Mod(commands.Cog):
     @mute.command(name="channel")
     @commands.guild_only()
     async def channel_mute(
-        self, ctx: commands.Context, user: discord.Member, channel: Optional[discord.TextChannel] = None, *, reason: str = None
+        self,
+        ctx: commands.Context,
+        user: discord.Member,
+        channel: Optional[discord.TextChannel] = None,
+        *,
+        reason: str = None
     ):
         """Mutes user in the specified channel"""
         author = ctx.author
@@ -949,7 +963,14 @@ class Mod(commands.Cog):
     @checks.mod_or_permissions(administrator=True)
     @mute.command(name="category")
     @commands.guild_only()
-    async def category_mute(self, ctx: commands.Context, user: discord.Member, category: Optional[discord.CategoryChannel] = None, *, reason: str = None):
+    async def category_mute(
+        self,
+        ctx: commands.Context,
+        user: discord.Member,
+        category: Optional[discord.CategoryChannel] = None,
+        *,
+        reason: str = None
+    ):
         """Mutes user in the specified category"""
         author = ctx.message.author
         guild = ctx.guild
@@ -957,7 +978,11 @@ class Mod(commands.Cog):
 
         category = category or ctx.channel.category
         if not category:
-            channels = [c for c in guild.channels if not c.category and not isinstance(c, discord.CategoryChannel)]
+            channels = [
+                c
+                for c in guild.channels
+                if not c.category and not isinstance(c, discord.CategoryChannel)
+            ]
         else:
             channels = [category, *category.channels]
         author = ctx.message.author
@@ -968,7 +993,11 @@ class Mod(commands.Cog):
         for channel in channels:
             mute_success.append(await self.mute_user(guild, channel, author, user, audit_reason))
             await asyncio.sleep(0.1)
-        await ctx.send(_("User has been muted in {} / {} channels in this category.").format(len([a for a in mute_success if a[0]]), len(mute_success)))
+        await ctx.send(
+            _("User has been muted in {} / {} channels in this category.").format(
+                len([a for a in mute_success if a[0]]), len(mute_success)
+            )
+        )
         try:
             await modlog.create_case(
                 self.bot,
@@ -997,7 +1026,11 @@ class Mod(commands.Cog):
         for channel in guild.channels:
             mute_success.append(await self.mute_user(guild, channel, author, user, audit_reason))
             await asyncio.sleep(0.1)
-        await ctx.send(_("User has been muted in {} / {} channels in this server.").format(len([a for a in mute_success if a[0]]), len(mute_success)))
+        await ctx.send(
+            _("User has been muted in {} / {} channels in this server.").format(
+                len([a for a in mute_success if a[0]]), len(mute_success)
+            )
+        )
         try:
             await modlog.create_case(
                 self.bot,
@@ -1047,7 +1080,9 @@ class Mod(commands.Cog):
         except discord.Forbidden:
             return False, mute_unmute_issues["permissions_issue"]
         else:
-            await self.settings.member(user).set_raw("perms_cache", str(channel.id), value=old_overs)
+            await self.settings.member(user).set_raw(
+                "perms_cache", str(channel.id), value=old_overs
+            )
             return True, None
 
     @commands.group()
@@ -1064,7 +1099,12 @@ class Mod(commands.Cog):
     @mod_or_voice_permissions(mute_members=True)
     @bot_has_voice_permissions(mute_members=True)
     async def voice_unmute(
-        self, ctx: commands.Context, user: discord.Member, channel: Optional[discord.VoiceChannel] = None, *, reason: str = None
+        self,
+        ctx: commands.Context,
+        user: discord.Member,
+        channel: Optional[discord.VoiceChannel] = None,
+        *,
+        reason: str = None
     ):
         """Unmutes the user in a voice channel"""
         if not channel:
@@ -1072,7 +1112,7 @@ class Mod(commands.Cog):
             if not user_voice_state:
                 await ctx.send(_("No voice state for the target!"))
                 return
-        
+
             channel = user_voice_state.channel
             if not channel:
                 await ctx.send(_("That user is not in a voice channel right now!"))
@@ -1084,7 +1124,11 @@ class Mod(commands.Cog):
         success, message = await self.unmute_user(guild, channel, author, user, audit_reason)
 
         if success:
-            await ctx.send(_("Unmuted {}#{} in channel {}").format(user.name, user.discriminator, channel.name))
+            await ctx.send(
+                _("Unmuted {}#{} in channel {}").format(
+                    user.name, user.discriminator, channel.name
+                )
+            )
             try:
                 await modlog.create_case(
                     self.bot,
@@ -1106,7 +1150,12 @@ class Mod(commands.Cog):
     @unmute.command(name="channel")
     @commands.guild_only()
     async def channel_unmute(
-        self, ctx: commands.Context, user: discord.Member, channel: Optional[discord.TextChannel] = None, *, reason: str = None
+        self,
+        ctx: commands.Context,
+        user: discord.Member,
+        channel: Optional[discord.TextChannel] = None,
+        *,
+        reason: str = None
     ):
         """Unmutes user in the current channel"""
         channel = channel or ctx.channel
@@ -1139,7 +1188,12 @@ class Mod(commands.Cog):
     @unmute.command(name="category")
     @commands.guild_only()
     async def category_unmute(
-        self, ctx: commands.Context, user: discord.Member, category: Optional[discord.CategoryChannel] = None, *, reason: str = None
+        self,
+        ctx: commands.Context,
+        user: discord.Member,
+        category: Optional[discord.CategoryChannel] = None,
+        *,
+        reason: str = None
     ):
         """Unmutes user in the category"""
         guild = ctx.guild
@@ -1148,7 +1202,11 @@ class Mod(commands.Cog):
 
         category = category or ctx.channel.category
         if not category:
-            channels = [c for c in guild.channels if not c.category and not isinstance(c, discord.CategoryChannel)]
+            channels = [
+                c
+                for c in guild.channels
+                if not c.category and not isinstance(c, discord.CategoryChannel)
+            ]
         else:
             channels = [category, *category.channels]
         guild = ctx.guild
@@ -1157,9 +1215,15 @@ class Mod(commands.Cog):
 
         unmute_success = []
         for channel in channels:
-            unmute_success.append(await self.unmute_user(guild, channel, author, user, audit_reason))
+            unmute_success.append(
+                await self.unmute_user(guild, channel, author, user, audit_reason)
+            )
             await asyncio.sleep(0.1)
-        await ctx.send(_("User has been unmuted in {} / {} channels in this category.").format(len([a for a in unmute_success if a[0]]), len(unmute_success)))
+        await ctx.send(
+            _("User has been unmuted in {} / {} channels in this category.").format(
+                len([a for a in unmute_success if a[0]]), len(unmute_success)
+            )
+        )
         try:
             await modlog.create_case(
                 self.bot,
@@ -1188,9 +1252,15 @@ class Mod(commands.Cog):
 
         unmute_success = []
         for channel in guild.channels:
-            unmute_success.append(await self.unmute_user(guild, channel, author, user, audit_reason))
+            unmute_success.append(
+                await self.unmute_user(guild, channel, author, user, audit_reason)
+            )
             await asyncio.sleep(0.1)
-        await ctx.send(_("User has been unmuted in {} / {} channels in this server.").format(len([a for a in unmute_success if a[0]]), len(unmute_success)))
+        await ctx.send(
+            _("User has been unmuted in {} / {} channels in this server.").format(
+                len([a for a in unmute_success if a[0]]), len(unmute_success)
+            )
+        )
         try:
             await modlog.create_case(
                 self.bot,

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -1,7 +1,7 @@
 import asyncio
 from datetime import datetime, timedelta
 from collections import deque, defaultdict, namedtuple
-from typing import Optional
+from typing import Optional, Union
 
 import discord
 
@@ -852,7 +852,7 @@ class Mod(commands.Cog):
         self,
         ctx: commands.Context,
         user: discord.Member,
-        channel: Optional[discord.TextChannel] = None,
+        channel: Union[discord.TextChannel, discord.CategoryChannel, None] = None,
         *,
         reason: str = None,
     ):
@@ -860,7 +860,11 @@ class Mod(commands.Cog):
         
         Defaults to channel"""
         if not ctx.invoked_subcommand:
-            await ctx.invoke(self.channel_mute, user=user, channel=channel, reason=reason)
+            if isinstance(channel, discord.CategoryChannel):
+                command = self.category_mute
+            else:
+                command = self.channel_mute
+            await ctx.invoke(command, user=user, channel=channel, reason=reason)
 
     @checks.mod_or_permissions(administrator=True)
     @mute.command(name="channel")
@@ -1044,7 +1048,7 @@ class Mod(commands.Cog):
         self,
         ctx: commands.Context,
         user: discord.Member,
-        channel: Optional[discord.TextChannel] = None,
+        channel: Union[discord.TextChannel, discord.CategoryChannel, None] = None,
         *,
         reason: str = None,
     ):
@@ -1052,7 +1056,11 @@ class Mod(commands.Cog):
 
         Defaults to channel"""
         if not ctx.invoked_subcommand:
-            await ctx.invoke(self.channel_unmute, user=user, channel=channel, reason=reason)
+            if isinstance(channel, discord.CategoryChannel):
+                command = self.category_unmute
+            else:
+                command = self.channel_unmute
+            await ctx.invoke(command, user=user, channel=channel, reason=reason)
 
     @checks.mod_or_permissions(administrator=True)
     @unmute.command(name="channel")

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -1249,8 +1249,7 @@ class Mod(commands.Cog):
         except discord.Forbidden:
             return False, mute_unmute_issues["permissions_issue"]
         else:
-            ids = (*self.settings.member(user).perms_cache.identifiers, str(channel.id))
-            await self.settings.driver.clear(*ids)
+            await self.settings.member(user).clear_raw("perms_cache", str(channel.id))
             return True, None
 
     @commands.group()


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [x] New feature

### Description of the changes

- Resolves #2076 
- Remove the voice mute / unmute commands - due to a Discord limitation updating overwrites does not modify the member's permissions if the member is already in a voice channel. Mass mutes / unmutes still affect voice channels.
- Add category mute / unmute to mass mute / unmute all channels in a category. If used in a channel with no category, it will modify all channels without a category (excluding categories themselves).
- Helper methods mute_user and unmute_user now take GuildChannel instead of solely TextChannel.
- The bot will not attempt to mute a member with the Administrator permission, as that permission bypasses channel overwrites anyway. The bot will still unmute members with the Administrator permission (see #2076).
- Mass muting / unmuting now reports how many actions were successful, and how many actions were attempted.
- Issues when muting / unmuting are now translated. These issues are also info-logged when mass muting / unmuting.
- Channels and categories other than the current one can now be specified - this takes advantage of the new typing.Optional converter.
- Audit reasons are now specified for mass mutes / unmutes.
- mute and unmute now default to mute channel and unmute channel, and match the checks of their subcommands. If a category channel is passed to either, they will instead default to mute category and unmute category.