### PR TITLE
[V3 Filter] Throw a filter Event on_filter_message_delete

### DIFF
--- a/redbot/cogs/filter/filter.py
+++ b/redbot/cogs/filter/filter.py
@@ -363,8 +363,8 @@ class Filter(commands.Cog):
 
         if hits:
             try:
-                self.bot.dispatch("filter_message_delete", message)
                 await message.delete()
+                self.bot.dispatch("filter_message_delete", message)
             except discord.HTTPException:
                 pass
             else:

--- a/redbot/cogs/filter/filter.py
+++ b/redbot/cogs/filter/filter.py
@@ -363,6 +363,7 @@ class Filter(commands.Cog):
 
         if hits:
             try:
+                self.bot.dispatch("filter_message_delete", message)
                 await message.delete()
             except discord.HTTPException:
                 pass

--- a/redbot/cogs/filter/filter.py
+++ b/redbot/cogs/filter/filter.py
@@ -364,7 +364,7 @@ class Filter(commands.Cog):
         if hits:
             try:
                 await message.delete()
-                self.bot.dispatch("filter_message_delete", message)
+                self.bot.dispatch("filter_message_delete", message, hits)
             except discord.HTTPException:
                 pass
             else:

--- a/redbot/cogs/filter/filter.py
+++ b/redbot/cogs/filter/filter.py
@@ -364,10 +364,10 @@ class Filter(commands.Cog):
         if hits:
             try:
                 await message.delete()
-                self.bot.dispatch("filter_message_delete", message, hits)
             except discord.HTTPException:
                 pass
             else:
+                self.bot.dispatch("filter_message_delete", message, hits)
                 if filter_count > 0 and filter_time > 0:
                     user_count += 1
                     await self.settings.member(author).filter_count.set(user_count)


### PR DESCRIPTION
reference to https://github.com/Cog-Creators/Red-DiscordBot/pull/2443

### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes

Like Sinbad and Kowlin talked in PR 2443, I now add an event to the filter cog. It is thrown when a message got deleted and provide the message to custom cogs, just listen to the on_filter_message_delete event.