### PR TITLE
Use python-Levenshtein-wheels

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,8 +4,8 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-"e1839a8" = { path = ".", editable = true, extras = ['mongo', 'voice'] }
+"red-discordbot" = { path = ".", editable = true, extras = ['mongo', 'voice'] }
 
 [dev-packages]
 tox = "*"
-"e1839a9" = { path = ".", editable = true, extras = ['docs', 'test', 'style'] }
+"red-discordbot" = { path = ".", editable = true, extras = ['docs', 'test', 'style'] }

--- a/Pipfile
+++ b/Pipfile
@@ -4,8 +4,8 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-"red-discordbot" = { path = ".", editable = true, extras = ['mongo', 'voice'] }
+red-discordbot = {path = ".",editable = true,extras = ['mongo', 'voice']}
 
 [dev-packages]
 tox = "*"
-"red-discordbot" = { path = ".", editable = true, extras = ['docs', 'test', 'style'] }
+red-discordbot = {path = ".",editable = true,extras = ['docs', 'test', 'style']}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -205,11 +205,43 @@
             ],
             "version": "==3.7.2"
         },
-        "python-levenshtein": {
+        "python-levenshtein-wheels": {
             "hashes": [
-                "sha256:033a11de5e3d19ea25c9302d11224e1a1898fe5abd23c61c7c360c25195e3eb1"
+                "sha256:0065529c8aec4c044468286177761857d36981ba6f7fdb62d7d5f7ffd143de5d",
+                "sha256:016924a59d689f9f47d5f7b26b70f31e309255e8dd72602c91e93ceb752b9f92",
+                "sha256:089d046ea7727e583233c71fef1046663ed67b96967063ae8ddc9f551e86a4fc",
+                "sha256:0aea217eab612acd45dcc3424a2e8dbd977cc309f80359d0c01971f1e65b9a9b",
+                "sha256:0beb91ad80b1573829066e5af36b80190c367be6e0a65292f073353b0388c7fc",
+                "sha256:0fa2ca69ef803bc6037a8c919e2e8a17b55e94c9c9ffcb4c21befbb15a1d0f40",
+                "sha256:11c77d0d74ab7f46f89a58ae9c2d67349ebc1ae3e18636627f9939d810167c31",
+                "sha256:19a68716a322486ddffc8bf7e5cf44a82f7700b05a10658e6e7fc5c7ae92b13d",
+                "sha256:19a95a01d28d63b042438ba860c4ace90362906a038fa77962ba33325d377d10",
+                "sha256:1a61f3a51e00a3608659bbaabb3f27af37c9dbe84d843369061a3e45cf0d5103",
+                "sha256:1c50aebebab403fb2dd415d70355446ac364dece502b0e2737a1a085bb9a4aa4",
+                "sha256:1e51cdc123625a28709662d24ea0cb4cf6f991845e6054d9f803c78da1d6b08f",
+                "sha256:1f0056d3216b0fe38f25c6f8ebc84bd9f6d34c55a7a9414341b674fb98961399",
+                "sha256:228b59460e9a786e498bdfc8011838b89c6054650b115c86c9c819a055a793b0",
+                "sha256:23020f9ff2cb3457a926dcc470b84f9bd5b7646bd8b8e06b915bdbbc905cb23f",
+                "sha256:3e6bcca97a7ff4e720352b57ddc26380c0583dcdd4b791acef7b574ad58468a7",
+                "sha256:3ed88f9e638da57647149115c34e0e120cae6f3d35eee7d77e22cc9c1d8eced3",
+                "sha256:445bf7941cb1fa05d6c2a4a502ad4868a5cacd92e8eb77b2bd008cdda9d37c55",
+                "sha256:4ba5e147d76d7ee884fd6eae461438b080bcc9f2c6eb9b576811e1bcfe8f808e",
+                "sha256:4bb128b719c30f3b9feacfe71a338ae07d39dbffc077139416f3535c89f12362",
+                "sha256:53c0c9964390368fd64460b690f168221c669766b193b7e80ae3950c2b9551f8",
+                "sha256:57c4edef81611098d37176278f2b6a3712bf864eed313496d7d80504805896d1",
+                "sha256:7f7283dfe50eac8a8cd9b777de9eb50b1edf7dbb46fc7cc9d9b0050d0c135021",
+                "sha256:7f9759095b3fc825464a72b1cae95125e610eba3c70f91557754c32a0bf32ea2",
+                "sha256:98727050ba70eb8d318ec8a8203531c20119347fc8f281102b097326812742ab",
+                "sha256:ac9cdf044dcb9481c7da782db01b50c1f0e7cdd78c8507b963b6d072829c0263",
+                "sha256:b679f951f842c38665aa54bea4d7403099131f71fac6d8584f893a731fe1266d",
+                "sha256:b8c183dc4aa4e95dc5c373eedc3d205c176805835611fcfec5d9050736c695c4",
+                "sha256:c2c76f483d05eddec60a5cd89e92385adef565a4f243b1d9a6abe2f6bd2a7c0a",
+                "sha256:c388baa3c04272a7c585d3da24030c142353eb26eb531dd2681502e6be7d7a26",
+                "sha256:cb0f2a711db665b5bf8697b5af3b9884bb1139385c5c12c2e472e4bbee62da99",
+                "sha256:cbac984d7b36e75b440d1c8ff9d3425d778364a0cbc23f8943383d4decd35d5e",
+                "sha256:f9084ed3b8997ad4353d124b903f2860a9695b9e080663276d9e58c32e293244"
             ],
-            "version": "==0.12.0"
+            "version": "==0.13.1"
         },
         "pyyaml": {
             "hashes": [
@@ -243,9 +275,10 @@
         },
         "red-lavalink": {
             "hashes": [
-                "sha256:6a1a34471ccf4630eee537049568dd87e8e93614f1d1ce355dd74e5b10079782"
+                "sha256:6348cc168572b1984e9831a29b4023f02372bb683fec8e863df5abeb605b630a",
+                "sha256:a5ab9d66d1a4728abe48ccb38a2a130a8a2d70fb23c9d9df2b747c82fbeb67a6"
             ],
-            "version": "==0.1.2"
+            "version": "==0.2.0"
         },
         "schema": {
             "hashes": [
@@ -598,11 +631,43 @@
             ],
             "version": "==0.10.0"
         },
-        "python-levenshtein": {
+        "python-levenshtein-wheels": {
             "hashes": [
-                "sha256:033a11de5e3d19ea25c9302d11224e1a1898fe5abd23c61c7c360c25195e3eb1"
+                "sha256:0065529c8aec4c044468286177761857d36981ba6f7fdb62d7d5f7ffd143de5d",
+                "sha256:016924a59d689f9f47d5f7b26b70f31e309255e8dd72602c91e93ceb752b9f92",
+                "sha256:089d046ea7727e583233c71fef1046663ed67b96967063ae8ddc9f551e86a4fc",
+                "sha256:0aea217eab612acd45dcc3424a2e8dbd977cc309f80359d0c01971f1e65b9a9b",
+                "sha256:0beb91ad80b1573829066e5af36b80190c367be6e0a65292f073353b0388c7fc",
+                "sha256:0fa2ca69ef803bc6037a8c919e2e8a17b55e94c9c9ffcb4c21befbb15a1d0f40",
+                "sha256:11c77d0d74ab7f46f89a58ae9c2d67349ebc1ae3e18636627f9939d810167c31",
+                "sha256:19a68716a322486ddffc8bf7e5cf44a82f7700b05a10658e6e7fc5c7ae92b13d",
+                "sha256:19a95a01d28d63b042438ba860c4ace90362906a038fa77962ba33325d377d10",
+                "sha256:1a61f3a51e00a3608659bbaabb3f27af37c9dbe84d843369061a3e45cf0d5103",
+                "sha256:1c50aebebab403fb2dd415d70355446ac364dece502b0e2737a1a085bb9a4aa4",
+                "sha256:1e51cdc123625a28709662d24ea0cb4cf6f991845e6054d9f803c78da1d6b08f",
+                "sha256:1f0056d3216b0fe38f25c6f8ebc84bd9f6d34c55a7a9414341b674fb98961399",
+                "sha256:228b59460e9a786e498bdfc8011838b89c6054650b115c86c9c819a055a793b0",
+                "sha256:23020f9ff2cb3457a926dcc470b84f9bd5b7646bd8b8e06b915bdbbc905cb23f",
+                "sha256:3e6bcca97a7ff4e720352b57ddc26380c0583dcdd4b791acef7b574ad58468a7",
+                "sha256:3ed88f9e638da57647149115c34e0e120cae6f3d35eee7d77e22cc9c1d8eced3",
+                "sha256:445bf7941cb1fa05d6c2a4a502ad4868a5cacd92e8eb77b2bd008cdda9d37c55",
+                "sha256:4ba5e147d76d7ee884fd6eae461438b080bcc9f2c6eb9b576811e1bcfe8f808e",
+                "sha256:4bb128b719c30f3b9feacfe71a338ae07d39dbffc077139416f3535c89f12362",
+                "sha256:53c0c9964390368fd64460b690f168221c669766b193b7e80ae3950c2b9551f8",
+                "sha256:57c4edef81611098d37176278f2b6a3712bf864eed313496d7d80504805896d1",
+                "sha256:7f7283dfe50eac8a8cd9b777de9eb50b1edf7dbb46fc7cc9d9b0050d0c135021",
+                "sha256:7f9759095b3fc825464a72b1cae95125e610eba3c70f91557754c32a0bf32ea2",
+                "sha256:98727050ba70eb8d318ec8a8203531c20119347fc8f281102b097326812742ab",
+                "sha256:ac9cdf044dcb9481c7da782db01b50c1f0e7cdd78c8507b963b6d072829c0263",
+                "sha256:b679f951f842c38665aa54bea4d7403099131f71fac6d8584f893a731fe1266d",
+                "sha256:b8c183dc4aa4e95dc5c373eedc3d205c176805835611fcfec5d9050736c695c4",
+                "sha256:c2c76f483d05eddec60a5cd89e92385adef565a4f243b1d9a6abe2f6bd2a7c0a",
+                "sha256:c388baa3c04272a7c585d3da24030c142353eb26eb531dd2681502e6be7d7a26",
+                "sha256:cb0f2a711db665b5bf8697b5af3b9884bb1139385c5c12c2e472e4bbee62da99",
+                "sha256:cbac984d7b36e75b440d1c8ff9d3425d778364a0cbc23f8943383d4decd35d5e",
+                "sha256:f9084ed3b8997ad4353d124b903f2860a9695b9e080663276d9e58c32e293244"
             ],
-            "version": "==0.12.0"
+            "version": "==0.13.1"
         },
         "pytz": {
             "hashes": [
@@ -640,6 +705,13 @@
                 "sha256:6a34b6a9841ad0fd827eeb158edb5826c5c5bd7babe2cde2a3f23eb85313af04"
             ],
             "version": "==0.7.0"
+        },
+        "red-lavalink": {
+            "hashes": [
+                "sha256:6348cc168572b1984e9831a29b4023f02372bb683fec8e863df5abeb605b630a",
+                "sha256:a5ab9d66d1a4728abe48ccb38a2a130a8a2d70fb23c9d9df2b747c82fbeb67a6"
+            ],
+            "version": "==0.2.0"
         },
         "requests": {
             "hashes": [
@@ -720,10 +792,10 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:34b9ae3742abed2f95d3970acf4d80533261d6061b51160b197f84e5b4c98b4c",
-                "sha256:fa736831a7b18bd2bfeef746beb622a92509e9733d645952da136b0639cd40cd"
+                "sha256:58c359370401e0af817fb0070911e599c5fdc836166306b04fd0f278151ed125",
+                "sha256:729f0bcab430e4ef137646805b5b1d8efbb43fe53d4a0f33328624a84a5121f7"
             ],
-            "version": "==16.2.0"
+            "version": "==16.3.0"
         },
         "websockets": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "57184ef83392116db24a1966022ad358f54048bb43d428d47a6e31f1a88fc434"
+            "sha256": "b9f385e4c53c659dd76e8722d1fb69c244d3a76e4b0dfc40956ff2493277c1f6"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -96,14 +96,6 @@
                 "sha256:f69c21288a962f4da86e56c4905b49d11aba7938d3d740e80d9e366ee4f1632d"
             ],
             "version": "==1.16.0"
-        },
-        "e1839a8": {
-            "editable": true,
-            "extras": [
-                "mongo",
-                "voice"
-            ],
-            "path": "."
         },
         "fuzzywuzzy": {
             "hashes": [
@@ -272,6 +264,14 @@
                 "sha256:6a34b6a9841ad0fd827eeb158edb5826c5c5bd7babe2cde2a3f23eb85313af04"
             ],
             "version": "==0.7.0"
+        },
+        "red-discordbot": {
+            "editable": true,
+            "extras": [
+                "mongo",
+                "voice"
+            ],
+            "path": "."
         },
         "red-lavalink": {
             "hashes": [
@@ -456,15 +456,6 @@
                 "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
             ],
             "version": "==0.14"
-        },
-        "e1839a9": {
-            "editable": true,
-            "extras": [
-                "docs",
-                "test",
-                "style"
-            ],
-            "path": "."
         },
         "filelock": {
             "hashes": [
@@ -705,6 +696,14 @@
                 "sha256:6a34b6a9841ad0fd827eeb158edb5826c5c5bd7babe2cde2a3f23eb85313af04"
             ],
             "version": "==0.7.0"
+        },
+        "red-discordbot": {
+            "editable": true,
+            "extras": [
+                "mongo",
+                "voice"
+            ],
+            "path": "."
         },
         "red-lavalink": {
             "hashes": [

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -176,12 +176,6 @@ def init_events(bot, cli_flags):
             print("\nInvite URL: {}\n".format(invite_url))
 
         bot.color = discord.Colour(await bot.db.color())
-        try:
-            import Levenshtein
-        except ImportError:
-            log.info(
-                "python-Levenshtein is not installed, fuzzy string matching will be a bit slower."
-            )
 
     @bot.event
     async def on_error(event_method, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,5 @@
-import distutils.ccompiler as ccompiler
 import os
 import re
-import tempfile
-from distutils.errors import CCompilerError, DistutilsPlatformError
 from setuptools import setup, find_packages
 
 install_requires = [
@@ -18,7 +15,7 @@ install_requires = [
     "idna-ssl==1.1.0",
     "idna==2.8",
     "multidict==4.5.2",
-    "python-levenshtein==0.12.0",
+    "python-levenshtein-wheels==0.13.1",
     "pyyaml==3.13",
     "raven==6.10.0",
     "raven-aiohttp==0.7.0",
@@ -70,19 +67,6 @@ if os.name == "nt":
     python_requires = ">=3.6.6,<3.8"
 
 
-def check_compiler_available():
-    m = ccompiler.new_compiler()
-
-    with tempfile.TemporaryDirectory() as tdir:
-        with open(os.path.join(tdir, "dummy.c"), "w") as tfile:
-            tfile.write("int main(int argc, char** argv) {return 0;}")
-        try:
-            m.compile([tfile.name], output_dir=tdir)
-        except (CCompilerError, DistutilsPlatformError):
-            return False
-    return True
-
-
 def get_version():
     with open("redbot/core/__init__.py") as f:
         version = re.search(
@@ -92,11 +76,6 @@ def get_version():
 
 
 if __name__ == "__main__":
-    if not check_compiler_available():
-        install_requires.remove(
-            next(r for r in install_requires if r.lower().startswith("python-levenshtein"))
-        )
-
     setup(
         name="Red-DiscordBot",
         version=get_version(),


### PR DESCRIPTION
This removes the compiler detection logic in setup.py. python-Levenshtein-wheels includes pre-built wheels for virtually all operating systems and architectures we support.