### PR TITLE
[Mod] Allow admin to choose amount of repeats for "deleterepeats"

### DIFF
--- a/redbot/cogs/mod/__init__.py
+++ b/redbot/cogs/mod/__init__.py
@@ -2,5 +2,7 @@ from redbot.core.bot import Red
 from .mod import Mod
 
 
-def setup(bot: Red):
-    bot.add_cog(Mod(bot))
+async def setup(bot: Red):
+    cog = Mod(bot)
+    await cog.initialize()
+    bot.add_cog(cog)

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -1,4 +1,4 @@
-from collections import deque, defaultdict
+from collections import defaultdict
 from typing import List, Tuple
 
 import discord
@@ -15,14 +15,18 @@ from .settings import ModSettings
 
 _ = T_ = Translator("Mod", __file__)
 
+__version__ = "1.0.0"
+
 
 @cog_i18n(_)
 class Mod(ModSettings, Events, KickBanMixin, MoveToCore, MuteMixin, ModInfo, commands.Cog):
     """Moderation tools."""
 
+    default_global_settings = {"version": ""}
+
     default_guild_settings = {
         "ban_mention_spam": False,
-        "delete_repeats": False,
+        "delete_repeats": -1,
         "ignored": False,
         "respect_hierarchy": True,
         "delete_delay": -1,
@@ -41,20 +45,38 @@ class Mod(ModSettings, Events, KickBanMixin, MoveToCore, MuteMixin, ModInfo, com
         self.bot = bot
 
         self.settings = Config.get_conf(self, 4961522000, force_registration=True)
+        self.settings.register_global(**self.default_global_settings)
         self.settings.register_guild(**self.default_guild_settings)
         self.settings.register_channel(**self.default_channel_settings)
         self.settings.register_member(**self.default_member_settings)
         self.settings.register_user(**self.default_user_settings)
         self.ban_queue: List[Tuple[int, int]] = []
         self.unban_queue: List[Tuple[int, int]] = []
-        self.cache: dict = defaultdict(lambda: deque(maxlen=3))
+        self.cache: dict = {}
         self.registration_task = self.bot.loop.create_task(self._casetype_registration())
         self.tban_expiry_task = self.bot.loop.create_task(self.check_tempban_expirations())
         self.last_case: dict = defaultdict(dict)
 
+    async def initialize(self):
+        await self._maybe_update_config()
+
     def __unload(self):
         self.registration_task.cancel()
         self.tban_expiry_task.cancel()
+
+    async def _maybe_update_config(self):
+        """Maybe update `delete_delay` value set by Config prior to Mod 1.0.0."""
+        if await self.settings.version():
+            return
+        guild_dict = await self.settings.all_guilds()
+        for guild_id, info in guild_dict.items():
+            delete_repeats = info.get("delete_repeats", False)
+            if delete_repeats:
+                val = 3
+            else:
+                val = -1
+            await self.settings.guild(discord.Object(id=guild_id)).delete_repeats.set(val)
+        await self.settings.version.set(__version__)
 
     @staticmethod
     async def _casetype_registration():

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -116,11 +116,17 @@ class ModSettings(MixinMeta):
             if repeats == -1:
                 await self.settings.guild(guild).delete_repeats.set(repeats)
                 await ctx.send(_("Repeated messages will be ignored."))
-            else:
-                repeats = min(max(repeats, 2), 20)  # Enforces the repeat limits
+            elif 2 <= repeats <= 20:
                 await self.settings.guild(guild).delete_repeats.set(repeats)
                 await ctx.send(
                     _("Messages repeated up to {num} times will be deleted.").format(num=repeats)
+                )
+            else:
+                await ctx.send(
+                    _(
+                        "Number of repeats must be between 2 and 20"
+                        " or equal to -1 if you want to disable this feature!"
+                    )
                 )
         else:
             repeats = await self.settings.guild(guild).delete_repeats()

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -1,3 +1,5 @@
+from collections import defaultdict, deque
+
 from redbot.core import commands, i18n, checks
 from redbot.core.utils.chat_formatting import box
 
@@ -112,12 +114,14 @@ class ModSettings(MixinMeta):
         """
         guild = ctx.guild
         if repeats is not None:
-            self.cache.pop(guild.id, None)  # remove cache with old repeat limits
             if repeats == -1:
                 await self.settings.guild(guild).delete_repeats.set(repeats)
+                self.cache.pop(guild.id, None)  # remove cache with old repeat limits
                 await ctx.send(_("Repeated messages will be ignored."))
             elif 2 <= repeats <= 20:
                 await self.settings.guild(guild).delete_repeats.set(repeats)
+                # purge and update cache to new repeat limits
+                self.cache[guild.id] = defaultdict(lambda: deque(maxlen=repeats))
                 await ctx.send(
                     _("Messages repeated up to {num} times will be deleted.").format(num=repeats)
                 )


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This allows admin to set how many times message has to be repeated before `deleterepeats` removes it. (resolves #2267)