### PR TITLE
[Audio] Track search and append fixes

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -1183,7 +1183,7 @@ class Audio(commands.Cog):
         player = lavalink.get_player(ctx.guild.id)
         guild_data = await self.config.guild(ctx.guild).all()
         if type(query) is not list:
-            if not (query.startswith("http") or query.startswith("localtracks")):
+            if not (query.startswith("http") or query.startswith("localtracks") or query.startswith("ytsearch:")):
                 query = f"ytsearch:{query}"
             tracks = await player.get_tracks(query)
             if not tracks:
@@ -1401,7 +1401,7 @@ class Audio(commands.Cog):
         pass
 
     @playlist.command(name="append")
-    async def _playlist_append(self, ctx, playlist_name, *url):
+    async def _playlist_append(self, ctx, playlist_name, *, url):
         """Add a track URL, playlist link, or quick search to a playlist.
 
         The track(s) will be appended to the end of the playlist.
@@ -2014,7 +2014,6 @@ class Audio(commands.Cog):
                 tracklist.append(track_obj)
             self._play_lock(ctx, False)
         elif not query.startswith("http"):
-            query = " ".join(query)
             query = "ytsearch:{}".format(query)
             search = True
             tracks = await player.get_tracks(query)

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -1183,7 +1183,11 @@ class Audio(commands.Cog):
         player = lavalink.get_player(ctx.guild.id)
         guild_data = await self.config.guild(ctx.guild).all()
         if type(query) is not list:
-            if not (query.startswith("http") or query.startswith("localtracks") or query.startswith("ytsearch:")):
+            if not (
+                query.startswith("http")
+                or query.startswith("localtracks")
+                or query.startswith("ytsearch:")
+            ):
                 query = f"ytsearch:{query}"
             tracks = await player.get_tracks(query)
             if not tracks:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
* Tracks had ytsearch: appended to it twice in some searching situations, accidentally introduced in the Spotify PR (#2328)
* Playlist append was joining strings with spaces in some situations before searching