### PR TITLE
Config reserved keywords

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = python -msphinx
+SPHINXBUILD   = python3 -msphinx
 SPHINXPROJ    = Red-DiscordBot
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/framework_config.rst
+++ b/docs/framework_config.rst
@@ -175,8 +175,8 @@ example, :py:meth:`Config.clear_all_guilds` resets all guild data. For member
 data, you can clear on both a per-guild and guild-independent basis, see
 :py:meth:`Config.clear_all_members` for more info.
 
-.. warning:: You cannot use these words as values in your Config dictionnary
-    since it can break the classes:
+.. warning:: If you use the dot notation (``config.foo.bar()``), you cannot use these
+    words as values in your Config dictionnary since it can break the classes:
 
     ``_defaults`` ; ``_get`` ; ``all`` ; ``clear`` ``clear_raw`` ; ``default``
     ``defaults`` ; ``driver`` ; ``force_registration`` ; ``get_attr`` ;
@@ -185,6 +185,9 @@ data, you can clear on both a per-guild and guild-independent basis, see
 
     All Python reserved keywords, such as ``global`` or ``from``, should be
     avoided too.
+    
+    However, you can still use these keywords if you use the
+    ``get_attr``/``get_raw``/``set_raw``/``clear_raw`` methods.
 
 **************
 Advanced Usage

--- a/docs/framework_config.rst
+++ b/docs/framework_config.rst
@@ -175,6 +175,17 @@ example, :py:meth:`Config.clear_all_guilds` resets all guild data. For member
 data, you can clear on both a per-guild and guild-independent basis, see
 :py:meth:`Config.clear_all_members` for more info.
 
+.. warning:: You cannot use these words as values in your Config dictionnary
+    since it can break the classes:
+
+    ``_defaults`` ; ``_get`` ; ``all`` ; ``clear`` ``clear_raw`` ; ``default``
+    ``defaults`` ; ``driver`` ; ``force_registration`` ; ``get_attr`` ;
+    ``get_raw`` ; ``identifiers`` ; ``is_group`` ; ``is_value`` ;
+    ``nested_update`` ; ``set`` ; ``set_raw``
+
+    All Python reserved keywords, such as ``global`` or ``from``, should be
+    avoided too.
+
 **************
 Advanced Usage
 **************


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

This PR adds a small warning in the Config docs, explaining which values should **not** be used to prevent class breaking. I myself encountered a bug by using `default` as a value, and it wasn't specified that it shouldn't be used, so I made that quickly with the help of Sinbad.

I also modified the Python interpreter in `redbot/docs/Makefile` so it uses `python3` instead of `python`, was quite annoying for me since it was calling Python 2.7

### Preview

![screen shot 2018-10-13 at 17 52 10](https://user-images.githubusercontent.com/23153234/46907295-bfda9600-cf10-11e8-81d9-bb322a42a88e.png)
