### PR TITLE
[Downloader] Fix problem with copying directory tree.

### DIFF
--- a/redbot/cogs/downloader/installable.py
+++ b/redbot/cogs/downloader/installable.py
@@ -114,6 +114,7 @@ class Installable(RepoJSONMixin):
         if self._location.is_file():
             copy_func = shutil.copy2
         else:
+            distutils.dir_util._path_created = {}
             copy_func = distutils.dir_util.copy_tree
 
         # noinspection PyBroadException

--- a/redbot/cogs/downloader/installable.py
+++ b/redbot/cogs/downloader/installable.py
@@ -114,6 +114,7 @@ class Installable(RepoJSONMixin):
         if self._location.is_file():
             copy_func = shutil.copy2
         else:
+            # clear copy_tree's cache to make sure missing directories are created (GH-2690)
             distutils.dir_util._path_created = {}
             copy_func = distutils.dir_util.copy_tree
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
fix #2685
This might not be perfect solution as we have to clear `distutils.dir_util._path_created` dict, but it seems like the best way to fix this, if we don't want to reimplement `distutils.dir_util.copy_tree`.