### PR TITLE
Adds support for non interactive use

### DIFF
--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -33,6 +33,9 @@ class Cleanup(commands.Cog):
         Tries its best to cleanup after itself if the response is positive.
         """
 
+        if ctx.assume_yes:
+            return True
+
         prompt = await ctx.send(
             _("Are you sure you want to delete {number} messages? (y/n)").format(number=number)
         )

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -424,35 +424,39 @@ class Downloader(commands.Cog):
             return await ctx.send(
                 _("None of the updated cogs were previously loaded. Update complete.")
             )
-        message = _("Would you like to reload the updated cogs?")
-        can_react = ctx.channel.permissions_for(ctx.me).add_reactions
-        if not can_react:
-            message += " (y/n)"
-        query: discord.Message = await ctx.send(message)
-        if can_react:
-            # noinspection PyAsyncCall
-            start_adding_reactions(query, ReactionPredicate.YES_OR_NO_EMOJIS, ctx.bot.loop)
-            pred = ReactionPredicate.yes_or_no(query, ctx.author)
-            event = "reaction_add"
-        else:
-            pred = MessagePredicate.yes_or_no(ctx)
-            event = "message"
-        try:
-            await ctx.bot.wait_for(event, check=pred, timeout=30)
-        except asyncio.TimeoutError:
-            await query.delete()
-            return
 
-        if pred.result is True:
+        if not ctx.assume_yes:
+            message = _("Would you like to reload the updated cogs?")
+            can_react = ctx.channel.permissions_for(ctx.me).add_reactions
+            if not can_react:
+                message += " (y/n)"
+            query: discord.Message = await ctx.send(message)
             if can_react:
-                with contextlib.suppress(discord.Forbidden):
-                    await query.clear_reactions()
-            await ctx.invoke(ctx.bot.get_cog("Core").reload, *cognames)
-        else:
-            if can_react:
-                await query.delete()
+                # noinspection PyAsyncCall
+                start_adding_reactions(query, ReactionPredicate.YES_OR_NO_EMOJIS, ctx.bot.loop)
+                pred = ReactionPredicate.yes_or_no(query, ctx.author)
+                event = "reaction_add"
             else:
-                await ctx.send(_("OK then."))
+                pred = MessagePredicate.yes_or_no(ctx)
+                event = "message"
+            try:
+                await ctx.bot.wait_for(event, check=pred, timeout=30)
+            except asyncio.TimeoutError:
+                await query.delete()
+                return
+
+            if not pred.result:
+                if can_react:
+                    await query.delete()
+                else:
+                    await ctx.send(_("OK then."))
+                return
+            else:
+                if can_react:
+                    with contextlib.suppress(discord.Forbidden):
+                        await query.clear_reactions()
+
+        await ctx.invoke(ctx.bot.get_cog("Core").reload, *cognames)
 
     @cog.command(name="list", usage="<repo_name>")
     async def _cog_list(self, ctx, repo: Repo):

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -23,6 +23,7 @@ class Context(commands.Context):
     """
 
     def __init__(self, **attrs):
+        self.assume_yes = attrs.pop("assume_yes", False)
         super().__init__(**attrs)
         self.permission_state: PermState = PermState.NORMAL
 


### PR DESCRIPTION

### Type

- [ ] Bugfix
- [X] Enhancement
- [X] New feature

### Description of the changes
Adds assume_yes to context
Changes cleanup's 100+ check
Changes cog update.

This prevents 3rd party cogs such as @mikeshardmind 's scheduler from needing to patch methods, and just add full support for it. If a scheduler ever is included in Red, this means there will already be a supported method for allowing commands which usually require confirmation.

3rd party cogs can be supported by things like a scheduler without the scheduler needing to be aware of those cogs.