### PR TITLE
[Dev] Use isawaitable over iscoroutine for [p]debug output

### DIFF
--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -116,7 +116,7 @@ class Dev(commands.Cog):
             await ctx.send(box("{}: {!s}".format(type(e).__name__, e), lang="py"))
             return
 
-        if asyncio.iscoroutine(result):
+        if inspect.isawaitable(result):
             result = await result
 
         self._last_result = result


### PR DESCRIPTION
Allows for non-coroutine awaitables (such as config's _ValueCtxManager) to be awaited from debug.