### PR TITLE
[V3 Downloader] Findcog fix with no repo installed

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -502,7 +502,7 @@ class Downloader(commands.Cog):
         if isinstance(cog_installable, Installable):
             made_by = ", ".join(cog_installable.author) or _("Missing from info.json")
             repo = self._repo_manager.get_repo(cog_installable.repo_name)
-            repo_url = repo.url
+            repo_url = _("Missing from installed repos") if repo is None else repo.url
             cog_name = cog_installable.name
         else:
             made_by = "26 & co."


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
The findcog command errors out if a repo is removed. To reproduce, install a repo, install and load a cog, remove the repo, and then use the findcog command on a command in the installed cog. This change informs the user that the repo is not installed instead of erroring out.