### PR TITLE
[V3 Audio] Match openJDK 11 on Ubuntu

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -80,7 +80,7 @@ async def get_java_version(loop) -> _JavaVersion:
         short_match = short_version_re.search(line)
         if match:
             return int(match["major"]), int(match["minor"])
-        if short_match:
+        elif short_match:
             return int(short_match["major"]), 0
 
     raise RuntimeError(

--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -72,12 +72,16 @@ async def get_java_version(loop) -> _JavaVersion:
     #     ...
     # We only care about the major and minor parts though.
     version_line_re = re.compile(r'version "(?P<major>\d+).(?P<minor>\d+).\d+(?:_\d+)?"')
+    short_version_re = re.compile(r'version "(?P<major>\d+)"')
 
     lines = version_info.splitlines()
     for line in lines:
         match = version_line_re.search(line)
+        short_match = short_version_re.search(line)
         if match:
             return int(match["major"]), int(match["minor"])
+        if short_match:
+            return int(short_match["major"]), 0
 
     raise RuntimeError(
         "The output of `java -version` was unexpected. Please report this issue on Red's "


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Using the OpenJDK 11 from java.net on Ubuntu 18 reports "11" as the version, failing the Java version check on loading audio on a new instance. This change will return "11 0" as the version, passing the check, instead of just "11".