### PR TITLE
[Trivia] Remove bold on a box

### DIFF
--- a/redbot/cogs/trivia/trivia.py
+++ b/redbot/cogs/trivia/trivia.py
@@ -57,7 +57,7 @@ class Trivia(commands.Cog):
             settings_dict = await settings.all()
             msg = box(
                 _(
-                    "**Current settings**\n"
+                    "Current settings\n"
                     "Bot gains points: {bot_plays}\n"
                     "Answer time limit: {delay} seconds\n"
                     "Lack of response timeout: {timeout} seconds\n"


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This is just removing bold that are on the box of `[p]triviaset` command since the Discord Markdown don't works inside boxes.