### PR TITLE
[Backport for 3.0.x] [Mod] Add missing check to voiceunban (cosmetic)

### DIFF
--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -892,6 +892,7 @@ class Mod(commands.Cog):
 
     @commands.command()
     @commands.guild_only()
+    @checks.admin_or_permissions(mute_members=True, deafen_members=True)
     async def voiceunban(self, ctx: commands.Context, user: discord.Member, *, reason: str = None):
         """Unban a user from speaking and listening in the server's voice channels."""
         user_voice_state = user.voice


### PR DESCRIPTION
Note: This is not a security issue, but a cosmetic one (see the voice perms check which is already inlined) for the help menu.

### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Fixes help menu