### PR TITLE
[mongo setup] Utilize getpass

### DIFF
--- a/redbot/core/drivers/red_mongo.py
+++ b/redbot/core/drivers/red_mongo.py
@@ -1,4 +1,5 @@
 import re
+from getpass import getpass
 from typing import Match, Pattern, Tuple
 from urllib.parse import quote_plus
 
@@ -259,7 +260,7 @@ def get_config_details():
         port = 0
 
     admin_uname = input("Enter login username: ")
-    admin_password = input("Enter login password: ")
+    admin_password = getpass("Enter login password: ")
 
     db_name = input("Enter mongodb database name: ")
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Mongo's setup used a base `input` call for the password. This uses Python's standard `getpass` module.