### PR TITLE
[Streams] Add ability to exclude rerun streams from alerts

### DIFF
--- a/docs/changelog_3_1_0.rst
+++ b/docs/changelog_3_1_0.rst
@@ -63,6 +63,7 @@ Mod
 ---
 
  * Admins can now decide how many times message has to be repeated before ``deleterepeats`` removes it (`#2437`_)
+ * Fix: make ``[p]ban [days]`` optional as per the doc (`#2602`_)
 
 -------------
 Setup Scripts
@@ -71,6 +72,12 @@ Setup Scripts
  * ``redbot-setup`` now uses the click CLI library (`#2579`_)
  * ``redbot-setup convert`` now used to convert between libraries (`#2579`_)
  * Backup support for Mongo is currently broken (`#2579`_)
+
+-------
+Streams
+-------
+
+ * Add support for custom stream alert messages per guild (`#2600`_)
 
 -----
 Tests
@@ -125,5 +132,7 @@ Utility Functions
 .. _#2591: https://github.com/Cog-Creators/Red-DiscordBot/pull/2591
 .. _#2592: https://github.com/Cog-Creators/Red-DiscordBot/pull/2592
 .. _#2595: https://github.com/Cog-Creators/Red-DiscordBot/pull/2595
+.. _#2600: https://github.com/Cog-Creators/Red-DiscordBot/pull/2600
+.. _#2602: https://github.com/Cog-Creators/Red-DiscordBot/pull/2602
 .. _#2604: https://github.com/Cog-Creators/Red-DiscordBot/pull/2604
 .. _#2606: https://github.com/Cog-Creators/Red-DiscordBot/pull/2606

--- a/docs/changelog_3_1_0.rst
+++ b/docs/changelog_3_1_0.rst
@@ -78,6 +78,7 @@ Streams
 -------
 
  * Add support for custom stream alert messages per guild (`#2600`_)
+ * Add ability to exclude rerun Twitch streams, and note rerun streams in embed status (`#2620`_)
 
 -----
 Tests
@@ -136,3 +137,4 @@ Utility Functions
 .. _#2602: https://github.com/Cog-Creators/Red-DiscordBot/pull/2602
 .. _#2604: https://github.com/Cog-Creators/Red-DiscordBot/pull/2604
 .. _#2606: https://github.com/Cog-Creators/Red-DiscordBot/pull/2606
+.. _#2620: https://github.com/Cog-Creators/Red-DiscordBot/pull/2620

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -174,7 +174,8 @@ class TwitchStream(Stream):
             # self.already_online = True
             #  In case of rename
             self.name = data["stream"]["channel"]["name"]
-            return self.make_embed(data)
+            is_rerun = True if data["stream"]["stream_type"] == "rerun" else False
+            return self.make_embed(data), is_rerun
         elif r.status == 400:
             raise InvalidTwitchCredentials()
         elif r.status == 404:
@@ -204,6 +205,7 @@ class TwitchStream(Stream):
 
     def make_embed(self, data):
         channel = data["stream"]["channel"]
+        is_rerun = data["stream"]["stream_type"] == "rerun"
         url = channel["url"]
         logo = channel["logo"]
         if logo is None:
@@ -211,6 +213,8 @@ class TwitchStream(Stream):
         status = channel["status"]
         if not status:
             status = "Untitled broadcast"
+        if is_rerun:
+            status += " - Rerun"
         embed = discord.Embed(title=status, url=url)
         embed.set_author(name=channel["display_name"])
         embed.add_field(name="Followers", value=channel["followers"])


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Addresses #2444
* Adds ignore_reruns setting per-guild so alerts can exclude rerun streams.
* Marks all rerun streams by appending to the status (title) so readers are aware of it anyway.
![image](https://user-images.githubusercontent.com/4382519/56744274-29e8b900-6746-11e9-9c18-5abbbd88d957.png)
