### PR TITLE
Add some errors for conversions and only allow MongoV2 creation

### DIFF
--- a/redbot/core/drivers/__init__.py
+++ b/redbot/core/drivers/__init__.py
@@ -28,7 +28,7 @@ def get_driver(type, *args, **kwargs):
         from .red_json import JSON
 
         return JSON(*args, **kwargs)
-    elif type == "MongoDB":
+    elif type == "MongoDBV2":
         from .red_mongo import Mongo
 
         return Mongo(*args, **kwargs)

--- a/redbot/core/drivers/__init__.py
+++ b/redbot/core/drivers/__init__.py
@@ -32,4 +32,9 @@ def get_driver(type, *args, **kwargs):
         from .red_mongo import Mongo
 
         return Mongo(*args, **kwargs)
+    elif type == "Mongo":
+        raise RuntimeError(
+            "Please convert to JSON first to continue using the bot."
+            " This is a required conversion prior to using the new Mongo driver."
+        )
     raise RuntimeError("Invalid driver type: '{}'".format(type))

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -153,10 +153,10 @@ def basic_setup():
 
     storage = get_storage_type()
 
-    storage_dict = {1: "JSON", 2: "MongoDBV2"}
+    storage_dict = {1: "JSON", 2: "MongoDB"}
     default_dirs["STORAGE_TYPE"] = storage_dict.get(storage, 1)
 
-    if storage_dict.get(storage, 1) == "MongoDBV2":
+    if storage_dict.get(storage, 1) == "MongoDB":
         from redbot.core.drivers.red_mongo import get_config_details
 
         default_dirs["STORAGE_DETAILS"] = get_config_details()
@@ -260,7 +260,7 @@ async def edit_instance():
     if confirm("Would you like to change the storage type? (y/n):"):
         storage = get_storage_type()
 
-        storage_dict = {1: "JSON", 2: "MongoDBV2", 3: "MongoDB"}
+        storage_dict = {1: "JSON", 2: "MongoDBV2"}
         default_dirs["STORAGE_TYPE"] = storage_dict[storage]
         if storage_dict.get(storage, 1) == "MongoDBV2":
             from redbot.core.drivers.red_mongo import get_config_details
@@ -279,7 +279,9 @@ async def edit_instance():
                 if confirm("Would you like to import your data? (y/n) "):
                     await mongo_to_json(current_data_dir, storage_details)
             elif instance_data["STORAGE_TYPE"] == "MongoDBV2":
-                raise NotImplementedError("We cannot convert from MongoDB2 to JSON at this time.")
+                raise NotImplementedError(
+                    "We cannot convert from this version of MongoDB to JSON at this time."
+                )
 
     if name != selected:
         save_config(selected, {}, remove=True)

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -114,7 +114,7 @@ def get_storage_type():
         print()
         print("Please choose your storage backend (if you're unsure, choose 1).")
         print("1. JSON (file storage, requires no database).")
-        print("2. MongoDB (not recommended, currently unstable)")
+        print("2. MongoDB")
         storage = input("> ")
         try:
             storage = int(storage)
@@ -153,10 +153,10 @@ def basic_setup():
 
     storage = get_storage_type()
 
-    storage_dict = {1: "JSON", 2: "MongoDB"}
+    storage_dict = {1: "JSON", 2: "MongoDBV2"}
     default_dirs["STORAGE_TYPE"] = storage_dict.get(storage, 1)
 
-    if storage_dict.get(storage, 1) == "MongoDB":
+    if storage_dict.get(storage, 1) == "MongoDBV2":
         from redbot.core.drivers.red_mongo import get_config_details
 
         default_dirs["STORAGE_DETAILS"] = get_config_details()
@@ -260,9 +260,9 @@ async def edit_instance():
     if confirm("Would you like to change the storage type? (y/n):"):
         storage = get_storage_type()
 
-        storage_dict = {1: "JSON", 2: "MongoDB"}
+        storage_dict = {1: "JSON", 2: "MongoDBV2", 3: "MongoDB"}
         default_dirs["STORAGE_TYPE"] = storage_dict[storage]
-        if storage_dict.get(storage, 1) == "MongoDB":
+        if storage_dict.get(storage, 1) == "MongoDBV2":
             from redbot.core.drivers.red_mongo import get_config_details
 
             storage_details = get_config_details()
@@ -272,12 +272,14 @@ async def edit_instance():
                 raise NotImplementedError("We cannot convert from JSON to MongoDB at this time.")
                 # if confirm("Would you like to import your data? (y/n) "):
                 #    await json_to_mongo(current_data_dir, storage_details)
-        else:
+        elif storage_dict.get(storage, 1) == "JSON":
             storage_details = instance_data["STORAGE_DETAILS"]
             default_dirs["STORAGE_DETAILS"] = {}
             if instance_data["STORAGE_TYPE"] == "MongoDB":
                 if confirm("Would you like to import your data? (y/n) "):
                     await mongo_to_json(current_data_dir, storage_details)
+            elif instance_data["STORAGE_TYPE"] == "MongoDBV2":
+                raise NotImplementedError("We cannot convert from MongoDB2 to JSON at this time.")
 
     if name != selected:
         save_config(selected, {}, remove=True)


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This allows us to differentiate between mongo v1 and v2 for the conversion process. It also adds not implemented errors for conversions between MongoV2 and anything else for the time being.