### PR TITLE
Allow [p]info customization

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -52,7 +52,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):
             embeds=True,
             color=15158332,
             fuzzy=False,
-            custom_text=None,
+            custom_info=None,
             help__page_char_limit=1000,
             help__max_pages_in_guild=2,
             help__tagline="",

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -52,6 +52,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):
             embeds=True,
             color=15158332,
             fuzzy=False,
+            custom_text=None,
             help__page_char_limit=1000,
             help__max_pages_in_guild=2,
             help__tagline="",

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -295,6 +295,7 @@ class Core(commands.Cog, CoreLogic):
         red_version = "[{}]({})".format(__version__, red_pypi)
         app_info = await self.bot.application_info()
         owner = app_info.owner
+        custom_text = await self.bot.db.custom_text()
 
         async with aiohttp.ClientSession() as session:
             async with session.get("{}/json".format(red_pypi)) as r:
@@ -318,6 +319,8 @@ class Core(commands.Cog, CoreLogic):
             embed.add_field(
                 name="Outdated", value="Yes, {} is available".format(data["info"]["version"])
             )
+        if custom_text:
+            embed.add_field(name="About this instance", value=custom_text, inline=False)
         embed.add_field(name="About Red", value=about, inline=False)
 
         embed.set_footer(
@@ -1019,6 +1022,27 @@ class Core(commands.Cog, CoreLogic):
         else:
             ctx.bot.disable_sentry()
             await ctx.send(_("Done. Sentry logging is now disabled."))
+
+    @_set.command()
+    @checks.is_owner()
+    async def custominfo(self, ctx: commands.Context, *, text: str=None):
+        """Customizes a section of [p]info
+
+        The maximum amount of allowed characters is 1024.
+        Supports markdown, links and "mentions".
+        Link example:
+        `[My link](https://example.com)`
+        """
+        if not text:
+            await ctx.bot.db.custom_text.clear()
+            await ctx.send(_("The custom text has been cleared."))
+            return
+        if len(text) <= 1024:
+            await ctx.bot.db.custom_text.set(text)
+            await ctx.send(_("The custom text has been set."))
+            await ctx.invoke(self.info)
+        else:
+            await ctx.bot.send(_("Characters must be fewer than 1024."))
 
     @commands.group()
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -295,7 +295,7 @@ class Core(commands.Cog, CoreLogic):
         red_version = "[{}]({})".format(__version__, red_pypi)
         app_info = await self.bot.application_info()
         owner = app_info.owner
-        custom_text = await self.bot.db.custom_text()
+        custom_info = await self.bot.db.custom_info()
 
         async with aiohttp.ClientSession() as session:
             async with session.get("{}/json".format(red_pypi)) as r:
@@ -319,8 +319,8 @@ class Core(commands.Cog, CoreLogic):
             embed.add_field(
                 name="Outdated", value="Yes, {} is available".format(data["info"]["version"])
             )
-        if custom_text:
-            embed.add_field(name="About this instance", value=custom_text, inline=False)
+        if custom_info:
+            embed.add_field(name="About this instance", value=custom_info, inline=False)
         embed.add_field(name="About Red", value=about, inline=False)
 
         embed.set_footer(
@@ -1034,11 +1034,11 @@ class Core(commands.Cog, CoreLogic):
         `[My link](https://example.com)`
         """
         if not text:
-            await ctx.bot.db.custom_text.clear()
+            await ctx.bot.db.custom_info.clear()
             await ctx.send(_("The custom text has been cleared."))
             return
         if len(text) <= 1024:
-            await ctx.bot.db.custom_text.set(text)
+            await ctx.bot.db.custom_info.set(text)
             await ctx.send(_("The custom text has been set."))
             await ctx.invoke(self.info)
         else:

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1025,7 +1025,7 @@ class Core(commands.Cog, CoreLogic):
 
     @_set.command()
     @checks.is_owner()
-    async def custominfo(self, ctx: commands.Context, *, text: str=None):
+    async def custominfo(self, ctx: commands.Context, *, text: str = None):
         """Customizes a section of [p]info
 
         The maximum amount of allowed characters is 1024.


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [X] New feature

### Description of the changes
This PR allows the user to further customize their own instance without resorting to editing core code.  
It gives the option to add a custom field to `[p]info`, as shown in the picture, while preserving the original credits.

![picture](https://user-images.githubusercontent.com/6267772/52244774-59262180-28df-11e9-91c1-f4f2f007503c.png)
