### PR TITLE
[Commands] Fix built in check decorator order affecting permissions

### DIFF
--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -156,6 +156,13 @@ class Command(CogCommandMixin, commands.Command):
         self._help_override = kwargs.pop("help_override", None)
         self.translator = kwargs.pop("i18n", None)
 
+    def _ensure_assignment_on_copy(self, other):
+        super()._ensure_assignment_on_copy(other)
+
+        # Red specific
+        other.requires = self.requires
+        return other
+
     @property
     def help(self):
         """Help string for this command.


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
There is an issue in the existing **dev** codebase where the following does not respect permissions:

```py
@checks.is_owner()
@commands.command()
async def command(ctx):
    pass
```
However, if the check and command decorators are flipped in order, everything works as intended. The issues is caused by the rewritten commands extension from d.py "copying" command objects on cog creation and wasn't keeping the `requires` object during this copy function.

## This ONLY affects the latest DEV code
3.0.2 is not impacted by this problem.