### PR TITLE
Add respectable aliases for consistency

### DIFF
--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -375,7 +375,7 @@ class Alias(commands.Cog):
             await ctx.send(_("There is no alias with the name `{name}`").format(name=alias_name))
 
     @checks.mod_or_permissions(manage_guild=True)
-    @alias.command(name="del", aliases=["delete", "remove"])
+    @alias.command(name="delete", aliases=["delete", "remove"])
     @commands.guild_only()
     async def _del_alias(self, ctx: commands.Context, alias_name: str):
         """Delete an existing alias on this server."""

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -375,7 +375,7 @@ class Alias(commands.Cog):
             await ctx.send(_("There is no alias with the name `{name}`").format(name=alias_name))
 
     @checks.mod_or_permissions(manage_guild=True)
-    @alias.command(name="delete", aliases=["delete", "remove"])
+    @alias.command(name="delete", aliases=["del", "remove"])
     @commands.guild_only()
     async def _del_alias(self, ctx: commands.Context, alias_name: str):
         """Delete an existing alias on this server."""
@@ -394,7 +394,7 @@ class Alias(commands.Cog):
             await ctx.send(_("Alias with name `{name}` was not found.").format(name=alias_name))
 
     @checks.is_owner()
-    @global_.command(name="delete", aliases=["delete", "remove"])
+    @global_.command(name="delete", aliases=["del", "remove"])
     async def _del_global_alias(self, ctx: commands.Context, alias_name: str):
         """Delete an existing global alias."""
         aliases = await self.unloaded_global_aliases()

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -394,7 +394,7 @@ class Alias(commands.Cog):
             await ctx.send(_("Alias with name `{name}` was not found.").format(name=alias_name))
 
     @checks.is_owner()
-    @global_.command(name="del", aliases=["delete", "remove"])
+    @global_.command(name="delete", aliases=["delete", "remove"])
     async def _del_global_alias(self, ctx: commands.Context, alias_name: str):
         """Delete an existing global alias."""
         aliases = await self.unloaded_global_aliases()

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -375,7 +375,7 @@ class Alias(commands.Cog):
             await ctx.send(_("There is no alias with the name `{name}`").format(name=alias_name))
 
     @checks.mod_or_permissions(manage_guild=True)
-    @alias.command(name="del")
+    @alias.command(name="del", aliases=["delete", "remove"])
     @commands.guild_only()
     async def _del_alias(self, ctx: commands.Context, alias_name: str):
         """Delete an existing alias on this server."""
@@ -394,7 +394,7 @@ class Alias(commands.Cog):
             await ctx.send(_("Alias with name `{name}` was not found.").format(name=alias_name))
 
     @checks.is_owner()
-    @global_.command(name="del")
+    @global_.command(name="del", aliases=["delete", "remove"])
     async def _del_global_alias(self, ctx: commands.Context, alias_name: str):
         """Delete an existing global alias."""
         aliases = await self.unloaded_global_aliases()

--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -296,7 +296,7 @@ class CustomCommands(commands.Cog):
                 )
             )
 
-    @customcom.command(name="delete")
+    @customcom.command(name="delete", aliases=["del", "remove"])
     @checks.mod_or_permissions(administrator=True)
     async def cc_delete(self, ctx, command: str.lower):
         """Delete a custom command.

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -246,7 +246,7 @@ class Downloader(commands.Cog):
             if repo.install_msg is not None:
                 await ctx.send(repo.install_msg.replace("[p]", ctx.prefix))
 
-    @repo.command(name="delete", aliases=["remove"], usage="<repo_name>")
+    @repo.command(name="delete", aliases=["remove", "del"], usage="<repo_name>")
     async def _repo_del(self, ctx, repo: Repo):
         """Remove a repo and its files."""
         await self._repo_manager.delete_repo(repo.name)

--- a/redbot/cogs/filter/filter.py
+++ b/redbot/cogs/filter/filter.py
@@ -236,7 +236,7 @@ class Filter(commands.Cog):
         else:
             await ctx.send(_("Those words were already in the filter."))
 
-    @_filter.command(name="remove", aliases=["delete", "del"])
+    @_filter.command(name="delete", aliases=["remove", "del"])
     async def filter_remove(self, ctx: commands.Context, *, words: str):
         """Remove words from the filter.
 

--- a/redbot/cogs/filter/filter.py
+++ b/redbot/cogs/filter/filter.py
@@ -236,7 +236,7 @@ class Filter(commands.Cog):
         else:
             await ctx.send(_("Those words were already in the filter."))
 
-    @_filter.command(name="remove")
+    @_filter.command(name="remove", aliases=["delete", "del"])
     async def filter_remove(self, ctx: commands.Context, *, words: str):
         """Remove words from the filter.
 

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -125,7 +125,7 @@ class Warnings(commands.Cog):
                 registered_actions.sort(key=lambda a: a["points"], reverse=True)
                 await ctx.send(_("Action {name} has been added.").format(name=name))
 
-    @warnaction.command(name="del")
+    @warnaction.command(name="del", aliases=["delete", "remove"])
     @commands.guild_only()
     async def action_del(self, ctx: commands.Context, action_name: str):
         """Delete the action with the specified name."""
@@ -175,7 +175,7 @@ class Warnings(commands.Cog):
 
         await ctx.send(_("The new reason has been registered."))
 
-    @warnreason.command(name="del", aliases=["remove"])
+    @warnreason.command(name="del", aliases=["remove", "delete"])
     @commands.guild_only()
     async def reason_del(self, ctx: commands.Context, reason_name: str):
         """Delete a warning reason."""

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -125,7 +125,7 @@ class Warnings(commands.Cog):
                 registered_actions.sort(key=lambda a: a["points"], reverse=True)
                 await ctx.send(_("Action {name} has been added.").format(name=name))
 
-    @warnaction.command(name="del", aliases=["delete", "remove"])
+    @warnaction.command(name="delete", aliases=["del", "remove"])
     @commands.guild_only()
     async def action_del(self, ctx: commands.Context, action_name: str):
         """Delete the action with the specified name."""
@@ -175,7 +175,7 @@ class Warnings(commands.Cog):
 
         await ctx.send(_("The new reason has been registered."))
 
-    @warnreason.command(name="del", aliases=["remove", "delete"])
+    @warnreason.command(name="delete", aliases=["remove", "del"])
     @commands.guild_only()
     async def reason_del(self, ctx: commands.Context, reason_name: str):
         """Delete a warning reason."""


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Before, there were a lot of different commands where some were using `del`, some using `delete` and others using `remove` (in the same context that `del` or `delete` could be).  This PR adds all of them to each of the commands (so that you can use `del`, `delete` or `remove` in the proper places), so that there is consistency between the commands.