### PR TITLE
[V3 Downloader] Always remove cog from installed in `[p]cog uninstall`

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -346,10 +346,10 @@ class Downloader(commands.Cog):
                 if poss_installed_path.exists():
                     ctx.bot.unload_extension(real_name)
                     await self._delete_cog(poss_installed_path)
-                    await self._remove_from_installed(cog)
                     uninstalled_cogs.append(inline(real_name))
                 else:
                     failed_cogs.append(real_name)
+                await self._remove_from_installed(cog)
 
             message = ""
             if uninstalled_cogs:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Cog should always be removed from list of installed cogs in Config, even if `[p]cog uninstall` can't find that cog in install path anymore.