### PR TITLE
[V3 Core] Graceful shutdown when SIGTERM is received

### DIFF
--- a/docs/autostart_systemd.rst
+++ b/docs/autostart_systemd.rst
@@ -49,6 +49,14 @@ To set the bot to start on boot, you must enable the service, again adding the i
 
 :code:`sudo systemctl enable red@instancename`
 
+If you need to shutdown the bot, you can use the ``[p]shutdown`` command or
+you can stop the service, still by adding the instance name after the **a**:
+
+:code:`sudo systemctl stop red@instancename`
+
+.. warning:: If the service doesn't stop in the next 10 seconds, the process is killed.
+    Check your logs to know the cause of the error that prevents the shutdown.
+
 To view Red’s log, you can acccess through journalctl:
 
 :code:`sudo journalctl -u red@instancename`

--- a/docs/autostart_systemd.rst
+++ b/docs/autostart_systemd.rst
@@ -28,6 +28,7 @@ Paste the following and replace all instances of :code:`username` with the usern
     Restart=always
     RestartSec=15
     RestartPreventExitStatus=0
+    TimeoutStopSec=10
 
     [Install]
     WantedBy=multi-user.target

--- a/docs/autostart_systemd.rst
+++ b/docs/autostart_systemd.rst
@@ -50,7 +50,7 @@ To set the bot to start on boot, you must enable the service, again adding the i
 :code:`sudo systemctl enable red@instancename`
 
 If you need to shutdown the bot, you can use the ``[p]shutdown`` command or
-you can stop the service, still by adding the instance name after the **a**:
+you can stop the service, still by adding the instance name after the **@**:
 
 :code:`sudo systemctl stop red@instancename`
 

--- a/docs/autostart_systemd.rst
+++ b/docs/autostart_systemd.rst
@@ -50,7 +50,7 @@ To set the bot to start on boot, you must enable the service, again adding the i
 :code:`sudo systemctl enable red@instancename`
 
 If you need to shutdown the bot, you can use the ``[p]shutdown`` command or
-you can stop the service, still by adding the instance name after the **@**:
+type the following command in the terminal, still by adding the instance name after the **@**:
 
 :code:`sudo systemctl stop red@instancename`
 

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -14,6 +14,7 @@ from redbot.core.cli import interactive_config, confirm, parse_cli_flags, ask_se
 from redbot.core.core_commands import Core
 from redbot.core.dev_commands import Dev
 from redbot.core import __version__
+from signal import SIGTERM
 import asyncio
 import logging.handlers
 import logging
@@ -110,6 +111,11 @@ def list_instances():
         sys.exit(0)
 
 
+async def sigterm_handler(red, log):
+    log.info("SIGTERM received. Quitting...")
+    await red.shutdown(restart=False)
+
+
 def main():
     description = "Red - Version {}".format(__version__)
     cli_flags = parse_cli_flags(sys.argv[1:])
@@ -139,6 +145,7 @@ def main():
     if cli_flags.dev:
         red.add_cog(Dev())
     loop = asyncio.get_event_loop()
+    loop.add_signal_handler(SIGTERM, lambda: asyncio.ensure_future(sigterm_handler(red, log)))
     tmp_data = {}
     loop.run_until_complete(_get_prefix_and_token(red, tmp_data))
     token = os.environ.get("RED_TOKEN", tmp_data["token"])

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -145,7 +145,8 @@ def main():
     if cli_flags.dev:
         red.add_cog(Dev())
     loop = asyncio.get_event_loop()
-    loop.add_signal_handler(SIGTERM, lambda: asyncio.ensure_future(sigterm_handler(red, log)))
+    if os.name == "posix":
+        loop.add_signal_handler(SIGTERM, lambda: asyncio.ensure_future(sigterm_handler(red, log)))
     tmp_data = {}
     loop.run_until_complete(_get_prefix_and_token(red, tmp_data))
     token = os.environ.get("RED_TOKEN", tmp_data["token"])


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

When the bot receives SIGTERM, it will close the connexion (with `bot.shutdown`) correctly. Without this handler, the process is killed and the gateway is stuck, with the bot still connected for a while. Using `sudo systemctl stop red.service <instance>` is now safe to correctly shutdown the bot.

What it looks like in the logs:
```
laggron@discordbots:~/RedDB-fork$ sudo systemctl stop redfork-discordbot.service
laggron@discordbots:~/RedDB-fork$ systemctl status redfork-discordbot.service
● redfork-discordbot.service - Red-DiscordBotV3:Red
   Loaded: loaded (/etc/systemd/system/redfork-discordbot.service; disabled; vendor preset: enabled)
   Active: inactive (dead)

[...]
Nov 03 11:50:28 discordbots pipenv[12401]: [03/11/2018 11:50] INFO __main__ sigterm_handler 115: SIGTERM received. Quitting...
Nov 03 11:50:28 discordbots pipenv[12401]: [03/11/2018 11:50] INFO manager shutdown_lavalink_server 115: Shutting down lavalink server.
```