### PR TITLE
[V3 Config] Update Mongo document organization to bypass doc size restriction

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -269,12 +269,7 @@ class Group(Value):
             dict access. These are casted to `str` for you.
         """
         path = tuple(str(p) for p in nested_path)
-        identifier_data = IdentifierData(
-            self.identifier_data.uuid,
-            self.identifier_data.category,
-            self.identifier_data.primary_key,
-            path,
-        )
+        identifier_data = self.identifier_data.add_identifier(*path)
         await self.driver.clear(identifier_data)
 
     def is_group(self, item: Any) -> bool:
@@ -392,12 +387,7 @@ class Group(Value):
             else:
                 default = poss_default
 
-        identifier_data = IdentifierData(
-            self.identifier_data.uuid,
-            self.identifier_data.category,
-            self.identifier_data.primary_key,
-            self.identifier_data.identifiers + path,
-        )
+        identifier_data = self.identifier_data.add_identifier(*path)
         try:
             raw = await self.driver.get(identifier_data)
         except KeyError:
@@ -475,12 +465,7 @@ class Group(Value):
             The value to store.
         """
         path = tuple(str(p) for p in nested_path)
-        identifier_data = IdentifierData(
-            self.identifier_data.uuid,
-            self.identifier_data.category,
-            self.identifier_data.primary_key,
-            self.identifier_data.identifiers + path,
-        )
+        identifier_data = self.identifier_data.add_identifier(*path)
         if isinstance(value, dict):
             value = _str_key_dict(value)
         await self.driver.set(identifier_data, value=value)

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -374,7 +374,7 @@ class Group(Value):
             If the value does not exist yet in Config's internal storage.
 
         """
-        path = [str(p) for p in nested_path]
+        path = tuple(str(p) for p in nested_path)
 
         if default is ...:
             poss_default = self.defaults
@@ -386,8 +386,14 @@ class Group(Value):
             else:
                 default = poss_default
 
+        identifier_data = IdentifierData(
+            self.identifier_data.uuid,
+            self.identifier_data.category,
+            self.identifier_data.primary_key,
+            self.identifier_data.identifiers + path
+        )
         try:
-            raw = await self.driver.get(self.identifier_data)
+            raw = await self.driver.get(identifier_data)
         except KeyError:
             if default is not ...:
                 return default

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -473,7 +473,7 @@ class Group(Value):
             self.identifier_data.uuid,
             self.identifier_data.category,
             self.identifier_data.primary_key,
-            path
+            self.identifier_data.identifiers + path
         )
         if isinstance(value, dict):
             value = _str_key_dict(value)
@@ -1085,7 +1085,13 @@ class Config:
         """
         if not scopes:
             # noinspection PyTypeChecker
-            group = Group(identifiers=(), defaults={}, driver=self.driver)
+            identifier_data = IdentifierData(
+                self.unique_identifier,
+                "",
+                (),
+                ()
+            )
+            group = Group(identifier_data, defaults={}, driver=self.driver)
         else:
             group = self._get_base_group(*scopes)
         await group.clear()

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -178,7 +178,11 @@ class Group(Value):
     """
 
     def __init__(
-        self, identifier_data: IdentifierData, defaults: dict, driver, force_registration: bool = False
+        self,
+        identifier_data: IdentifierData,
+        defaults: dict,
+        driver,
+        force_registration: bool = False,
     ):
         self._defaults = defaults
         self.force_registration = force_registration
@@ -235,7 +239,9 @@ class Group(Value):
             )
         elif is_value:
             return Value(
-                identifier_data=new_identifiers, default_value=self._defaults[item], driver=self.driver
+                identifier_data=new_identifiers,
+                default_value=self._defaults[item],
+                driver=self.driver,
             )
         elif self.force_registration:
             raise AttributeError("'{}' is not a valid registered Group or value.".format(item))
@@ -267,7 +273,7 @@ class Group(Value):
             self.identifier_data.uuid,
             self.identifier_data.category,
             self.identifier_data.primary_key,
-            path
+            path,
         )
         await self.driver.clear(identifier_data)
 
@@ -390,7 +396,7 @@ class Group(Value):
             self.identifier_data.uuid,
             self.identifier_data.category,
             self.identifier_data.primary_key,
-            self.identifier_data.identifiers + path
+            self.identifier_data.identifiers + path,
         )
         try:
             raw = await self.driver.get(identifier_data)
@@ -473,7 +479,7 @@ class Group(Value):
             self.identifier_data.uuid,
             self.identifier_data.category,
             self.identifier_data.primary_key,
-            self.identifier_data.identifiers + path
+            self.identifier_data.identifiers + path,
         )
         if isinstance(value, dict):
             value = _str_key_dict(value)
@@ -1085,12 +1091,7 @@ class Config:
         """
         if not scopes:
             # noinspection PyTypeChecker
-            identifier_data = IdentifierData(
-                self.unique_identifier,
-                "",
-                (),
-                ()
-            )
+            identifier_data = IdentifierData(self.unique_identifier, "", (), ())
             group = Group(identifier_data, defaults={}, driver=self.driver)
         else:
             group = self._get_base_group(*scopes)

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -381,7 +381,7 @@ class Group(Value):
                 default = poss_default
 
         try:
-            raw = await self.driver.get(*self.identifiers, *path)
+            raw = await self.driver.get(self.identifier_data)
         except KeyError:
             if default is not ...:
                 return default
@@ -459,7 +459,7 @@ class Group(Value):
         path = [str(p) for p in nested_path]
         if isinstance(value, dict):
             value = _str_key_dict(value)
-        await self.driver.set(*self.identifiers, *path, value=value)
+        await self.driver.set(self.identifier_data, value=value)
 
 
 class Config:

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -262,8 +262,14 @@ class Group(Value):
             Multiple arguments that mirror the arguments passed in for nested
             dict access. These are casted to `str` for you.
         """
-        path = [str(p) for p in nested_path]
-        await self.driver.clear(*self.identifiers, *path)
+        path = tuple(str(p) for p in nested_path)
+        identifier_data = IdentifierData(
+            self.identifier_data.uuid,
+            self.identifier_data.category,
+            self.identifier_data.primary_key,
+            path
+        )
+        await self.driver.clear(identifier_data)
 
     def is_group(self, item: Any) -> bool:
         """A helper method for `__getattr__`. Most developers will have no need
@@ -456,10 +462,16 @@ class Group(Value):
         value
             The value to store.
         """
-        path = [str(p) for p in nested_path]
+        path = tuple(str(p) for p in nested_path)
+        identifier_data = IdentifierData(
+            self.identifier_data.uuid,
+            self.identifier_data.category,
+            self.identifier_data.primary_key,
+            path
+        )
         if isinstance(value, dict):
             value = _str_key_dict(value)
-        await self.driver.set(self.identifier_data, value=value)
+        await self.driver.set(identifier_data, value=value)
 
 
 class Config:
@@ -1031,7 +1043,7 @@ class Config:
         if guild is None:
             group = self._get_base_group(self.MEMBER)
             try:
-                dict_ = await self.driver.get(*group.identifiers)
+                dict_ = await self.driver.get(group.identifier_data)
             except KeyError:
                 pass
             else:
@@ -1040,7 +1052,7 @@ class Config:
         else:
             group = self._get_base_group(self.MEMBER, str(guild.id))
             try:
-                guild_data = await self.driver.get(*group.identifiers)
+                guild_data = await self.driver.get(group.identifier_data)
             except KeyError:
                 pass
             else:

--- a/redbot/core/drivers/__init__.py
+++ b/redbot/core/drivers/__init__.py
@@ -1,4 +1,6 @@
-__all__ = ["get_driver"]
+from .red_base import IdentifierData
+
+__all__ = ["get_driver", "IdentifierData"]
 
 
 def get_driver(type, *args, **kwargs):

--- a/redbot/core/drivers/red_base.py
+++ b/redbot/core/drivers/red_base.py
@@ -1,4 +1,36 @@
-__all__ = ["BaseDriver"]
+from typing import Tuple
+
+__all__ = ["BaseDriver", "IdentifierData"]
+
+
+class IdentifierData:
+    def __init__(self, uuid: str, category: str, primary_key: Tuple[str], identifiers: Tuple[str]):
+        self.uuid = uuid
+        self.category = category
+        self.primary_key = primary_key
+        self.identifiers = identifiers
+
+    def __repr__(self):
+        return (
+            f"<IdentifierData uuid={self.uuid} category={self.category} primary_key={self.primary_key}"
+            f" identifiers={self.identifiers}>"
+        )
+
+    def add_identifier(self, identifier: str) -> "IdentifierData":
+        if not isinstance(identifier, str):
+            raise ValueError("Identifiers must be strings.")
+
+        return IdentifierData(
+            self.uuid,
+            self.category,
+            self.primary_key,
+            self.identifiers + (identifier,)
+        )
+
+    def to_tuple(self):
+        return (
+            self.uuid, self.category, *self.primary_key, *self.identifiers
+        )
 
 
 class BaseDriver:
@@ -6,14 +38,13 @@ class BaseDriver:
         self.cog_name = cog_name
         self.unique_cog_identifier = identifier
 
-    async def get(self, *identifiers: str):
+    async def get(self, identifier_data: IdentifierData):
         """
         Finds the value indicate by the given identifiers.
 
         Parameters
         ----------
-        identifiers
-            A list of identifiers that correspond to nested dict accesses.
+        identifier_data
 
         Returns
         -------
@@ -33,20 +64,19 @@ class BaseDriver:
         """
         raise NotImplementedError
 
-    async def set(self, *identifiers: str, value=None):
+    async def set(self, identifier_data: IdentifierData, value=None):
         """
         Sets the value of the key indicated by the given identifiers.
 
         Parameters
         ----------
-        identifiers
-            A list of identifiers that correspond to nested dict accesses.
+        identifier_data
         value
             Any JSON serializable python object.
         """
         raise NotImplementedError
 
-    async def clear(self, *identifiers: str):
+    async def clear(self, identifier_data: IdentifierData):
         """
         Clears out the value specified by the given identifiers.
 
@@ -54,7 +84,6 @@ class BaseDriver:
 
         Parameters
         ----------
-        identifiers
-            A list of identifiers that correspond to nested dict accesses.
+        identifier_data
         """
         raise NotImplementedError

--- a/redbot/core/drivers/red_base.py
+++ b/redbot/core/drivers/red_base.py
@@ -5,10 +5,26 @@ __all__ = ["BaseDriver", "IdentifierData"]
 
 class IdentifierData:
     def __init__(self, uuid: str, category: str, primary_key: Tuple[str], identifiers: Tuple[str]):
-        self.uuid = uuid
-        self.category = category
-        self.primary_key = primary_key
-        self.identifiers = identifiers
+        self._uuid = uuid
+        self._category = category
+        self._primary_key = primary_key
+        self._identifiers = identifiers
+
+    @property
+    def uuid(self):
+        return self._uuid
+
+    @property
+    def category(self):
+        return self._category
+
+    @property
+    def primary_key(self):
+        return self._primary_key
+
+    @property
+    def identifiers(self):
+        return self._identifiers
 
     def __repr__(self):
         return (

--- a/redbot/core/drivers/red_base.py
+++ b/redbot/core/drivers/red_base.py
@@ -32,12 +32,12 @@ class IdentifierData:
             f" identifiers={self.identifiers}>"
         )
 
-    def add_identifier(self, identifier: str) -> "IdentifierData":
-        if not isinstance(identifier, str):
+    def add_identifier(self, *identifier: str) -> "IdentifierData":
+        if not all(isinstance(i, str) for i in identifier):
             raise ValueError("Identifiers must be strings.")
 
         return IdentifierData(
-            self.uuid, self.category, self.primary_key, self.identifiers + (identifier,)
+            self.uuid, self.category, self.primary_key, self.identifiers + identifier
         )
 
     def to_tuple(self):

--- a/redbot/core/drivers/red_base.py
+++ b/redbot/core/drivers/red_base.py
@@ -37,16 +37,13 @@ class IdentifierData:
             raise ValueError("Identifiers must be strings.")
 
         return IdentifierData(
-            self.uuid,
-            self.category,
-            self.primary_key,
-            self.identifiers + (identifier,)
+            self.uuid, self.category, self.primary_key, self.identifiers + (identifier,)
         )
 
     def to_tuple(self):
         return tuple(
-            item for item in
-            (self.uuid, self.category, *self.primary_key, *self.identifiers)
+            item
+            for item in (self.uuid, self.category, *self.primary_key, *self.identifiers)
             if len(item) > 0
         )
 

--- a/redbot/core/drivers/red_base.py
+++ b/redbot/core/drivers/red_base.py
@@ -44,8 +44,10 @@ class IdentifierData:
         )
 
     def to_tuple(self):
-        return (
-            self.uuid, self.category, *self.primary_key, *self.identifiers
+        return tuple(
+            item for item in
+            (self.uuid, self.category, *self.primary_key, *self.identifiers)
+            if len(item) > 0
         )
 
 

--- a/redbot/core/drivers/red_json.py
+++ b/redbot/core/drivers/red_json.py
@@ -6,7 +6,7 @@ import logging
 
 from ..json_io import JsonIO
 
-from .red_base import BaseDriver
+from .red_base import BaseDriver, IdentifierData
 
 __all__ = ["JSON"]
 
@@ -93,16 +93,16 @@ class JSON(BaseDriver):
             self.data = {}
             self.jsonIO._save_json(self.data)
 
-    async def get(self, *identifiers: Tuple[str]):
+    async def get(self, identifier_data: IdentifierData):
         partial = self.data
-        full_identifiers = (self.unique_cog_identifier, *identifiers)
+        full_identifiers = identifier_data.to_tuple()
         for i in full_identifiers:
             partial = partial[i]
         return copy.deepcopy(partial)
 
-    async def set(self, *identifiers: str, value=None):
+    async def set(self, identifier_data: IdentifierData, value=None):
         partial = self.data
-        full_identifiers = (self.unique_cog_identifier, *identifiers)
+        full_identifiers = identifier_data.to_tuple()
         for i in full_identifiers[:-1]:
             if i not in partial:
                 partial[i] = {}
@@ -111,9 +111,9 @@ class JSON(BaseDriver):
         partial[full_identifiers[-1]] = copy.deepcopy(value)
         await self.jsonIO._threadsafe_save_json(self.data)
 
-    async def clear(self, *identifiers: str):
+    async def clear(self, identifier_data: IdentifierData):
         partial = self.data
-        full_identifiers = (self.unique_cog_identifier, *identifiers)
+        full_identifiers = identifier_data.to_tuple()
         try:
             for i in full_identifiers[:-1]:
                 partial = partial[i]

--- a/redbot/core/drivers/red_mongo.py
+++ b/redbot/core/drivers/red_mongo.py
@@ -149,9 +149,7 @@ class Mongo(BaseDriver):
             update_stmt = {"$set": value}
 
         await mongo_collection.update_one(
-            {"RED_uuid": uuid, "RED_primary_key": primary_key},
-            update=update_stmt,
-            upsert=True,
+            {"RED_uuid": uuid, "RED_primary_key": primary_key}, update=update_stmt, upsert=True
         )
 
     def generate_primary_key_filter(self, identifier_data: IdentifierData):

--- a/redbot/core/drivers/red_mongo.py
+++ b/redbot/core/drivers/red_mongo.py
@@ -117,10 +117,7 @@ class Mongo(BaseDriver):
         if dot_identifiers != "":
             proj[dot_identifiers] = True
 
-            partial = await mongo_collection.find_one(
-                filter=pkey_filter,
-                projection=proj,
-            )
+            partial = await mongo_collection.find_one(filter=pkey_filter, projection=proj)
         else:
             # The case here is for partial primary keys like all_members()
             cursor = mongo_collection.find(filter=pkey_filter, projection=proj)

--- a/redbot/core/drivers/red_mongo.py
+++ b/redbot/core/drivers/red_mongo.py
@@ -137,13 +137,20 @@ class Mongo(BaseDriver):
         primary_key = list(map(self._escape_key, self.get_primary_key(identifier_data)))
         dot_identifiers = ".".join(map(self._escape_key, identifier_data.identifiers))
         if isinstance(value, dict):
+            if len(value) == 0:
+                await self.clear(identifier_data)
+                return
             value = self._escape_dict_keys(value)
 
         mongo_collection = self.get_collection()
+        if len(dot_identifiers) > 0:
+            update_stmt = {"$set": {dot_identifiers: value}}
+        else:
+            update_stmt = {"$set": value}
 
         await mongo_collection.update_one(
             {"RED_uuid": uuid, "RED_primary_key": primary_key},
-            update={"$set": {dot_identifiers: value}},
+            update=update_stmt,
             upsert=True,
         )
 

--- a/redbot/core/drivers/red_mongo.py
+++ b/redbot/core/drivers/red_mongo.py
@@ -90,7 +90,7 @@ class Mongo(BaseDriver):
 
         partial = await mongo_collection.find_one(
             filter={"RED_uuid": uuid, "RED_primary_key": primary_key},
-            projection={dot_identifiers: True}
+            projection={dot_identifiers: True},
         )
 
         if partial is None:
@@ -138,10 +138,7 @@ class Mongo(BaseDriver):
             await mongo_collection.delete_many(pkey_filter)
         else:
             dot_identifiers = ".".join(map(self._escape_key, identifier_data.identifiers))
-            await mongo_collection.update_one(
-                pkey_filter,
-                update={"$unset": {dot_identifiers: 1}}
-            )
+            await mongo_collection.update_one(pkey_filter, update={"$unset": {dot_identifiers: 1}})
 
     @staticmethod
     def _escape_key(key: str) -> str:

--- a/redbot/core/drivers/red_mongo.py
+++ b/redbot/core/drivers/red_mongo.py
@@ -134,6 +134,7 @@ class Mongo(BaseDriver):
         mongo_collection = self.get_collection()
         pkey_filter = self.generate_primary_key_filter(identifier_data)
         if len(identifier_data.identifiers) == 0:
+            # This covers cases 2-4
             await mongo_collection.delete_many(pkey_filter)
         else:
             dot_identifiers = ".".join(map(self._escape_key, identifier_data.identifiers))
@@ -141,7 +142,6 @@ class Mongo(BaseDriver):
                 pkey_filter,
                 update={"$unset": {dot_identifiers: 1}}
             )
-        raise NotImplementedError
 
     @staticmethod
     def _escape_key(key: str) -> str:

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -269,8 +269,9 @@ async def edit_instance():
             default_dirs["STORAGE_DETAILS"] = storage_details
 
             if instance_data["STORAGE_TYPE"] == "JSON":
-                if confirm("Would you like to import your data? (y/n) "):
-                    await json_to_mongo(current_data_dir, storage_details)
+                raise NotImplementedError("We cannot convert from JSON to MongoDB at this time.")
+                # if confirm("Would you like to import your data? (y/n) "):
+                #    await json_to_mongo(current_data_dir, storage_details)
         else:
             storage_details = instance_data["STORAGE_DETAILS"]
             default_dirs["STORAGE_DETAILS"] = {}


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

This PR reorganizes how the Mongo driver stores data on the database. It will create many more documents than the current implementation but they will each be significantly smaller than the current documents. Because of this reorganization, any existing Mongo data will not be readable by this PR and will need to be migrated using a future tool.

### Warning: Breaking Changes
* The `__init__` signature for Group and Value has changed in this PR.
* The signature for `driver.get()`, `driver.set()`, and `driver.clear()` has also changed.

