### PR TITLE
[V3 Help] Menus in help

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -52,7 +52,6 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):
             color=15158332,
             fuzzy=False,
             help__page_char_limit=1000,
-            help__max_pages_in_guild=2,
             help__tagline="",
             disabled_commands=[],
             disabled_command_msg="That command is disabled.",

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1014,25 +1014,6 @@ class Core(commands.Cog, CoreLogic):
         await ctx.bot.db.help.page_char_limit.set(limit)
         await ctx.send(_("Done. The character limit per page has been set to {}.").format(limit))
 
-    @helpset.command(name="maxpages")
-    async def helpset_maxpages(self, ctx: commands.Context, pages: int):
-        """Set the maximum number of help pages sent in a server channel.
-
-        This setting only applies to embedded help.
-
-        If a help message contains more pages than this value, the help message will
-        be sent to the command author via DM. This is to help reduce spam in server
-        text channels.
-
-        The default value is 2 pages.
-        """
-        if pages < 0:
-            await ctx.send(_("You must give a value of zero or greater!"))
-            return
-
-        await ctx.bot.db.help.max_pages_in_guild.set(pages)
-        await ctx.send(_("Done. The page limit has been set to {}.").format(pages))
-
     @helpset.command(name="tagline")
     async def helpset_tagline(self, ctx: commands.Context, *, tagline: str = None):
         """

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1074,7 +1074,6 @@ class Core(commands.Cog, CoreLogic):
         """Toggle whether help will be sent in a DM or not.
          If this is enabled, the help message will be sent to the
         command author via DM.
-        I
          The default value is None
         """
         current_setting = ctx.bot.pm_help

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1069,6 +1069,22 @@ class Core(commands.Cog, CoreLogic):
         await ctx.bot.db.help.tagline.set(tagline)
         await ctx.send(_("The tagline has been set to {}.").format(tagline[:1900]))
 
+    @helpset.command(name="dm")
+    async def helpset_toggle_dm(self, ctx: commands.Context):
+        """Toggle whether help will be sent in a DM or not.
+         If this is enabled, the help message will be sent to the
+        command author via DM.
+        I
+         The default value is None
+        """
+        current_setting = ctx.bot.pm_help
+        ctx.bot.pm_help = not current_setting
+        await ctx.send(
+            _("Done. Help will now be sent in {}.").format(
+                _("DMs") if not current_setting else _("the channel")
+            )
+        )
+
     @commands.command()
     @checks.is_owner()
     async def listlocales(self, ctx: commands.Context):

--- a/redbot/core/help_formatter.py
+++ b/redbot/core/help_formatter.py
@@ -327,9 +327,6 @@ async def help(ctx: commands.Context, *, command_name: str = ""):
         else:
             pages = await formatter.format_help_for(ctx, command)
 
-    max_pages_in_guild = await ctx.bot.db.help.max_pages_in_guild()
-    if len(pages) > max_pages_in_guild:
-        pm_destination = True
     if ctx.guild and not ctx.guild.me.permissions_in(ctx.channel).send_messages:
         pm_destination = True
     try:

--- a/redbot/core/help_formatter.py
+++ b/redbot/core/help_formatter.py
@@ -32,7 +32,7 @@ import inspect
 import itertools
 import re
 
-from redbot.core.utils import menus
+from .utils import menus
 from . import commands
 from .i18n import Translator
 from .utils.chat_formatting import pagify

--- a/redbot/core/help_formatter.py
+++ b/redbot/core/help_formatter.py
@@ -348,7 +348,7 @@ async def help(ctx: commands.Context, *, command_name: str = ""):
                 else:
                     await destination.send(page)
         else:
-            await menus.menu(ctx, pages, menus.DEFAULT_CONTROLS)
+            await menus.menu(ctx, pages, menus.DEFAULT_CONTROLS, timeout=60.0)
 
     except discord.Forbidden:
         await ctx.channel.send(

--- a/redbot/core/help_formatter.py
+++ b/redbot/core/help_formatter.py
@@ -23,20 +23,19 @@ discord.py 1.0.0a
 
 This help formatter contains work by Rapptz (Danny) and SirThane#1780.
 """
+import inspect
+import itertools
+import re
 from collections import namedtuple
 from typing import List, Optional, Union
 
 import discord
 from discord.ext.commands import formatter as dpy_formatter
-import inspect
-import itertools
-import re
 
-from .utils import menus
 from . import commands
 from .i18n import Translator
+from .utils import fuzzy_command_search, format_fuzzy_results, menus
 from .utils.chat_formatting import pagify
-from .utils import fuzzy_command_search, format_fuzzy_results
 
 _ = Translator("Help", __file__)
 

--- a/redbot/core/utils/menus.py
+++ b/redbot/core/utils/menus.py
@@ -89,7 +89,7 @@ async def menu(
             await message.clear_reactions()
         except discord.Forbidden:  # cannot remove all reactions
             for key in controls.keys():
-                await message.remove_reaction(key, ctx.bot.user)
+                await message.remove_reaction(key, ctx.me)
         return None
 
     return await controls[react.emoji](ctx, pages, controls, message, page, timeout, react.emoji)


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

This modifies the help_formatter to use the `utils.menus` system to display help on servers.

It does not use it for pm, as you cannot manage reactions in pm.

It uses the built in configuration for maximum page size to split cog commands into multiple pages.
It uses the built in `helpset pagecharlimit` to set a guideline on how many cogs are displayed per page.

This obsoletes `max_pages_in_guild` and so it is removed.