### PR TITLE
Remove unnecessary "or" from Config doc

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -465,7 +465,7 @@ class Group(Value):
 class Config:
     """Configuration manager for cogs and Red.
 
-    You should always use `get_conf` or to instantiate a Config object. Use
+    You should always use `get_conf` to instantiate a Config object. Use
     `get_core_conf` for Config used in the core package.
 
     .. important::


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Removes an unnecessary "or" from Config doc. The doc previously said
"You should always use `get_conf` or to instantiate a Config object."
which has an "or" but only one option. This removes that or.

If there is a second option, that option should be added instead.