### PR TITLE
Small typo fix: Anilist → AniList

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ plugins directly from Discord! A few examples are:
 - Casino
 - Reaction roles
 - Slow Mode
-- Anilist
+- AniList
 - And much, much more!
 
 Feel free to take a [peek](https://cogboard.red/t/approved-repositories/210) at a list of


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Keeping in-line with AniList branding, just a small fix to fix the casing of AniList's name. 😄 