### PR TITLE
Fix text formatting issue in session.py

### DIFF
--- a/redbot/cogs/trivia/session.py
+++ b/redbot/cogs/trivia/session.py
@@ -114,7 +114,7 @@ class TriviaSession:
             async with self.ctx.typing():
                 await asyncio.sleep(3)
             self.count += 1
-            msg = bold(_("**Question number {num}!").format(num=self.count)) + "\n\n" + question
+            msg = bold(_("Question number {num}!").format(num=self.count)) + "\n\n" + question
             await self.ctx.send(msg)
             continue_ = await self.wait_for_answer(answers, delay, timeout)
             if continue_ is False:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Removed two asterisks from a string: the "Question number {}" message was being emboldened twice from the left side, which made the bot send messages with two redundant asterisks.
