### PR TITLE
Use V2 of RTD's configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,5 @@
+version: 2
+
 formats:
   - pdf
 
@@ -6,7 +8,9 @@ build:
 
 python:
   version: 3.7
-  pip_install: true
-  extra_requirements:
-    - docs
-    - mongo
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+        - mongo

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,7 @@ build:
 python:
   version: 3.7
   install:
+    - requirements: docs/requirements.txt
     - method: pip
       path: .
       extra_requirements:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+# We still need this because RTD is special
+setuptools==40.8.0


### PR DESCRIPTION
RTD is still failing because they don't have native 3.7 support, but it'll come soon.