### PR TITLE
[V3 Test] Make sure that trivia test will use utf-8 encoding

### DIFF
--- a/tests/cogs/test_trivia.py
+++ b/tests/cogs/test_trivia.py
@@ -8,7 +8,7 @@ def test_trivia_lists():
     assert list_names
     problem_lists = []
     for l in list_names:
-        with l.open() as f:
+        with l.open(encoding="utf-8") as f:
             try:
                 dict_ = yaml.safe_load(f)
             except yaml.error.YAMLError as e:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This will make sure that utf-8 encoding used during a test as that's how trivia cog opens files. This may help some devs (including me) whose default system encoding isn't utf-8 (on my Windows it's `cp1250`) and therefore trivia fails for them during local testing.