### PR TITLE
[Core utils] Modify chmod use in `safe_delete`

### DIFF
--- a/redbot/core/utils/__init__.py
+++ b/redbot/core/utils/__init__.py
@@ -58,13 +58,13 @@ logging.getLogger().addFilter(_fuzzy_log_filter)
 def safe_delete(pth: Path):
     if pth.exists():
         for root, dirs, files in os.walk(str(pth)):
-            os.chmod(root, 0o755)
+            os.chmod(root, 0o700)
 
             for d in dirs:
-                os.chmod(os.path.join(root, d), 0o755)
+                os.chmod(os.path.join(root, d), 0o700)
 
             for f in files:
-                os.chmod(os.path.join(root, f), 0o755)
+                os.chmod(os.path.join(root, f), 0o700)
 
         shutil.rmtree(str(pth), ignore_errors=True)
 


### PR DESCRIPTION
 - Takes a pessimistic approach that it's possible chmod succeeds, but
 deletion fails and does not make the entire dir world readable

### Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

This has probably never had an actual impact, but my linter keeps reminding me it's there every time I open the utils up, and it is technically possible should the application or host crash in between these calls.
