### PR TITLE
V3: regex extension on java -version

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -71,7 +71,7 @@ async def get_java_version(loop) -> _JavaVersion:
     #     ... version "MAJOR.MINOR.PATCH[_BUILD]" ...
     #     ...
     # We only care about the major and minor parts though.
-    version_line_re = re.compile(r'version "(?P<major>\d+).(?P<minor>\d+).\d+(?:_\d+)?"')
+    version_line_re = re.compile(r'version "(?P<major>\d+).(?P<minor>\d+).\d+(?:_\d+)?(-\S+)?"')
     short_version_re = re.compile(r'version "(?P<major>\d+)"')
 
     lines = version_info.splitlines()

--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -71,7 +71,7 @@ async def get_java_version(loop) -> _JavaVersion:
     #     ... version "MAJOR.MINOR.PATCH[_BUILD]" ...
     #     ...
     # We only care about the major and minor parts though.
-    version_line_re = re.compile(r'version "(?P<major>\d+).(?P<minor>\d+).\d+(?:_\d+)?(?:-\S+)?"')
+    version_line_re = re.compile(r'version "(?P<major>\d+).(?P<minor>\d+).\d+(?:_\d+)?(?:-[A-Za-z0-9]+)?"')
     short_version_re = re.compile(r'version "(?P<major>\d+)"')
 
     lines = version_info.splitlines()

--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -71,8 +71,9 @@ async def get_java_version(loop) -> _JavaVersion:
     #     ... version "MAJOR.MINOR.PATCH[_BUILD]" ...
     #     ...
     # We only care about the major and minor parts though.
-    version_line_re = re.compile(r'version "(?P<major>\d+).(?P<minor>\d+)'
-                                 r'.\d+(?:_\d+)?(?:-[A-Za-z0-9]+)?"')
+    version_line_re = re.compile(
+        r'version "(?P<major>\d+).(?P<minor>\d+).\d+(?:_\d+)?(?:-[A-Za-z0-9]+)?"'
+    )
     short_version_re = re.compile(r'version "(?P<major>\d+)"')
 
     lines = version_info.splitlines()

--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -71,7 +71,7 @@ async def get_java_version(loop) -> _JavaVersion:
     #     ... version "MAJOR.MINOR.PATCH[_BUILD]" ...
     #     ...
     # We only care about the major and minor parts though.
-    version_line_re = re.compile(r'version "(?P<major>\d+).(?P<minor>\d+).\d+(?:_\d+)?(-\S+)?"')
+    version_line_re = re.compile(r'version "(?P<major>\d+).(?P<minor>\d+).\d+(?:_\d+)?(?:-\S+)?"')
     short_version_re = re.compile(r'version "(?P<major>\d+)"')
 
     lines = version_info.splitlines()

--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -71,7 +71,8 @@ async def get_java_version(loop) -> _JavaVersion:
     #     ... version "MAJOR.MINOR.PATCH[_BUILD]" ...
     #     ...
     # We only care about the major and minor parts though.
-    version_line_re = re.compile(r'version "(?P<major>\d+).(?P<minor>\d+).\d+(?:_\d+)?(?:-[A-Za-z0-9]+)?"')
+    version_line_re = re.compile(r'version "(?P<major>\d+).(?P<minor>\d+)'
+                                 r'.\d+(?:_\d+)?(?:-[A-Za-z0-9]+)?"')
     short_version_re = re.compile(r'version "(?P<major>\d+)"')
 
     lines = version_info.splitlines()


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Some java version could not be detected because it [didn't match the regular expression](https://user-images.githubusercontent.com/18033169/49187907-46d0ba00-f369-11e8-8828-280c239818f2.png). This fixes it.
Regex comparison:
```py
r'version "(?P<major>\d+).(?P<minor>\d+).\d+(?:_\d+)?"'
r'version "(?P<major>\d+).(?P<minor>\d+).\d+(?:_\d+)?(-\S+)?"'
```
The first one does not match `version "1.8.0_181-heroku"` but the second one does.

https://github.com/Cog-Creators/Red-DiscordBot/pull/2315 Pull request on V3/release/3.0.0 instead of V3/develop
