### PR TITLE
[help_formatter] Remove unused characters

### DIFF
--- a/redbot/core/help_formatter.py
+++ b/redbot/core/help_formatter.py
@@ -115,7 +115,7 @@ class Help(dpy_formatter.HelpFormatter):
     def get_ending_note(self):
         # command_name = self.context.invoked_with
         return (
-            "Type {0}help <command> for more info on a command.\n"
+            "Type {0}help <command> for more info on a command. "
             "You can also type {0}help <category> for more info on a category.".format(
                 self.context.clean_prefix
             )


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Removes unused `\n` that are in the footer of help messages since we can't use the line break in embeds footers.
