### PR TITLE
V3: extends regex finding on java -version

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -71,7 +71,7 @@ async def get_java_version(loop) -> _JavaVersion:
     #     ... version "MAJOR.MINOR.PATCH[_BUILD]" ...
     #     ...
     # We only care about the major and minor parts though.
-    version_line_re = re.compile(r'version "(?P<major>\d+).(?P<minor>\d+).\d+(?:_\d+)?"')
+    version_line_re = re.compile(r'version "(?P<major>\d+).(?P<minor>\d+).\d+(?:_\d+)?(-\S+)?"')
 
     lines = version_info.splitlines()
     for line in lines:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Some java version could not be detected because it [didn't match the regular expression](https://user-images.githubusercontent.com/18033169/49186437-f8212100-f364-11e8-87c9-4bcca531eeb8.png). This fixes it.
Regex comparison:
```py
r'version "(?P<major>\d+).(?P<minor>\d+).\d+(?:_\d+)?"'
r'version "(?P<major>\d+).(?P<minor>\d+).\d+(?:_\d+)?(-\S+)?"'
```
The first one does not match `version "1.8.0_181-heroku"` but the second one does.