### PR TITLE
[Docs] Adds `self` recommendation to `cog_data_path`

### DIFF
--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -112,7 +112,8 @@ def cog_data_path(cog_instance=None, raw_name: str = None) -> Path:
     Parameters
     ----------
     cog_instance
-        The instance of the cog you wish to get a data path for.
+        The instance of the cog you wish to get a data path for. 
+        If calling from a command or method of your cog, this should be ``self``.
     raw_name : str
         The name of the cog to get a data path for.
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

This change adds the help text of "If calling from a command or method of your cog, this should be self." from `bundled_data_path` to `cog_data_path`. This removes the inconsistency between the two. This bit of text can help people who are unsure of what a "cog instance" is to understand how to use `cog_data_path`.