### PR TITLE
[Audio] Fix type mismatch between config defaults and set value

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -48,7 +48,7 @@ class Audio(commands.Cog):
             "ws_port": "2332",
             "password": "youshallnotpass",
             "status": False,
-            "current_build": [3, 0, 0, "alpha", 0],
+            "current_build": redbot.core.VersionInfo.from_str("3.0.0a0").to_json(),
             "use_external_lavalink": False,
         }
 


### PR DESCRIPTION
current_build is now set as a dict, but its default was a list.

This resolves the error in `[p]audioset settings`.