### PR TITLE
Pretties up the output when libraries fail to install

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -305,10 +305,11 @@ class Downloader(commands.Cog):
             return
 
         if not await repo.install_requirements(cog, self.LIB_PATH):
+            libraries = '`, `'.join(cog.requirements)
             await ctx.send(
                 _(
                     "Failed to install the required libraries for `{cog_name}`: `{libraries}`"
-                ).format(cog_name=cog.name, libraries=cog.requirements)
+                ).format(cog_name=cog.name, libraries=libraries)
             )
             return
 

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -305,7 +305,7 @@ class Downloader(commands.Cog):
             return
 
         if not await repo.install_requirements(cog, self.LIB_PATH):
-            libraries = '`, `'.join(cog.requirements)
+            libraries = "`, `".join(cog.requirements)
             await ctx.send(
                 _(
                     "Failed to install the required libraries for `{cog_name}`: `{libraries}`"

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -307,9 +307,9 @@ class Downloader(commands.Cog):
         if not await repo.install_requirements(cog, self.LIB_PATH):
             libraries = humanize_list(tuple(map(inline, cog.requirements)))
             await ctx.send(
-                _(
-                    "Failed to install the required libraries for `{cog_name}`: {libraries}"
-                ).format(cog_name=cog.name, libraries=libraries)
+                _("Failed to install the required libraries for `{cog_name}`: {libraries}").format(
+                    cog_name=cog.name, libraries=libraries
+                )
             )
             return
 

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -305,10 +305,10 @@ class Downloader(commands.Cog):
             return
 
         if not await repo.install_requirements(cog, self.LIB_PATH):
-            libraries = "`, `".join(cog.requirements)
+            libraries = humanize_list(tuple(map(inline, cog.requirements)))
             await ctx.send(
                 _(
-                    "Failed to install the required libraries for `{cog_name}`: `{libraries}`"
+                    "Failed to install the required libraries for `{cog_name}`: {libraries}"
                 ).format(cog_name=cog.name, libraries=libraries)
             )
             return


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

Fixes #2575

Previously, when a cog failed to install libraries, the resulting message would print the raw list of requirements. This PR changes that message to comma separate those libraries in order to look nicer.

Example before:

![Before](https://i.imgur.com/5jtlwwa.png)

Example after:

![After](https://i.imgur.com/KycRrCW.png)