### PR TITLE
[V3 Streams] toggle mentions on for roles being alerted

### DIFF
--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -28,7 +28,7 @@ from . import streamtypes as _streamtypes
 from collections import defaultdict
 import asyncio
 import re
-from typing import Optional, List
+from typing import Optional, List, Tuple
 
 CHECK_DELAY = 60
 
@@ -551,7 +551,10 @@ class Streams(commands.Cog):
                                 await role.edit(mentionable=False)
                         await self.save_streams()
 
-    async def _get_mention_str(self, guild: discord.Guild):
+    async def _get_mention_str(self, guild: discord.Guild) -> Tuple[str, List[discord.Role]]:
+        """Returns a 2-tuple with the string containing the mentions, and a list of
+        all roles which need to have their `mentionable` property set back to False.
+        """
         settings = self.db.guild(guild)
         mentions = []
         roles = []

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -396,9 +396,6 @@ class Streams(commands.Cog):
     async def role(self, ctx: commands.Context, *, role: discord.Role):
         """Toggle a role mention."""
         current_setting = await self.db.role(role).mention()
-        if not role.mentionable:
-            await ctx.send("That role is not mentionable!")
-            return
         if current_setting:
             await self.db.role(role).mention.set(False)
             await ctx.send(
@@ -408,11 +405,17 @@ class Streams(commands.Cog):
             )
         else:
             await self.db.role(role).mention.set(True)
-            await ctx.send(
-                _(
-                    "When a stream or community is live, `@\u200b{role.name}` will be mentioned."
-                ).format(role=role)
-            )
+            msg = _(
+                "When a stream or community is live, `@\u200b{role.name}` will be mentioned."
+            ).format(role=role)
+            if not role.mentionable:
+                msg += " " + _(
+                    "Since the role is not mentionable, it will be momentarily made mentionable "
+                    "when announcing a streamalert. Please make sure I have the correct "
+                    "permissions to manage this role, or else members of this role won't receive "
+                    "a notification."
+                )
+            await ctx.send(msg)
 
     @streamset.command()
     @commands.guild_only()


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #1831. Enables mentions for roles that aren't already mentionable, sends the message, then disables role mentions for roles it had to toggle that for