### PR TITLE
Mention voice channel in `[p]userinfo`

### DIFF
--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -145,7 +145,7 @@ class ModInfo(MixinMeta):
         if voice_state and voice_state.channel:
             data.add_field(
                 name=_("Current voice channel"),
-                value="{0.name} (ID {0.id})".format(voice_state.channel),
+                value="{0.mention}".format(voice_state.channel),
                 inline=False,
             )
         data.set_footer(text=_("Member #{} | User ID: {}").format(member_number, user.id))

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -145,7 +145,7 @@ class ModInfo(MixinMeta):
         if voice_state and voice_state.channel:
             data.add_field(
                 name=_("Current voice channel"),
-                value="{0.mention}".format(voice_state.channel),
+                value="{0.mention} ID: {0.id}".format(voice_state.channel),
                 inline=False,
             )
         data.set_footer(text=_("Member #{} | User ID: {}").format(member_number, user.id))


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Now mentions voice channel instead of displaying name of channel, as Discord just released an update allowing for VCs to be mentioned and join on click.