### PR TITLE
Add `[p]cleanup between`

### DIFF
--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -290,7 +290,7 @@ class Cleanup(commands.Cog):
     ):
         """Delete the messages between Messsage One and Message Two, providing the messages IDs.
 
-        The first message ID should be the older message, and the second one the newer.
+        The first message ID should be the older message and the second one the newer.
 
         Example:
             `[p]cleanup between 123456789123456789 987654321987654321`

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -10,6 +10,7 @@ from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils.mod import slow_deletion, mass_purge
 from redbot.cogs.mod.log import log
 from redbot.core.utils.predicates import MessagePredicate
+from .converters import RawMessageIds
 
 _ = Translator("Cleanup", __file__)
 
@@ -211,7 +212,7 @@ class Cleanup(commands.Cog):
     @cleanup.command()
     @commands.guild_only()
     @commands.bot_has_permissions(manage_messages=True)
-    async def after(self, ctx: commands.Context, message_id: int, delete_pinned: bool = False):
+    async def after(self, ctx: commands.Context, message_id: RawMessageIds, delete_pinned: bool = False):
         """Delete all messages after a specified message.
 
         To get a message id, enable developer mode in Discord's
@@ -242,7 +243,7 @@ class Cleanup(commands.Cog):
     @commands.guild_only()
     @commands.bot_has_permissions(manage_messages=True)
     async def before(
-        self, ctx: commands.Context, message_id: int, number: int, delete_pinned: bool = False
+        self, ctx: commands.Context, message_id: RawMessageIds, number: int, delete_pinned: bool = False
     ):
         """Deletes X messages before specified message.
 
@@ -275,7 +276,7 @@ class Cleanup(commands.Cog):
     @commands.guild_only()
     @commands.bot_has_permissions(manage_messages=True)
     async def between(
-        self, ctx: commands.Context, one: int, two: int, delete_pinned: bool = False
+        self, ctx: commands.Context, one: RawMessageIds, two: RawMessageIds, delete_pinned: bool = False
     ):
         """Delete the messages between Messsage One and Message Two, providing the messages IDs.
 
@@ -289,11 +290,11 @@ class Cleanup(commands.Cog):
         try:
             mone = await channel.fetch_message(one)
         except discord.errors.Notfound:
-            return await ctx.send(f"Could not find a message with the ID of {one}.")
+            return await ctx.send(_("Could not find a message with the ID of {id}.".format(id=one)))
         try:
             mtwo = await channel.fetch_message(two)
         except discord.errors.Notfound:
-            return await ctx.send(f"Could not find a message with the ID of {two}.")
+            return await ctx.send(_("Could not find a message with the ID of {id}.".format(id=two)))
         to_delete = await self.get_messages_for_deletion(
             channel=channel, before=mtwo, after=mone, delete_pinned=delete_pinned
         )

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -274,6 +274,40 @@ class Cleanup(commands.Cog):
     @cleanup.command()
     @commands.guild_only()
     @commands.bot_has_permissions(manage_messages=True)
+    async def between(
+        self, ctx: commands.Context, one: int, two: int, delete_pinned: bool = False
+    ):
+        """Delete the messages between Messsage One and Message Two, providing the messages IDs.
+
+        The first message ID should be the older message, and the second one the newer.
+
+        Example:
+            `[p]cleanup between 123456789123456789 987654321987654321`
+        """
+        channel = ctx.channel
+        author = ctx.author
+        try:
+            mone = await channel.fetch_message(one)
+        except discord.errors.Notfound:
+            return await ctx.send(f"Could not find a message with the ID of {one}.")
+        try:
+            mtwo = await channel.fetch_message(two)
+        except discord.errors.Notfound:
+            return await ctx.send(f"Could not find a message with the ID of {two}.")
+        to_delete = await self.get_messages_for_deletion(
+            channel=channel, before=mtwo, after=mone, delete_pinned=delete_pinned
+        )
+        to_delete.append(ctx.message)
+        reason = "{}({}) deleted {} messages in channel {}.".format(
+            author.name, author.id, len(to_delete), channel.name
+        )
+        log.info(reason)
+
+        await mass_purge(to_delete, channel)
+
+    @cleanup.command()
+    @commands.guild_only()
+    @commands.bot_has_permissions(manage_messages=True)
     async def messages(self, ctx: commands.Context, number: int, delete_pinned: bool = False):
         """Delete the last X messages.
 

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -212,7 +212,9 @@ class Cleanup(commands.Cog):
     @cleanup.command()
     @commands.guild_only()
     @commands.bot_has_permissions(manage_messages=True)
-    async def after(self, ctx: commands.Context, message_id: RawMessageIds, delete_pinned: bool = False):
+    async def after(
+        self, ctx: commands.Context, message_id: RawMessageIds, delete_pinned: bool = False
+    ):
         """Delete all messages after a specified message.
 
         To get a message id, enable developer mode in Discord's
@@ -243,7 +245,11 @@ class Cleanup(commands.Cog):
     @commands.guild_only()
     @commands.bot_has_permissions(manage_messages=True)
     async def before(
-        self, ctx: commands.Context, message_id: RawMessageIds, number: int, delete_pinned: bool = False
+        self,
+        ctx: commands.Context,
+        message_id: RawMessageIds,
+        number: int,
+        delete_pinned: bool = False,
     ):
         """Deletes X messages before specified message.
 
@@ -276,7 +282,11 @@ class Cleanup(commands.Cog):
     @commands.guild_only()
     @commands.bot_has_permissions(manage_messages=True)
     async def between(
-        self, ctx: commands.Context, one: RawMessageIds, two: RawMessageIds, delete_pinned: bool = False
+        self,
+        ctx: commands.Context,
+        one: RawMessageIds,
+        two: RawMessageIds,
+        delete_pinned: bool = False,
     ):
         """Delete the messages between Messsage One and Message Two, providing the messages IDs.
 
@@ -290,11 +300,15 @@ class Cleanup(commands.Cog):
         try:
             mone = await channel.fetch_message(one)
         except discord.errors.Notfound:
-            return await ctx.send(_("Could not find a message with the ID of {id}.".format(id=one)))
+            return await ctx.send(
+                _("Could not find a message with the ID of {id}.".format(id=one))
+            )
         try:
             mtwo = await channel.fetch_message(two)
         except discord.errors.Notfound:
-            return await ctx.send(_("Could not find a message with the ID of {id}.".format(id=two)))
+            return await ctx.send(
+                _("Could not find a message with the ID of {id}.".format(id=two))
+            )
         to_delete = await self.get_messages_for_deletion(
             channel=channel, before=mtwo, after=mone, delete_pinned=delete_pinned
         )

--- a/redbot/cogs/cleanup/converters.py
+++ b/redbot/cogs/cleanup/converters.py
@@ -1,0 +1,12 @@
+from redbot.core.commands import Converter, BadArgument
+from redbot.core.i18n import Translator
+
+_ = Translator("Cleanup", __file__)
+
+
+class RawMessageIds(Converter):
+    async def convert(self, ctx, argument):
+        if argument.isnumeric() and len(argument) >= 17:
+            return int(argument)
+
+        raise BadArgument(_("{} doesn't look like a valid message ID.").format(argument))


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [X] New feature

### Description of the changes
This PR closes #2544; adds `[p]cleanup between <message id one> <message id two>` to cleanup messages between the two messages.