### PR TITLE
[Setup] Fix wrong var used for instance data in `remove_instance`

### DIFF
--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -440,7 +440,7 @@ async def remove_instance(instance):
             collection = await db.get_collection(name)
             await collection.drop()
     else:
-        pth = Path(instance_data["DATA_PATH"])
+        pth = Path(instance_vals["DATA_PATH"])
         safe_delete(pth)
     save_config(instance, {}, remove=True)
     print("The instance {} has been removed\n".format(instance))


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Before this PR `remove_instance` used `instance_data` variable, which contains all instances (so instance names are keys), not the chosen one and that caused `KeyError`