### PR TITLE
String format failure when `set` invoked without subcommand

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -656,7 +656,7 @@ class Core(commands.Cog, CoreLogic):
                     guild.get_role(await ctx.bot.db.guild(ctx.guild).mod_role()) or "Not set"
                 )
                 prefixes = await ctx.bot.db.guild(ctx.guild).prefix()
-                guild_settings = _("Admin role: {admin_role}\nMod role: {mod_role}\n").format(
+                guild_settings = _("Admin role: {admin}\nMod role: {mod}\n").format(
                     admin=admin_role, mod=mod_role
                 )
             else:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes error when invoking `set` alone due to string format identifiers not being consistent, introduced in https://github.com/Cog-Creators/Red-DiscordBot/commit/e3db3c03419ab19626b367e86d004b8c0f67d8c6