### PR TITLE
[Core] Improve API token converter

### DIFF
--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -1,7 +1,9 @@
 import re
-from typing import TYPE_CHECKING
+import functools
+from typing import TYPE_CHECKING, Optional, List, Dict
 
 import discord
+from discord.ext import commands as dpy_commands
 
 from . import BadArgument
 from ..i18n import Translator
@@ -9,7 +11,7 @@ from ..i18n import Translator
 if TYPE_CHECKING:
     from .context import Context
 
-__all__ = ["GuildConverter"]
+__all__ = ["GuildConverter", "APIToken", "DictConverter", "get_validated_dict_converter"]
 
 _ = Translator("commands.converter", __file__)
 
@@ -47,16 +49,20 @@ class APIToken(discord.ext.commands.Converter):
     This will parse the input argument separating the key value pairs into a 
     format to be used for the core bots API token storage.
     
-    This will split the argument by either `;` or `,` and return a dict
+    This will split the argument by either `;` ` `, or `,` and return a dict
     to be stored. Since all API's are different and have different naming convention,
     this leaves the onus on the cog creator to clearly define how to setup the correct
     credential names for their cogs.
+
+    Note: Core usage of this has been replaced with DictConverter use instead.
+
+    This may be removed at a later date (with warning)
     """
 
     async def convert(self, ctx, argument) -> dict:
         bot = ctx.bot
         result = {}
-        match = re.split(r";|,", argument)
+        match = re.split(r";|,| ", argument)
         # provide two options to split incase for whatever reason one is part of the api key we're using
         if len(match) > 1:
             result[match[0]] = "".join(r for r in match[1:])
@@ -65,3 +71,48 @@ class APIToken(discord.ext.commands.Converter):
         if not result:
             raise BadArgument(_("The provided tokens are not in a valid format."))
         return result
+
+
+class DictConverter(dpy_commands.Converter):
+    """
+    Converts pairs of space seperated values to a dict
+    """
+
+    def __init__(self, *expected_keys: str, split_commas=False):
+        self.expected_keys = expected_keys
+        self.split_commas = split_commas
+
+    async def convert(self, ctx: "Context", argument: str) -> Dict[str, str]:
+
+        ret: Dict[str, str] = {}
+        pattern = r";|,| " if self.split_commas else " "
+        args = re.split(pattern, argument)
+
+        if len(args) % 2 != 0:
+            raise BadArgument()
+
+        iterator = iter(args)
+
+        for key in iterator:
+            if self.expected_keys and key not in self.expected_keys:
+                raise BadArgument(_("Unexpected key {key}").format(key))
+
+            ret[key] = next(iterator)
+
+        return ret
+
+
+def get_validated_dict_converter(*expected_keys: str, split_commas=False) -> type:
+    """
+    Returns a typechecking safe `DictConverter` suitable for use with discord.py
+    """
+
+    class PartialMeta(type(DictConverter)):
+        __call__ = functools.partialmethod(
+            type(DictConverter).__call__, *expected_keys, split_commas=split_commas
+        )
+
+    class ValidatedConverter(DictConverter, metaclass=PartialMeta):
+        pass
+
+    return ValidatedConverter

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -42,7 +42,7 @@ log = logging.getLogger("red")
 
 _ = i18n.Translator("Core", __file__)
 
-TokenConverter = commands.get_validated_dict_converter(split_commas=True)
+TokenConverter = commands.get_dict_converter(delims=[" ", ",", ";"])
 
 
 class CoreLogic:

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -42,6 +42,8 @@ log = logging.getLogger("red")
 
 _ = i18n.Translator("Core", __file__)
 
+TokenConverter = commands.get_validated_dict_converter(split_commas=True)
+
 
 class CoreLogic:
     def __init__(self, bot: "Red"):
@@ -1057,7 +1059,7 @@ class Core(commands.Cog, CoreLogic):
 
     @_set.command()
     @checks.is_owner()
-    async def api(self, ctx: commands.Context, service: str, *tokens: commands.converter.APIToken):
+    async def api(self, ctx: commands.Context, service: str, *, tokens: TokenConverter):
         """Set various external API tokens.
         
         This setting will be asked for by some 3rd party cogs and some core cogs.
@@ -1070,8 +1072,7 @@ class Core(commands.Cog, CoreLogic):
         """
         if ctx.channel.permissions_for(ctx.me).manage_messages:
             await ctx.message.delete()
-        entry = {k: v for t in tokens for k, v in t.items()}
-        await ctx.bot.db.api_tokens.set_raw(service, value=entry)
+        await ctx.bot.db.api_tokens.set_raw(service, value=tokens)
         await ctx.send(_("`{service}` API tokens have been set.").format(service=service))
 
     @commands.group()


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [X] New feature

### Description of the changes

This adds a new generalized DictConverter and uses it.

This does not remove the prior converter, though if we decide to remove it at a later date, we should mark it as deprecated before doing so and wait at least a minor patch.

This also includes an additional function for generating a typechecking safe version of the DictConverter with specific parameters set already (in keeping with a long term goal of Red being completely runnable under `mypy --strict`)

### User facing changes

Users will be allowed to seperate their keys and values with their choice of space, comma, and semicolon in `[p]set api` rather than just commas and semicolons