### PR TITLE
[V3 Audio] Fix for audioset status

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -125,9 +125,7 @@ class Audio(commands.Cog):
 
         async def _players_check():
             try:
-                get_players = [
-                    p for p in lavalink.players if p.current is not None and p.is_playing
-                ]
+                get_players = [p for p in lavalink.players if p.current is not None]
                 get_single_title = get_players[0].current.title
                 if get_single_title == "Unknown title":
                     get_single_title = get_players[0].current.uri


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Revert player.is_playing check added to the playing players list for audioset status in #2473. This addition would cause no status to be shown when a local track was played and skip was used.