### PR TITLE
[Help] Detatch menu usage into a task

### DIFF
--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -551,7 +551,7 @@ class RedHelpFormatter:
                         )
         else:
             # Specifically ensuring the menu's message is sent prior to returning
-            m = await ctx.send(embed=pages[0]) if embed else ctx.send(pages[0])
+            m = await (ctx.send(embed=pages[0]) if embed else ctx.send(pages[0]))
             c = menus.DEFAULT_CONTROLS if len(pages) > 1 else {"\N{CROSS MARK}": menus.close_menu}
             # Allow other things to happen during menu timeout/interaction.
             asyncio.create_task(menus.menu(ctx, pages, c, message=m))


### PR DESCRIPTION

### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

  - This resolves #2712
  - This is a minor API change. Conceptually, the difference is minor in
  nature `bot.send_help_for` returns when help has been sent, however
  this can now be prior to when the help menu (if one is in use) is
  closed.
  - This should not be considered breaking as there is and has been a
  a warning about this file's APIs being still up for unannounced modifications
  No developers should be currently relying on this behavior.

