### PR TITLE
Added Filterlog

### DIFF
--- a/redbot/cogs/filter/filter.py
+++ b/redbot/cogs/filter/filter.py
@@ -383,12 +383,12 @@ class Filter(commands.Cog):
                         logenabled = await self.settings.guild(server).filter_log()
                         if logenabled and isinstance(logchannel, discord.TextChannel):
                             embed = discord.Embed(color=discord.Color.red())
-                            embed.set_author(name=_('Message get filtered'))
-                            embed.add_field(name=_('Member'), value='{0.name}#{0.discriminator}\n({0.id})'.format(author))
-                            embed.add_field(name=_('Channel'), value=message.channel.mention)
+                            embed.set_author(name=_("Message get filtered"))
+                            embed.add_field(name=_("Member"), value="{0.name}#{0.discriminator}\n({0.id})".format(author))
+                            embed.add_field(name=_("Channel"), value=message.channel.mention)
                             if message.content:
-                                embed.add_field(name=_('Message'), value=message.clean_content, inline=False)
-                            embed.set_footer(text=_('Message ID: {0} | {1}').format(message.id, datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')))
+                                embed.add_field(name=_("Message"), value=message.clean_content, inline=False)
+                            embed.set_footer(text=_("Message ID: {0} | {1}").format(message.id, datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")))
                             await logchannel.send(embed=embed)
                     except discord.HTTPException:
                         pass

--- a/redbot/cogs/filter/filter.py
+++ b/redbot/cogs/filter/filter.py
@@ -384,11 +384,20 @@ class Filter(commands.Cog):
                         if logenabled and isinstance(logchannel, discord.TextChannel):
                             embed = discord.Embed(color=discord.Color.red())
                             embed.set_author(name=_("Message get filtered"))
-                            embed.add_field(name=_("Member"), value="{0.name}#{0.discriminator}\n({0.id})".format(author))
+                            embed.add_field(
+                                name=_("Member"),
+                                value="{0.name}#{0.discriminator}\n({0.id})".format(author),
+                            )
                             embed.add_field(name=_("Channel"), value=message.channel.mention)
                             if message.content:
-                                embed.add_field(name=_("Message"), value=message.clean_content, inline=False)
-                            embed.set_footer(text=_("Message ID: {0} | {1}").format(message.id, datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")))
+                                embed.add_field(
+                                    name=_("Message"), value=message.clean_content, inline=False
+                                )
+                            embed.set_footer(
+                                text=_("Message ID: {0} | {1}").format(
+                                    message.id, datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+                                )
+                            )
                             await logchannel.send(embed=embed)
                     except discord.HTTPException:
                         pass

--- a/redbot/cogs/filter/filter.py
+++ b/redbot/cogs/filter/filter.py
@@ -72,7 +72,6 @@ class Filter(commands.Cog):
             await self.settings.guild(guild).filter_log.set(not logging)
             await ctx.send(_("Logging is now enabled. Please check the logchanel settings."))
 
-
     @filterset.command(name="logchannel")
     async def filter_set_logchanel(self, ctx: commands.Context, channel: discord.TextChannel):
         """Set the chanel to log deleted messages.


### PR DESCRIPTION
I added a log system for filtered messages.
It can set up a log channel. As default it is disabled, but when a channel is set up it can be enabled.
All is set up per guild.

If it is enabled, it will post every filtered message with user and message content to the channel wich was given in the setup.

### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

Two new commands for the filter cog.

* [p]filterset logenabled - will toggle the "FilterLog" settings
* [p]filterset logchannel [channel] - will set the channnel for logging