### PR TITLE
Spelling correction of method name in Tunnel

### DIFF
--- a/redbot/cogs/reports/reports.py
+++ b/redbot/cogs/reports/reports.py
@@ -165,7 +165,7 @@ class Reports(commands.Cog):
         if channel is None:
             return None
 
-        files: List[discord.File] = await Tunnel.files_from_attatch(msg)
+        files: List[discord.File] = await Tunnel.files_from_attach(msg)
 
         ticket_number = await self.config.guild(guild).next_ticket()
         await self.config.guild(guild).next_ticket.set(ticket_number + 1)

--- a/redbot/core/utils/tunnel.py
+++ b/redbot/core/utils/tunnel.py
@@ -158,6 +158,8 @@ class Tunnel(metaclass=TunnelMeta):
                 files.append(discord.File(_fp, filename=a.filename))
         return files
 
+    files_from_attatch = files_from_attach
+
     async def communicate(
         self, *, message: discord.Message, topic: str = None, skip_message_content: bool = False
     ):

--- a/redbot/core/utils/tunnel.py
+++ b/redbot/core/utils/tunnel.py
@@ -132,7 +132,7 @@ class Tunnel(metaclass=TunnelMeta):
         return rets
 
     @staticmethod
-    async def files_from_attatch(m: discord.Message) -> List[discord.File]:
+    async def files_from_attach(m: discord.Message) -> List[discord.File]:
         """
         makes a list of file objects from a message
         returns an empty list if none, or if the sum of file sizes
@@ -201,10 +201,10 @@ class Tunnel(metaclass=TunnelMeta):
             content = topic
 
         if message.attachments:
-            attach = await self.files_from_attatch(message)
+            attach = await self.files_from_attach(message)
             if not attach:
                 await message.channel.send(
-                    "Could not forward attatchments. "
+                    "Could not forward attachments. "
                     "Total size of attachments in a single "
                     "message must be less than 8MB."
                 )

--- a/redbot/core/utils/tunnel.py
+++ b/redbot/core/utils/tunnel.py
@@ -158,6 +158,7 @@ class Tunnel(metaclass=TunnelMeta):
                 files.append(discord.File(_fp, filename=a.filename))
         return files
 
+    # Backwards-compatible typo fix (GH-2496)
     files_from_attatch = files_from_attach
 
     async def communicate(


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fix for wrong spelling in method name `files_from_attatch`, I changed it to `files_from_attach` in all its appearances.

This is actually breaking change, because of change of method's name, lol.