### PR TITLE
Install SHARED_LIBRARY requirements during library installation

### DIFF
--- a/docs/framework_downloader.rst
+++ b/docs/framework_downloader.rst
@@ -40,8 +40,7 @@ Keys specific to the cog info.json (case sensitive)
   Downloader will not deal with this functionality but it may be useful for other cogs.
 
 - ``requirements`` (list of strings) - list of required libraries that are
-  passed to pip on cog install. ``SHARED_LIBRARIES`` do NOT go in this
-  list.
+  passed to pip on cog install.
 
 - ``tags`` (list of strings) - A list of strings that are related to the
   functionality of the cog. Used to aid in searching.

--- a/docs/framework_downloader.rst
+++ b/docs/framework_downloader.rst
@@ -40,7 +40,8 @@ Keys specific to the cog info.json (case sensitive)
   Downloader will not deal with this functionality but it may be useful for other cogs.
 
 - ``requirements`` (list of strings) - list of required libraries that are
-  passed to pip on cog install.
+  passed to pip on cog install. ``SHARED_LIBRARIES`` do NOT go in this
+  list.
 
 - ``tags`` (list of strings) - A list of strings that are related to the
   functionality of the cog. Used to aid in searching.

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -140,7 +140,9 @@ class Downloader(commands.Cog):
         failed = []
 
         for repo in repos:
-            if not await repo.install_libraries(target_dir=self.SHAREDLIB_PATH, req_target_dir=self.LIB_PATH):
+            if not await repo.install_libraries(
+                target_dir=self.SHAREDLIB_PATH, req_target_dir=self.LIB_PATH
+            ):
                 failed.extend(repo.available_libraries)
 
         # noinspection PyTypeChecker

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -140,7 +140,7 @@ class Downloader(commands.Cog):
         failed = []
 
         for repo in repos:
-            if not await repo.install_libraries(target_dir=self.SHAREDLIB_PATH):
+            if not await repo.install_libraries(target_dir=self.SHAREDLIB_PATH, req_target_dir=self.LIB_PATH):
                 failed.extend(repo.available_libraries)
 
         # noinspection PyTypeChecker
@@ -312,7 +312,7 @@ class Downloader(commands.Cog):
 
         await self._add_to_installed(cog)
 
-        await repo.install_libraries(self.SHAREDLIB_PATH)
+        await repo.install_libraries(target_dir=self.SHAREDLIB_PATH, req_target_dir=self.LIB_PATH)
 
         await ctx.send(_("Cog `{cog_name}` successfully installed.").format(cog_name=cog_name))
         if cog.install_msg is not None:

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -383,7 +383,7 @@ class Repo(RepoJSONMixin):
         return await cog.copy_to(target_dir=target_dir)
 
     async def install_libraries(
-        self, target_dir: Path, libraries: Tuple[Installable] = ()
+        self, target_dir: Path, req_target_dir: Path, libraries: Tuple[Installable] = ()
     ) -> bool:
         """Install shared libraries to the target directory.
 
@@ -394,6 +394,8 @@ class Repo(RepoJSONMixin):
         ----------
         target_dir : pathlib.Path
             Directory to install shared libraries to.
+        req_target_dir : pathlib.Path
+            Directory to install shared library requirements to.
         libraries : `tuple` of `Installable`
             A subset of available libraries.
 
@@ -412,7 +414,9 @@ class Repo(RepoJSONMixin):
         if len(libraries) > 0:
             ret = True
             for lib in libraries:
-                ret = ret and await lib.copy_to(target_dir=target_dir)
+                ret = (ret and
+                       await self.install_requirements(cog=lib, target_dir=req_target_dir) and
+                       await lib.copy_to(target_dir=target_dir))
             return ret
         return True
 

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -414,9 +414,11 @@ class Repo(RepoJSONMixin):
         if len(libraries) > 0:
             ret = True
             for lib in libraries:
-                ret = (ret and
-                       await self.install_requirements(cog=lib, target_dir=req_target_dir) and
-                       await lib.copy_to(target_dir=target_dir))
+                ret = (
+                    ret
+                    and await self.install_requirements(cog=lib, target_dir=req_target_dir)
+                    and await lib.copy_to(target_dir=target_dir)
+                )
             return ret
         return True
 

--- a/redbot/pytest/downloader.py
+++ b/redbot/pytest/downloader.py
@@ -14,7 +14,9 @@ __all__ = [
     "repo_norun",
     "bot_repo",
     "INFO_JSON",
+    "LIBRARY_INFO_JSON",
     "installable",
+    "library_installable",
     "fake_run_noprint",
 ]
 
@@ -92,6 +94,19 @@ INFO_JSON = {
     "type": "COG",
 }
 
+LIBRARY_INFO_JSON = {
+    "author": ("seputaes",),
+    "bot_version": (3, 0, 0),
+    "description": "A long library description",
+    "hidden": False,  # libraries are always hidden, this tests it will be flipped
+    "install_msg": "A library install message",
+    "required_cogs": {},
+    "requirements": ("tabulate"),
+    "short": "A short library description",
+    "tags": ("libtag1", "libtag2"),
+    "type": "SHARED_LIBRARY",
+}
+
 
 @pytest.fixture
 def installable(tmpdir):
@@ -100,4 +115,14 @@ def installable(tmpdir):
     info_path.write_text(json.dumps(INFO_JSON), "utf-8")
 
     cog_info = Installable(Path(str(cog_path)))
+    return cog_info
+
+
+@pytest.fixture
+def library_installable(tmpdir):
+    lib_path = tmpdir.mkdir("test_repo").mkdir("test_lib")
+    info_path = lib_path.join("info.json")
+    info_path.write_text(json.dumps(LIBRARY_INFO_JSON), "utf-8")
+
+    cog_info = Installable(Path(str(lib_path)))
     return cog_info

--- a/tests/cogs/downloader/test_downloader.py
+++ b/tests/cogs/downloader/test_downloader.py
@@ -40,6 +40,22 @@ async def test_add_repo(monkeypatch, repo_manager):
 
 
 @pytest.mark.asyncio
+async def test_lib_install_requirements(monkeypatch, library_installable, repo, tmpdir):
+    monkeypatch.setattr("redbot.cogs.downloader.repo_manager.Repo._run", fake_run_noprint)
+    monkeypatch.setattr(
+        "redbot.cogs.downloader.repo_manager.Repo.available_libraries", (library_installable,)
+    )
+
+    lib_path = Path(str(tmpdir)) / "cog_data_path" / "lib"
+    sharedlib_path = lib_path / "cog_shared"
+    sharedlib_path.mkdir(parents=True, exist_ok=True)
+
+    result = await repo.install_libraries(target_dir=sharedlib_path, req_target_dir=lib_path)
+
+    assert result is True
+
+
+@pytest.mark.asyncio
 async def test_remove_repo(monkeypatch, repo_manager):
     monkeypatch.setattr("redbot.cogs.downloader.repo_manager.Repo._run", fake_run_noprint)
 

--- a/tests/cogs/downloader/test_installable.py
+++ b/tests/cogs/downloader/test_installable.py
@@ -15,6 +15,17 @@ def test_process_info_file(installable):
             assert getattr(installable, k) == v
 
 
+def test_process_lib_info_file(library_installable):
+    for k, v in LIBRARY_INFO_JSON.items():
+        if k == "type":
+            assert library_installable.type == InstallableType.SHARED_LIBRARY
+        elif k == "hidden":
+            # libraries are always hidden, even if False
+            assert library_installable.hidden is True
+        else:
+            assert getattr(library_installable, k) == v
+
+
 # noinspection PyProtectedMember
 def test_location_is_dir(installable):
     assert installable._location.exists()


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

This change modifies downloader/repo_manager to also install requirements for `SHARED_LIBRARY` InstallableType's. If multiple cogs in a repository utilize the shared library, this allows the requirements needed by specifically that library to be defined once in the library's `info.json` file, rather than having to define them in each cog which consumes the library.

Additionally, adds tests to:
- Validate correct parsing of `SHARED_LIBRARY` type `info.json` files
- Validate the call path of `repo.install_libraries` when the repo contains available libraries.

resolves #2381 