### PR TITLE
Fix Command.error decorator

### DIFF
--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -397,7 +397,7 @@ class Command(CogCommandMixin, commands.Command):
                     break
         return old_rule, new_rule
 
-    async def error(self, coro):
+    def error(self, coro):
         """
         A decorator that registers a coroutine as a local error handler.
 
@@ -434,7 +434,7 @@ class Command(CogCommandMixin, commands.Command):
         discord.ClientException
             The coroutine is not actually a coroutine.
         """
-        return await super().error(coro)
+        return super().error(coro)
 
 
 class GroupMixin(discord.ext.commands.GroupMixin):


### PR DESCRIPTION

### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Last minute adjustments I made to #2458 were incorrect, Command.error should be a decorator which does things with a coroutine, not a coroutine itself.