### PR TITLE
[Docs] Update Mac install instructions for Java

### DIFF
--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -92,7 +92,7 @@ one-by-one:
     brew install python --with-brewed-openssl
     brew install git
     brew tap caskroom/versions
-    brew cask install java8
+    brew cask install homebrew/cask-versions/adoptopenjdk8
 
 It's possible you will have network issues. If so, go in your Applications folder, inside it, go in the Python 3.7 folder then double click ``Install certificates.command``
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Change the docs from the non existent Java 8 cask to an OpenJDK cask suggested by the Homebrew project: see https://github.com/Homebrew/brew/pull/6035 and https://github.com/Homebrew/homebrew-cask-versions/issues/7253
Also solves #2662.