### PR TITLE
[Audio] Add songs when search-queuing

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -2212,7 +2212,8 @@ class Audio(commands.Cog):
                 player.add(ctx.author, search_choice)
             else:
                 return await self._embed_msg(ctx, _("Track exceeds maximum length."))
-        player.add(ctx.author, search_choice)
+        else:
+            player.add(ctx.author, search_choice)
         if not player.current:
             await player.play()
         await ctx.send(embed=embed)

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -2212,6 +2212,7 @@ class Audio(commands.Cog):
                 player.add(ctx.author, search_choice)
             else:
                 return await self._embed_msg(ctx, _("Track exceeds maximum length."))
+        player.add(ctx.author, search_choice)
         if not player.current:
             await player.play()
         await ctx.send(embed=embed)


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Searching for a song and pressing the reaction to queue a song would not add the song to the queue if audioset maxlength was off. This was an omission from #2465.