### PR TITLE
Changes default locale value to `en-US`

### DIFF
--- a/docs/changelog_3_1_0.rst
+++ b/docs/changelog_3_1_0.rst
@@ -35,8 +35,9 @@ Core
 
  * Delete cooldown messages when expired (`#2469`_)
  * ``[p]set locale`` now only accepts actual locales (`#2553`_)
- * ``[p]listlocales`` now displays en-US (`#2553`_)
+ * ``[p]listlocales`` now displays ``en-US`` (`#2553`_)
  * ``redbot --version`` will now give you current version of Red (`#2567`_)
+ * Default locale changed from ``en`` to ``en-US`` (`#2642`_)
 
 ------
 Config
@@ -146,3 +147,4 @@ Utility Functions
 .. _#2605: https://github.com/Cog-Creators/Red-DiscordBot/pull/2605
 .. _#2606: https://github.com/Cog-Creators/Red-DiscordBot/pull/2606
 .. _#2620: https://github.com/Cog-Creators/Red-DiscordBot/pull/2620
+.. _#2642: https://github.com/Cog-Creators/Red-DiscordBot/pull/2642

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -45,7 +45,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):
             owner=None,
             whitelist=[],
             blacklist=[],
-            locale="en",
+            locale="en-US",
             embeds=True,
             color=15158332,
             fuzzy=False,


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
The default locale was previously `en`. With the check added to `[p]set locale` in #2553, `en` is technically an invalid locale (it still works, but it isn't one that is *supposed* to be used).
This fixes that issue by setting the default locale to `en-US`, which is a locale that is able to be set with `[p]set locale` and the locale recommended by the help text of `[p]set locale` to change back to English.

Fixes #2641