### PR TITLE
[V3 Mod] In [p]userinfo, enhance the code to obtain the user avatar url

### DIFF
--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -1366,8 +1366,7 @@ class Mod(commands.Cog):
         name = filter_invites(name)
 
         if user.avatar:
-            avatar = user.avatar_url
-            avatar = avatar.replace("webp", "png")
+            avatar = user.avatar_url_as(static_format="png")
             data.set_author(name=name, url=avatar)
             data.set_thumbnail(url=avatar)
         else:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Rather than applying `.replace()` to the default avatar url for `.webp`, use the d.py method to get an avatar in a specific format directly. This makes the code less cumbersome, and also makes it clearer that `.gif` avatars are not affected.