### PR TITLE
[V3 Downloader] suppress `ExtensionNotLoaded` in `[p]cog uninstall` when unloading cog

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -344,7 +344,8 @@ class Downloader(commands.Cog):
 
                 poss_installed_path = (await self.cog_install_path()) / real_name
                 if poss_installed_path.exists():
-                    ctx.bot.unload_extension(real_name)
+                    with contextlib.suppress(commands.ExtensionNotLoaded):
+                        ctx.bot.unload_extension(real_name)
                     await self._delete_cog(poss_installed_path)
                     uninstalled_cogs.append(inline(real_name))
                 else:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #2622 
After discord.py dep update, `unload_extension` started to raise `discord.errors.ExtensionNotLoaded`, when extension wasn't loaded. This addresses the issue by suppressing this error when downloader tries to unload the cog during the uninstallation