### PR TITLE
[p]slowmode

### DIFF
--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -12,6 +12,7 @@ from .kickban import KickBanMixin
 from .movetocore import MoveToCore
 from .mutes import MuteMixin
 from .names import ModInfo
+from .slowmode import Slowmode
 from .settings import ModSettings
 
 _ = T_ = Translator("Mod", __file__)
@@ -36,6 +37,7 @@ class Mod(
     MoveToCore,
     MuteMixin,
     ModInfo,
+    Slowmode,
     commands.Cog,
     metaclass=CompositeMetaClass,
 ):

--- a/redbot/cogs/mod/slowmode.py
+++ b/redbot/cogs/mod/slowmode.py
@@ -23,9 +23,7 @@ class Slowmode(MixinMeta):
         You can specify the unit using `s`, `m` or `h` as suffix.
         Use without parameters or set to 0 to disable.
         """
-        if interval is None:
-            interval = 0
-        else:
+        if interval:
             match = re.match(r"(?i)(\d{1,5})([a-zA-Z])?", interval)
             if match:
                 interval = int(match.group(1))
@@ -36,6 +34,8 @@ class Slowmode(MixinMeta):
             if not match or not 0 <= interval <= 21600:
                 await ctx.send(_("Interval must be between 0 seconds and 6 hours!"))
                 return
+        else:
+            interval = 0
         await ctx.channel.edit(slowmode_delay=interval)
         if interval > 0:
             interval = humanize_timedelta(seconds=interval)

--- a/redbot/cogs/mod/slowmode.py
+++ b/redbot/cogs/mod/slowmode.py
@@ -1,6 +1,8 @@
-import discord
-from redbot.core import commands, i18n, checks
+import re
 from .abc import MixinMeta
+from datetime import timedelta
+from redbot.core import commands, i18n, checks
+from redbot.core.utils.chat_formatting import humanize_timedelta
 
 _ = i18n.Translator("Mod", __file__)
 
@@ -13,18 +15,32 @@ class Slowmode(MixinMeta):
     @commands.command()
     @commands.guild_only()
     @commands.bot_has_permissions(manage_channels=True)
-    @checks.mod_or_permissions(manage_channels=True)
-    async def slowmode(self, ctx, interval: int = 0):
+    @checks.admin_or_permissions(manage_channels=True)
+    async def slowmode(self, ctx, interval: str = None):
         """Changes channel's slowmode setting.
 
-        Interval can be anything from 0 to 21600 seconds.
+        Interval can be anything from 0 seconds to 6 hours.
+        You can specify the unit using `s`, `m` or `h` as suffix.
         Use without parameters or set to 0 to disable.
         """
-        if 0 <= interval <= 21600:
-            await ctx.send(_("Interval must be between 0 and 21600 seconds!"))
-            return
+        if interval is None:
+            interval = 0
+        else:
+            match = re.match(r'(?i)(\d{1,5})([a-zA-Z])?', interval)
+            if match:
+                interval = int(match.group(1))
+                if match.group(2) is not None:
+                    interval = {
+                        "s": 1,
+                        "m": 60,
+                        "h": 60 * 60,
+                    }.get(match.group(2).lower(), -1) * interval
+            if not match or not 0 <= interval <= 21600:
+                await ctx.send(_("Interval must be between 0 seconds and 6 hours!"))
+                return
         await ctx.channel.edit(slowmode_delay=interval)
         if interval > 0:
-            await ctx.send(_(f"Slowmode interval is now {interval} seconds."))
+            interval = humanize_timedelta(seconds=interval)
+            await ctx.send(_(f"Slowmode interval is now {interval}."))
         else:
             await ctx.send(_("Slowmode has been disabled."))

--- a/redbot/cogs/mod/slowmode.py
+++ b/redbot/cogs/mod/slowmode.py
@@ -1,0 +1,29 @@
+import discord
+from redbot.core import commands, i18n, checks
+from .abc import MixinMeta
+
+_ = i18n.Translator("Mod", __file__)
+
+class Slowmode(MixinMeta):
+    """
+    Commands regarding channel slowmode management.
+    """
+
+    @commands.command()
+    @commands.guild_only()
+    @commands.bot_has_permissions(manage_channels=True)
+    @checks.mod_or_permissions(manage_channels=True)
+    async def slowmode(self, ctx, interval: int = 0):
+        """Changes channel's slowmode setting.
+
+        Interval can be anything from 0 to 21600 seconds.
+        Use without parameters or set to 0 to disable.
+        """
+        if 0 <= interval <= 21600:
+            await ctx.send(_("Interval must be between 0 and 21600 seconds!"))
+            return
+        await ctx.channel.edit(slowmode_delay=interval)
+        if interval > 0:
+            await ctx.send(_(f"Slowmode interval is now {interval} seconds."))
+        else:
+            await ctx.send(_("Slowmode has been disabled."))

--- a/redbot/cogs/mod/slowmode.py
+++ b/redbot/cogs/mod/slowmode.py
@@ -3,6 +3,7 @@ from .abc import MixinMeta
 
 _ = i18n.Translator("Mod", __file__)
 
+
 class Slowmode(MixinMeta):
     """
     Commands regarding channel slowmode management.

--- a/redbot/cogs/mod/slowmode.py
+++ b/redbot/cogs/mod/slowmode.py
@@ -24,7 +24,7 @@ class Slowmode(MixinMeta):
         Use without parameters or set to 0 to disable.
         """
         if interval:
-            match = re.match(r"(?i)(\d{1,5})([a-zA-Z])?", interval)
+            match = re.match(r"(?i)(\d{1,5})([a-zA-Z])?$", interval)
             if match:
                 interval = int(match.group(1))
                 if match.group(2) is not None:

--- a/redbot/cogs/mod/slowmode.py
+++ b/redbot/cogs/mod/slowmode.py
@@ -18,7 +18,7 @@ class Slowmode(MixinMeta):
         Interval can be anything from 0 to 21600 seconds.
         Use without parameters or set to 0 to disable.
         """
-        if 0 <= interval <= 21600:
+        if not 0 <= interval <= 21600:
             await ctx.send(_("Interval must be between 0 and 21600 seconds!"))
             return
         await ctx.channel.edit(slowmode_delay=interval)

--- a/redbot/cogs/mod/slowmode.py
+++ b/redbot/cogs/mod/slowmode.py
@@ -14,7 +14,7 @@ class Slowmode(MixinMeta):
     @commands.bot_has_permissions(manage_channels=True)
     @checks.mod_or_permissions(manage_channels=True)
     async def slowmode(self, ctx, interval: int = 0):
-        """Changes channel's slowmode setting.
+        """Change channel's slowmode setting.
 
         Interval can be anything from 0 to 21600 seconds.
         Use without parameters or set to 0 to disable.

--- a/redbot/cogs/mod/slowmode.py
+++ b/redbot/cogs/mod/slowmode.py
@@ -1,3 +1,4 @@
+import discord
 from redbot.core import commands, i18n, checks
 from .abc import MixinMeta
 
@@ -14,12 +15,12 @@ class Slowmode(MixinMeta):
     @commands.bot_has_permissions(manage_channels=True)
     @checks.mod_or_permissions(manage_channels=True)
     async def slowmode(self, ctx, interval: int = 0):
-        """Change channel's slowmode setting.
+        """Changes channel's slowmode setting.
 
         Interval can be anything from 0 to 21600 seconds.
         Use without parameters or set to 0 to disable.
         """
-        if not 0 <= interval <= 21600:
+        if 0 <= interval <= 21600:
             await ctx.send(_("Interval must be between 0 and 21600 seconds!"))
             return
         await ctx.channel.edit(slowmode_delay=interval)

--- a/redbot/cogs/mod/slowmode.py
+++ b/redbot/cogs/mod/slowmode.py
@@ -1,4 +1,3 @@
-import discord
 from redbot.core import commands, i18n, checks
 from .abc import MixinMeta
 

--- a/redbot/cogs/mod/slowmode.py
+++ b/redbot/cogs/mod/slowmode.py
@@ -39,6 +39,6 @@ class Slowmode(MixinMeta):
         await ctx.channel.edit(slowmode_delay=interval)
         if interval > 0:
             interval = humanize_timedelta(seconds=interval)
-            await ctx.send(_(f"Slowmode interval is now {interval}."))
+            await ctx.send(_("Slowmode interval is now {}.".format(interval)))
         else:
             await ctx.send(_("Slowmode has been disabled."))

--- a/redbot/cogs/mod/slowmode.py
+++ b/redbot/cogs/mod/slowmode.py
@@ -26,15 +26,13 @@ class Slowmode(MixinMeta):
         if interval is None:
             interval = 0
         else:
-            match = re.match(r'(?i)(\d{1,5})([a-zA-Z])?', interval)
+            match = re.match(r"(?i)(\d{1,5})([a-zA-Z])?", interval)
             if match:
                 interval = int(match.group(1))
                 if match.group(2) is not None:
-                    interval = {
-                        "s": 1,
-                        "m": 60,
-                        "h": 60 * 60,
-                    }.get(match.group(2).lower(), -1) * interval
+                    interval = {"s": 1, "m": 60, "h": 60 * 60}.get(
+                        match.group(2).lower(), -1
+                    ) * interval
             if not match or not 0 <= interval <= 21600:
                 await ctx.send(_("Interval must be between 0 seconds and 6 hours!"))
                 return

--- a/redbot/cogs/mod/slowmode.py
+++ b/redbot/cogs/mod/slowmode.py
@@ -16,29 +16,26 @@ class Slowmode(MixinMeta):
     @commands.guild_only()
     @commands.bot_has_permissions(manage_channels=True)
     @checks.admin_or_permissions(manage_channels=True)
-    async def slowmode(self, ctx, interval: str = None):
+    async def slowmode(
+        self,
+        ctx,
+        *,
+        interval: commands.TimedeltaConverter(
+            minimum=timedelta(seconds=0), maximum=timedelta(hours=6)
+        ) = timedelta(seconds=0),
+    ):
         """Changes channel's slowmode setting.
 
         Interval can be anything from 0 seconds to 6 hours.
-        You can specify the unit using `s`, `m` or `h` as suffix.
-        Use without parameters or set to 0 to disable.
+        Use without parameters to disable.
         """
-        if interval:
-            match = re.match(r"(?i)(\d{1,5})([a-zA-Z])?$", interval)
-            if match:
-                interval = int(match.group(1))
-                if match.group(2) is not None:
-                    interval = {"s": 1, "m": 60, "h": 60 * 60}.get(
-                        match.group(2).lower(), -1
-                    ) * interval
-            if not match or not 0 <= interval <= 21600:
-                await ctx.send(_("Interval must be between 0 seconds and 6 hours!"))
-                return
-        else:
-            interval = 0
-        await ctx.channel.edit(slowmode_delay=interval)
-        if interval > 0:
-            interval = humanize_timedelta(seconds=interval)
-            await ctx.send(_("Slowmode interval is now {}.".format(interval)))
+        seconds = interval.total_seconds()
+        await ctx.channel.edit(slowmode_delay=seconds)
+        if seconds > 0:
+            await ctx.send(
+                _("Slowmode interval is now {interval}.").format(
+                    interval=humanize_timedelta(timedelta=interval)
+                )
+            )
         else:
             await ctx.send(_("Slowmode has been disabled."))


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes

This PR adds a `[p]slowmode [interval=0]` command, for easy slowmode management on a channel. This lets anyone with `Manage Channels` permission or a `Mod` role to change the slowmode setting.

Could be changed to require `0` to disable instead of having it there by default, this is up for discussion.