### PR TITLE
[V3 Alias] Customize Parameters

### DIFF
--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -1,8 +1,10 @@
 from copy import copy
-from re import search
+from re import findall, search
+from string import Formatter
 from typing import Generator, Tuple, Iterable, Optional
 
 import discord
+from discord.ext.commands.view import StringView, quoted_word
 from redbot.core import Config, commands, checks
 from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils.chat_formatting import box
@@ -11,6 +13,21 @@ from redbot.core.bot import Red
 from .alias_entry import AliasEntry
 
 _ = Translator("Alias", __file__)
+
+
+class _TrackingFormatter(Formatter):
+    def __init__(self):
+        super().__init__()
+        self.max = -1
+
+    def get_value(self, key, args, kwargs):
+        if isinstance(key, int):
+            self.max = max((key, self.max))
+        return super().get_value(key, args, kwargs)
+
+
+class ArgParseError(Exception):
+    pass
 
 
 @cog_i18n(_)
@@ -80,8 +97,20 @@ class Alias(commands.Cog):
         return not bool(search(r"\s", alias_name)) and alias_name.isprintable()
 
     async def add_alias(
-        self, ctx: commands.Context, alias_name: str, command: Tuple[str], global_: bool = False
+        self, ctx: commands.Context, alias_name: str, command: str, global_: bool = False
     ) -> AliasEntry:
+        indices = findall(r"{(\d+)}", command)
+        indices = [int(a[0]) for a in indices]
+        low = min(indices)
+        indices = [a - low for a in indices]
+        high = max(indices)
+        gaps = set(indices).symmetric_difference(range(high + 1))
+        if gaps:
+            raise ArgParseError(
+                _("Arguments must be sequential. Missing arguments: ")
+                + ", ".join(str(i + low) for i in gaps)
+            )
+        command = command.format(*(f"{{{i}}}" for i in range(-low, high + low)))
         alias = AliasEntry(alias_name, command, ctx.author, global_=global_)
 
         if global_:
@@ -143,6 +172,11 @@ class Alias(commands.Cog):
         """
         known_content_length = len(prefix) + len(alias.name)
         extra = message.content[known_content_length:].strip()
+        view = StringView(extra)
+        extra = []
+        while not view.eof:
+            extra.append(quoted_word(view))
+            view.skip_ws()
         return extra
 
     async def maybe_call_alias(
@@ -169,8 +203,13 @@ class Alias(commands.Cog):
         new_message = copy(message)
         args = self.get_extra_args_from_alias(message, prefix, alias)
 
+        trackform = _TrackingFormatter()
+        command = trackform.format(alias.command, *args)
+
         # noinspection PyDunderSlots
-        new_message.content = "{}{} {}".format(prefix, alias.command, args)
+        new_message.content = "{}{} {}".format(
+            prefix, command, " ".join(args[trackform.max + 1 :])
+        )
         await self.bot.process_commands(new_message)
 
     @commands.group()
@@ -228,7 +267,10 @@ class Alias(commands.Cog):
         # At this point we know we need to make a new alias
         #   and that the alias name is valid.
 
-        await self.add_alias(ctx, alias_name, command)
+        try:
+            await self.add_alias(ctx, alias_name, command)
+        except ArgParseError as e:
+            return await ctx.send(" ".join(e.args))
 
         await ctx.send(
             _("A new alias with the trigger `{name}` has been created.").format(name=alias_name)
@@ -274,7 +316,10 @@ class Alias(commands.Cog):
             return
         # endregion
 
-        await self.add_alias(ctx, alias_name, command, global_=True)
+        try:
+            await self.add_alias(ctx, alias_name, command, global_=True)
+        except ArgParseError as e:
+            return await ctx.send(" ".join(e.args))
 
         await ctx.send(
             _("A new global alias with the trigger `{name}` has been created.").format(

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -214,7 +214,7 @@ class Alias(commands.Cog):
         try:
             args = self.get_extra_args_from_alias(message, prefix, alias)
         except commands.BadArgument as bae:
-            return self.bot.dispatch("on_command_error", await self.bot.get_context(message), bae)
+            return
 
         trackform = _TrackingFormatter()
         command = trackform.format(alias.command, *args)

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -99,18 +99,23 @@ class Alias(commands.Cog):
     async def add_alias(
         self, ctx: commands.Context, alias_name: str, command: str, global_: bool = False
     ) -> AliasEntry:
-        indices = findall(r"{(\d+)}", command)
-        indices = [int(a[0]) for a in indices]
-        low = min(indices)
-        indices = [a - low for a in indices]
-        high = max(indices)
-        gaps = set(indices).symmetric_difference(range(high + 1))
-        if gaps:
-            raise ArgParseError(
-                _("Arguments must be sequential. Missing arguments: ")
-                + ", ".join(str(i + low) for i in gaps)
-            )
-        command = command.format(*(f"{{{i}}}" for i in range(-low, high + low)))
+        indices = findall(r"{(\d*)}", command)
+        if indices:
+            try:
+                indices = [int(a[0]) for a in indices]
+            except IndexError:
+                raise ArgParseError(_("Arguments must be specified with a number."))
+            low = min(indices)
+            indices = [a - low for a in indices]
+            high = max(indices)
+            gaps = set(indices).symmetric_difference(range(high + 1))
+            if gaps:
+                raise ArgParseError(
+                    _("Arguments must be sequential. Missing arguments: ")
+                    + ", ".join(str(i + low) for i in gaps)
+                )
+            command = command.format(*(f"{{{i}}}" for i in range(-low, high + low + 1)))
+
         alias = AliasEntry(alias_name, command, ctx.author, global_=global_)
 
         if global_:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [X] New feature

### Description of the changes
Allows customizing where parameters are placed in aliases using positional formatting arguments. Like with #2051, the bot will verify and correct newly created aliases if it can, and return a user-friendly error if it can't.
Parsing follows discord.py's parsing style. Quoted phrases are considered one argument and will be inserted appropriately.
Unused parameters are appended to the end.

Examples:

`[p]alias add oneban ban {0} 1`
`[p]oneban @zephyrkul too much fluff`
turns into: `[p]ban @zephyrkul 1 too much fluff`

`[p]alias add banhammer ban {1} 7`
corrected into: `[p]ban {0} 7`
`[p]banhammer @zephyrkul trolling`
turns into: `[p]ban @zephyrkul 7 trolling`

`[p]alias add badban ban {0} {2}`
returns: `Arguments must be sequential. Missing arguments: 1`
No alias is created.

`[p]alias add nonum ban {} 1`
returns: `Arguments must be specified with a number.`
No alias is created.