### PR TITLE
[Audio] Fix for localtrack playing

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -1181,7 +1181,7 @@ class Audio(commands.Cog):
         player = lavalink.get_player(ctx.guild.id)
         guild_data = await self.config.guild(ctx.guild).all()
         if type(query) is not list:
-            if not query.startswith("http"):
+            if not (query.startswith("http") or query.startswith("localtracks")):
                 query = f"ytsearch:{query}"
             tracks = await player.get_tracks(query)
             if not tracks:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
#2328 introduced an error where local tracks being queued through [p]local play or [p]play were being treated as items to be searched on YouTube instead of playing the actual local track.