### PR TITLE
Added support for comparing PermissionOverwrites

### DIFF
--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -543,6 +543,10 @@ class PermissionOverwrite:
     +-----------+------------------------------------------+
     | Operation |               Description                |
     +===========+==========================================+
+    | x == y    | Checks if two overwrites are equal.      |
+    +-----------+------------------------------------------+
+    | x != y    | Checks if two overwrites are not equal.  |
+    +-----------+------------------------------------------+
     | iter(x)   | Returns an iterator of (perm, value)     |
     |           | pairs. This allows this class to be used |
     |           | as an iterable in e.g. set/list/dict     |
@@ -565,6 +569,9 @@ class PermissionOverwrite:
                 raise ValueError("no permission called {0}.".format(key))
 
             setattr(self, key, value)
+    
+    def __eq__(self, other):
+        return self._values == other._values
 
     def _set(self, key, value):
         if value not in (True, None, False):

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -569,7 +569,7 @@ class PermissionOverwrite:
                 raise ValueError("no permission called {0}.".format(key))
 
             setattr(self, key, value)
-    
+
     def __eq__(self, other):
         return self._values == other._values
 


### PR DESCRIPTION
When trying to check if a specific permission overwrite is already set on a channel, it can be done by fetching the already existing overwrite and comparing it with a one you want to set. Comparing them directly wasn't possible before, and this small change allows for that.
Could be expanded for other operations, not sure how it should work though.