### PR TITLE
[V3 Alias] Fix alias help

### DIFF
--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -288,7 +288,10 @@ class Alias(commands.Cog):
         """Try to execute help for the base command of the alias."""
         is_alias, alias = await self.is_alias(ctx.guild, alias_name=alias_name)
         if is_alias:
-            base_cmd = alias.command[0]
+            if self.is_command(alias.command):
+                base_cmd = alias.command
+            else:
+                base_cmd = alias.command.rsplit(" ", 1)[0]
 
             new_msg = copy(ctx.message)
             new_msg.content = _("{prefix}help {command}").format(


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Alias help would only return the first character of the invoked command previously. This change shows help for basic commands that are aliased (i.e. just `ping`) or aliased commands that have an argument included (i.e. `audioset role beep` with `beep` being a role name)