### PR TITLE
[V3 Streams] Fix stream alerts with no configured mentions

### DIFF
--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -543,7 +543,7 @@ class Streams(commands.Cog):
                                 mention=mention_str, stream=stream
                             )
                         else:
-                            content = _("{stream.name} is live!").format(stream=stream.name)
+                            content = _("{stream.name} is live!").format(stream=stream)
 
                         m = await channel.send(content, embed=embed)
                         stream._messages_cache.append(m)


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Fixes stream alerts not getting sent if there's no configured alert mention