### PR TITLE
Sanitize API tokens in debug and eval

### DIFF
--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -61,13 +61,18 @@ class Dev(commands.Cog):
         return pagify(msg, delims=["\n", " "], priority=True, shorten_by=10)
 
     @staticmethod
-    def sanitize_output(ctx: commands.Context, input_: str) -> str:
+    def sanitize_output(ctx: commands.Context, keys: dict, input_: str) -> str:
         """Hides the bot's token from a string."""
         token = ctx.bot.http.token
         r = "[EXPUNGED]"
         result = input_.replace(token, r)
         result = result.replace(token.lower(), r)
         result = result.replace(token.upper(), r)
+        for provider, data in keys.items():
+            for name, key in data.items():
+                result = result.replace(key, r)
+                result = result.replace(key.upper(), r)
+                result = result.replace(key.lower(), r)
         return result
 
     @commands.command()
@@ -121,7 +126,8 @@ class Dev(commands.Cog):
 
         self._last_result = result
 
-        result = self.sanitize_output(ctx, str(result))
+        api_keys = await ctx.bot.db.api_tokens()
+        result = self.sanitize_output(ctx, api_keys, str(result))))
 
         await ctx.send_interactive(self.get_pages(result), box_lang="py")
 
@@ -185,7 +191,8 @@ class Dev(commands.Cog):
             msg = "{}{}".format(printed, result)
         else:
             msg = printed
-        msg = self.sanitize_output(ctx, msg)
+        api_keys = await ctx.bot.db.api_tokens()
+        msg = self.sanitize_output(ctx, api_keys, msg)
 
         await ctx.send_interactive(self.get_pages(msg), box_lang="py")
 

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -127,7 +127,7 @@ class Dev(commands.Cog):
         self._last_result = result
 
         api_keys = await ctx.bot.db.api_tokens()
-        result = self.sanitize_output(ctx, api_keys, str(result))))
+        result = self.sanitize_output(ctx, api_keys, str(result))
 
         await ctx.send_interactive(self.get_pages(result), box_lang="py")
 


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Sanitizes API tokens when running `[p]debug` and `[p]eval`, in the same way as it sanitizes the bot's token.