### PR TITLE
Fixed KeyError on specific message edge-case

### DIFF
--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -84,6 +84,8 @@ class CommandObj:
         return "{:%d/%m/%Y %H:%M:%S}".format(datetime.utcnow())
 
     async def get(self, message: discord.Message, command: str) -> Tuple[str, Dict]:
+        if not command:
+            raise NotFound()
         ccinfo = await self.db(message.guild).commands.get_raw(command, default=None)
         if not ccinfo:
             raise NotFound()


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

After some deep testing, it turns out that when `get_raw` gets passed in an empty string, it returns the same thing `self.db(message.guild).get_raw("commands")` would return. This seems to be an underlying config issue with empty string handling, but this isn't a place to discuss this I guess.

Instead of all of this importing in #2698, my suggestion would be to just check if the `command` passed is an empty string, and if so - `raise NotFound()`
Appears to be working great with fixing #2697 just fine. A comment could be left to indicate the specific case this check checks for.