### PR TITLE
Change command name and add aliases to show for its for resume and pause

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -909,7 +909,7 @@ class Audio(commands.Cog):
             await self._clear_react(message)
             await ctx.invoke(self.skip)
 
-    @commands.command(aliases=["resume", "play"])
+    @commands.command()
     @commands.guild_only()
     async def rp(self, ctx):
         """Pause or resume a playing track."""

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -904,14 +904,14 @@ class Audio(commands.Cog):
             await ctx.invoke(self.stop)
         elif react == "pause":
             await self._clear_react(message)
-            await ctx.invoke(self.pause)
+            await ctx.invoke(self.rp)
         elif react == "next":
             await self._clear_react(message)
             await ctx.invoke(self.skip)
 
-    @commands.command()
+    @commands.command(aliases=["resume", "play"])
     @commands.guild_only()
-    async def pause(self, ctx):
+    async def rp(self, ctx):
         """Pause or resume a playing track."""
         dj_enabled = await self.config.guild(ctx.guild).dj_enabled()
         if not self._player_check(ctx):


### PR DESCRIPTION
### Type

- [X] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Chance command name to `rp` for `resume/pause`, and add aliases for the command to let users know that it is used for resuming also, as when I was looking, I thought it was only for pausing and could not find the resume command.