### PR TITLE
Change send_help for group of group to show correct help menu

### DIFF
--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -26,34 +26,6 @@ class Context(commands.Context):
         super().__init__(**attrs)
         self.permission_state: PermState = PermState.NORMAL
 
-    async def command_from_message(self, message: discord.Message):
-        """Get the command from a message without arguments.
-        
-        Parameters
-        ----------
-        message: discord.Message
-            The message to get the command from.
-        
-        Returns
-        ----------
-        Optional[commands.Command]
-            The command invoked or None if no command was invoked.
-        """
-        message_context = await self.bot.get_context(message)
-        if not message_context.valid:
-            return None
-
-        maybe_command = message_context.command
-        command = maybe_command
-        while isinstance(maybe_command, commands.Group):
-            message_context.view.skip_ws()
-            possible = message_context.view.get_word()
-            maybe_command = maybe_command.all_commands.get(possible, None)
-            if maybe_command:
-                command = maybe_command
-
-        return command
-
     async def send(self, content=None, **kwargs):
         """Sends a message to the destination with the content given.
 
@@ -99,7 +71,18 @@ class Context(commands.Context):
             A list of help messages which were sent to the user.
 
         """
-        command = await self.command_from_message(self.message)
+        # First, get the variables ready
+        command = None
+        text_command = ""
+        content = self.message.content.replace(self.prefix, "").split(" ")
+        # Then run through every word, adding it to a variable, and if its an actual command, assigns it to a variable, ending with the most nested one
+        for word in content:
+            if text_command != "":
+                text_command += " "
+            text_command += word
+            maybe_command = self.bot.get_command(text_command)
+            if maybe_command:
+                command = maybe_command
         embed_wanted = await self.bot.embed_requested(
             self.channel, self.author, command=self.bot.get_command("help")
         )


### PR DESCRIPTION
Before, if I ran `[p]groupone grouptwo unknown_command`, it would show help as if I'd done `[p]help groupone`.  Now, it shows help as if I'd done `[p]help groupone grouptwo`.

### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Before, if someone ran `[p]groupone grouptwo unknown_command`, help would be displayed as if they had run `[p]help groupone`:
![image](https://user-images.githubusercontent.com/42872277/55882175-0e8c8400-5b72-11e9-81da-9cb2ecd9f90e.png)
After this PR, if someone ran `[p]groupone grouptwo unknown_command`, help would be displayed as if they had run `[p]help groupone grouptwo`, since it would seem like the person would not know that is not a subcommand of `grouptwo`, and so displaying help for `groupone` would mean nothing, but showing help for `grouptwo` shows that that subcommand does not exist, and gives a list of the correct ones.
![image](https://user-images.githubusercontent.com/42872277/55882320-53b0b600-5b72-11e9-9647-4dd0b4c6373b.png)