### PR TITLE
Adds a check to [p]set locale

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1009,11 +1009,26 @@ class Core(commands.Cog, CoreLogic):
 
         To reset to English, use "en-US".
         """
-        i18n.set_locale(locale_name)
+        red_dist = pkg_resources.get_distribution("red-discordbot")
+        red_path = Path(red_dist.location) / "redbot"
+        locale_list = [loc.stem for loc in list(red_path.glob("**/*.po"))]
 
-        await ctx.bot.db.locale.set(locale_name)
+        if locale_name in locale_list or locale_name == "en-US":
 
-        await ctx.send(_("Locale has been set."))
+            i18n.set_locale(locale_name)
+
+            await ctx.bot.db.locale.set(locale_name)
+
+            await ctx.send(_("Locale has been set."))
+
+        else:
+
+            await ctx.send(
+                _(
+                    "Invalid locale. Use `{prefix}listlocales` to get "
+                    "a list of available locales."
+                ).format(prefix=ctx.prefix)
+            )
 
     @_set.command()
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1011,9 +1011,9 @@ class Core(commands.Cog, CoreLogic):
         """
         red_dist = pkg_resources.get_distribution("red-discordbot")
         red_path = Path(red_dist.location) / "redbot"
-        locale_list = [loc.stem for loc in list(red_path.glob("**/*.po"))]
+        locale_list = [loc.stem.lower() for loc in list(red_path.glob("**/*.po"))]
 
-        if locale_name in locale_list or locale_name == "en-US":
+        if locale_name.lower() in locale_list or locale_name.lower() == "en-us":
 
             i18n.set_locale(locale_name)
 
@@ -1149,7 +1149,9 @@ class Core(commands.Cog, CoreLogic):
         async with ctx.channel.typing():
             red_dist = pkg_resources.get_distribution("red-discordbot")
             red_path = Path(red_dist.location) / "redbot"
-            locale_list = sorted(set([loc.stem for loc in list(red_path.glob("**/*.po"))]))
+            locale_list = [loc.stem for loc in list(red_path.glob("**/*.po"))]
+            locale_list.append("en-US")
+            locale_list = sorted(set(locale_list))
             if not locale_list:
                 await ctx.send("No languages found.")
                 return

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1012,17 +1012,11 @@ class Core(commands.Cog, CoreLogic):
         red_dist = pkg_resources.get_distribution("red-discordbot")
         red_path = Path(red_dist.location) / "redbot"
         locale_list = [loc.stem.lower() for loc in list(red_path.glob("**/*.po"))]
-
         if locale_name.lower() in locale_list or locale_name.lower() == "en-us":
-
             i18n.set_locale(locale_name)
-
             await ctx.bot.db.locale.set(locale_name)
-
             await ctx.send(_("Locale has been set."))
-
         else:
-
             await ctx.send(
                 _(
                     "Invalid locale. Use `{prefix}listlocales` to get "


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Fixes #2552 by adding an explicit check as to whether or not `locale_name` is a valid locale.
I would like a little bit of feedback on this change.
- Right now, `locale_name` is case sensitive. Should that remain case sensitive or should I allow it to accept it case insensitively?
- I made the invalid locale string an i18n string, however I don't know the process for how those are supposed to be made or if that will break anything. Should that remain an i18n string or should I make it a normal string?