### PR TITLE
[V3 Audio] Local track verify on playlist start

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -1260,6 +1260,9 @@ class Audio(commands.Cog):
         try:
             player = lavalink.get_player(ctx.guild.id)
             for track in playlists[playlist_name]["tracks"]:
+                if track["info"]["uri"].startswith("localtracks/"):
+                    if not os.path.isfile(track["info"]["uri"]):
+                        continue
                 player.add(author_obj, lavalink.rest_api.Track(data=track))
                 track_count = track_count + 1
             embed = discord.Embed(


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Adding a local track to a saved playlist, deleting the file, and then starting the playlist would cause an exception to occur in the Lavalink server. This change verifies that the local track exists before loading it via a playlist.