### PR TITLE
[V3 Mod] Support global users with userinfo

### DIFF
--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -42,7 +42,7 @@ class Mod(commands.Cog):
     def __init__(self, bot: Red):
         super().__init__()
         self.bot = bot
-        self.settings = Config.get_conf(self, 4_961_522_000, force_registration=True)
+        self.settings = Config.get_conf(self, 4961522000, force_registration=True)
 
         self.settings.register_guild(**self.default_guild_settings)
         self.settings.register_channel(**self.default_channel_settings)
@@ -1315,8 +1315,8 @@ class Mod(commands.Cog):
             is_member = True
 
         #  A special case for a special someone :^)
-        special_date = datetime(2016, 1, 10, 6, 8, 4, 443_000)
-        is_special = user.id == 96_130_341_705_637_888 and guild.id == 133_049_272_517_001_216
+        special_date = datetime(2016, 1, 10, 6, 8, 4, 443000)
+        is_special = user.id == 96130341705637888 and guild.id == 133049272517001216
 
         since_created = (ctx.message.created_at - user.created_at).days
         user_created = user.created_at.strftime("%d %b %Y %H:%M")

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -56,7 +56,7 @@ class Mod(commands.Cog):
     def __init__(self, bot: Red):
         super().__init__()
         self.bot = bot
-        self.settings = Config.get_conf(self, 4961522000, force_registration=True)
+        self.settings = Config.get_conf(self, 4_961_522_000, force_registration=True)
 
         self.settings.register_guild(**self.default_guild_settings)
         self.settings.register_channel(**self.default_channel_settings)
@@ -1333,10 +1333,10 @@ class Mod(commands.Cog):
     @commands.bot_has_permissions(embed_links=True)
     async def userinfo(self, ctx, *, user: Union[discord.Member, int] = None):
         """Show information about a user.
-        
+
         This includes fields for status, discord join date, server
         join date, voice state and previous names/nicknames.
-        
+
         If the user has no roles, previous names or previous nicknames,
         these fields will be omitted.
         """
@@ -1349,9 +1349,12 @@ class Mod(commands.Cog):
             user_id = user
             user = self.bot.get_user(user_id)
             if not user:
-                try:
-                    user = await self.bot.get_user_info(user_id)
-                except (discord.errors.Forbidden, discord.errors.NotFound):
+                if self.bot.is_owner(ctx.author):
+                    try:
+                        user = await self.bot.get_user_info(user_id)
+                    except (discord.errors.Forbidden, discord.errors.NotFound):
+                        pass
+                if not user:
                     await ctx.send(_("User {id} not found.").format(id=user_id))
                     return
             is_member = False

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -1306,10 +1306,13 @@ class Mod(commands.Cog):
             user = author
         if isinstance(user, int):
             user_id = user
-            user = await self.bot.get_user_info(user_id)
+            user = self.bot.get_user(user_id)
             if not user:
-                await ctx.send(_("User {id} not found.").format(id=user_id))
-                return
+                try:
+                    user = await self.bot.get_user_info(user_id)
+                except discord.errors.Forbidden:
+                    await ctx.send(_("User {id} not found.").format(id=user_id))
+                    return
             is_member = False
         else:
             is_member = True

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -1310,7 +1310,7 @@ class Mod(commands.Cog):
             if not user:
                 try:
                     user = await self.bot.get_user_info(user_id)
-                except discord.errors.Forbidden:
+                except (discord.errors.Forbidden, discord.errors.NotFound):
                     await ctx.send(_("User {id} not found.").format(id=user_id))
                     return
             is_member = False


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes

The `[p]userinfo` command can now fetch informations about any Discord user, even if he doesn't share a server with the bot, using the `bot.get_user_info(ID)` endpoint.

### Example

![image](https://user-images.githubusercontent.com/23153234/47824422-0cc1c780-dd6d-11e8-8c9d-145ea1602d05.png)