### PR TITLE
Add fix for help docstring markdown

### DIFF
--- a/redbot/core/help_formatter.py
+++ b/redbot/core/help_formatter.py
@@ -159,11 +159,11 @@ class Help(dpy_formatter.HelpFormatter):
             # <long doc> section
             if self.command.help:
                 splitted = self.command.help.split("\n\n")
-                name = "__{0}__".format(splitted[0])
+                name = "__{0}".format(splitted[0])
                 value = "\n\n".join(splitted[1:]).replace("[p]", self.context.clean_prefix)
                 if value == "":
                     value = EMPTY_STRING
-                field = EmbedField(name[:252], value[:1024], False)
+                field = EmbedField(name[:250] + "__", value[:1024], False)
                 emb["fields"].append(field)
 
             # end it here if it's just a regular command


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Before this change, it would add the ending underscores to the original string, and then grab the first 252 characters.  If it is a long docstring, it will end up in malformed markdown, as show below:
![image](https://user-images.githubusercontent.com/42872277/56039242-d025cf00-5d01-11e9-9636-37e452113fd8.png)
After this, it makes a string with the first two beginning underscores plus the string, then later when adding the field, it gets the first 250 characters and *then* adds the underscores to make sure they get added for proper markdown:
![image](https://user-images.githubusercontent.com/42872277/56039299-fe0b1380-5d01-11e9-820d-c9f2778a795a.png)