### PR TITLE
[V3 Cog] Add default cooldown to slots

### DIFF
--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -116,7 +116,7 @@ class Economy(commands.Cog):
         "PAYDAY_CREDITS": 120,
         "SLOT_MIN": 5,
         "SLOT_MAX": 100,
-        "SLOT_TIME": 1,
+        "SLOT_TIME": 5,
         "REGISTER_CREDITS": 0,
     }
 

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -116,7 +116,7 @@ class Economy(commands.Cog):
         "PAYDAY_CREDITS": 120,
         "SLOT_MIN": 5,
         "SLOT_MAX": 100,
-        "SLOT_TIME": 0,
+        "SLOT_TIME": 1,
         "REGISTER_CREDITS": 0,
     }
 


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Increases the slots cool down to 1 by default. Without this cool down a user can spam slots very quickly to get lots of money with minimal effort and investment. Theoretically multiple users doing this at once could use up the bots rate limits.
Doesn't help all the already existing bots, but going forwards it would be an improvement.