### PR TITLE
[CustomCom] Better display for [p]cc list

### DIFF
--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -8,9 +8,9 @@ from typing import Mapping, Tuple, Dict
 import discord
 
 from redbot.core import Config, checks, commands
-from redbot.core.utils.chat_formatting import box, pagify
 from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils import menus
+from redbot.core.utils.chat_formatting import box, pagify, escape
 from redbot.core.utils.predicates import MessagePredicate
 
 _ = Translator("CustomCommands", __file__)
@@ -347,12 +347,15 @@ class CustomCommands(commands.Cog):
                 result = responses
             else:
                 continue
-            if len(result) > 52:
-                result = result[:49] + "..."
             # Don't put a line-break in preview
             newline_pos = result.find("\n")
             if newline_pos != -1:
                 result = result[:newline_pos] + "..."
+            # Cut preview to 52 characters max
+            if len(result) > 52:
+                result = result[:49] + "..."
+            # Escape markdown and mass mentions
+            result = escape(result, formatting=True, mass_mentions=True)
             results.append((f"{ctx.clean_prefix}{command}", result))
 
         if await ctx.embed_requested():

--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -339,7 +339,7 @@ class CustomCommands(commands.Cog):
             return
 
         results = []
-        for command, body in cc_dict.items():
+        for command, body in sorted(cc_dict.items(), key=lambda t: t[0]):
             responses = body["response"]
             if isinstance(responses, list):
                 result = ", ".join(responses)

--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -326,7 +326,11 @@ class CustomCommands(commands.Cog):
     @customcom.command(name="list")
     @checks.bot_has_permissions(add_reactions=True)
     async def cc_list(self, ctx: commands.Context):
-        """List all available custom commands."""
+        """List all available custom commands.
+
+        The list displays a preview of each command's response, with
+        markdown escaped and newlines replaced with spaces.
+        """
         cc_dict = await CommandObj.get_commands(self.config.guild(ctx.guild))
 
         if not cc_dict:
@@ -347,13 +351,12 @@ class CustomCommands(commands.Cog):
                 result = responses
             else:
                 continue
-            # Don't put a line-break in preview
-            newline_pos = result.find("\n")
-            if newline_pos != -1:
-                result = result[:newline_pos] + "..."
+            # Replace newlines with spaces
             # Cut preview to 52 characters max
             if len(result) > 52:
                 result = result[:49] + "..."
+            # Replace newlines with spaces
+            result = result.replace("\n", " ")
             # Escape markdown and mass mentions
             result = escape(result, formatting=True, mass_mentions=True)
             results.append((f"{ctx.clean_prefix}{command}", result))

--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -349,9 +349,10 @@ class CustomCommands(commands.Cog):
                 continue
             if len(result) > 52:
                 result = result[:49] + "..."
+            # Don't put a line-break in preview
             newline_pos = result.find("\n")
             if newline_pos != -1:
-                result = result[:newline_pos]
+                result = result[:newline_pos] + "..."
             results.append((f"{ctx.clean_prefix}{command}", result))
 
         if await ctx.embed_requested():

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -515,6 +515,9 @@ class RepoManager:
     def __init__(self):
         self._repos = {}
 
+        loop = asyncio.get_event_loop()
+        loop.create_task(self._load_repos(set=True))  # str_name: Repo
+
     async def initialize(self):
         await self._load_repos(set=True)
 

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -515,9 +515,6 @@ class RepoManager:
     def __init__(self):
         self._repos = {}
 
-        loop = asyncio.get_event_loop()
-        loop.create_task(self._load_repos(set=True))  # str_name: Repo
-
     async def initialize(self):
         await self._load_repos(set=True)
 

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -825,7 +825,7 @@ class Mod(commands.Cog):
     @admin_or_voice_permissions(mute_members=True, deafen_members=True)
     @bot_has_voice_permissions(mute_members=True, deafen_members=True)
     async def voiceunban(self, ctx: commands.Context, user: discord.Member, *, reason: str = None):
-        """Unban a the user from speaking and listening in the server's voice channels."""
+        """Unban a user from speaking and listening in the server's voice channels."""
         user_voice_state = user.voice
         if user_voice_state is None:
             await ctx.send(_("No voice state for that user!"))


### PR DESCRIPTION
Uses a menu, optionally embedded with respect to the embed settings, for scrolling through the custom command list, each cc with a ~50 character preview. Format is purposefully similar to the help menu.

Resolves #2104.