### PR TITLE
Fix logic for setting description to a visually empty string

### DIFF
--- a/redbot/core/help_formatter.py
+++ b/redbot/core/help_formatter.py
@@ -132,7 +132,7 @@ class Help(dpy_formatter.HelpFormatter):
             description = (
                 inspect.cleandoc(translator(self.command.__doc__))
                 if self.command.__doc__
-                else EMPTY_STRING
+                else None  # delay setting this to `EMPTY_STRING` until after formatting
             )
         else:
             description = self.command.description

--- a/redbot/core/help_formatter.py
+++ b/redbot/core/help_formatter.py
@@ -137,12 +137,12 @@ class Help(dpy_formatter.HelpFormatter):
         else:
             description = self.command.description
 
-        if not description == "" and description is not None:
-            description = "*{0}*".format(description)
-
         if description:
             # <description> portion
+            description = "*{0}*".format(description)
             emb["embed"]["description"] = description[:2046]
+        else:
+            description = EMPTY_STRING  # Visually empty, not actually.
 
         tagline = await self.context.bot.db.help.tagline()
         if tagline:


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Prevents breaking help for commands without a docstring
Resolves #2415 