### PR TITLE
[V3 Utils] Markdown helpers escape special chars

### DIFF
--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -67,6 +67,7 @@ def bold(text: str) -> str:
         The marked up text.
 
     """
+    text = escape(text, formatting=True)
     return "**{}**".format(text)
 
 
@@ -104,7 +105,10 @@ def inline(text: str) -> str:
         The marked up text.
 
     """
-    return "`{}`".format(text)
+    if "`" in text:
+        return "``{}``".format(text)
+    else:
+        return "`{}`".format(text)
 
 
 def italics(text: str) -> str:
@@ -121,6 +125,7 @@ def italics(text: str) -> str:
         The marked up text.
 
     """
+    text = escape(text, formatting=True)
     return "*{}*".format(text)
 
 
@@ -276,6 +281,7 @@ def strikethrough(text: str) -> str:
         The marked up text.
 
     """
+    text = escape(text, formatting=True)
     return "~~{}~~".format(text)
 
 
@@ -293,6 +299,7 @@ def underline(text: str) -> str:
         The marked up text.
 
     """
+    text = escape(text, formatting=True)
     return "__{}__".format(text)
 
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Implements #1841
From my tests escaping italics (`*`) that get passed to `italics()` doesn't work, the string still won't show up properly. If you can think of a way let me know.