### PR TITLE
[V3 ModLog] Change register_casetypes behavior

### DIFF
--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -746,7 +746,6 @@ async def register_casetypes(new_types: List[dict]) -> List[CaseType]:
 
     Raises
     ------
-    RuntimeError
     KeyError
     ValueError
     AttributeError

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -761,13 +761,9 @@ async def register_casetypes(new_types: List[dict]) -> List[CaseType]:
         try:
             ct = await register_casetype(**new_type)
         except RuntimeError:
-            raise
-        except ValueError:
-            raise
-        except AttributeError:
-            raise
-        except TypeError:
-            raise
+            # We pass here because RuntimeError signifies the case was
+            # already registered.
+            pass
         else:
             type_list.append(ct)
     else:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Since `modlog.register_casetypes()` is often used when setting up a cog, this PR ignores all `RuntimeError`s as they just signify that a particular case type has already been registered.

resolves #2543 