### PR TITLE
[V3 core] on_message_without_command dispatch

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -210,7 +210,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):
             if ctx.valid:
                 return await self.invoke(ctx)
 
-        await self.dispatch("on_message_without_command", message)
+        self.dispatch("on_message_without_command", message)
 
     @staticmethod
     def list_packages():

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -210,7 +210,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):
             if ctx.valid:
                 return await self.invoke(ctx)
 
-        self.dispatch("on_message_without_command", message)
+        self.dispatch("message_without_command", message)
 
     @staticmethod
     def list_packages():

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -197,6 +197,21 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):
     async def get_context(self, message, *, cls=commands.Context):
         return await super().get_context(message, cls=cls)
 
+    async def process_commands(self, message: discord.Message):
+        """
+        modification from the base to do the same thing in the command case
+        
+        but dispatch an additional event for cogs which want to handle normal messages
+        differently to command messages, 
+        without the overhead of additional get_context calls per cog
+        """
+        if not message.author.bot:
+            ctx = await self.get_context(message)
+            if ctx.valid:
+                return await self.invoke(ctx)
+
+        await self.dispatch("on_message_without_command", message)
+
     @staticmethod
     def list_packages():
         """Lists packages present in the cogs the folder"""


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [X] New feature

### Description of the changes

Implements a new dispatch for messages which were not treated as a command. 

Should reduce overhead compared to the current best method of each event generating a context for the message to check validity if they want to process commands differently to normal messages, while still handling both.