### PR TITLE
[V3 Trivia] Update "World" trivias to reflect legislative changes

### DIFF
--- a/redbot/cogs/trivia/data/lists/worldcapitals.yaml
+++ b/redbot/cogs/trivia/data/lists/worldcapitals.yaml
@@ -74,7 +74,7 @@ What is the capital of Bulgaria?:
 What is the capital of Burkina Faso?:
 - Ouagadougou
 What is the capital of Burundi?:
-- Bujumbura
+- Gitega
 What is the capital of Cabo Verde?:
 - Praia
 What is the capital of Cambodia?:
@@ -235,8 +235,6 @@ What is the capital of Lithuania?:
 - Vilnius
 What is the capital of Luxembourg?:
 - Luxembourg
-What is the capital of Macedonia?:
-- Skopje
 What is the capital of Madagascar?:
 - Antananarivo
 What is the capital of Malawi?:
@@ -292,6 +290,8 @@ What is the capital of Nigeria?:
 What is the capital of North Korea?:
 - Pyongyang
 - pyong yang
+What is the capital of North Macedonia?:
+- Skopje
 What is the capital of Norway?:
 - Oslo
 What is the capital of Oman?:
@@ -338,7 +338,7 @@ What is the capital of Samoa?:
 What is the capital of San Marino?:
 - San Marino
 - sanmarino
-What is the capital of Sao Tome and Principe?:
+What is the capital of São Tomé and Príncipe?:
 - São Tomé
 - sao tome
 - saotome
@@ -371,6 +371,7 @@ What is the capital of Spain?:
 What is the capital of Sri Lanka?:
 - Sri Jayawardenepura Kotte
 - srijawawardenpurakotte
+- Kotte
 What is the capital of Sudan?:
 - Khartoum
 What is the capital of Suriname?:

--- a/redbot/cogs/trivia/data/lists/worldflags.yaml
+++ b/redbot/cogs/trivia/data/lists/worldflags.yaml
@@ -54,7 +54,7 @@ What country is represented by this flag? https://i.imgur.com/6UkAfly.png:
 What country is represented by this flag? https://i.imgur.com/7qSsp7Z.png:
 - Samoa
 What country is represented by this flag? https://i.imgur.com/7weskDc.png:
-- Macedonia
+- North Macedonia
 What country is represented by this flag? https://i.imgur.com/8F5aqVG.png:
 - Germany
 What country is represented by this flag? https://i.imgur.com/8LFhQVn.png:
@@ -62,7 +62,8 @@ What country is represented by this flag? https://i.imgur.com/8LFhQVn.png:
 - People's Republic of Korea
 What country is represented by this flag? https://i.imgur.com/8OzbswS.png:
 - Armenia
-What country is represented by this flag? https://i.imgur.com/AKvyrB8.png:
+What country is represented by this flag? https://i.imgur.com/JVcBYTS.png:
+- São Tomé and Príncipe
 - Sao Tome and Principe
 - Sao Tome
 What country is represented by this flag? https://i.imgur.com/AMccj7Q.png:

--- a/redbot/cogs/trivia/data/lists/worldmap.yaml
+++ b/redbot/cogs/trivia/data/lists/worldmap.yaml
@@ -15,7 +15,9 @@ What country is highlighted on this map? https://i.imgur.com/19AMqVD.png:
 What country is highlighted on this map? https://i.imgur.com/1GT6807.png:
 - Guinea
 What country is highlighted on this map? https://i.imgur.com/1MHPIUv.png:
+- São Tomé and Príncipe
 - Sao Tome and Principe
+- Sao Tome
 What country is highlighted on this map? https://i.imgur.com/1xVJiLb.png:
 - Nepal
 What country is highlighted on this map? https://i.imgur.com/21wXDZ6.png:
@@ -124,9 +126,7 @@ What country is highlighted on this map? https://i.imgur.com/E6lQFbg.png:
 What country is highlighted on this map? https://i.imgur.com/EE9jicV.png:
 - Tonga
 What country is highlighted on this map? https://i.imgur.com/EQSChbH.png:
-- Macedonia
-- FYROM
-- the former Yugoslav Republic of Macedonia
+- North Macedonia
 What country is highlighted on this map? https://i.imgur.com/EdETzhx.png:
 - Paraguay
 What country is highlighted on this map? https://i.imgur.com/FHCjY5w.png:
@@ -342,6 +342,7 @@ What country is highlighted on this map? https://i.imgur.com/kBdjnEv.png:
 What country is highlighted on this map? https://i.imgur.com/kHtsSx9.png:
 - Cote d'Ivoire
 - Ivory Coast
+- Cote Divoire
 What country is highlighted on this map? https://i.imgur.com/lHMAntb.png:
 - Pakistan
 What country is highlighted on this map? https://i.imgur.com/lIIYtBD.png:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Changed the trivia list to account for capital city changes, and country name changes. Additionally, some questions had correct answers added:
- Burundi changed their de jure capital from Bujumbura to Gitega, see [Bloomberg](https://www.bloomberg.com/news/articles/2018-12-24/burundi-moves-political-capital-from-bujumbura-to-gitega).
- F.Y.R. Macedonia is now officially called North Macedonia, see [UN News](https://news.un.org/en/story/2019/02/1032731).
- The flag for São Tomé and Príncipe was broken, so it's replaced with a working one.
- São Tomé and Príncipe was spelt without diacritics by default, whereas now the name with diacritics is default.
- The capital of Sri Lanka is also commonly known as Kotte (rather than the long name Sri Jayawardenepura Kotte), so it is added as a valid answer.