### PR TITLE
[Audio] Fix for prev command display

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -2064,7 +2064,7 @@ class Audio(commands.Cog):
                     player.current.title, player.current.uri.replace("localtracks/", "")
                 )
             else:
-                description = f"**[{player.current.title}]({player.current.title})**"
+                description = f"**[{player.current.title}]({player.current.uri})**"
             embed = discord.Embed(
                 colour=await ctx.embed_colour(),
                 title=_("Replaying Track"),


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
The prev command display was changed in #2024 and had a wrong variable, leading to the user notification for the action looking a bit strange.