### PR TITLE
[Permissions] Exclude `@everyone` role when retrieving rules

### DIFF
--- a/redbot/core/commands/requires.py
+++ b/redbot/core/commands/requires.py
@@ -531,7 +531,10 @@ class Requires:
         if category is not None:
             channels.append(category)
 
-        model_chain = [author, *channels, *author.roles, guild]
+        # We want author roles sorted highest to lowest, and exclude the @everyone role
+        author_roles = reversed(author.roles[1:])
+
+        model_chain = [author, *channels, *author_roles, guild]
 
         for rules in rules_chain:
             for model in model_chain:


### PR DESCRIPTION
This fixes two issues:
- Rules for roles being checked in the wrong order
- Setting a guild rule for a channel which shares its ID with the guild will apply the rule to the entire server. This issue still exists in global rules, however.