### PR TITLE
Adding support for GitHub Funding

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+patreon: Red_Devs


### PR DESCRIPTION
GitHub now allows us linking to other funding platforms with this simple file! :tada:

### Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
