### PR TITLE
Minor changes to install docs

### DIFF
--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -67,8 +67,7 @@ Debian/Raspbian Stretch. This guide will tell you how. First, run the following 
 
     sudo apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python-openssl python3-openssl git unzip \
-    default-jre
+    xz-utils tk-dev libffi-dev liblzma-dev python3-openssl git unzip default-jre
 
 Complete the rest of the installation by `installing Python 3.7 with pyenv <install-python-pyenv>`.
 
@@ -127,9 +126,8 @@ Now, install python, pip, git and java with the following commands:
 .. code-block:: none
 
     sudo apt install python3.7 python3.7-dev build-essential libssl-dev libffi-dev git \
-    unzip default-jre wget -y
-    wget https://bootstrap.pypa.io/get-pip.py
-    sudo python3.7 get-pip.py
+    unzip default-jre curl -y
+    curl https://bootstrap.pypa.io/get-pip.py | sudo python3.7
 
 .. _install-python-pyenv:
 

--- a/docs/venv_guide.rst
+++ b/docs/venv_guide.rst
@@ -24,7 +24,7 @@ to keep it in a location which is easy to type out the path to. From now, we'll 
 ~~~~~~~~~~~~~~~~~~~~~~~~
 Create your virtual environment with the following command::
 
-    python3 -m venv path/to/venv/
+    python3.7 -m venv path/to/venv/
 
 And activate it with the following command::
 


### PR DESCRIPTION
- When creating a venv, use `python3.7` instead of `python3`
- Remove unnecessary dependency from pyenv pre-requirements on Debian
- Use curl over wget for get-pip on Xenial
