### PR TITLE
[V3 Config] Make bot.add_cog() a coroutine

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -53,6 +53,13 @@ async def _get_prefix_and_token(red, indict):
     indict["prefix"] = await red.db.prefix()
 
 
+async def load_initial_cogs(red: Red, cli_flags):
+    await red.add_cog(Core(red))
+    await red.add_cog(CogManagerUI())
+    if cli_flags.dev:
+        await red.add_cog(Dev())
+
+
 def list_instances():
     if not data_manager.config_file.exists():
         print(
@@ -106,15 +113,12 @@ def main():
     red = Red(cli_flags=cli_flags, description=description, pm_help=None)
     init_global_checks(red)
     init_events(red, cli_flags)
-    red.add_cog(Core(red))
-    red.add_cog(CogManagerUI())
-    if cli_flags.dev:
-        red.add_cog(Dev())
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(load_initial_cogs(red, cli_flags))
     # noinspection PyProtectedMember
     modlog._init()
     # noinspection PyProtectedMember
     bank._init()
-    loop = asyncio.get_event_loop()
     if os.name == "posix":
         loop.add_signal_handler(SIGTERM, lambda: asyncio.ensure_future(sigterm_handler(red, log)))
     tmp_data = {}

--- a/redbot/cogs/admin/__init__.py
+++ b/redbot/cogs/admin/__init__.py
@@ -1,5 +1,5 @@
 from .admin import Admin
 
 
-def setup(bot):
-    bot.add_cog(Admin())
+async def setup(bot):
+    await bot.add_cog(Admin())

--- a/redbot/cogs/alias/__init__.py
+++ b/redbot/cogs/alias/__init__.py
@@ -2,5 +2,5 @@ from .alias import Alias
 from redbot.core.bot import Red
 
 
-def setup(bot: Red):
-    bot.add_cog(Alias(bot))
+async def setup(bot: Red):
+    await bot.add_cog(Alias(bot))

--- a/redbot/cogs/audio/__init__.py
+++ b/redbot/cogs/audio/__init__.py
@@ -28,4 +28,4 @@ async def setup(bot: commands.Bot):
 
     await cog.initialize()
 
-    bot.add_cog(cog)
+    await bot.add_cog(cog)

--- a/redbot/cogs/bank/__init__.py
+++ b/redbot/cogs/bank/__init__.py
@@ -1,5 +1,5 @@
 from .bank import Bank, check_global_setting_guildowner, check_global_setting_admin
 
 
-def setup(bot):
-    bot.add_cog(Bank(bot))
+async def setup(bot):
+    await bot.add_cog(Bank(bot))

--- a/redbot/cogs/cleanup/__init__.py
+++ b/redbot/cogs/cleanup/__init__.py
@@ -2,5 +2,5 @@ from .cleanup import Cleanup
 from redbot.core.bot import Red
 
 
-def setup(bot: Red):
-    bot.add_cog(Cleanup(bot))
+async def setup(bot: Red):
+    await bot.add_cog(Cleanup(bot))

--- a/redbot/cogs/customcom/__init__.py
+++ b/redbot/cogs/customcom/__init__.py
@@ -1,5 +1,5 @@
 from .customcom import CustomCommands
 
 
-def setup(bot):
-    bot.add_cog(CustomCommands(bot))
+async def setup(bot):
+    await bot.add_cog(CustomCommands(bot))

--- a/redbot/cogs/dataconverter/__init__.py
+++ b/redbot/cogs/dataconverter/__init__.py
@@ -2,5 +2,5 @@ from redbot.core.bot import Red
 from .dataconverter import DataConverter
 
 
-def setup(bot: Red):
-    bot.add_cog(DataConverter(bot))
+async def setup(bot: Red):
+    await bot.add_cog(DataConverter(bot))

--- a/redbot/cogs/downloader/__init__.py
+++ b/redbot/cogs/downloader/__init__.py
@@ -4,4 +4,4 @@ from .downloader import Downloader
 async def setup(bot):
     cog = Downloader(bot)
     await cog.initialize()
-    bot.add_cog(cog)
+    await bot.add_cog(cog)

--- a/redbot/cogs/economy/__init__.py
+++ b/redbot/cogs/economy/__init__.py
@@ -2,5 +2,5 @@ from redbot.core.bot import Red
 from .economy import Economy
 
 
-def setup(bot: Red):
-    bot.add_cog(Economy(bot))
+async def setup(bot: Red):
+    await bot.add_cog(Economy(bot))

--- a/redbot/cogs/filter/__init__.py
+++ b/redbot/cogs/filter/__init__.py
@@ -2,5 +2,5 @@ from .filter import Filter
 from redbot.core.bot import Red
 
 
-def setup(bot: Red):
-    bot.add_cog(Filter(bot))
+async def setup(bot: Red):
+    await bot.add_cog(Filter(bot))

--- a/redbot/cogs/general/__init__.py
+++ b/redbot/cogs/general/__init__.py
@@ -1,5 +1,5 @@
 from .general import General
 
 
-def setup(bot):
-    bot.add_cog(General())
+async def setup(bot):
+    await bot.add_cog(General())

--- a/redbot/cogs/image/__init__.py
+++ b/redbot/cogs/image/__init__.py
@@ -4,4 +4,4 @@ from .image import Image
 async def setup(bot):
     cog = Image(bot)
     await cog.initialize()
-    bot.add_cog(cog)
+    await bot.add_cog(cog)

--- a/redbot/cogs/mod/__init__.py
+++ b/redbot/cogs/mod/__init__.py
@@ -2,5 +2,5 @@ from redbot.core.bot import Red
 from .mod import Mod
 
 
-def setup(bot: Red):
-    bot.add_cog(Mod(bot))
+async def setup(bot: Red):
+    await bot.add_cog(Mod(bot))

--- a/redbot/cogs/modlog/__init__.py
+++ b/redbot/cogs/modlog/__init__.py
@@ -2,5 +2,5 @@ from redbot.core.bot import Red
 from .modlog import ModLog
 
 
-def setup(bot: Red):
-    bot.add_cog(ModLog(bot))
+async def setup(bot: Red):
+    await bot.add_cog(ModLog(bot))

--- a/redbot/cogs/permissions/__init__.py
+++ b/redbot/cogs/permissions/__init__.py
@@ -10,4 +10,4 @@ async def setup(bot):
     # order, so we want to circumvent that.
     bot.add_listener(cog.cog_added, "on_cog_add")
     bot.add_listener(cog.command_added, "on_command_add")
-    bot.add_cog(cog)
+    await bot.add_cog(cog)

--- a/redbot/cogs/reports/__init__.py
+++ b/redbot/cogs/reports/__init__.py
@@ -2,5 +2,5 @@ from redbot.core.bot import Red
 from .reports import Reports
 
 
-def setup(bot: Red):
-    bot.add_cog(Reports(bot))
+async def setup(bot: Red):
+    await bot.add_cog(Reports(bot))

--- a/redbot/cogs/streams/__init__.py
+++ b/redbot/cogs/streams/__init__.py
@@ -4,4 +4,4 @@ from .streams import Streams
 async def setup(bot):
     cog = Streams(bot)
     await cog.initialize()
-    bot.add_cog(cog)
+    await bot.add_cog(cog)

--- a/redbot/cogs/trivia/__init__.py
+++ b/redbot/cogs/trivia/__init__.py
@@ -4,7 +4,7 @@ from .session import *
 from .log import *
 
 
-def setup(bot):
+async def setup(bot):
     """Load Trivia."""
     cog = Trivia()
-    bot.add_cog(cog)
+    await bot.add_cog(cog)

--- a/redbot/cogs/warnings/__init__.py
+++ b/redbot/cogs/warnings/__init__.py
@@ -1,5 +1,5 @@
 from .warnings import Warnings
 
 
-def setup(bot):
-    bot.add_cog(Warnings(bot))
+async def setup(bot):
+    await bot.add_cog(Warnings(bot))

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -230,7 +230,8 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):
         try:
             await lib.setup(self)
         except TypeError:
-            log.exception(f"Setup functions are now required to be coroutines: {name}")
+            del lib
+            raise discord.ClientException(f"Setup functions are now required to be coroutines: {name}")
 
         self.extensions[name] = lib
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -19,6 +19,7 @@ from .rpc import RPCMixin
 from .utils import common_filters
 
 log = logging.getLogger("red.bot")
+CUSTOM_GROUPS = "CUSTOM_GROUPS"
 
 
 def _is_submodule(parent, child):
@@ -75,6 +76,10 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):
         )
 
         self.db.register_user(embeds=None)
+
+        log.warning("The following line must be uncommented once #2545 is merged.")
+        # self.db.init_custom(CUSTOM_GROUPS, 2)
+        self.db.register_custom(CUSTOM_GROUPS)
 
         async def prefix_manager(bot, message):
             if not cli_flags.prefix:
@@ -414,7 +419,18 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):
         self.dispatch("cog_add", cog)
 
     async def _register_custom_groups(self, cog):
-        pass
+        async def add_group_info(conf: Config):
+            cogname = conf.cog_name
+            uuid = conf.unique_identifier
+            log.warning("The following lines must be uncommented once #2545 is merged.")
+            # group_info = conf.custom_groups
+            # await self.db.custom(CUSTOM_GROUPS, cogname, uuid).set(group_info)
+
+        for attr in dir(cog):
+            _attr = getattr(cog, attr)
+            if not isinstance(_attr, Config):
+                continue
+            await add_group_info(_attr)
 
     def add_command(self, command: commands.Command):
         if not isinstance(command, commands.Command):


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes
This PR makes `bot.add_cog()` a coroutine and requires all cog `setup` functions to be coroutines as well. `bot.add_cog()` is overridden and used to save custom group information initialized during the cog's `__init__`.

This PR depends on #2545.
