### PR TITLE
[Core/Utils] Fix for Message Predicate Utility

### DIFF
--- a/redbot/core/utils/predicates.py
+++ b/redbot/core/utils/predicates.py
@@ -744,7 +744,7 @@ class MessagePredicate(Callable[[discord.Message], bool]):
             if not same_context(m):
                 return False
             try:
-                self.result = collection.index(m.content)
+                self.result = collection.index(m.content.lower())
             except ValueError:
                 return False
             else:


### PR DESCRIPTION
Added a missing str.lower() method when checking to see if the content is in the list.

### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
`lower_contained_in` method now correctly lowercases the user's input.