### PR TITLE
[V3 Core] Allow central storage of API keys

### DIFF
--- a/redbot/cogs/image/__init__.py
+++ b/redbot/cogs/image/__init__.py
@@ -1,6 +1,7 @@
 from .image import Image
 
 
-def setup(bot):
-    n = Image(bot)
-    bot.add_cog(n)
+async def setup(bot):
+    cog = Image(bot)
+    await cog.initialize()
+    bot.add_cog(cog)

--- a/redbot/cogs/image/image.py
+++ b/redbot/cogs/image/image.py
@@ -32,6 +32,7 @@ class Image(commands.Cog):
         imgur_token = await self.settings.imgur_client_id()
         if imgur_token is not None and "imgur" not in await self.bot.db.api_tokens():
             await self.bot.db.api_tokens.set_raw("imgur", value={"client_id": imgur_token})
+            await self.config.settings.imgur_client_id.set(None)
 
     @commands.group(name="imgur")
     async def _imgur(self, ctx):

--- a/redbot/cogs/image/image.py
+++ b/redbot/cogs/image/image.py
@@ -32,7 +32,7 @@ class Image(commands.Cog):
         imgur_token = await self.settings.imgur_client_id()
         if imgur_token is not None and "imgur" not in await self.bot.db.api_tokens():
             await self.bot.db.api_tokens.set_raw("imgur", value={"client_id": imgur_token})
-            await self.config.settings.imgur_client_id.clear()
+            await self.settings.imgur_client_id.clear()
 
     @commands.group(name="imgur")
     async def _imgur(self, ctx):

--- a/redbot/cogs/image/image.py
+++ b/redbot/cogs/image/image.py
@@ -32,7 +32,7 @@ class Image(commands.Cog):
         imgur_token = await self.settings.imgur_client_id()
         if imgur_token is not None and "imgur" not in await self.bot.db.api_tokens():
             await self.bot.db.api_tokens.set_raw("imgur", value={"client_id": imgur_token})
-            await self.config.settings.imgur_client_id.set(None)
+            await self.config.settings.imgur_client_id.clear()
 
     @commands.group(name="imgur")
     async def _imgur(self, ctx):

--- a/redbot/cogs/image/image.py
+++ b/redbot/cogs/image/image.py
@@ -19,8 +19,6 @@ class Image(commands.Cog):
     def __init__(self, bot):
         super().__init__()
         self.bot = bot
-        self.settings = Config.get_conf(self, identifier=2652104208, force_registration=True)
-        self.settings.register_global(**self.default_global)
         self.session = aiohttp.ClientSession()
         self.imgur_base_url = "https://api.imgur.com/3/"
 
@@ -43,7 +41,7 @@ class Image(commands.Cog):
         """
         url = self.imgur_base_url + "gallery/search/time/all/0"
         params = {"q": term}
-        imgur_client_id = await self.settings.imgur_client_id()
+        imgur_client_id = await ctx.bot.db.api_tokens.get_raw("imgur", default=None)
         if not imgur_client_id:
             await ctx.send(
                 _(
@@ -51,7 +49,7 @@ class Image(commands.Cog):
                 ).format(prefix=ctx.prefix)
             )
             return
-        headers = {"Authorization": "Client-ID {}".format(imgur_client_id)}
+        headers = {"Authorization": "Client-ID {}".format(imgur_client_id["client_id"])}
         async with self.session.get(url, headers=headers, params=params) as search_get:
             data = await search_get.json()
 
@@ -96,7 +94,7 @@ class Image(commands.Cog):
             await ctx.send_help()
             return
 
-        imgur_client_id = await self.settings.imgur_client_id()
+        imgur_client_id = await ctx.bot.db.api_tokens.get_raw("imgur", default=None)
         if not imgur_client_id:
             await ctx.send(
                 _(
@@ -106,7 +104,7 @@ class Image(commands.Cog):
             return
 
         links = []
-        headers = {"Authorization": "Client-ID {}".format(imgur_client_id)}
+        headers = {"Authorization": "Client-ID {}".format(imgur_client_id["client_id"])}
         url = self.imgur_base_url + "gallery/r/{}/{}/{}/0".format(subreddit, sort, window)
 
         async with self.session.get(url, headers=headers) as sub_get:
@@ -130,7 +128,7 @@ class Image(commands.Cog):
 
     @checks.is_owner()
     @commands.command()
-    async def imgurcreds(self, ctx, imgur_client_id: str):
+    async def imgurcreds(self, ctx):
         """Set the Imgur Client ID.
 
         To get an Imgur Client ID:
@@ -143,9 +141,9 @@ class Image(commands.Cog):
         7. Enter a valid email address and a description
         8. Check the captcha box and click next
         9. Your Client ID will be on the next page.
+        10. do `[p]set api imgur client_id,your_client_id`
         """
-        await self.settings.imgur_client_id.set(imgur_client_id)
-        await ctx.send(_("The Imgur Client ID has been set!"))
+        await ctx.send_help()
 
     @commands.guild_only()
     @commands.command()

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -80,16 +80,17 @@ class Streams(commands.Cog):
     async def move_api_keys(self):
         """Move the API keys from cog stored config to core bot config if they exist."""
         tokens = await self.db.tokens()
-        existing_keys = await self.bot.db.api_tokens()
+        youtube = await self.bot.db.api_tokens.get_raw("youtube", default={})
+        twitch = await self.bot.db.api_tokens.get_raw("twitch", default={})
         for token_type, token in tokens.items():
             if token_type == "YoutubeStream":
-                if "youtube" not in existing_keys:
+                if "api_key" not in youtube:
                     await self.bot.db.api_tokens.set_raw("youtube", value={"api_key": token})
             if token_type == "TwitchStream":
                 # Don't need to check Community since they're set the same
-                if "twitch" not in existing_keys:
+                if "client_id" not in twitch:
                     await self.bot.db.api_tokens.set_raw("twitch", value={"client_id": token})
-        await self.db.tokens.set({})
+        await self.db.tokens.clear()
 
     @commands.command()
     async def twitch(self, ctx: commands.Context, channel_name: str):

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -89,6 +89,7 @@ class Streams(commands.Cog):
                 # Don't need to check Community since they're set the same
                 if "twitch" not in existing_keys:
                     await self.bot.db.api_tokens.set_raw("twitch", value={"client_id": token})
+        await self.db.tokens.set({})
 
     @commands.command()
     async def twitch(self, ctx: commands.Context, channel_name: str):

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -83,13 +83,11 @@ class Streams(commands.Cog):
         youtube = await self.bot.db.api_tokens.get_raw("youtube", default={})
         twitch = await self.bot.db.api_tokens.get_raw("twitch", default={})
         for token_type, token in tokens.items():
-            if token_type == "YoutubeStream":
-                if "api_key" not in youtube:
-                    await self.bot.db.api_tokens.set_raw("youtube", value={"api_key": token})
-            if token_type == "TwitchStream":
+            if token_type == "YoutubeStream" and "api_key" not in youtube:
+                await self.bot.db.api_tokens.set_raw("youtube", value={"api_key": token})
+            if token_type == "TwitchStream" and "client_id" not in twitch:
                 # Don't need to check Community since they're set the same
-                if "client_id" not in twitch:
-                    await self.bot.db.api_tokens.set_raw("twitch", value={"client_id": token})
+                await self.bot.db.api_tokens.set_raw("twitch", value={"client_id": token})
         await self.db.tokens.clear()
 
     @commands.command()

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -79,14 +79,14 @@ class Streams(commands.Cog):
     @commands.command()
     async def twitch(self, ctx: commands.Context, channel_name: str):
         """Check if a Twitch channel is live."""
-        token = await self.bot.db.api_tokens.get_raw("twitch", default={"client_id":None})
+        token = await self.bot.db.api_tokens.get_raw("twitch", default={"client_id": None})
         stream = TwitchStream(name=channel_name, token=token)
         await self.check_online(ctx, stream)
 
     @commands.command()
     async def youtube(self, ctx: commands.Context, channel_id_or_name: str):
         """Check if a YouTube channel is live."""
-        apikey = await self.bot.db.api_tokens.get_raw("youtube", default={"api_key":None})
+        apikey = await self.bot.db.api_tokens.get_raw("youtube", default={"api_key": None})
         is_name = self.check_name_or_id(channel_id_or_name)
         if is_name:
             stream = YoutubeStream(name=channel_id_or_name, token=apikey)

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -36,6 +36,7 @@ class TwitchCommunity:
         self.channels = kwargs.pop("channels", [])
         self._messages_cache = kwargs.pop("_messages_cache", [])
         self._token = kwargs.pop("token", None)
+        self.token_name = "twitch"
         self.type = self.__class__.__name__
 
     async def get_community_id(self):
@@ -243,7 +244,7 @@ class TwitchStream(Stream):
     def __init__(self, **kwargs):
         self.id = kwargs.pop("id", None)
         self._token = kwargs.pop("token", None)
-        self.token_ame = "twitch"
+        self.token_name = "twitch"
         super().__init__(**kwargs)
 
     async def is_online(self):

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -9,6 +9,7 @@ from .errors import (
 )
 from random import choice, sample
 from string import ascii_letters
+from typing import ClassVar
 import discord
 import aiohttp
 import json
@@ -30,13 +31,15 @@ def rnd(url):
 
 
 class TwitchCommunity:
+
+    token_name = "twitch"
+
     def __init__(self, **kwargs):
         self.name = kwargs.pop("name")
         self.id = kwargs.pop("id", None)
         self.channels = kwargs.pop("channels", [])
         self._messages_cache = kwargs.pop("_messages_cache", [])
         self._token = kwargs.pop("token", None)
-        self.token_name = "twitch"
         self.type = self.__class__.__name__
 
     async def get_community_id(self):
@@ -128,13 +131,15 @@ class TwitchCommunity:
 
 
 class Stream:
+
+    token_name: ClassVar[str]
+
     def __init__(self, **kwargs):
         self.name = kwargs.pop("name", None)
         self.channels = kwargs.pop("channels", [])
         # self.already_online = kwargs.pop("already_online", False)
         self._messages_cache = kwargs.pop("_messages_cache", [])
         self.type = self.__class__.__name__
-        self.token_name = None
 
     async def is_online(self):
         raise NotImplementedError()
@@ -157,10 +162,12 @@ class Stream:
 
 
 class YoutubeStream(Stream):
+
+    token_name = "youtube"
+
     def __init__(self, **kwargs):
         self.id = kwargs.pop("id", None)
         self._token = kwargs.pop("token", None)
-        self.token_name = "youtube"
         super().__init__(**kwargs)
 
     async def is_online(self):
@@ -241,10 +248,12 @@ class YoutubeStream(Stream):
 
 
 class TwitchStream(Stream):
+
+    token_name = "twitch"
+
     def __init__(self, **kwargs):
         self.id = kwargs.pop("id", None)
         self._token = kwargs.pop("token", None)
-        self.token_name = "twitch"
         super().__init__(**kwargs)
 
     async def is_online(self):

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -39,8 +39,10 @@ class TwitchCommunity:
         self.type = self.__class__.__name__
 
     async def get_community_id(self):
-        headers = {"Accept": "application/vnd.twitchtv.v5+json", 
-                   "Client-ID": str(self._token["client_id"])}
+        headers = {
+            "Accept": "application/vnd.twitchtv.v5+json",
+            "Client-ID": str(self._token["client_id"]),
+        }
         params = {"name": self.name}
         async with aiohttp.ClientSession() as session:
             async with session.get(
@@ -62,8 +64,10 @@ class TwitchCommunity:
                 self.id = await self.get_community_id()
             except CommunityNotFound:
                 raise
-        headers = {"Accept": "application/vnd.twitchtv.v5+json", 
-                   "Client-ID": str(self._token["client_id"])}
+        headers = {
+            "Accept": "application/vnd.twitchtv.v5+json",
+            "Client-ID": str(self._token["client_id"]),
+        }
         params = {"community_id": self.id, "limit": 100}
         url = TWITCH_BASE_URL + "/kraken/streams"
         async with aiohttp.ClientSession() as session:
@@ -82,8 +86,10 @@ class TwitchCommunity:
             raise APIError()
 
     async def make_embed(self, streams: list) -> discord.Embed:
-        headers = {"Accept": "application/vnd.twitchtv.v5+json", 
-                   "Client-ID": str(self._token["client_id"])}
+        headers = {
+            "Accept": "application/vnd.twitchtv.v5+json",
+            "Client-ID": str(self._token["client_id"]),
+        }
         async with aiohttp.ClientSession() as session:
             async with session.get(
                 "{}/{}".format(TWITCH_COMMUNITIES_ENDPOINT, self.id), headers=headers
@@ -245,8 +251,10 @@ class TwitchStream(Stream):
             self.id = await self.fetch_id()
 
         url = TWITCH_STREAMS_ENDPOINT + self.id
-        header = {"Client-ID": str(self._token["client_id"]), 
-                  "Accept": "application/vnd.twitchtv.v5+json"}
+        header = {
+            "Client-ID": str(self._token["client_id"]),
+            "Accept": "application/vnd.twitchtv.v5+json",
+        }
 
         async with aiohttp.ClientSession() as session:
             async with session.get(url, headers=header) as r:
@@ -267,8 +275,10 @@ class TwitchStream(Stream):
             raise APIError()
 
     async def fetch_id(self):
-        header = {"Client-ID": str(self._token["client_id"]), 
-                  "Accept": "application/vnd.twitchtv.v5+json"}
+        header = {
+            "Client-ID": str(self._token["client_id"]),
+            "Accept": "application/vnd.twitchtv.v5+json",
+        }
         url = TWITCH_ID_ENDPOINT + self.name
 
         async with aiohttp.ClientSession() as session:

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -331,6 +331,9 @@ class TwitchStream(Stream):
 
 
 class HitboxStream(Stream):
+
+    token_name = None # This streaming services don't currently require an API key
+
     async def is_online(self):
         url = "https://api.hitbox.tv/media/live/" + self.name
 
@@ -368,6 +371,9 @@ class HitboxStream(Stream):
 
 
 class MixerStream(Stream):
+
+    token_name = None # This streaming services don't currently require an API key
+
     async def is_online(self):
         url = "https://mixer.com/api/v1/channels/" + self.name
 
@@ -409,6 +415,9 @@ class MixerStream(Stream):
 
 
 class PicartoStream(Stream):
+
+    token_name = None # This streaming services don't currently require an API key
+
     async def is_online(self):
         url = "https://api.picarto.tv/v1/channel/name/" + self.name
 

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -9,7 +9,7 @@ from .errors import (
 )
 from random import choice, sample
 from string import ascii_letters
-from typing import ClassVar
+from typing import ClassVar, Optional
 import discord
 import aiohttp
 import json
@@ -132,7 +132,7 @@ class TwitchCommunity:
 
 class Stream:
 
-    token_name: ClassVar[str]
+    token_name: ClassVar[Optional[str]] = None
 
     def __init__(self, **kwargs):
         self.name = kwargs.pop("name", None)
@@ -332,7 +332,7 @@ class TwitchStream(Stream):
 
 class HitboxStream(Stream):
 
-    token_name = None # This streaming services don't currently require an API key
+    token_name = None  # This streaming services don't currently require an API key
 
     async def is_online(self):
         url = "https://api.hitbox.tv/media/live/" + self.name
@@ -372,7 +372,7 @@ class HitboxStream(Stream):
 
 class MixerStream(Stream):
 
-    token_name = None # This streaming services don't currently require an API key
+    token_name = None  # This streaming services don't currently require an API key
 
     async def is_online(self):
         url = "https://mixer.com/api/v1/channels/" + self.name
@@ -416,7 +416,7 @@ class MixerStream(Stream):
 
 class PicartoStream(Stream):
 
-    token_name = None # This streaming services don't currently require an API key
+    token_name = None  # This streaming services don't currently require an API key
 
     async def is_online(self):
         url = "https://api.picarto.tv/v1/channel/name/" + self.name

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -57,6 +57,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):
             help__tagline="",
             disabled_commands=[],
             disabled_command_msg="That command is disabled.",
+            api_tokens={}
         )
 
         self.db.register_guild(

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -57,7 +57,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):
             help__tagline="",
             disabled_commands=[],
             disabled_command_msg="That command is disabled.",
-            api_tokens={}
+            api_tokens={},
         )
 
         self.db.register_guild(

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -39,3 +39,27 @@ class GuildConverter(discord.Guild):
             raise BadArgument(_('Server "{name}" not found.').format(name=argument))
 
         return ret
+
+class APIToken(discord.ext.commands.Converter):
+    """Converts to a `dict` object.
+
+    This will parse the input argument separating the key value pairs into a 
+    format to be used for the core bots API token storage.
+    
+    This will split the argument by eiher `;` or `,` and return a dict
+    to be stored. Since all API's are different and have different naming convention,
+    this leaves the owness on the cog creator to clearly define how to setup the correct
+    credential names for their cogs.
+    """
+    async def convert(self, ctx, argument) -> dict:
+        bot = ctx.bot
+        result = {}
+        match = re.split(r";|,", argument)
+        # provide two options to split incase for whatever reason one is part of the api key we're using
+        if len(match) > 1:
+            result[match[0]] = "".join(r for r in match[1:])
+        else:
+            raise BadArgument(_("The provided tokens are not in a valid format."))
+        if not result:
+            raise BadArgument(_("The provided tokens are not in a valid format."))
+        return result

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -40,6 +40,7 @@ class GuildConverter(discord.Guild):
 
         return ret
 
+
 class APIToken(discord.ext.commands.Converter):
     """Converts to a `dict` object.
 
@@ -51,6 +52,7 @@ class APIToken(discord.ext.commands.Converter):
     this leaves the owness on the cog creator to clearly define how to setup the correct
     credential names for their cogs.
     """
+
     async def convert(self, ctx, argument) -> dict:
         bot = ctx.bot
         result = {}

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1022,9 +1022,7 @@ class Core(commands.Cog, CoreLogic):
 
     @_set.command()
     @checks.is_owner()
-    async def api(
-        self, ctx: commands.Context, service:str, *tokens:commands.converter.APIToken
-    ):
+    async def api(self, ctx: commands.Context, service: str, *tokens: commands.converter.APIToken):
         """Set various external API tokens.
         
         This setting will be asked for by some 3rd party cogs and some core cogs.
@@ -1038,7 +1036,7 @@ class Core(commands.Cog, CoreLogic):
         if ctx.channel.permissions_for(ctx.me).manage_messages:
             await ctx.message.delete()
         entry = {}
-        entry[service] = {k:v for t in tokens for k, v in t.items()}
+        entry[service] = {k: v for t in tokens for k, v in t.items()}
         await ctx.bot.db.api_tokens.set(entry)
         await ctx.send(_("`{service}` API tokens have been set.").format(service=service))
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1035,9 +1035,8 @@ class Core(commands.Cog, CoreLogic):
         """
         if ctx.channel.permissions_for(ctx.me).manage_messages:
             await ctx.message.delete()
-        entry = {}
-        entry[service] = {k: v for t in tokens for k, v in t.items()}
-        await ctx.bot.db.api_tokens.set(entry)
+        entry = {k: v for t in tokens for k, v in t.items()}
+        await ctx.bot.db.api_tokens.set_raw(service, value=entry)
         await ctx.send(_("`{service}` API tokens have been set.").format(service=service))
 
     @commands.group()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1020,6 +1020,28 @@ class Core(commands.Cog, CoreLogic):
             ctx.bot.disable_sentry()
             await ctx.send(_("Done. Sentry logging is now disabled."))
 
+    @_set.command()
+    @checks.is_owner()
+    async def api(
+        self, ctx: commands.Context, service:str, *tokens:commands.converter.APIToken
+    ):
+        """Set various external API tokens.
+        
+        This setting will be asked for by some 3rd party cogs and some core cogs.
+
+        To add the keys provide the service name and the tokens as a comma separated
+        list of key,values as described by the cog requesting this command.
+
+        Note: API tokens are sensitive and should only be used in a private channel
+        or in DM with the bot.
+        """
+        if ctx.channel.permissions_for(ctx.me).manage_messages:
+            await ctx.message.delete()
+        entry = {}
+        entry[service] = {k:v for t in tokens for k, v in t.items()}
+        await ctx.bot.db.api_tokens.set(entry)
+        await ctx.send(_("`{service}` API tokens have been set.").format(service=service))
+
     @commands.group()
     @checks.is_owner()
     async def helpset(self, ctx: commands.Context):


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes

Create a central location to store external API tokens that can be used between cogs without requiring each cog to be loaded to share keys.

This adds `[p]set api` to the core commands and a special converter to return a dict for any type of API token. Not all API's use the exact same naming convention and not all cog creators will want to use this but it *should* provide a means for cog creators to share keys between cogs and store any type of key they want. An example setting multiple tokens such as the client_id and client_secret would be `[p]set api twitch client_id,12345 client_secret,123456` to ensure flexibility on multiple API's. 

This also updates the Streams cog to utilize the central database.