### PR TITLE
[V3 Audio] Queue clean and queue clear addition

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -1800,25 +1800,35 @@ class Audio(commands.Cog):
         return embed
 
     @queue.command(name="clear")
-    @checks.mod_or_permissions(administrator=True)
     @commands.guild_only()
     async def _queue_clear(self, ctx):
         """Clears the queue."""
         player = lavalink.get_player(ctx.guild.id)
+        dj_enabled = await self.config.guild(ctx.guild).dj_enabled()
         if not self._player_check(ctx) or not player.queue:
             return await self._embed_msg(ctx, _("There's nothing in the queue."))
         player = lavalink.get_player(ctx.guild.id)
+        if dj_enabled:
+            if not await self._can_instaskip(ctx, ctx.author) and not await self._is_alone(
+                ctx, ctx.author
+            ):
+                return await self._embed_msg(ctx, _("You need the DJ role to clear the queue."))
         player.queue.clear()
         await self._embed_msg(ctx, _("The queue has been cleared."))
 
     @queue.command(name="clean")
-    @checks.mod_or_permissions(administrator=True)
     @commands.guild_only()
     async def _queue_clean(self, ctx):
         """Removes songs from the queue if the requester is not in the voice channel."""
         player = lavalink.get_player(ctx.guild.id)
+        dj_enabled = await self.config.guild(ctx.guild).dj_enabled()
         if not self._player_check(ctx) or not player.queue:
             return await self._embed_msg(ctx, _("There's nothing in the queue."))
+        if dj_enabled:
+            if not await self._can_instaskip(ctx, ctx.author) and not await self._is_alone(
+                ctx, ctx.author
+            ):
+                return await self._embed_msg(ctx, _("You need the DJ role to clean the queue."))
         clean_tracks = []
         removed_tracks = 0
         listeners = player.channel.members

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -1613,7 +1613,7 @@ class Audio(commands.Cog):
             )
             await ctx.send(embed=embed)
 
-    @commands.command()
+    @commands.group(invoke_without_command=True)
     @commands.guild_only()
     async def queue(self, ctx, *, page="1"):
         """List the queue.
@@ -1798,6 +1798,47 @@ class Audio(commands.Cog):
             )
         )
         return embed
+
+    @queue.command(name="clear")
+    @checks.mod_or_permissions(administrator=True)
+    @commands.guild_only()
+    async def _queue_clear(self, ctx):
+        """Clears the queue."""
+        player = lavalink.get_player(ctx.guild.id)
+        if not self._player_check(ctx) or not player.queue:
+            return await self._embed_msg(ctx, _("There's nothing in the queue."))
+        player = lavalink.get_player(ctx.guild.id)
+        player.queue.clear()
+        await self._embed_msg(ctx, _("The queue has been cleared."))
+
+    @queue.command(name="clean")
+    @checks.mod_or_permissions(administrator=True)
+    @commands.guild_only()
+    async def _queue_clean(self, ctx):
+        """Removes songs from the queue if the requester is not in the voice channel."""
+        player = lavalink.get_player(ctx.guild.id)
+        if not self._player_check(ctx) or not player.queue:
+            return await self._embed_msg(ctx, _("There's nothing in the queue."))
+        clean_tracks = []
+        removed_tracks = 0
+        listeners = player.channel.members
+        for track in player.queue:
+            if track.requester in listeners:
+                clean_tracks.append(track)
+            else:
+                removed_tracks += 1
+        player.queue = clean_tracks
+        if removed_tracks == 0:
+            await self._embed_msg(
+                ctx, _("Removed 0 tracks.").format(removed_tracks=removed_tracks)
+            )
+        else:
+            await self._embed_msg(
+                ctx,
+                _(
+                    "Removed {removed_tracks} tracks queued by members outside of the voice channel."
+                ).format(removed_tracks=removed_tracks),
+            )
 
     @commands.command()
     @commands.guild_only()

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -1839,9 +1839,7 @@ class Audio(commands.Cog):
                 removed_tracks += 1
         player.queue = clean_tracks
         if removed_tracks == 0:
-            await self._embed_msg(
-                ctx, _("Removed 0 tracks.").format(removed_tracks=removed_tracks)
-            )
+            await self._embed_msg(ctx, _("Removed 0 tracks."))
         else:
             await self._embed_msg(
                 ctx,


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes
* [p]queue clear clears the queue but keeps the bot playing the current song.
* [p]queue clean clears the queue of songs queued by someone outside of the voice channel.