### PR TITLE
Fix minor typo

### DIFF
--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -254,7 +254,7 @@ async def reset_red():
         "please select option 5 in the launcher."
     )
     await asyncio.sleep(2)
-    print("\nIf you continue you will remove these instanes.\n")
+    print("\nIf you continue you will remove these instances.\n")
     for instance in list(instances.keys()):
         print("    - {}".format(instance))
     await asyncio.sleep(3)


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
There was a minor typo in launcher.py that misspelled "instances." This PR fixes that typo.