### PR TITLE
Fix permissions hook removal

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import os
 import logging
 from collections import Counter
@@ -236,20 +237,13 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):
         if cog is None:
             return
 
-        for when in ("before", "after"):
+        for cls in inspect.getmro(cog.__class__):
             try:
-                hook = getattr(cog, f"_{cog.__class__.__name__}__red_permissions_{when}")
+                hook = getattr(cog, f"_{cls.__name__}__permissions_hook")
             except AttributeError:
                 pass
             else:
-                self.remove_permissions_hook(hook, when)
-
-        try:
-            hook = getattr(cog, f"_{cog.__class__.__name__}__red_permissions_before")
-        except AttributeError:
-            pass
-        else:
-            self.remove_permissions_hook(hook)
+                self.remove_permissions_hook(hook)
 
         super().remove_cog(cogname)
 
@@ -390,10 +384,17 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):
             )
         if not hasattr(cog, "requires"):
             commands.Cog.__init__(cog)
+
+        for cls in inspect.getmro(cog.__class__):
+            try:
+                hook = getattr(cog, f"_{cls.__name__}__permissions_hook")
+            except AttributeError:
+                pass
+            else:
+                self.add_permissions_hook(hook)
+
         for attr in dir(cog):
             _attr = getattr(cog, attr)
-            if attr == f"_{cog.__class__.__name__}__permissions_hook":
-                self.add_permissions_hook(_attr)
             if isinstance(_attr, discord.ext.commands.Command) and not isinstance(
                 _attr, commands.Command
             ):


### PR DESCRIPTION
Some in-progress work slipped through #2149, and I figure it should be fixed before RC2.

I've also just decided to allow discovery of permissions hooks from superclasses as well. We should try to be more aware of the possibility of cog superclasses moving forward.