### PR TITLE
[V3 Audio] Add option for dc at queue end

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -237,7 +237,7 @@ class Audio(commands.Cog):
                 await notify_channel.send(embed=embed)
 
         if event_type == lavalink.LavalinkEvents.QUEUE_END and disconnect:
-            if playing_servers == 0:
+            if status and playing_servers == 0:
                 await self.bot.change_presence(activity=None)
             await player.disconnect()
 

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -237,9 +237,6 @@ class Audio(commands.Cog):
                 await notify_channel.send(embed=embed)
 
         if event_type == lavalink.LavalinkEvents.QUEUE_END and disconnect:
-            playing_servers = await _players_check()
-            if status and playing_servers[1] == 0:
-                await self.bot.change_presence(activity=None)
             await player.disconnect()
 
         if event_type == lavalink.LavalinkEvents.QUEUE_END and status:

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -237,7 +237,8 @@ class Audio(commands.Cog):
                 await notify_channel.send(embed=embed)
 
         if event_type == lavalink.LavalinkEvents.QUEUE_END and disconnect:
-            if status and playing_servers == 0:
+            playing_servers = await _players_check()
+            if status and playing_servers[1] == 0:
                 await self.bot.change_presence(activity=None)
             await player.disconnect()
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes
This addition adds a toggle for having the bot instantly disconnect when the queue ends. It takes precedence over the audioset emptydisconnect setting as it disconnects immediately when the queue or single song is finished.