### PR TITLE
[V3 Economy] lookup users from the guild instead of using stored names

### DIFF
--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -370,8 +370,11 @@ class Economy(commands.Cog):
             try:
                 name = guild.get_member(acc[0]).display_name
             except AttributeError:
-                name = f"{acc[1]['name']} ({str(acc[0])})"
-            balance = acc[1]['balance']
+                user_id = ""
+                if await ctx.bot.is_owner(ctx.author):
+                    user_id = f"({str(acc[0])})"
+                name = f"{acc[1]['name']} {user_id}"
+            balance = acc[1]["balance"]
 
             if acc[0] != author.id:
                 highscores.append(


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This supersedes #2636 as it removes the need to even use the saved nicknames by getting users from the bots cache. This also adjusts the leaderboard to display usernames at the end of the line rather than the beginning since we cannot control user names length with zero-width and other special width characters.