### PR TITLE
[V3 - Trivia] Change Swaziland to its new name, eSwatini (whilst keeping Swaziland as an option)

### DIFF
--- a/redbot/cogs/trivia/data/lists/worldcapitals.yaml
+++ b/redbot/cogs/trivia/data/lists/worldcapitals.yaml
@@ -134,6 +134,8 @@ What is the capital of Eritrea?:
 - Asmara
 What is the capital of Estonia?:
 - Tallinn
+What is the capital of eSwatini (Swaziland)?:
+- Mbabane
 What is the capital of Ethiopia?:
 - Addis Ababa
 - addisababa
@@ -373,8 +375,6 @@ What is the capital of Sudan?:
 - Khartoum
 What is the capital of Suriname?:
 - Paramaribo
-What is the capital of Swaziland?:
-- Mbabane
 What is the capital of Sweden?:
 - Stockholm
 What is the capital of Switzerland?:

--- a/redbot/cogs/trivia/data/lists/worldflags.yaml
+++ b/redbot/cogs/trivia/data/lists/worldflags.yaml
@@ -426,6 +426,7 @@ What country is represented by this flag? https://i.imgur.com/wwxWE9U.png:
 - Solomon Islands
 - Solomon
 What country is represented by this flag? https://i.imgur.com/xhVuaYj.png:
+- eSwatini
 - Swaziland
 What country is represented by this flag? https://i.imgur.com/y5PJwXq.png:
 - Papua New Guinea


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Added eSwatini as the main name for what was formerly Swaziland in the trivia lists.
https://www.bbc.co.uk/news/world-africa-43821512