### PR TITLE
Delete cooldown messages when expired

### DIFF
--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -229,7 +229,8 @@ def init_events(bot, cli_flags):
             await ctx.send(
                 "This command is on cooldown. Try again in {}.".format(
                     humanize_timedelta(seconds=error.retry_after)
-                )
+                ),
+                delete_after=error.retry_after,
             )
         else:
             log.exception(type(error).__name__, exc_info=error)


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
It delete cooldown message when cooldown is expired to avoid having unnecessary messages in channels.

Note : It's a suggestion, personally I use it because it's a thing that was reported to me and finally I prefer like that.