### PR TITLE
[V3 cleanup] Respect delete_pinned parameter

### DIFF
--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -96,7 +96,7 @@ class Cleanup(commands.Cog):
         ):
             if message.created_at < two_weeks_ago:
                 break
-            if check(message):
+            if message_filter(message):
                 collected.append(message)
                 if number and number <= len(collected):
                     break


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Cleanup's helper method to collect messages to delete was incorrectly filtering by check rather than message_filter, causing delete_after to be ignored.