### PR TITLE
[V3 Audio] Disallow seek during active vote

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -1983,6 +1983,7 @@ class Audio(commands.Cog):
     async def seek(self, ctx, seconds: int = 30):
         """Seek ahead or behind on a track by seconds."""
         dj_enabled = await self.config.guild(ctx.guild).dj_enabled()
+        vote_enabled = await self.config.guild(ctx.guild).vote_enabled()
         if not self._player_check(ctx):
             return await self._embed_msg(ctx, _("Nothing playing."))
         player = lavalink.get_player(ctx.guild.id)
@@ -1995,6 +1996,13 @@ class Audio(commands.Cog):
                 ctx, ctx.author
             ):
                 return await self._embed_msg(ctx, _("You need the DJ role to use seek."))
+        if vote_enabled:
+            if not await self._can_instaskip(ctx, ctx.author) and not await self._is_alone(
+                ctx, ctx.author
+            ):
+                return await self._embed_msg(
+                    ctx, _("There are other people listening - vote to skip instead.")
+                )
         if player.current:
             if player.current.is_stream:
                 return await self._embed_msg(ctx, _("Can't seek on a stream."))


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Users are able to use seek to skip songs while voteskip is active. This change prevents users from doing so.