### PR TITLE
[V3/Config] New config methods

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -151,6 +151,64 @@ class Value:
         """
         await self.driver.set(*self.identifiers, value=value)
 
+    async def inc(self, value: int) -> int:
+        """Increment and return the value of the data element pointed to by `identifiers`.
+
+        Example
+        -------
+        ::
+
+            # Increments and returns a global value "foo" by 3.
+            new = await conf.foo.inc(3)
+
+            # You can also decrement a value using by negative numbers
+            new = await conf.foo.inc(-3)
+
+            # Floats are also supported
+            new = await conf.foo.inc(3.834)
+
+        Parameters
+        ----------
+        value : int
+            Integer that will be used to increment a value.
+
+        Returns
+        -------
+        `int` or `float`
+            The stored value plus the value given as a integer or float.
+
+        """
+        if isinstance(self.default, bool) or not isinstance(self.default, (int, float)):
+            raise TypeError("Config inc method only supports integer or float values.")
+        try:
+            new_value = await self.driver.inc(*self.identifiers, value=value, default=self.default)
+        except TypeError as e:
+            raise TypeError("Config inc method requires an integer or float for value.") from e
+        return new_value
+
+    async def toggle(self) -> bool:
+        """Toggles a Boolean value between True and False as pointed to by `identifiers`.
+
+        Example
+        -------
+        ::
+
+            # Assume the global value "foo" is currently True.
+            # The following will change it to False, and return the result.
+            new = await conf.foo.toggle()
+
+        Returns
+        -------
+        `bool`
+            The opposite of the originally stored value.
+
+        """
+        if not isinstance(self.default, bool):
+            raise TypeError("Config toggle method can only toggle Boolean values.")
+
+        new_value = await self.driver.toggle(*self.identifiers, default=self.default)
+        return new_value
+
     async def clear(self):
         """
         Clears the value from record for the data element pointed to by `identifiers`.

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -386,6 +386,39 @@ async def test_value_ctxmgr_saves(config):
 
 
 @pytest.mark.asyncio
+async def test_toggle(config):
+    config.register_global(foo=True)
+    value = await config.list1.toggle()
+    assert value is False
+
+
+@pytest.mark.asyncio
+async def test_inc_values(config):
+    defaults = {"bar": 0, "baz": {"subgroup": 10}}
+    config.register_global(foo=defaults)
+    negative = await config.bar.inc(-5)
+    nested = await config.baz.subgroup.inc(10)
+    assert negative == -5
+    assert nested == 20
+
+
+@pytest.mark.asyncio
+async def test_toggle_bad_values(config):
+    config.register_global(foo=5)
+    with pytest.raises(TypeError):
+        await config.foo.toggle()
+
+
+@pytest.mark.asyncio
+async def test_inc_bad_values(config):
+    defaults = {"foo": "bar", "baz": True}
+    config.register_global(defaults)
+    with pytest.raises(TypeError):
+        await config.foo.inc(10)
+        await config.baz.inc(10)
+
+
+@pytest.mark.asyncio
 async def test_value_ctxmgr_immutable(config):
     config.register_global(foo=True)
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -412,7 +412,7 @@ async def test_toggle_bad_values(config):
 @pytest.mark.asyncio
 async def test_inc_bad_values(config):
     defaults = {"foo": "bar", "baz": True}
-    config.register_global(defaults)
+    config.register_global(foo=defaults)
     with pytest.raises(TypeError):
         await config.foo.inc(10)
         await config.baz.inc(10)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -388,7 +388,7 @@ async def test_value_ctxmgr_saves(config):
 @pytest.mark.asyncio
 async def test_toggle(config):
     config.register_global(foo=True)
-    value = await config.list1.toggle()
+    value = await config.foo.toggle()
     assert value is False
 
 
@@ -396,8 +396,8 @@ async def test_toggle(config):
 async def test_inc_values(config):
     defaults = {"bar": 0, "baz": {"subgroup": 10}}
     config.register_global(foo=defaults)
-    negative = await config.bar.inc(-5)
-    nested = await config.baz.subgroup.inc(10)
+    negative = await config.foo.bar.inc(-5)
+    nested = await config.foo.baz.subgroup.inc(10)
     assert negative == -5
     assert nested == 20
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -415,6 +415,7 @@ async def test_inc_bad_values(config):
     config.register_global(foo=defaults)
     with pytest.raises(TypeError):
         await config.foo.inc(10)
+    with pytest.raises(TypeError):
         await config.baz.inc(10)
 
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [X] New feature

### Description of the changes

This adds some quality of life methods to config. The two new operations are `inc` and `toggle`. These work like `set`, but for specific value types. They also return the new value. This aims to solve repetition in calling.

**Examples for Incrementing**
```py
# Add 3 to a number
new = await config.foo.inc(3)
await ctx.send(f"Incremented foo from {new - 3} to {new}.")

# Subtract 5
new = await config.foo.inc(-5)
await ctx.send(f"Incremented foo from {new - 5} to {new}.")
```
**Example for Toggle**
```py
new = await config.foo.toggle()
await ctx.send(f"Changed foo from {not new} to {new}.")
```

**Example of doing this without these methods**
```py
current = await config.foo()
await config.foo.set(value=(not current))
await ctx.send(f"Changed foo from {current} to {not current}.")
```
I included some tests, and this is working with the both the json and mongo drivers. This shouldn't break any current usage of config. 

**DISCLAIMER**
I'm setting this up to be implemented in 3.1 and not prior to release.

