### PR TITLE
[V3 Permissions] Find things uniquely for models

### DIFF
--- a/redbot/cogs/permissions/converters.py
+++ b/redbot/cogs/permissions/converters.py
@@ -12,7 +12,7 @@ class GlobalUniqueObjectFinder(commands.Converter):
         objects = set(ctx.bot.get_all_channels())
         objects += set(ctx.bot.users)
         for guild in ctx.bot.guilds:
-            objects += {r for r in guild.roles if not r.is_default}
+            objects += {r for r in guild.roles if not r.is_default()}
             objects.add(guild)
 
         for func in (

--- a/redbot/cogs/permissions/converters.py
+++ b/redbot/cogs/permissions/converters.py
@@ -1,4 +1,4 @@
-import reports
+import re
 from typing import NamedTuple, Union, Optional, cast, Type
 
 from redbot.core import commands
@@ -31,16 +31,16 @@ class GlobalUniqueObjectFinder(commands.Converter):
                 return maybe_matches[0]
             if len(maybe_matches) > 0:
                 raise commands.BadArgument(
-                    "Could not uniquely match that, please use an id or mention for this", arg
+                    _("Could not uniquely match that, please use an id or mention for this"), arg
                 )
         raise commands.BadArgument(
-            "Could not uniquely match that, please use an id or mention for this", arg
+            _("Could not uniquely match that, please use an id or mention for this"), arg
         )
 
 
 class GuildUniqueObjectFinder(commands.Converter):
     async def convert(self, ctx: commands.Context, arg: str):
-        objects = {str(c.id): c for c in guild.channels}
+        objects = {str(c.id): c for c in ctx.guild.channels}
         objects.update({str(u.id): u for u in ctx.guild.members})
         objects.update({str(r.id): r for r in ctx.guild.roles})
 
@@ -57,10 +57,10 @@ class GuildUniqueObjectFinder(commands.Converter):
                 return maybe_matches[0]
             if len(maybe_matches) > 0:
                 raise commands.BadArgument(
-                    "Could not uniquely match that, please use an id or mention for this", arg
+                    _("Could not uniquely match that, please use an id or mention for this"), arg
                 )
         raise commands.BadArgument(
-            "Could not uniquely match that, please use an id or mention for this", arg
+            _("Could not uniquely match that, please use an id or mention for this"), arg
         )
 
 

--- a/redbot/cogs/permissions/converters.py
+++ b/redbot/cogs/permissions/converters.py
@@ -9,16 +9,13 @@ from redbot.core.i18n import Translator
 
 _ = Translator("PermissionsConverters", __file__)
 
-MENTION_RE = re.compile(r"^<(?:(?:@[!&]?)|#)(\d{15,21})>$")
+MENTION_RE = re.compile(r"^<?(?:(?:@[!&]?)?|#)(\d{15,21})>?$")
 
 
 def _match_id(arg: str) -> Optional[int]:
-    if arg.isdigit() and 15 <= len(arg) <= 21:
-        return int(arg)
-    else:
-        m = MENTION_RE.match(arg)
-        if m:
-            return int(m.group(1))
+    m = MENTION_RE.match(arg)
+    if m:
+        return int(m.group(1))
 
 
 class GlobalUniqueObjectFinder(commands.Converter):
@@ -54,7 +51,7 @@ class GlobalUniqueObjectFinder(commands.Converter):
 
         maybe_matches = []
         for obj in objects:
-            if str(obj) == arg or obj.name == arg:
+            if obj.name == arg or str(obj) == arg:
                 maybe_matches.append(obj)
 
         if ctx.guild is not None:
@@ -106,10 +103,13 @@ class GuildUniqueObjectFinder(commands.Converter):
 
         maybe_matches = []
         for obj in objects:
-            if str(obj) == arg or obj.name == arg:
+            if obj.name == arg or str(obj) == arg:
                 maybe_matches.append(obj)
-            elif isinstance(obj, discord.Member) and obj.nick == arg:
-                maybe_matches.append(obj)
+            try:
+                if obj.nick == arg:
+                    maybe_matches.append(obj)
+            except AttributeError:
+                pass
 
         if not maybe_matches:
             raise commands.BadArgument(

--- a/redbot/cogs/permissions/converters.py
+++ b/redbot/cogs/permissions/converters.py
@@ -23,7 +23,9 @@ class GlobalUniqueObjectFinder(commands.Converter):
 
         m = MENETION_RE.match(arg)
         if m:
-            return objects[m.group(2)]
+            ret = objects.get(m.group(2), None)
+            if ret:
+                return ret
 
         for func in (lambda obj: str(obj) == arg, lambda obj: obj.name == arg):
             maybe_matches = list(filter(func, objects))
@@ -49,7 +51,9 @@ class GuildUniqueObjectFinder(commands.Converter):
 
         m = MENETION_RE.match(arg)
         if m:
-            return objects[m.group(2)]
+            ret = objects.get(m.group(2), None)
+            if ret:
+                return ret
 
         for func in (lambda obj: str(obj) == arg, lambda obj: obj.name == arg):
             maybe_matches = list(filter(func, objects))

--- a/redbot/cogs/permissions/converters.py
+++ b/redbot/cogs/permissions/converters.py
@@ -6,6 +6,58 @@ from redbot.core.i18n import Translator
 _ = Translator("PermissionsConverters", __file__)
 
 
+class GlobalUniqueObjectFinder(commands.Converter):
+    @staticmethod
+    async def convert(ctx: commands.Context, arg: str):
+        objects = set(ctx.bot.get_all_channels())
+        objects += set(ctx.bot.users)
+        for guild in ctx.bot.guilds:
+            objects += {r for r in guild.roles if not r.is_default}
+            objects.add(guild)
+
+        for func in (
+            lambda obj: str(obj.id) == arg,
+            lambda obj: getattr(obj, "mention", False) == arg,
+            lambda obj: str(obj) == arg,
+            lambda obj: obj.name == arg,
+        ):
+            maybe_matches = list(filter(func, objects))
+            if len(maybe_matches) == 1:
+                return maybe_matches[0]
+            if len(maybe_matches) > 0:
+                raise commands.BadArgument(
+                    "Could not uniquely match that, please use an id or mention for this", arg
+                )
+        raise commands.BadArgument(
+            "Could not uniquely match that, please use an id or mention for this", arg
+        )
+
+
+class GuildUniqueObjectFinder(commands.Converter):
+    @staticmethod
+    async def convert(ctx: commands.Context, arg: str):
+        objects = set(ctx.guild.channels)
+        objects += set(ctx.guild.members)
+        objects += set(ctx.guild.roles)
+
+        for func in (
+            lambda obj: str(obj.id) == arg,
+            lambda obj: getattr(obj, "mention", False) == arg,
+            lambda obj: str(obj) == arg,
+            lambda obj: obj.name == arg,
+        ):
+            maybe_matches = list(filter(func, objects))
+            if len(maybe_matches) == 1:
+                return maybe_matches[0]
+            if len(maybe_matches) > 0:
+                raise commands.BadArgument(
+                    "Could not uniquely match that, please use an id or mention for this", arg
+                )
+        raise commands.BadArgument(
+            "Could not uniquely match that, please use an id or mention for this", arg
+        )
+
+
 class CogOrCommand(NamedTuple):
     type: str
     name: str

--- a/redbot/cogs/permissions/permissions.py
+++ b/redbot/cogs/permissions/permissions.py
@@ -14,7 +14,13 @@ from redbot.core.utils.chat_formatting import box
 from redbot.core.utils.menus import start_adding_reactions
 from redbot.core.utils.predicates import ReactionPredicate, MessagePredicate
 
-from .converters import CogOrCommand, RuleType, ClearableRuleType
+from .converters import (
+    CogOrCommand,
+    RuleType,
+    ClearableRuleType,
+    GuildUniqueObjectFinder,
+    GlobalUniqueObjectFinder,
+)
 
 _ = Translator("Permissions", __file__)
 
@@ -275,7 +281,7 @@ class Permissions(commands.Cog):
         ctx: commands.Context,
         allow_or_deny: RuleType,
         cog_or_command: CogOrCommand,
-        who_or_what: commands.GlobalPermissionModel,
+        who_or_what: GlobalUniqueObjectFinder,
     ):
         """Add a global rule to a command.
 
@@ -303,7 +309,7 @@ class Permissions(commands.Cog):
         ctx: commands.Context,
         allow_or_deny: RuleType,
         cog_or_command: CogOrCommand,
-        who_or_what: commands.GuildPermissionModel,
+        who_or_what: GuildUniqueObjectFinder,
     ):
         """Add a rule to a command in this server.
 
@@ -328,7 +334,7 @@ class Permissions(commands.Cog):
         self,
         ctx: commands.Context,
         cog_or_command: CogOrCommand,
-        who_or_what: commands.GlobalPermissionModel,
+        who_or_what: GlobalUniqueObjectFinder,
     ):
         """Remove a global rule from a command.
 
@@ -351,7 +357,7 @@ class Permissions(commands.Cog):
         ctx: commands.Context,
         cog_or_command: CogOrCommand,
         *,
-        who_or_what: commands.GuildPermissionModel,
+        who_or_what: GuildUniqueObjectFinder,
     ):
         """Remove a server rule from a command.
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

This is a safety measure to prevent accidentally passing a user when you wanted a role with the same name. See discord discussion, and @Kowlin 

If it can't find it uniquely, it should tell them to use an id.