### PR TITLE
[Audio] Set cwd for localtracks on playlist start

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -775,8 +775,11 @@ class Audio(commands.Cog):
             f for f in os.listdir(os.getcwd()) if not os.path.isfile(f) if f == "localtracks"
         )
         if not localtracks_folder:
-            await self._embed_msg(ctx, _("No localtracks folder."))
-            return False
+            if ctx.invoked_with == "start":
+                return False
+            else:
+                await self._embed_msg(ctx, _("No localtracks folder."))
+                return False
         else:
             return True
 
@@ -1516,6 +1519,8 @@ class Audio(commands.Cog):
             player = lavalink.get_player(ctx.guild.id)
             for track in playlists[playlist_name]["tracks"]:
                 if track["info"]["uri"].startswith("localtracks/"):
+                    if not await self._localtracks_check(ctx):
+                        pass
                     if not os.path.isfile(track["info"]["uri"]):
                         continue
                 if maxlength > 0:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
If the playlist start command was used on a playlist that included local tracks as the first command, before any local commands were used, the player would drop all of the local tracks from being queued as they "didn't exist" in the cwd - audio hadn't moved to the localtracks dir yet. This change checks the _localtracks_check function first to change the cwd before doing the verification that the tracks exist in the localtracks dir.