### PR TITLE
[Audio] Rename current_build to current_version in Config

### DIFF
--- a/redbot/cogs/audio/__init__.py
+++ b/redbot/cogs/audio/__init__.py
@@ -34,14 +34,14 @@ async def download_lavalink(session):
 
 async def maybe_download_lavalink(loop, cog):
     jar_exists = LAVALINK_JAR_FILE.exists()
-    current_build = redbot.core.VersionInfo.from_json(await cog.config.current_build())
+    current_build = redbot.core.VersionInfo.from_json(await cog.config.current_version())
 
     if not jar_exists or current_build < redbot.core.version_info:
         log.info("Downloading Lavalink.jar")
         LAVALINK_DOWNLOAD_DIR.mkdir(parents=True, exist_ok=True)
         async with ClientSession(loop=loop) as session:
             await download_lavalink(session)
-        await cog.config.current_build.set(redbot.core.version_info.to_json())
+        await cog.config.current_version.set(redbot.core.version_info.to_json())
 
     shutil.copyfile(str(BUNDLED_APP_YML_FILE), str(APP_YML_FILE))
 

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -48,7 +48,7 @@ class Audio(commands.Cog):
             "ws_port": "2332",
             "password": "youshallnotpass",
             "status": False,
-            "current_build": redbot.core.VersionInfo.from_str("3.0.0a0").to_json(),
+            "current_version": redbot.core.VersionInfo.from_str("3.0.0a0").to_json(),
             "use_external_lavalink": False,
         }
 

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -192,7 +192,10 @@ class Group(Value):
     async def _get(self, default: Dict[str, Any] = ...) -> Dict[str, Any]:
         default = default if default is not ... else self.defaults
         raw = await super()._get(default)
-        return self.nested_update(raw, default)
+        if isinstance(raw, dict):
+            return self.nested_update(raw, default)
+        else:
+            return raw
 
     # noinspection PyTypeChecker
     def __getattr__(self, item: str) -> Union["Group", Value]:


### PR DESCRIPTION
The change introduced in #2201 caused the following traceback for users who hadn't previously loaded audio whilst on 3.0.0rc1.post1.

```py
Exception during loading of cog
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/redbot/core/core_commands.py", line 104, in _load
    await bot.load_extension(spec)
  File "/usr/local/lib/python3.7/dist-packages/redbot/core/bot.py", line 228, in load_extension
    await lib.setup(self)
  File "/usr/local/lib/python3.7/dist-packages/redbot/cogs/audio/__init__.py", line 52, in setup
    await maybe_download_lavalink(bot.loop, cog)
  File "/usr/local/lib/python3.7/dist-packages/redbot/cogs/audio/__init__.py", line 37, in maybe_download_lavalink
    current_build = redbot.core.VersionInfo.from_json(await cog.config.current_build())
  File "/usr/local/lib/python3.7/dist-packages/redbot/core/config.py", line 195, in _get
    return self.nested_update(raw, default)
  File "/usr/local/lib/python3.7/dist-packages/redbot/core/config.py", line 418, in nested_update
    for key, value in current.items():
AttributeError: 'list' object has no attribute 'items'
```

As a fix, I've simply renamed the `current_build` key to `current_version`. This means the `current_version` key will always be a dict and never a list, and `current_build` having no defaults means it won't mess with `[p]audioset settings`.