### PR TITLE
[V3 Mod] Mute/Unmute QOL

### DIFF
--- a/redbot/cogs/mod/casetypes.py
+++ b/redbot/cogs/mod/casetypes.py
@@ -56,17 +56,17 @@ CASETYPES = [
         "audit_type": "member_update",
     },
     {
-        "name": "vmute",
-        "default_setting": False,
-        "image": "\N{SPEAKER WITH CANCELLATION STROKE}",
-        "case_str": "Voice Mute",
-        "audit_type": "overwrite_update",
-    },
-    {
         "name": "cmute",
         "default_setting": False,
         "image": "\N{SPEAKER WITH CANCELLATION STROKE}",
         "case_str": "Channel Mute",
+        "audit_type": "overwrite_update",
+    },
+    {
+        "name": "catmute",
+        "default_setting": False,
+        "image": "\N{SPEAKER WITH CANCELLATION STROKE}",
+        "case_str": "Category Mute",
         "audit_type": "overwrite_update",
     },
     {
@@ -77,17 +77,17 @@ CASETYPES = [
         "audit_type": "overwrite_update",
     },
     {
-        "name": "vunmute",
-        "default_setting": False,
-        "image": "\N{SPEAKER}",
-        "case_str": "Voice Unmute",
-        "audit_type": "overwrite_update",
-    },
-    {
         "name": "cunmute",
         "default_setting": False,
         "image": "\N{SPEAKER}",
         "case_str": "Channel Unmute",
+        "audit_type": "overwrite_update",
+    },
+    {
+        "name": "catunmute",
+        "default_setting": False,
+        "image": "\N{SPEAKER}",
+        "case_str": "Category Unmute",
         "audit_type": "overwrite_update",
     },
     {

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -296,12 +296,8 @@ class MuteMixin(MixinMeta):
         guild = ctx.guild
         audit_reason = get_audit_reason(author, reason)
 
-        # try categories first, to reduce API calls for synced channels
-        channels = guild.categories
-        channels += [c for c in guild.channels if c not in guild.categories]
-
         mute_success = {}
-        for channel in guild.categories + guild.channels:
+        for channel in guild.channels:
             mute_success[channel] = await self.mute_user(
                 guild, channel, author, user, audit_reason
             )
@@ -476,10 +472,6 @@ class MuteMixin(MixinMeta):
         guild = ctx.guild
         author = ctx.author
         audit_reason = get_audit_reason(author, reason)
-
-        # try categories first, to reduce API calls for synced channels
-        channels = guild.categories
-        channels += [c for c in guild.channels if c not in guild.categories]
 
         unmute_success = {}
         for channel in guild.channels:

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -329,9 +329,7 @@ class MuteMixin(MixinMeta):
             await ctx.send(e)
 
         await ctx.send(
-            _(
-                "{user} has been muted in {success} / {total} channels in this server."
-            ).format(
+            _("{user} has been muted in {success} / {total} channels in this server.").format(
                 user=user,
                 success=sum(1 for v in mute_success.values() if v[0]),
                 total=len(mute_success),
@@ -397,7 +395,11 @@ class MuteMixin(MixinMeta):
                 )
             except RuntimeError as e:
                 await ctx.send(e)
-            await ctx.send(_("{user} has been unmuted in channel {channel}.").format(user=user, channel=channel))
+            await ctx.send(
+                _("{user} has been unmuted in channel {channel}.").format(
+                    user=user, channel=channel
+                )
+            )
         else:
             await ctx.send(issue)
 
@@ -406,7 +408,12 @@ class MuteMixin(MixinMeta):
     @commands.bot_has_permissions(manage_roles=True)
     @commands.guild_only()
     async def category_unmute(
-        self, ctx: commands.Context, user: discord.Member, category: Optional[discord.CategoryChannel] = None, *, reason: str = None
+        self,
+        ctx: commands.Context,
+        user: discord.Member,
+        category: Optional[discord.CategoryChannel] = None,
+        *,
+        reason: str = None,
     ):
         """Unmute a user in this server."""
         guild = ctx.guild
@@ -421,7 +428,9 @@ class MuteMixin(MixinMeta):
 
         unmute_success = {}
         for channel in channels:
-            unmute_success[channel] = await self.unmute_user(guild, channel, author, user, audit_reason)
+            unmute_success[channel] = await self.unmute_user(
+                guild, channel, author, user, audit_reason
+            )
             await asyncio.sleep(0.1)
 
         to_log = "\n".join(
@@ -440,7 +449,7 @@ class MuteMixin(MixinMeta):
                 author,
                 reason,
                 until=None,
-                channel=None
+                channel=None,
             )
         except RuntimeError as e:
             await ctx.send(e)
@@ -474,7 +483,9 @@ class MuteMixin(MixinMeta):
 
         unmute_success = {}
         for channel in guild.channels:
-            unmute_success[channel] = await self.unmute_user(guild, channel, author, user, audit_reason)
+            unmute_success[channel] = await self.unmute_user(
+                guild, channel, author, user, audit_reason
+            )
             await asyncio.sleep(0.1)
 
         to_log = "\n".join(
@@ -493,15 +504,13 @@ class MuteMixin(MixinMeta):
                 author,
                 reason,
                 until=None,
-                channel=None
+                channel=None,
             )
         except RuntimeError as e:
             await ctx.send(e)
 
         await ctx.send(
-            _(
-                "{user} has been muted in {success} / {total} channels in this server."
-            ).format(
+            _("{user} has been muted in {success} / {total} channels in this server.").format(
                 user=user,
                 success=sum(1 for v in unmute_success.values() if v[0]),
                 total=len(unmute_success),


### PR DESCRIPTION
### Type

- [X] Enhancement

### Description of the changes
Rewritten version of #2179 after class compositing. Part of #2500. There's a bit of weirdness with mute v. unmute in terms of permissions, strings, and attributes which I'd like to take another pass at tomorrow, before this is merged.

* ~~Guild mute / unmute will act on categories first, then on channels, to attempt to save on API calls. Resolves #1607.~~ lol nah fam
* Remove the voice mute / unmute commands - due to a Discord limitation updating overwrites does not modify the member's permissions if the member is already in a voice channel. Mass mutes / unmutes still affect voice channels.
* Add category mute / unmute to mass mute / unmute all channels in a category. If used in a channel with no category, it will modify all channels without a category (excluding categories themselves).
* Mass muting / unmuting now reports how many actions were successful, and how many actions were attempted.
* Channels and categories other than the current one can now be specified - this takes advantage of d.py's typing.Optional converter.
* mute and unmute now default to mute channel and unmute channel, and match the checks of their subcommands. If a category channel is passed to either, they will instead default to mute category and unmute category.
* Cleaned up various user-facing strings.