### PR TITLE
[V3 Mod] [p]modset: Fix KeyError

### DIFF
--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -311,13 +311,15 @@ class Mod(commands.Cog):
         if not cur_setting:
             await self.settings.guild(guild).reinvite_on_unban.set(True)
             await ctx.send(
-                _("Users unbanned with {command} will be reinvited.").format(f"{ctx.prefix}unban")
+                _("Users unbanned with {command} will be reinvited.").format(
+                    command=f"{ctx.prefix}unban"
+                )
             )
         else:
             await self.settings.guild(guild).reinvite_on_unban.set(False)
             await ctx.send(
                 _("Users unbanned with {command} will not be reinvited.").format(
-                    f"{ctx.prefix}unban"
+                    command=f"{ctx.prefix}unban"
                 )
             )
 


### PR DESCRIPTION
Code fix by @aikaterna, added as an co-author. **Now featuring 100% more the correct branch!**

### Type

- [x] Bugfix
### Description of the changes

This PR fixes an issue with ``modset reinvite`` not functioning. Traceback for old error below.

```
Exception in command 'modset reinvite'
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/discord/ext/commands/core.py", line 61, in wrapped
    ret = await coro(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/redbot/cogs/mod/mod.py", line 320, in reinvite
    f"{ctx.prefix}unban"
KeyError: 'command'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/discord/ext/commands/bot.py", line 898, in invoke
    await ctx.command.invoke(ctx)
  File "/usr/local/lib/python3.6/dist-packages/redbot/core/commands/commands.py", line 409, in invoke
    await super().invoke(ctx)
  File "/usr/local/lib/python3.6/dist-packages/discord/ext/commands/core.py", line 1024, in invoke
    await ctx.invoked_subcommand.invoke(ctx)
  File "/usr/local/lib/python3.6/dist-packages/discord/ext/commands/core.py", line 614, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/usr/local/lib/python3.6/dist-packages/discord/ext/commands/core.py", line 70, in wrapped
    raise CommandInvokeError(e) from e
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: KeyError: 'command'
```