### PR TITLE
Remove permissions's `p` alias

### DIFF
--- a/redbot/cogs/permissions/permissions.py
+++ b/redbot/cogs/permissions/permissions.py
@@ -103,7 +103,7 @@ class Permissions(commands.Cog):
         self.config.register_custom(COG)
         self.config.register_custom(COMMAND)
 
-    @commands.group(aliases=["p"])
+    @commands.group()
     async def permissions(self, ctx: commands.Context):
         """Command permission management tools."""
         pass


### PR DESCRIPTION
People can readd it with the alias cog, but core red should not monopolize short aliases.

What about those servers that want play even shorter?

### Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
