### PR TITLE
[Warnings] Fix actions not being taken

### DIFF
--- a/redbot/cogs/warnings/helpers.py
+++ b/redbot/cogs/warnings/helpers.py
@@ -19,9 +19,11 @@ async def warning_points_add_check(
     act = {}
     async with guild_settings.actions() as registered_actions:
         for a in registered_actions:
+            # Actions are sorted in decreasing order of points.
+            # The first action we find where the user is above the threshold will be the
+            # highest action we can take.
             if points >= a["points"]:
                 act = a
-            else:
                 break
     if act and act["exceed_command"] is not None:  # some action needs to be taken
         await create_and_invoke_context(ctx, act["exceed_command"], user)

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -9,7 +9,7 @@ from redbot.cogs.warnings.helpers import (
     get_command_for_dropping_points,
     warning_points_remove_check,
 )
-from redbot.core import Config, modlog, checks, commands
+from redbot.core import Config, checks, commands
 from redbot.core.bot import Red
 from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils.mod import is_admin_or_superior
@@ -34,15 +34,14 @@ class Warnings(commands.Cog):
         self.config.register_guild(**self.default_guild)
         self.config.register_member(**self.default_member)
         self.bot = bot
-        loop = asyncio.get_event_loop()
-        loop.create_task(self.register_warningtype())
 
-    @staticmethod
-    async def register_warningtype():
-        try:
-            await modlog.register_casetype("warning", True, "\N{WARNING SIGN}", "Warning", None)
-        except RuntimeError:
-            pass
+    # We're not utilising modlog yet - no need to register a casetype
+    # @staticmethod
+    # async def register_warningtype():
+    #     try:
+    #         await modlog.register_casetype("warning", True, "\N{WARNING SIGN}", "Warning", None)
+    #     except RuntimeError:
+    #         pass
 
     @commands.group()
     @commands.guild_only()


### PR DESCRIPTION
When multiple warning actions were registered, and the user didn't exceed the points for the highest action on the list, no action was taken.

Resolves #2106.

Also commented out the casetype registration for warnings, since it's not actually using modlog yet.