### PR TITLE
Adds `[p]datapath` to print the bot's data path

### DIFF
--- a/docs/changelog_3_1_0.rst
+++ b/docs/changelog_3_1_0.rst
@@ -38,6 +38,7 @@ Core
  * ``[p]listlocales`` now displays ``en-US`` (`#2553`_)
  * ``redbot --version`` will now give you current version of Red (`#2567`_)
  * Default locale changed from ``en`` to ``en-US`` (`#2642`_)
+ * New command ``[p]datapath`` that prints the bot's datapath (`#2652`_)
 
 ------
 Config
@@ -150,3 +151,4 @@ Utility Functions
 .. _#2620: https://github.com/Cog-Creators/Red-DiscordBot/pull/2620
 .. _#2639: https://github.com/Cog-Creators/Red-DiscordBot/pull/2639
 .. _#2642: https://github.com/Cog-Creators/Red-DiscordBot/pull/2642
+.. _#2652: https://github.com/Cog-Creators/Red-DiscordBot/pull/2652

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1380,6 +1380,16 @@ class Core(commands.Cog, CoreLogic):
             else:
                 await ctx.send(_("Message delivered to {}").format(destination))
 
+    @commands.command(hidden=True)
+    @checks.is_owner()
+    async def datapath(self, ctx: commands.Context):
+        """Prints the bot's data path."""
+        from redbot.core.data_manager import basic_config
+
+        data_dir = Path(basic_config["DATA_PATH"])
+        msg = _("Data path: {path}").format(path=data_dir)
+        await ctx.send(box(msg))
+
     @commands.group()
     @checks.is_owner()
     async def whitelist(self, ctx: commands.Context):


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [X] New feature

### Description of the changes
Adds a new command, `[p]datapath`. This command will print the bot's data path. This simplifies the process of finding the data path from needing to use the install path in `[p]paths`.
Fixes #2651