### PR TITLE
[Cleanup] Use `fetch_message` instead of no longer existing `get_message`

### DIFF
--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -262,7 +262,7 @@ class Cleanup(commands.Cog):
         author = ctx.author
 
         try:
-            before = await channel.get_message(message_id)
+            before = await channel.fetch_message(message_id)
         except discord.NotFound:
             return await ctx.send(_("Message not found."))
 


### PR DESCRIPTION
cleanup before use get_message wich isn't possible anymore in dp 1.0.1. so I changed it to fetch_message

### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
