### PR TITLE
[V3 permissions] prevent locking out owner

### DIFF
--- a/redbot/core/commands/requires.py
+++ b/redbot/core/commands/requires.py
@@ -417,9 +417,13 @@ class Requires:
 
         """
         await self._verify_bot(ctx)
-        # Owner-only commands are non-overrideable
+
+        # Owner should never be locked out of commands for user permissions.
+        if await ctx.bot.is_owner(ctx.author):
+            return True
+        # Owner-only commands are non-overrideable, and we already checked for owner.
         if self.privilege_level is PrivilegeLevel.BOT_OWNER:
-            return await ctx.bot.is_owner(ctx.author)
+            return False
 
         hook_result = await ctx.bot.verify_permissions_hooks(ctx)
         if hook_result is not None:


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This pulls the commit from #2257 onto `V3/release/3.0.0` (where it is *also* needed).

This also partially fixes #2313, though there is more to be done with that.