### PR TITLE
[V3 General] Urban no embed fix, capitals standardization

### DIFF
--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -263,7 +263,7 @@ class General(commands.Cog):
 
         except aiohttp.ClientError:
             await ctx.send(
-                _("No Urban dictionary entries were found, or there was an error in the process.")
+                _("No Urban Dictionary entries were found, or there was an error in the process.")
             )
             return
 

--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -269,9 +269,7 @@ class General(commands.Cog):
 
         if data.get("error") != 404:
             if not data["list"]:
-                return await ctx.send(
-                    _("No Urban Dictionary entries were found.")
-                )
+                return await ctx.send(_("No Urban Dictionary entries were found."))
             if await ctx.embed_requested():
                 # a list of embeds
                 embeds = []

--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -263,12 +263,15 @@ class General(commands.Cog):
 
         except aiohttp.ClientError:
             await ctx.send(
-                _("No Urban dictionary entries were found, or there was an error in the process")
+                _("No Urban dictionary entries were found, or there was an error in the process.")
             )
             return
 
         if data.get("error") != 404:
-
+            if not data["list"]:
+                return await ctx.send(
+                    _("No Urban Dictionary entries were found.")
+                )
             if await ctx.embed_requested():
                 # a list of embeds
                 embeds = []
@@ -303,14 +306,14 @@ class General(commands.Cog):
             else:
                 messages = []
                 for ud in data["list"]:
-                    ud.set_default("example", "N/A")
+                    ud.setdefault("example", "N/A")
                     description = _("{definition}\n\n**Example:** {example}").format(**ud)
                     if len(description) > 2048:
                         description = "{}...".format(description[:2045])
 
                     message = _(
                         "<{permalink}>\n {word} by {author}\n\n{description}\n\n"
-                        "{thumbs_down} Down / {thumbs_up} Up, Powered by urban dictionary"
+                        "{thumbs_down} Down / {thumbs_up} Up, Powered by Urban Dictionary."
                     ).format(word=ud.pop("word").capitalize(), description=description, **ud)
                     messages.append(message)
 
@@ -325,6 +328,5 @@ class General(commands.Cog):
                     )
         else:
             await ctx.send(
-                _("No Urban dictionary entries were found, or there was an error in the process.")
+                _("No Urban Dictionary entries were found, or there was an error in the process.")
             )
-            return


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
* Using the urban command with embeds disabled will throw an error:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/discord/ext/commands/core.py", line 61, in wrapped
    ret = await coro(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/redbot/cogs/general/general.py", line 310, in urban
    ud.set_default("example", "N/A")
AttributeError: 'dict' object has no attribute 'set_default'
```
The change on line 309 addresses this.

* Standardized the capitalization of "Urban Dictionary" across the command.

* Adds a response when a search is not found instead of failing silently.