### PR TITLE
Logging enhancements and cleanup

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -2,29 +2,31 @@
 
 # Discord Version check
 
+import asyncio
+import logging
+import os
 import sys
+
 import discord
+
+import redbot.logging
 from redbot.core.bot import Red, ExitCodes
 from redbot.core.cog_manager import CogManagerUI
-from redbot.core.data_manager import create_temp_config, load_basic_configuration, config_file
 from redbot.core.json_io import JsonIO
 from redbot.core.global_checks import init_global_checks
 from redbot.core.events import init_events
 from redbot.core.cli import interactive_config, confirm, parse_cli_flags
 from redbot.core.core_commands import Core
 from redbot.core.dev_commands import Dev
-from redbot.core import modlog, bank
+from redbot.core import modlog, bank, data_manager
 from signal import SIGTERM
-import asyncio
-import logging.handlers
-import logging
-import os
 
 # Let's not force this dependency, uvloop is much faster on cpython
 if sys.implementation.name == "cpython":
     try:
         import uvloop
     except ImportError:
+        uvloop = None
         pass
     else:
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
@@ -32,52 +34,13 @@ if sys.implementation.name == "cpython":
 if sys.platform == "win32":
     asyncio.set_event_loop(asyncio.ProactorEventLoop())
 
+log = logging.getLogger("red.main")
 
 #
 #               Red - Discord Bot v3
 #
 #         Made by Twentysix, improved by many
 #
-
-
-def init_loggers(cli_flags):
-    # d.py stuff
-    dpy_logger = logging.getLogger("discord")
-    dpy_logger.setLevel(logging.WARNING)
-    console = logging.StreamHandler()
-    console.setLevel(logging.WARNING)
-    dpy_logger.addHandler(console)
-
-    # Red stuff
-
-    logger = logging.getLogger("red")
-
-    red_format = logging.Formatter(
-        "%(asctime)s %(levelname)s %(module)s %(funcName)s %(lineno)d: %(message)s",
-        datefmt="[%d/%m/%Y %H:%M]",
-    )
-
-    stdout_handler = logging.StreamHandler(sys.stdout)
-    stdout_handler.setFormatter(red_format)
-
-    if cli_flags.debug:
-        os.environ["PYTHONASYNCIODEBUG"] = "1"
-        logger.setLevel(logging.DEBUG)
-    else:
-        logger.setLevel(logging.INFO)
-
-    from redbot.core.data_manager import core_data_path
-
-    logfile_path = core_data_path() / "red.log"
-    fhandler = logging.handlers.RotatingFileHandler(
-        filename=str(logfile_path), encoding="utf-8", mode="a", maxBytes=10 ** 7, backupCount=5
-    )
-    fhandler.setFormatter(red_format)
-
-    logger.addHandler(fhandler)
-    logger.addHandler(stdout_handler)
-
-    return logger
 
 
 async def _get_prefix_and_token(red, indict):
@@ -91,14 +54,14 @@ async def _get_prefix_and_token(red, indict):
 
 
 def list_instances():
-    if not config_file.exists():
+    if not data_manager.config_file.exists():
         print(
             "No instances have been configured! Configure one "
             "using `redbot-setup` before trying to run the bot!"
         )
         sys.exit(1)
     else:
-        data = JsonIO(config_file)._load_json()
+        data = JsonIO(data_manager.config_file)._load_json()
         text = "Configured Instances:\n\n"
         for instance_name in sorted(data.keys()):
             text += "{}\n".format(instance_name)
@@ -125,13 +88,19 @@ def main():
     if cli_flags.no_instance:
         print(
             "\033[1m"
-            "Warning: The data will be placed in a temporary folder and removed on next system reboot."
+            "Warning: The data will be placed in a temporary folder and removed on next system "
+            "reboot."
             "\033[0m"
         )
         cli_flags.instance_name = "temporary_red"
-        create_temp_config()
-    load_basic_configuration(cli_flags.instance_name)
-    log = init_loggers(cli_flags)
+        data_manager.create_temp_config()
+    data_manager.load_basic_configuration(cli_flags.instance_name)
+    redbot.logging.init_logging(cli_flags.debug)
+
+    log.debug("====Basic Config====")
+    log.debug("Data Path: %s", data_manager._base_data_path())
+    log.debug("Storage Type: %s", data_manager.storage_type())
+
     red = Red(cli_flags=cli_flags, description=description, pm_help=None)
     init_global_checks(red)
     init_events(red, cli_flags)

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -95,7 +95,9 @@ def main():
         cli_flags.instance_name = "temporary_red"
         data_manager.create_temp_config()
     data_manager.load_basic_configuration(cli_flags.instance_name)
-    redbot.logging.init_logging(cli_flags.debug)
+    redbot.logging.init_logging(
+        level=cli_flags.logging_level, location=data_manager.core_data_path() / "logs"
+    )
 
     log.debug("====Basic Config====")
     log.debug("Data Path: %s", data_manager._base_data_path())

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import asyncio
+import logging
 
 
 def confirm(m=""):
@@ -97,7 +98,14 @@ def parse_cli_flags(args):
         "login. This is useful for testing the boot "
         "process.",
     )
-    parser.add_argument("--debug", action="store_true", help="Sets the loggers level as debug")
+    parser.add_argument(
+        "--debug",
+        action="store_const",
+        dest="logging_level",
+        const=logging.DEBUG,
+        default=logging.INFO,
+        help="Sets the loggers level as debug",
+    )
     parser.add_argument("--dev", action="store_true", help="Enables developer mode")
     parser.add_argument(
         "--mentionable",

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -569,12 +569,8 @@ class Config:
         # We have to import this here otherwise we have a circular dependency
         from .data_manager import basic_config
 
-        log.debug("Basic config: \n\n{}".format(basic_config))
-
         driver_name = basic_config.get("STORAGE_TYPE", "JSON")
         driver_details = basic_config.get("STORAGE_DETAILS", {})
-
-        log.debug("Using driver: '{}'".format(driver_name))
 
         driver = get_driver(
             driver_name, cog_name, uuid, data_path_override=cog_path_override, **driver_details

--- a/redbot/core/json_io.py
+++ b/redbot/core/json_io.py
@@ -47,7 +47,6 @@ class JsonIO:
         And:
             https://www.mjmwired.net/kernel/Documentation/filesystems/ext4.txt#310
         """
-        log.debug("Saving file {}".format(self.path))
         filename = self.path.stem
         tmp_file = "{}-{}.tmp".format(filename, uuid4().fields[0])
         tmp_path = self.path.parent / tmp_file
@@ -80,7 +79,6 @@ class JsonIO:
 
     # noinspection PyUnresolvedReferences
     def _load_json(self):
-        log.debug("Reading file {}".format(self.path))
         with self.path.open(encoding="utf-8", mode="r") as f:
             data = json.load(f)
         return data

--- a/redbot/logging.py
+++ b/redbot/logging.py
@@ -1,0 +1,69 @@
+import logging.handlers
+import pathlib
+import re
+import sys
+
+from redbot.core import data_manager
+
+MAX_OLD_LOGS = 9
+
+
+def init_logging(debug: bool) -> None:
+    dpy_logger = logging.getLogger("discord")
+    dpy_logger.setLevel(logging.WARNING)
+    base_logger = logging.getLogger("red")
+    if debug is True:
+        base_logger.setLevel(logging.DEBUG)
+    else:
+        base_logger.setLevel(logging.INFO)
+
+    formatter = logging.Formatter(
+        "[{asctime}] [{levelname}] {name}: {message}", datefmt="%Y-%m-%d %H:%M:%S", style="{"
+    )
+
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(formatter)
+    base_logger.addHandler(stdout_handler)
+    dpy_logger.addHandler(stdout_handler)
+
+    logs_dir = data_manager.core_data_path() / "logs"
+    if not logs_dir.exists():
+        logs_dir.mkdir(parents=True, exist_ok=True)
+    # Rotate old logs
+    paths = []
+    for path in logs_dir.iterdir():
+        match = re.match(r"red\.(?P<log_num>\d+)\.part(?P<part>\d+)\.log", path.name)
+        if match:
+            log_num = int(match["log_num"])
+            if log_num < MAX_OLD_LOGS:
+                paths.append((log_num, match["part"], path))
+            else:
+                path.unlink()
+            continue
+        match = re.match(r"latest\.part(?P<part>\d+)\.log", path.name)
+        if match:
+            paths.append((0, match["part"], path))
+    for log_num, part, path in sorted(paths, reverse=True):
+        path.replace(path.parent / f"red.{log_num + 1}.part{part}.log")
+
+    fhandler = logging.handlers.RotatingFileHandler(
+        filename=logs_dir / "latest.part0.log",
+        encoding="utf-8",
+        mode="a",
+        maxBytes=500_000,  # About 500KB per logfile
+        backupCount=9,     # Maximum 10 parts to each log
+    )
+    fhandler.namer = _namer
+    fhandler.setFormatter(formatter)
+
+    base_logger.addHandler(fhandler)
+
+
+def _namer(defaultname: str) -> str:
+    # This renames `latest.part0.log` to `latest.part1.log` and so on, when the original gets too
+    # large. `defaultname` is in the format `latest.part0.log.X`, where X is the index of the next
+    # part.
+    # See the `doRollover` method of `logging.handlers.RotatingFileHandler`.
+    path = pathlib.Path(defaultname)
+    part_num = path.suffix[1:]
+    return path.parent / f"latest.part{part_num}.log"

--- a/redbot/logging.py
+++ b/redbot/logging.py
@@ -51,7 +51,7 @@ def init_logging(debug: bool) -> None:
         encoding="utf-8",
         mode="a",
         maxBytes=500_000,  # About 500KB per logfile
-        backupCount=9,     # Maximum 10 parts to each log
+        backupCount=9,  # Maximum 10 parts to each log
     )
     fhandler.namer = _namer
     fhandler.setFormatter(formatter)


### PR DESCRIPTION
- Removed debug log messages every time `Config.get_conf` is used or a JSON file is read/saved. The basic configuration is now logged once with DEBUG when the bot starts up instead.
- Changed logging output format to reverse date order, include seconds, and use the logger's name instead of the module, function and line number.
- Log files are now kept in the `DATAPATH/core/logs` directory. ~~Each time Red is restarted, a new log is created, and the old ones renamed in a rotating fashion.~~ *(see discussion below)* There can be a maximum of 9 logs in total.
- Each log file now has a smaller max size of ~~500KB~~ 1MB before it will be split into multiple parts. There are also a maximum of 9 parts of each log.
- Discord.py logger now uses the same output formatter as red's loggers
- Moved logging setup code into `redbot.logging` module.
