### PR TITLE
use find_namespace_packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import os
 import re
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 
 install_requires = [
     "aiohttp-json-rpc==0.11.2",
@@ -76,8 +76,8 @@ if __name__ == "__main__":
     setup(
         name="Red-DiscordBot",
         version=get_version(),
-        packages=(
-            find_packages(include=("redbot", "redbot.*")) + ["discord", "discord.ext.commands"]
+        packages=find_namespace_packages(
+            include=["redbot", "redbot.*", "discord", "discord.ext.commands"]
         ),
         package_data={"": ["locales/*.po", "data/*", "data/**/*"]},
         url="https://github.com/Cog-Creators/Red-DiscordBot",


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes the install issue:
```
Processing /red_src
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/Red_DiscordBot.egg-info
    writing pip-egg-info/Red_DiscordBot.egg-info/PKG-INFO
    writing dependency_links to pip-egg-info/Red_DiscordBot.egg-info/dependency_links.txt
    writing entry points to pip-egg-info/Red_DiscordBot.egg-info/entry_points.txt
    writing requirements to pip-egg-info/Red_DiscordBot.egg-info/requires.txt
    writing top-level names to pip-egg-info/Red_DiscordBot.egg-info/top_level.txt
    writing manifest file 'pip-egg-info/Red_DiscordBot.egg-info/SOURCES.txt'
    error: package directory 'discord' does not exist
```
Needed for #2273.