### PR TITLE
[V3 Downloader] Tell user how to load the cog after [p]cog install

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -318,7 +318,11 @@ class Downloader(commands.Cog):
 
         await repo.install_libraries(target_dir=self.SHAREDLIB_PATH, req_target_dir=self.LIB_PATH)
 
-        await ctx.send(_("Cog `{cog_name}` successfully installed.").format(cog_name=cog_name))
+        await ctx.send(
+            _(
+                "Cog `{cog_name}` successfully installed. You can load it with {prefix}load {cog_name}"
+            ).format(cog_name=cog_name, prefix=ctx.prefix)
+        )
         if cog.install_msg is not None:
             await ctx.send(cog.install_msg.replace("[p]", ctx.prefix))
 

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -320,7 +320,7 @@ class Downloader(commands.Cog):
 
         await ctx.send(
             _(
-                "Cog `{cog_name}` successfully installed. You can load it with {prefix}load {cog_name}"
+                "Cog `{cog_name}` successfully installed. You can load it with `{prefix}load {cog_name}`"
             ).format(cog_name=cog_name, prefix=ctx.prefix)
         )
         if cog.install_msg is not None:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
While it's better to not load cog during install, it might be good to tell the user, how it can be loaded (and therefore notify him that it's not loaded).