### PR TITLE
[V3 mongo] Fix missing URI variable assignment

### DIFF
--- a/redbot/core/drivers/red_mongo.py
+++ b/redbot/core/drivers/red_mongo.py
@@ -9,7 +9,7 @@ _conn = None
 
 
 def _initialize(**kwargs):
-    kwargs.get("URI", "mongodb")
+    uri = kwargs.get("URI", "mongodb")
     host = kwargs["HOST"]
     port = kwargs["PORT"]
     admin_user = kwargs["USERNAME"]


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
#2159 was missing a variable assignment, causing NameErrors for mongodb users