### PR TITLE
[V3 Downloader] Stop including subpackages in cog list

### DIFF
--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -173,9 +173,7 @@ class Repo(RepoJSONMixin):
                         Installable(location=name)
                     )
         """
-        for file_finder, name, is_pkg in pkgutil.walk_packages(
-            path=[str(self.folder_path)], onerror=lambda name: None
-        ):
+        for file_finder, name, is_pkg in pkgutil.iter_modules(path=[str(self.folder_path)]):
             if is_pkg:
                 curr_modules.append(Installable(location=self.folder_path / name))
         self.available_modules = curr_modules


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Before this change, cog list would also include subpackages (because `pkgutil.walk_packages()` is recursive), so for example, if cog `rlstats` also had submodule `rlstats.submodule`, it would be included on cog list, which is unintended.

I'll also add that internally `walk_packages()` gives you items from `iter_modules()` generator and also submodules and that's the only difference between them, [link](https://github.com/python/cpython/blob/3.7/Lib/pkgutil.py#L53-L107)
Oh and it also doesn't have to import all those packages because of that.