### PR TITLE
Bump minimum python version to 3.7.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,7 +31,7 @@ We love receiving contributions from our community. Any assistance you can provi
 # 2. Ground Rules
 We've made a point to use [ZenHub](https://www.zenhub.com/) (a plugin for GitHub) as our main source of collaboration and coordination. Your experience contributing to Red will be greatly improved if you go get that plugin.
 1. Ensure cross compatibility for Windows, Mac OS and Linux.
-2. Ensure all Python features used in contributions exist and work in Python 3.6 and above.
+2. Ensure all Python features used in contributions exist and work in Python 3.7 and above.
 3. Create new tests for code you add or bugs you fix. It helps us help you by making sure we don't accidentally break anything :grinning:
 4. Create any issues for new features you'd like to implement and explain why this feature is useful to everyone and not just you personally.
 5. Don't add new cogs unless specifically given approval in an issue discussing said cog idea.
@@ -53,7 +53,7 @@ Red's repository is configured to follow a particular development workflow, usin
 
 ### 4.1 Setting up your development environment
 The following requirements must be installed prior to setting up:
- - Python 3.6.2 or greater (3.6.6 or greater on Windows)
+ - Python 3.7.0 or greater
  - git
  - pip
  - pipenv
@@ -79,7 +79,7 @@ Note: If you haven't used `pipenv` before but are comfortable with virtualenvs, 
 We've recently started using [tox](https://github.com/tox-dev/tox) to run all of our tests. It's extremely simple to use, and if you followed the previous section correctly, it is already installed to your virtual environment.
 
 Currently, tox does the following, creating its own virtual environments for each stage:
-- Runs all of our unit tests with [pytest](https://github.com/pytest-dev/pytest) on python 3.6 and 3.7 (test environments `py36` and `py37`)
+- Runs all of our unit tests with [pytest](https://github.com/pytest-dev/pytest) on python 3.7 (test environment `py37`)
 - Ensures documentation builds without warnings, and all hyperlinks have a valid destination (test environment `docs`)
 - Ensures that the code meets our style guide with [black](https://github.com/ambv/black) (test environment `style`)
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ build:
   image: latest
 
 python:
-  version: 3.6
+  version: 3.7
   pip_install: true
   extra_requirements:
     - docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ notifications:
 sudo: true
 
 python:
-- 3.6.6
 - 3.7
 env:
   global:
@@ -23,15 +22,15 @@ script:
 jobs:
   include:
 
-    - python: 3.6.6
+    - python: 3.7
       env: TOXENV=docs
-    - python: 3.6.6
+    - python: 3.7
       env: TOXENV=style
 
     # These jobs only occur on tag creation if the prior ones succeed
     - stage: PyPi Deployment
       if: tag IS present
-      python: 3.6.6
+      python: 3.7
       env:
         - DEPLOYING=true
         - TOXENV=py36
@@ -43,11 +42,11 @@ jobs:
           skip_cleanup: true
           on:
             repo: Cog-Creators/Red-DiscordBot
-            python: 3.6.6
+            python: 3.7
             tags: true
     - stage: Crowdin Deployment
       if: tag IS present
-      python: 3.6.6
+      python: 3.7
       env:
         - DEPLOYING=true
         - TOXENV=py36
@@ -63,5 +62,5 @@ jobs:
         skip_cleanup: true
         on:
           repo: Cog-Creators/Red-DiscordBot
-          python: 3.6.6
+          python: 3.7
           tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,16 @@ language: python
 cache: pip
 notifications:
   email: false
-sudo: true
 
 python:
-- 3.7
+- 3.7.2
 env:
   global:
-    PIPENV_IGNORE_VIRTUALENVS=1
+    - PIPENV_IGNORE_VIRTUALENVS=1
   matrix:
-    TOXENV=py
+    - TOXENV=py
+    - TOXENV=docs
+    - TOXENV=style
 
 install:
 - pip install --upgrade pip tox
@@ -21,16 +22,10 @@ script:
 
 jobs:
   include:
-
-    - python: 3.7
-      env: TOXENV=docs
-    - python: 3.7
-      env: TOXENV=style
-
     # These jobs only occur on tag creation if the prior ones succeed
     - stage: PyPi Deployment
       if: tag IS present
-      python: 3.7
+      python: 3.7.2
       env:
         - DEPLOYING=true
         - TOXENV=py36
@@ -42,11 +37,10 @@ jobs:
           skip_cleanup: true
           on:
             repo: Cog-Creators/Red-DiscordBot
-            python: 3.7
             tags: true
     - stage: Crowdin Deployment
       if: tag IS present
-      python: 3.7
+      python: 3.7.2
       env:
         - DEPLOYING=true
         - TOXENV=py36
@@ -62,5 +56,4 @@ jobs:
         skip_cleanup: true
         on:
           repo: Cog-Creators/Red-DiscordBot
-          python: 3.7
           tags: true

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     <img src="https://img.shields.io/badge/Support-Red!-yellow.svg" alt="Support Red on Patreon!">
   </a>
   <a href="https://www.python.org/downloads/">
-    <img src="https://img.shields.io/badge/Made%20With-Python%203-blue.svg?style=for-the-badge" alt="Made with Python 3">
+    <img src="https://img.shields.io/badge/Made%20With-Python%203.7-blue.svg?style=for-the-badge" alt="Made with Python 3">
   </a>
   <a href="https://crowdin.com/project/red-discordbot">
     <img src="https://d322cqt584bo4o.cloudfront.net/red-discordbot/localized.svg" alt="Localized with Crowdin">

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     <img src="https://img.shields.io/badge/Support-Red!-yellow.svg" alt="Support Red on Patreon!">
   </a>
   <a href="https://www.python.org/downloads/">
-    <img src="https://img.shields.io/badge/Made%20With-Python%203.7-blue.svg?style=for-the-badge" alt="Made with Python 3">
+    <img src="https://img.shields.io/badge/Made%20With-Python%203.7-blue.svg?style=for-the-badge" alt="Made with Python 3.7">
   </a>
   <a href="https://crowdin.com/project/red-discordbot">
     <img src="https://d322cqt584bo4o.cloudfront.net/red-discordbot/localized.svg" alt="Localized with Crowdin">

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -202,7 +202,7 @@ linkcheck_ignore = [r"https://java.com*", r"https://chocolatey.org*"]
 
 # Intersphinx
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.6", None),
+    "python": ("https://docs.python.org/3", None),
     "dpy": ("https://discordpy.readthedocs.io/en/rewrite/", None),
     "motor": ("https://motor.readthedocs.io/en/stable/", None),
 }

--- a/docs/guide_cog_creation.rst
+++ b/docs/guide_cog_creation.rst
@@ -17,7 +17,7 @@ you in the process.
 Getting started
 ---------------
 
-To start off, be sure that you have installed Python 3.6.2 or higher (3.6.6 or higher on Windows).
+To start off, be sure that you have installed Python 3.7.
 Open a terminal or command prompt and type :code:`pip install -U git+https://github.com/Cog-Creators/Red-DiscordBot@V3/develop#egg=redbot[test]`
 (note that if you get an error with this, try again but put :code:`python -m` in front of the command
 This will install the latest version of V3.

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -16,10 +16,12 @@ Installing the pre-requirements
 Please install the pre-requirements using the commands listed for your operating system.
 
 The pre-requirements are:
- - Python 3.6.2 or greater
+ - Python 3.7.0 or greater
  - pip 9.0 or greater
  - git
  - Java Runtime Environment 8 or later (for audio support)
+
+.. _install-arch:
 
 ~~~~~~~~~~
 Arch Linux
@@ -29,15 +31,25 @@ Arch Linux
 
     sudo pacman -Syu python-pip git base-devel jre8-openjdk
 
-~~~~~~~~
-CentOS 7
-~~~~~~~~
+.. _install-centos:
+.. _install-fedora:
+.. _install-rhel:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+CentOS 7, Fedora, and RHEL
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: none
 
     yum -y groupinstall development
     yum -y install https://centos7.iuscommunity.org/ius-release.rpm
-    yum -y install yum-utils wget which python36u python36u-pip python36u-devel openssl-devel libffi-devel git2u java-1.8.0-openjdk
+    sudo yum install zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel \
+    openssl-devel xz xz-devel libffi-devel git2u java-1.8.0-openjdk
+
+Complete the rest of the installation by `installing Python 3.7 with pyenv <install-python-pyenv>`.
+
+.. _install-debian:
+.. _install-raspbian:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Debian and Raspbian Stretch
@@ -53,27 +65,13 @@ Debian/Raspbian Stretch. This guide will tell you how. First, run the following 
 
 .. code-block:: none
 
-    sudo apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev git unzip default-jre
-    curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+    sudo apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+    xz-utils tk-dev libffi-dev git unzip default-jre
 
-After that last command, you may see a warning about 'pyenv' not being in the load path. Follow the
-instructions given to fix that, then close and reopen your shell.
+Complete the rest of the installation by `installing Python 3.7 with pyenv <install-python-pyenv>`.
 
-Then run the following command:
-
-.. code-block:: none
-
-    CONFIGURE_OPTS=--enable-optimizations pyenv install 3.7.0 -v
-
-This may take a long time to complete.
-
-After that is finished, run:
-
-.. code-block:: none
-
-    pyenv global 3.7.0
-
-Pyenv is now installed and your system should be configured to run Python 3.7.
+.. _install-mac:
 
 ~~~
 Mac
@@ -91,24 +89,27 @@ one-by-one:
 
 .. code-block:: none
 
-    brew install python3 --with-brewed-openssl
+    brew install python --with-brewed-openssl
     brew install git
     brew tap caskroom/versions
     brew cask install java8
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-Ubuntu 18.04 Bionic Beaver
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _install-ubuntu-bionic:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Ubuntu 18.04 Bionic Beaver and 18.10 Cosmic Cuttlefish
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: none
 
-    sudo apt install python3.6-dev python3-pip build-essential libssl-dev libffi-dev git unzip default-jre -y
+    sudo apt install python3.7 python3.7-dev python3.7-venv python3-pip build-essential \
+    libssl-dev libffi-dev git unzip default-jre -y
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 Ubuntu 16.04 Xenial Xerus
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-We recommend adding the ``deadsnakes`` apt repository to install Python 3.6.2 or greater:
+We recommend adding the ``deadsnakes`` apt repository to install Python 3.7 or greater:
 
 .. code-block:: none
 
@@ -120,9 +121,41 @@ Now, install python, pip, git and java with the following commands:
 
 .. code-block:: none
 
-    sudo apt install python3.6-dev build-essential libssl-dev libffi-dev git unzip default-jre wget -y
+    sudo apt install python3.7 python3.7-dev build-essential libssl-dev libffi-dev git \
+    unzip default-jre wget -y
     wget https://bootstrap.pypa.io/get-pip.py
-    sudo python3.6 get-pip.py
+    sudo python3.7 get-pip.py
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Installing Python with pyenv
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On distributions where Python 3.7 needs to be compiled from source, we recommend the use of pyenv.
+This simplifies the compilation process and has the added bonus of simplifying setting up Red in a
+virtual environment.
+
+.. code-block:: none
+
+    curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+
+After this command, you may see a warning about 'pyenv' not being in the load path. Follow the
+instructions given to fix that, then close and reopen your shell.
+
+Then run the following command:
+
+.. code-block:: none
+
+    CONFIGURE_OPTS=--enable-optimizations pyenv install 3.7.1 -v
+
+This may take a long time to complete.
+
+After that is finished, run:
+
+.. code-block:: none
+
+    pyenv global 3.7.1
+
+Pyenv is now installed and your system should be configured to run Python 3.7.
 
 ------------------------------
 Creating a Virtual Environment
@@ -142,25 +175,25 @@ Choose one of the following commands to install Red.
 .. note::
 
     If you're not inside an activated virtual environment, include the ``--user`` flag with all
-    ``pip3`` commands.
+    ``python3.7 -m pip`` commands.
 
 To install without audio support:
 
 .. code-block:: none
 
-    pip3 install -U Red-DiscordBot
+    python3.7 -m pip install -U Red-DiscordBot
 
 Or, to install with audio support:
 
 .. code-block:: none
 
-    pip3 install -U Red-DiscordBot[voice]
+    python3.7 -m pip install -U Red-DiscordBot[voice]
 
 Or, install with audio and MongoDB support:
 
 .. code-block:: none
 
-    pip3 install -U Red-DiscordBot[voice,mongo]
+    python3.7 -m pip install -U Red-DiscordBot[voice,mongo]
 
 .. note::
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -67,7 +67,8 @@ Debian/Raspbian Stretch. This guide will tell you how. First, run the following 
 
     sudo apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python-openssl git unzip default-jre
+    xz-utils tk-dev libffi-dev liblzma-dev python-openssl python3-openssl git unzip \
+    default-jre
 
 Complete the rest of the installation by `installing Python 3.7 with pyenv <install-python-pyenv>`.
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -67,7 +67,7 @@ Debian/Raspbian Stretch. This guide will tell you how. First, run the following 
 
     sudo apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev git unzip default-jre
+    xz-utils tk-dev libffi-dev liblzma-dev python-openssl git unzip default-jre
 
 Complete the rest of the installation by `installing Python 3.7 with pyenv <install-python-pyenv>`.
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -95,7 +95,9 @@ one-by-one:
     brew tap caskroom/versions
     brew cask install java8
 
+.. _install-ubuntu:
 .. _install-ubuntu-bionic:
+.. _install-ubuntu-cosmic:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Ubuntu 18.04 Bionic Beaver and 18.10 Cosmic Cuttlefish
@@ -105,6 +107,8 @@ Ubuntu 18.04 Bionic Beaver and 18.10 Cosmic Cuttlefish
 
     sudo apt install python3.7 python3.7-dev python3.7-venv python3-pip build-essential \
     libssl-dev libffi-dev git unzip default-jre -y
+
+.. _install-ubuntu-xenial:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 Ubuntu 16.04 Xenial Xerus
@@ -127,6 +131,8 @@ Now, install python, pip, git and java with the following commands:
     wget https://bootstrap.pypa.io/get-pip.py
     sudo python3.7 get-pip.py
 
+.. _install-python-pyenv:
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Installing Python with pyenv
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -146,7 +152,7 @@ Then run the following command:
 
 .. code-block:: none
 
-    CONFIGURE_OPTS=--enable-optimizations pyenv install 3.7.1 -v
+    CONFIGURE_OPTS=--enable-optimizations pyenv install 3.7.2 -v
 
 This may take a long time to complete.
 
@@ -154,7 +160,7 @@ After that is finished, run:
 
 .. code-block:: none
 
-    pyenv global 3.7.1
+    pyenv global 3.7.2
 
 Pyenv is now installed and your system should be configured to run Python 3.7.
 

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -8,7 +8,7 @@ Installing Red on Windows
 Needed Software
 ---------------
 
-The following software dependencies can all be installed quickly and easily through powershell, 
+The following software dependencies can all be installed quickly and easily through powershell,
 using a trusted package manager for windows called `Chocolatey <https://chocolatey.org>`_
 
 We also provide instructions for manually installing all of the dependencies.
@@ -17,7 +17,7 @@ We also provide instructions for manually installing all of the dependencies.
 Installing using powershell and chocolatey
 ******************************************
 
-To install via powershell, search "powershell" in the windows start menu, 
+To install via powershell, search "powershell" in the windows start menu,
 right-click on it and then click "Run as administrator"
 
 Then run each of the following commands:
@@ -34,7 +34,7 @@ Then run each of the following commands:
 Manually installing dependencies
 ********************************
 
-* `Python <https://www.python.org/downloads/>`_ - Red needs Python 3.6.6 or greater on Windows
+* `Python <https://www.python.org/downloads/>`_ - Red needs Python 3.7.0 or greater
 
 .. note:: Please make sure that the box to add Python to PATH is CHECKED, otherwise
           you may run into issues when trying to run Red

--- a/docs/venv_guide.rst
+++ b/docs/venv_guide.rst
@@ -68,7 +68,7 @@ Using ``pyenv virtualenv``
 Using ``pyenv virtualenv`` saves you the headache of remembering where you installed your virtual
 environments. If you haven't already, install pyenv with `pyenv-installer`_.
 
-First, ensure your pyenv interpreter is set to python 3.6.2 or greater with the following command::
+First, ensure your pyenv interpreter is set to python 3.7.0 or greater with the following command::
 
     pyenv version
 

--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -3,12 +3,7 @@ import warnings
 import discord
 import colorama
 
-# Let's do all the dumb version checking in one place.
-if sys.platform == "win32":
-    # Due to issues with ProactorEventLoop prior to 3.6.6 (bpo-26819)
-    MIN_PYTHON_VERSION = (3, 6, 6)
-else:
-    MIN_PYTHON_VERSION = (3, 6, 2)
+MIN_PYTHON_VERSION = (3, 7, 0)
 
 if sys.version_info < MIN_PYTHON_VERSION:
     print(

--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -8,6 +8,7 @@ import asyncio
 import aiohttp
 
 import pkg_resources
+from redbot import MIN_PYTHON_VERSION
 from redbot.setup import (
     basic_setup,
     load_existing_config,
@@ -27,12 +28,6 @@ INTRO = "==========================\nRed Discord Bot - Launcher\n===============
 
 IS_WINDOWS = os.name == "nt"
 IS_MAC = sys.platform == "darwin"
-
-if IS_WINDOWS:
-    # Due to issues with ProactorEventLoop prior to 3.6.6 (bpo-26819)
-    MIN_PYTHON_VERSION = (3, 6, 6)
-else:
-    MIN_PYTHON_VERSION = (3, 6, 2)
 
 PYTHON_OK = sys.version_info >= MIN_PYTHON_VERSION
 

--- a/setup.py
+++ b/setup.py
@@ -64,10 +64,7 @@ extras_require = {
     "style": ["black==18.9b0", "click==7.0", "toml==0.10.0"],
 }
 
-python_requires = ">=3.6.2,<3.8"
-if os.name == "nt":
-    # Due to issues with ProactorEventLoop prior to 3.6.6 (bpo-26819)
-    python_requires = ">=3.6.6,<3.8"
+python_requires = ">=3.7,<3.8"
 
 
 def check_compiler_available():
@@ -116,7 +113,6 @@ if __name__ == "__main__":
             "Intended Audience :: Developers",
             "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
             "Operating System :: OS Independent",
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Topic :: Communications :: Chat",
             "Topic :: Documentation :: Sphinx",

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@
 
 [tox]
 envlist =
-    py36
     py37
     docs
     style
@@ -24,7 +23,7 @@ commands =
 description = Attempt to build docs with sphinx-build
 whitelist_externals =
     sphinx-build
-basepython = python3.6
+basepython = python3.7
 extras = docs, mongo
 commands =
     sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out/html" -W -bhtml
@@ -39,7 +38,7 @@ setenv =
     # This is just for Windows
     # Prioritise make.bat over any make.exe which might be on PATH
     PATHEXT=.BAT;.EXE
-basepython = python3.6
+basepython = python3.7
 extras = style
 commands =
     make stylecheck


### PR DESCRIPTION
This will be due for Red 3.1.

This is in anticipation of #2246, although I've written that PR to not break on 3.6, the feature itself is not usable on 3.6. So I think the best way forward is to simply require python 3.7. This also allows devs and cog creators to utilise all of the new features in 3.7.