### PR TITLE
[V3 Admin] Fix errors when hierarchy issues are raised

### DIFF
--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -145,7 +145,7 @@ class Admin(commands.Cog):
             # noinspection PyTypeChecker
             await self._addrole(ctx, user, rolename)
         else:
-            await self.complain(ctx, T_(USER_HIERARCHY_ISSUE), member=ctx.author, role=rolename)
+            await self.complain(ctx, T_(USER_HIERARCHY_ISSUE), member=user, role=rolename)
 
     @commands.command()
     @commands.guild_only()

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -111,7 +111,9 @@ class Admin(commands.Cog):
             await member.add_roles(role)
         except discord.Forbidden:
             if not self.pass_hierarchy_check(ctx, role):
-                await self.complain(ctx, T_(HIERARCHY_ISSUE), role=role, member=member, verb=_("add"))
+                await self.complain(
+                    ctx, T_(HIERARCHY_ISSUE), role=role, member=member, verb=_("add")
+                )
             else:
                 await self.complain(ctx, T_(GENERIC_FORBIDDEN))
         else:
@@ -126,7 +128,9 @@ class Admin(commands.Cog):
             await member.remove_roles(role)
         except discord.Forbidden:
             if not self.pass_hierarchy_check(ctx, role):
-                await self.complain(ctx, T_(HIERARCHY_ISSUE), role=role, member=member, verb=_("remove"))
+                await self.complain(
+                    ctx, T_(HIERARCHY_ISSUE), role=role, member=member, verb=_("remove")
+                )
             else:
                 await self.complain(ctx, T_(GENERIC_FORBIDDEN))
         else:
@@ -152,7 +156,9 @@ class Admin(commands.Cog):
             # noinspection PyTypeChecker
             await self._addrole(ctx, user, rolename)
         else:
-            await self.complain(ctx, T_(USER_HIERARCHY_ISSUE), member=user, role=rolename, verb=_("add"))
+            await self.complain(
+                ctx, T_(USER_HIERARCHY_ISSUE), member=user, role=rolename, verb=_("add")
+            )
 
     @commands.command()
     @commands.guild_only()
@@ -170,7 +176,9 @@ class Admin(commands.Cog):
             # noinspection PyTypeChecker
             await self._removerole(ctx, user, rolename)
         else:
-            await self.complain(ctx, T_(USER_HIERARCHY_ISSUE), member=user, role=rolename, verb=_("remove"))
+            await self.complain(
+                ctx, T_(USER_HIERARCHY_ISSUE), member=user, role=rolename, verb=_("remove")
+            )
 
     @commands.group()
     @commands.guild_only()

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -20,14 +20,21 @@ GENERIC_FORBIDDEN = _(
 )
 
 HIERARCHY_ISSUE = _(
-    "I tried to add {role.name} to {member.display_name} but that role"
+    "I tried to {verb} {role.name} to {member.display_name} but that role"
     " is higher than my highest role in the Discord hierarchy so I was"
     " unable to successfully add it. Please give me a higher role and "
     "try again."
 )
 
 USER_HIERARCHY_ISSUE = _(
-    "I tried to add {role.name} to {member.display_name} but that role"
+    "I tried to {verb} {role.name} to {member.display_name} but that role"
+    " is higher than your highest role in the Discord hierarchy so I was"
+    " unable to successfully add it. Please get a higher role and "
+    "try again."
+)
+
+ROLE_USER_HIERARCHY_ISSUE = _(
+    "I tried to edit {role.name} but that role"
     " is higher than your highest role in the Discord hierarchy so I was"
     " unable to successfully add it. Please get a higher role and "
     "try again."
@@ -104,7 +111,7 @@ class Admin(commands.Cog):
             await member.add_roles(role)
         except discord.Forbidden:
             if not self.pass_hierarchy_check(ctx, role):
-                await self.complain(ctx, T_(HIERARCHY_ISSUE), role=role, member=member)
+                await self.complain(ctx, T_(HIERARCHY_ISSUE), role=role, member=member, verb=_("add"))
             else:
                 await self.complain(ctx, T_(GENERIC_FORBIDDEN))
         else:
@@ -119,7 +126,7 @@ class Admin(commands.Cog):
             await member.remove_roles(role)
         except discord.Forbidden:
             if not self.pass_hierarchy_check(ctx, role):
-                await self.complain(ctx, T_(HIERARCHY_ISSUE), role=role, member=member)
+                await self.complain(ctx, T_(HIERARCHY_ISSUE), role=role, member=member, verb=_("remove"))
             else:
                 await self.complain(ctx, T_(GENERIC_FORBIDDEN))
         else:
@@ -145,7 +152,7 @@ class Admin(commands.Cog):
             # noinspection PyTypeChecker
             await self._addrole(ctx, user, rolename)
         else:
-            await self.complain(ctx, T_(USER_HIERARCHY_ISSUE), member=user, role=rolename)
+            await self.complain(ctx, T_(USER_HIERARCHY_ISSUE), member=user, role=rolename, verb=_("add"))
 
     @commands.command()
     @commands.guild_only()
@@ -163,7 +170,7 @@ class Admin(commands.Cog):
             # noinspection PyTypeChecker
             await self._removerole(ctx, user, rolename)
         else:
-            await self.complain(ctx, T_(USER_HIERARCHY_ISSUE))
+            await self.complain(ctx, T_(USER_HIERARCHY_ISSUE), member=user, role=rolename, verb=_("remove"))
 
     @commands.group()
     @commands.guild_only()
@@ -190,7 +197,7 @@ class Admin(commands.Cog):
         reason = "{}({}) changed the colour of role '{}'".format(author.name, author.id, role.name)
 
         if not self.pass_user_hierarchy_check(ctx, role):
-            await self.complain(ctx, T_(USER_HIERARCHY_ISSUE))
+            await self.complain(ctx, T_(ROLE_USER_HIERARCHY_ISSUE), role=role)
             return
 
         try:
@@ -218,7 +225,7 @@ class Admin(commands.Cog):
         )
 
         if not self.pass_user_hierarchy_check(ctx, role):
-            await self.complain(ctx, T_(USER_HIERARCHY_ISSUE))
+            await self.complain(ctx, T_(ROLE_USER_HIERARCHY_ISSUE), role=role)
             return
 
         try:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This fixes a few things:
+ When using `[p]addrole` to apply a role to another user, the bot says it tried to add the role to the user issuing the command.
+ When removing a role with `[p]removerole` and hierarchy is not met the bot would complain saying it's trying to add a role.
+ When editing roles and hierarchy is not met the bot errors out rather than properly complaining.