### PR TITLE
[V3 Core] Handle webhooks gracefully in automod immunity

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -186,13 +186,23 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):
     async def is_admin(self, member: discord.Member):
         """Checks if a member is an admin of their guild."""
         admin_role = await self.db.guild(member.guild).admin_role()
-        return any(role.id == admin_role for role in member.roles)
+        try:
+            if any(role.id == admin_role for role in member.roles):
+                return True
+        except AttributeError:  # someone passed a webhook to this
+            pass
+        return False
 
     async def is_mod(self, member: discord.Member):
         """Checks if a member is a mod or admin of their guild."""
         mod_role = await self.db.guild(member.guild).mod_role()
         admin_role = await self.db.guild(member.guild).admin_role()
-        return any(role.id in (mod_role, admin_role) for role in member.roles)
+        try:
+            if any(role.id in (mod_role, admin_role) for role in member.roles):
+                return True
+        except AttributeError:  # someone passed a webhook to this
+            pass
+        return False
 
     async def get_context(self, message, *, cls=commands.Context):
         return await super().get_context(message, cls=cls)
@@ -334,8 +344,14 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):
             ids_to_check = [to_check.id]
         else:
             author = getattr(to_check, "author", to_check)
-            ids_to_check = [r.id for r in author.roles]
-            ids_to_check.append(author.id)
+            try:
+                ids_to_check = [r.id for r in author.roles]
+            except AttributeError:
+                # webhook messages are a user not member,
+                # cheaper than isinstance
+                return True  # webhooks require significant permissions to enable.
+            else:
+                ids_to_check.append(author.id)
 
         immune_ids = await self.db.guild(guild).autoimmune_ids()
 


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

resolves #2336 

This fix is under the assumption that webhook messages do get parsed by events which would take mod actions. Webhook messages have a few quirks to them. (user object in guild for author for one)

This makes them immune to automated moderation actions, but not count as a mod or admin as they require significant permissions to set up, but are automated in nature themselves.
