### PR TITLE
[Mod] Fixed loud RuntimeError on modlog cases

### DIFF
--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -1574,7 +1574,7 @@ class Mod(commands.Cog):
         try:
             mod_channel = await modlog.get_modlog_channel(case.guild)
         except RuntimeError:
-            return # We're expecting None here, since None is raised in get_modlog
+            return  # We're expecting None here, since None is raised in get_modlog
         use_embeds = await case.bot.embed_requested(mod_channel, case.guild.me)
         case_content = await case.message_content(use_embeds)
         if use_embeds:

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -1570,7 +1570,6 @@ class Mod(commands.Cog):
         """
         An event for modlog case creation
         """
-        mod_channel = await modlog.get_modlog_channel(case.guild)
         try:
             mod_channel = await modlog.get_modlog_channel(case.guild)
         except RuntimeError:

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -1573,7 +1573,7 @@ class Mod(commands.Cog):
         try:
             mod_channel = await modlog.get_modlog_channel(case.guild)
         except RuntimeError:
-            return  # We're expecting None here, since None is raised in get_modlog
+            return
         use_embeds = await case.bot.embed_requested(mod_channel, case.guild.me)
         case_content = await case.message_content(use_embeds)
         if use_embeds:

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -1571,8 +1571,10 @@ class Mod(commands.Cog):
         An event for modlog case creation
         """
         mod_channel = await modlog.get_modlog_channel(case.guild)
-        if mod_channel is None:
-            return
+        try:
+            mod_channel = await modlog.get_modlog_channel(case.guild)
+        except RuntimeError:
+            return # We're expecting None here, since None is raised in get_modlog
         use_embeds = await case.bot.embed_requested(mod_channel, case.guild.me)
         case_content = await case.message_content(use_embeds)
         if use_embeds:

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -666,29 +666,30 @@ async def register_casetypes(new_types: List[dict]) -> List[CaseType]:
         return type_list
 
 
-async def get_modlog_channel(guild: discord.Guild) -> Union[discord.TextChannel, None]:
+async def get_modlog_channel(guild: discord.Guild) -> discord.TextChannel:
     """
-    Get the current modlog channel
+    Get the current modlog channel.
 
     Parameters
     ----------
     guild: `discord.Guild`
-        The guild to get the modlog channel for
+        The guild to get the modlog channel for.
 
     Returns
     -------
-    `discord.TextChannel` or `None`
-        The channel object representing the modlog channel
+    `discord.TextChannel`
+        The channel object representing the modlog channel.
 
     Raises
     ------
     RuntimeError
-        If the modlog channel is not found
+        If the modlog channel is not found.
 
     """
     if hasattr(guild, "get_channel"):
         channel = guild.get_channel(await _conf.guild(guild).mod_log())
     else:
+        # For unit tests only
         channel = await _conf.guild(guild).mod_log()
     if channel is None:
         raise RuntimeError("Failed to get the mod log channel!")


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

This change stops the loud modlog error from occurring if no modlog channel is found.