### PR TITLE
Fix for modset reinvite

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,7 @@ redbot/core/utils/common_filters.py      @mikeshardmind
 # Cogs
 redbot/cogs/admin/*                 @tekulvw
 redbot/cogs/alias/*                 @tekulvw
-redbot/cogs/audio/*                 @aikaterna @atiwiex
+redbot/cogs/audio/*                 @aikaterna
 redbot/cogs/bank/*                  @tekulvw
 redbot/cogs/cleanup/*               @palmtree5
 redbot/cogs/customcom/*             @palmtree5

--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -8,7 +8,7 @@ from typing import Mapping, Tuple, Dict
 import discord
 
 from redbot.core import Config, checks, commands
-from redbot.core.utils.chat_formatting import box, pagify
+from redbot.core.utils.chat_formatting import box, pagify, escape
 from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils.predicates import MessagePredicate
 
@@ -89,6 +89,13 @@ class CommandObj:
         else:
             return ccinfo["response"], ccinfo.get("cooldowns", {})
 
+    async def get_full(self, message: discord.Message, command: str) -> Dict:
+        ccinfo = await self.db(message.guild).commands.get_raw(command, default=None)
+        if ccinfo:
+            return ccinfo
+        else:
+            raise NotFound()
+
     async def create(self, ctx: commands.Context, command: str, *, response):
         """Create a custom command"""
         # Check if this command is already registered as a customcommand
@@ -98,7 +105,7 @@ class CommandObj:
         ctx.cog.prepare_args(response if isinstance(response, str) else response[0])
         author = ctx.message.author
         ccinfo = {
-            "author": {"id": author.id, "name": author.name},
+            "author": {"id": author.id, "name": str(author)},
             "command": command,
             "cooldowns": {},
             "created_at": self.get_now(),
@@ -291,8 +298,8 @@ class CustomCommands(commands.Cog):
     @customcom.command(name="delete")
     @checks.mod_or_permissions(administrator=True)
     async def cc_delete(self, ctx, command: str.lower):
-        """Delete a custom command
-.
+        """Delete a custom command.
+
         Example:
         - `[p]customcom delete yourcommand`
         """
@@ -356,6 +363,52 @@ class CustomCommands(commands.Cog):
         else:
             for page in pagify(_commands, delims=[" ", "\n"]):
                 await ctx.author.send(box(page))
+
+    @customcom.command(name="show")
+    async def cc_show(self, ctx, command_name: str):
+        """Shows a custom command's reponses and its settings."""
+
+        try:
+            cmd = await self.commandobj.get_full(ctx.message, command_name)
+        except NotFound:
+            ctx.send(_("I could not not find that custom command."))
+            return
+
+        responses = cmd["response"]
+
+        if isinstance(responses, str):
+            responses = [responses]
+
+        author = ctx.guild.get_member(cmd["author"]["id"])
+        # If the author is still in the server, show their current name
+        if author:
+            author = "{} ({})".format(author, cmd["author"]["id"])
+        else:
+            author = "{} ({})".format(cmd["author"]["name"], cmd["author"]["id"])
+
+        _type = _("Random") if len(responses) > 1 else _("Normal")
+
+        text = _(
+            "Command: {}\n"
+            "Author: {}\n"
+            "Created: {}\n"
+            "Type: {}\n".format(command_name, author, cmd["created_at"], _type)
+        )
+
+        cooldowns = cmd["cooldowns"]
+
+        if cooldowns:
+            cooldown_text = _("Cooldowns:\n")
+            for rate, per in cooldowns.items():
+                cooldown_text += _("{} seconds per {}\n".format(per, rate))
+            text += cooldown_text
+
+        text += _("Responses:\n")
+        responses = ["- " + r for r in responses]
+        text += "\n".join(responses)
+
+        for p in pagify(text):
+            await ctx.send(box(p, lang="yaml"))
 
     async def on_message(self, message):
         is_private = isinstance(message.channel, discord.abc.PrivateChannel)

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -311,13 +311,15 @@ class Mod(commands.Cog):
         if not cur_setting:
             await self.settings.guild(guild).reinvite_on_unban.set(True)
             await ctx.send(
-                _("Users unbanned with {command} will be reinvited.").format(f"{ctx.prefix}unban")
+                _("Users unbanned with {command} will be reinvited.").format(
+                    command=f"{ctx.prefix}unban"
+                )
             )
         else:
             await self.settings.guild(guild).reinvite_on_unban.set(False)
             await ctx.send(
                 _("Users unbanned with {command} will not be reinvited.").format(
-                    f"{ctx.prefix}unban"
+                    command=f"{ctx.prefix}unban"
                 )
             )
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -197,14 +197,14 @@ class CoreLogic:
 
     async def _reload(
         self, cog_names: Sequence[str]
-    ) -> Tuple[List[str], List[str], List[str], List[str]]:
+    ) -> Tuple[List[str], List[str], List[str], List[str], List[Tuple[str, str]]]:
         await self._unload(cog_names)
 
         loaded, load_failed, not_found, already_loaded, load_failed_with_reason = await self._load(
             cog_names
         )
 
-        return loaded, load_failed, not_found, already_loaded
+        return loaded, load_failed, not_found, already_loaded, load_failed_with_reason
 
     async def _name(self, name: Optional[str] = None) -> str:
         """

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -116,7 +116,7 @@ class Dev(commands.Cog):
             await ctx.send(box("{}: {!s}".format(type(e).__name__, e), lang="py"))
             return
 
-        if asyncio.iscoroutine(result):
+        if inspect.isawaitable(result):
             result = await result
 
         self._last_result = result

--- a/redbot/core/errors.py
+++ b/redbot/core/errors.py
@@ -14,3 +14,10 @@ class PackageAlreadyLoaded(RedError):
 
     def __str__(self) -> str:
         return f"There is already a package named {self.spec.name.split('.')[-1]} loaded"
+
+
+class CogLoadError(RedError):
+    """Raised by a cog when it cannot load itself.
+    The message will be send to the user."""
+
+    pass


### PR DESCRIPTION
Code fix by @aikaterna, added as an co-author

### Type

- [x] Bugfix
### Description of the changes

This PR fixes an issue with ``modset reinvite`` not functioning. Traceback for old error below.

```
Exception in command 'modset reinvite'
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/discord/ext/commands/core.py", line 61, in wrapped
    ret = await coro(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/redbot/cogs/mod/mod.py", line 320, in reinvite
    f"{ctx.prefix}unban"
KeyError: 'command'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/discord/ext/commands/bot.py", line 898, in invoke
    await ctx.command.invoke(ctx)
  File "/usr/local/lib/python3.6/dist-packages/redbot/core/commands/commands.py", line 409, in invoke
    await super().invoke(ctx)
  File "/usr/local/lib/python3.6/dist-packages/discord/ext/commands/core.py", line 1024, in invoke
    await ctx.invoked_subcommand.invoke(ctx)
  File "/usr/local/lib/python3.6/dist-packages/discord/ext/commands/core.py", line 614, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/usr/local/lib/python3.6/dist-packages/discord/ext/commands/core.py", line 70, in wrapped
    raise CommandInvokeError(e) from e
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: KeyError: 'command'
```