### PR TITLE
Remove error when unbanning an unknown user

### DIFF
--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -508,8 +508,9 @@ class KickBanMixin(MixinMeta):
         click the user and select 'Copy ID'."""
         guild = ctx.guild
         author = ctx.author
-        user = await self.bot.fetch_user(user_id)
-        if not user:
+        try:
+            user = await self.bot.fetch_user(user_id)
+        except discord.errors.NotFound:
             await ctx.send(_("Couldn't find a user with that ID!"))
             return
         audit_reason = get_audit_reason(ctx.author, reason)


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
When trying to unban a user with an invalid ID (whether user deleted or a bad ID), `[p]unban` used to run into an error when it couldn't get the user.  This also fixes #2542.