### PR TITLE
[V3 General] Clarify options on rps

### DIFF
--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -28,7 +28,7 @@ class RPSParser:
         elif argument == "scissors":
             self.choice = RPS.scissors
         else:
-            raise ValueError
+            self.choice = None
 
 
 @cog_i18n(_)
@@ -121,6 +121,8 @@ class General(commands.Cog):
         """Play Rock Paper Scissors."""
         author = ctx.author
         player_choice = your_choice.choice
+        if not player_choice:
+            return await ctx.send("This isn't a valid option. Try rock, paper, or scissors.")
         red_choice = choice((RPS.rock, RPS.paper, RPS.scissors))
         cond = {
             (RPS.rock, RPS.paper): False,


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
When using the rps command, if a user enters in something besides the expected values it returns `Converting to "RPSParser" failed for parameter "your_choice".` which can be confusing. This change prompts users to use one of the specified options instead.