### PR TITLE
[Core] Added co-owners to outdated message warnings

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -104,7 +104,9 @@ def main():
     log.debug("Data Path: %s", data_manager._base_data_path())
     log.debug("Storage Type: %s", data_manager.storage_type())
 
-    red = Red(cli_flags=cli_flags, description=description, dm_help=None)
+    red = Red(
+        cli_flags=cli_flags, description=description, dm_help=None, fetch_offline_members=True
+    )
     init_global_checks(red)
     init_events(red, cli_flags)
     red.add_cog(Core(red))

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -131,15 +131,13 @@ def init_events(bot, cli_flags):
                         owners.append(co_owner)
 
                 for owner in owners:
-                    try:
+                    with contextlib.suppress(discord.HTTPException):
                         await owner.send(
                             "Your Red instance is out of date! {} is the current "
                             "version, however you are using {}!".format(
                                 data["info"]["version"], red_version
                             )
                         )
-                    except (discord.HTTPException, discord.Forbidden):
-                        pass
         INFO2 = []
 
         mongo_enabled = storage_type() != "JSON"

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -119,13 +119,17 @@ def init_events(bot, cli_flags):
                     "Outdated version! {} is available "
                     "but you're using {}".format(data["info"]["version"], red_version)
                 )
-                owner = await bot.fetch_user(bot.owner_id)
-                await owner.send(
-                    "Your Red instance is out of date! {} is the current "
-                    "version, however you are using {}!".format(
-                        data["info"]["version"], red_version
+                owners = []
+                owners.append(await bot.fetch_user(bot.owner_id))
+                for co_owner in bot._co_owners:
+                    owners.append(await bot.fetch_user(co_owner))
+                for owner in owners:
+                    await owner.send(
+                        "Your Red instance is out of date! {} is the current "
+                        "version, however you are using {}!".format(
+                            data["info"]["version"], red_version
+                        )
                     )
-                )
         INFO2 = []
 
         mongo_enabled = storage_type() != "JSON"

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -119,17 +119,27 @@ def init_events(bot, cli_flags):
                     "Outdated version! {} is available "
                     "but you're using {}".format(data["info"]["version"], red_version)
                 )
+
                 owners = []
-                owners.append(await bot.fetch_user(bot.owner_id))
+                owner = bot.get_user(bot.owner_id)
+                if owner is not None:
+                    owners.append(owner)
+
                 for co_owner in bot._co_owners:
-                    owners.append(await bot.fetch_user(co_owner))
+                    co_owner = await bot.get_user(co_owner)
+                    if co_owner is not None:
+                        owners.append(co_owner)
+
                 for owner in owners:
-                    await owner.send(
-                        "Your Red instance is out of date! {} is the current "
-                        "version, however you are using {}!".format(
-                            data["info"]["version"], red_version
+                    try:
+                        await owner.send(
+                            "Your Red instance is out of date! {} is the current "
+                            "version, however you are using {}!".format(
+                                data["info"]["version"], red_version
+                            )
                         )
-                    )
+                    except (discord.HTTPException, discord.Forbidden):
+                        pass
         INFO2 = []
 
         mongo_enabled = storage_type() != "JSON"


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

Since Co-owners are acting as another owner (Especially in the case of Team applications) they should receive the warnings of an outdated bot on start up.