### PR TITLE
[Audio] Lavalink 3.0/3.1 compatibility updates

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -96,9 +96,12 @@ async def start_lavalink_server(loop):
     if not java_available:
         raise RuntimeError("You must install Java 1.8+ for Lavalink to run.")
 
-    extra_flags = ""
     if java_version == (1, 8):
         extra_flags = "-Dsun.zip.disableMemoryMapping=true"
+    elif java_version >= (11, 0):
+        extra_flags = "-Djdk.tls.client.protocols=TLSv1.2"
+    else:
+        extra_flags = ""
 
     from . import LAVALINK_DOWNLOAD_DIR, LAVALINK_JAR_FILE
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ extras_require = {
         "sphinxcontrib-websupport==1.1.0",
         "urllib3==1.24.1",
     ],
-    "voice": ["red-lavalink==0.1.2"],
+    "voice": ["red-lavalink==0.2.0"],
     "style": ["black==18.9b0", "click==7.0", "toml==0.10.0"],
 }
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
- Update to red-lavalink v0.2.0 (blocked by ~~Cog-Creators/Red-Lavalink#41~~ ~~red-lavalink release~~)
- Force lavalink to use TLSv1.2 on java 11+ ~~(blocked by #2270)~~

I would add equalizer support now, but there's no way to know the full Lavalink version (3.1.1+) and thus whether it's supported ahead of time. It's being worked on, though.