### PR TITLE
[V3 core_commands] Catch exception when message is deleted

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -500,7 +500,10 @@ class Core(commands.Cog, CoreLogic):
         try:
             await self.bot.wait_for("message", check=pred, timeout=15)
         except asyncio.TimeoutError:
-            await query.delete()
+            try:
+                await query.delete()
+            except discord.errors.NotFound:
+                pass
         else:
             await self.leave_confirmation(guilds[pred.result], ctx)
 


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fix the `discord.errors.NotFound` error that appear on `[p]servers` command, when "To leave a server, just type its number." message is deleted.

Thanks to aika for suggest me to fix this and for helping.