### PR TITLE
[V3 Audio] If bot has move members perm, it can join to user-limited channels

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -986,8 +986,10 @@ class Audio(commands.Cog):
                     return await self._embed_msg(ctx, _("That URL is not allowed."))
         if not self._player_check(ctx):
             try:
-                if not ctx.author.voice.channel.permissions_for(ctx.me).connect or self._userlimit(
-                    ctx.author.voice.channel
+                if (
+                    not ctx.author.voice.channel.permissions_for(ctx.me).connect
+                    or not ctx.author.voice.channel.permissions_for(ctx.me).move_members
+                    and self._userlimit(ctx.author.voice.channel)
                 ):
                     return await self._embed_msg(
                         ctx, _("I don't have permission to connect to your channel.")
@@ -1645,8 +1647,10 @@ class Audio(commands.Cog):
                 return False
         if not self._player_check(ctx):
             try:
-                if not ctx.author.voice.channel.permissions_for(ctx.me).connect or self._userlimit(
-                    ctx.author.voice.channel
+                if (
+                    not ctx.author.voice.channel.permissions_for(ctx.me).connect
+                    or not ctx.author.voice.channel.permissions_for(ctx.me).move_members
+                    and self._userlimit(ctx.author.voice.channel)
                 ):
                     return await self._embed_msg(
                         ctx, _("I don't have permission to connect to your channel.")
@@ -2029,8 +2033,10 @@ class Audio(commands.Cog):
 
         if not self._player_check(ctx):
             try:
-                if not ctx.author.voice.channel.permissions_for(ctx.me).connect or self._userlimit(
-                    ctx.author.voice.channel
+                if (
+                    not ctx.author.voice.channel.permissions_for(ctx.me).connect
+                    or not ctx.author.voice.channel.permissions_for(ctx.me).move_members
+                    and self._userlimit(ctx.author.voice.channel)
                 ):
                     return await self._embed_msg(
                         ctx, _("I don't have permission to connect to your channel.")


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Before this, when you wanted to play some music on full voice channel and bot had permission to move members (which allows you to join the user-limited channel) it wouldn't join and reply with "I don't have permission to connect to your channel." even though it could. This PR fixes this behavior.

I'm not sure if it was a right choice to not put this check in `_userlimit` method. I can change it, if you think it will be better this way.