### PR TITLE
swap unsafe `yaml.load` usage for `yaml.safe_load`

### DIFF
--- a/redbot/cogs/trivia/trivia.py
+++ b/redbot/cogs/trivia/trivia.py
@@ -504,7 +504,7 @@ class Trivia(commands.Cog):
 
         with path.open(encoding="utf-8") as file:
             try:
-                dict_ = yaml.load(file)
+                dict_ = yaml.safe_load(file)
             except yaml.error.YAMLError as exc:
                 raise InvalidListError("YAML parsing failed.") from exc
             else:

--- a/tests/cogs/test_trivia.py
+++ b/tests/cogs/test_trivia.py
@@ -10,7 +10,7 @@ def test_trivia_lists():
     for l in list_names:
         with l.open() as f:
             try:
-                dict_ = yaml.load(f)
+                dict_ = yaml.safe_load(f)
             except yaml.error.YAMLError as e:
                 problem_lists.append((l.stem, "YAML error:\n{!s}".format(e)))
             else:


### PR DESCRIPTION
Related to #2323

Recommend additionally adding a step in CI
ensuring use of `yaml.load` is prevented from existing in the code base.