### PR TITLE
[Config] Migrate UUID for JSON backend

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -566,7 +566,7 @@ class Config:
     @staticmethod
     def _create_uuid(identifier: int):
         hash_ = hashlib.sha256()
-        hash_.update(bytes(str(identifier), 'utf8'))
+        hash_.update(bytes(str(identifier), "utf8"))
         return hash_.hexdigest()[-16:]
 
     @classmethod
@@ -619,11 +619,7 @@ class Config:
         driver_details = basic_config.get("STORAGE_DETAILS", {})
 
         driver = get_driver(
-            driver_name,
-            cog_name,
-            uuid,
-            data_path_override=cog_path_override,
-            **driver_details
+            driver_name, cog_name, uuid, data_path_override=cog_path_override, **driver_details
         )
         if driver_name == BackendType.JSON.value:
             driver.migrate_identifier(identifier)

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -7,7 +7,7 @@ import hashlib
 
 import discord
 
-from .data_manager import cog_data_path, core_data_path, storage_type
+from .data_manager import cog_data_path, core_data_path
 from .drivers import get_driver, IdentifierData, BackendType
 
 if TYPE_CHECKING:
@@ -625,7 +625,7 @@ class Config:
             data_path_override=cog_path_override,
             **driver_details
         )
-        if storage_type() == BackendType.JSON.value:
+        if driver_name == BackendType.JSON.value:
             driver.migrate_identifier(identifier)
 
         conf = cls(

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -3,7 +3,6 @@ import collections
 from copy import deepcopy
 from typing import Any, Union, Tuple, Dict, Awaitable, AsyncContextManager, TypeVar, TYPE_CHECKING
 import weakref
-import hashlib
 
 import discord
 
@@ -565,9 +564,7 @@ class Config:
 
     @staticmethod
     def _create_uuid(identifier: int):
-        hash_ = hashlib.sha256()
-        hash_.update(bytes(str(identifier), "utf8"))
-        return hash_.hexdigest()[-16:]
+        return str(identifier)
 
     @classmethod
     def get_conf(cls, cog_instance, identifier: int, force_registration=False, cog_name=None):

--- a/redbot/core/drivers/red_json.py
+++ b/redbot/core/drivers/red_json.py
@@ -96,6 +96,18 @@ class JSON(BaseDriver):
             self.data = {}
             self.jsonIO._save_json(self.data)
 
+    def migrate_identifier(self, raw_identifier: int):
+        if self.unique_cog_identifier in self.data:
+            # Data has already been migrated
+            return
+        poss_identifiers = [str(raw_identifier), str(hash(raw_identifier))]
+        for ident in poss_identifiers:
+            if ident in self.data:
+                self.data[self.unique_cog_identifier] = self.data[ident]
+                del self.data[ident]
+                self.jsonIO._save_json(self.data)
+                break
+
     async def get(self, identifier_data: IdentifierData):
         partial = self.data
         full_identifiers = identifier_data.to_tuple()


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Due to some unforeseen issues with the previous method of generating/saving the unique identifier number, we've had to implement a way to migrate all previous identifiers to a safer generation/saving method.

This code requires all users to migrate to JSON (from both old and new Mongo drivers), and load the bot one time before converting back to Mongo. All JSON users will be unaffected.

## Note
It's important to note that if existing MongoDBV2 users do NOT migrate back to JSON after this PR, their bot will still connect to discord successfully, but all existing data will be inaccessible to the bot. Performing the JSON conversion and load will make data accessible again.