### PR TITLE
V3/fix/info fix

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -13,7 +13,6 @@ from collections import namedtuple
 from pathlib import Path
 from random import SystemRandom
 from string import ascii_letters, digits
-from distutils.version import StrictVersion
 from typing import TYPE_CHECKING, Union
 
 import aiohttp
@@ -259,7 +258,7 @@ class Core(commands.Cog, CoreLogic):
         author_repo = "https://github.com/Twentysix26"
         org_repo = "https://github.com/Cog-Creators"
         red_repo = org_repo + "/Red-DiscordBot"
-        red_pypi = "https://pypi.python.org/pypi/Red-DiscordBot"
+        red_pypi = "https://pypi.org/pypi/Red-DiscordBot"
         support_server_url = "https://discord.gg/red"
         dpy_repo = "https://github.com/Rapptz/discord.py"
         python_url = "https://www.python.org/"
@@ -274,7 +273,13 @@ class Core(commands.Cog, CoreLogic):
         async with aiohttp.ClientSession() as session:
             async with session.get("{}/json".format(red_pypi)) as r:
                 data = await r.json()
-        outdated = StrictVersion(data["info"]["version"]) > StrictVersion(__version__)
+        newest_version_released_at = datetime.datetime.strptime(
+            data["releases"][data["info"]["version"], "%Y-%m-%dT%H:%M:%S"
+        )
+        installed_version_released_at = datetime.datetime.strptime(
+            data["releases"][__version__], "%Y-%m-%dT%H:%M:%S"
+        )
+        outdated = newest_version_released_at > installed_version_released_at
         about = (
             "This is an instance of [Red, an open source Discord bot]({}) "
             "created by [Twentysix]({}) and [improved by many]({}).\n\n"

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -13,7 +13,6 @@ from collections import namedtuple
 from pathlib import Path
 from random import SystemRandom
 from string import ascii_letters, digits
-from distutils.version import StrictVersion
 from typing import TYPE_CHECKING, Union
 
 import aiohttp
@@ -259,7 +258,7 @@ class Core(commands.Cog, CoreLogic):
         author_repo = "https://github.com/Twentysix26"
         org_repo = "https://github.com/Cog-Creators"
         red_repo = org_repo + "/Red-DiscordBot"
-        red_pypi = "https://pypi.python.org/pypi/Red-DiscordBot"
+        red_pypi = "https://pypi.org/pypi/Red-DiscordBot"
         support_server_url = "https://discord.gg/red"
         dpy_repo = "https://github.com/Rapptz/discord.py"
         python_url = "https://www.python.org/"
@@ -274,7 +273,13 @@ class Core(commands.Cog, CoreLogic):
         async with aiohttp.ClientSession() as session:
             async with session.get("{}/json".format(red_pypi)) as r:
                 data = await r.json()
-        outdated = StrictVersion(data["info"]["version"]) > StrictVersion(__version__)
+        newest_version_released_at = datetime.datetime.strptime(
+            data["releases"][data["info"]["version"][0]["upload_time"], "%Y-%m-%dT%H:%M:%S"
+        )
+        installed_version_released_at = datetime.datetime.strptime(
+            data["releases"][__version__][0]["upload_time"], "%Y-%m-%dT%H:%M:%S"
+        )
+        outdated = newest_version_released_at > installed_version_released_at
         about = (
             "This is an instance of [Red, an open source Discord bot]({}) "
             "created by [Twentysix]({}) and [improved by many]({}).\n\n"

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -3,8 +3,7 @@ import codecs
 import datetime
 import logging
 import traceback
-from datetime import timedelta
-from distutils.version import StrictVersion
+from datetime import timedelta, datetime
 from typing import List
 
 import aiohttp
@@ -127,9 +126,16 @@ def init_events(bot, cli_flags):
 
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.get("https://pypi.python.org/pypi/red-discordbot/json") as r:
+                async with session.get("{}/json".format(red_pypi)) as r:
                     data = await r.json()
-            if StrictVersion(data["info"]["version"]) > StrictVersion(red_version):
+            newest_version_released_at = datetime.strptime(
+                data["releases"][data["info"]["version"], "%Y-%m-%dT%H:%M:%S"
+            )
+            installed_version_released_at = datetime.strptime(
+                data["releases"][__version__], "%Y-%m-%dT%H:%M:%S"
+            )
+            outdated = newest_version_released_at > installed_version_released_at
+            if outdated:
                 INFO.append(
                     "Outdated version! {} is available "
                     "but you're using {}".format(data["info"]["version"], red_version)

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -3,8 +3,7 @@ import codecs
 import datetime
 import logging
 import traceback
-from datetime import timedelta
-from distutils.version import StrictVersion
+from datetime import timedelta, datetime
 from typing import List
 
 import aiohttp
@@ -127,9 +126,16 @@ def init_events(bot, cli_flags):
 
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.get("https://pypi.python.org/pypi/red-discordbot/json") as r:
+                async with session.get("{}/json".format(red_pypi)) as r:
                     data = await r.json()
-            if StrictVersion(data["info"]["version"]) > StrictVersion(red_version):
+            newest_version_released_at = datetime.strptime(
+                data["releases"][data["info"]["version"][0]["upload_time"], "%Y-%m-%dT%H:%M:%S"
+            )
+            installed_version_released_at = datetime.strptime(
+                data["releases"][red_version][0]["upload_time"], "%Y-%m-%dT%H:%M:%S"
+            )
+            outdated = newest_version_released_at > installed_version_released_at
+            if outdated:
                 INFO.append(
                     "Outdated version! {} is available "
                     "but you're using {}".format(data["info"]["version"], red_version)


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This fixes the issue with the info command in RC1 that relates to the outdated bot check (for good measure, I made the same changes to the message that appears on startup as well). I'm dropping the use of `distutils.version.StrictVersion` in favor of reading in the upload time for both the currently running release and the most recent release straight from PyPI's API (using `datetime.datetime.strptime` because `datetime.datetime.fromisoformat` is new in Python 3.7 and we support 3.6)