### PR TITLE
[Commands] Added optional default_unit to the TimedeltaConverter

### DIFF
--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -224,7 +224,7 @@ class TimedeltaConverter(dpy_commands.Converter):
     allowed_units : Optional[List[str]]
         If provided, you can constrain a user to expressing the amount of time
         in specific units. The units you can chose to provide are the same as the
-        parser understands. `weeks` `days` `hours` `minutes` `seconds`
+        parser understands: `weeks` `days` `hours` `minutes` `seconds`
     default_unit : Optional[str]
         If provided, it will additionally try to match integer-only input into
         a timedelta, using the unit specified. Same units as in `allowed_units`
@@ -254,6 +254,7 @@ class TimedeltaConverter(dpy_commands.Converter):
 
 def get_timedelta_converter(
     *,
+    default_unit: Optional[str] = None,
     maximum: Optional[timedelta] = None,
     minimum: Optional[timedelta] = None,
     allowed_units: Optional[List[str]] = None,
@@ -273,7 +274,11 @@ def get_timedelta_converter(
     allowed_units : Optional[List[str]]
         If provided, you can constrain a user to expressing the amount of time
         in specific units. The units you can chose to provide are the same as the
-        parser understands. `weeks` `days` `hours` `minutes` `seconds`
+        parser understands: `weeks` `days` `hours` `minutes` `seconds`
+    default_unit : Optional[str]
+        If provided, it will additionally try to match integer-only input into
+        a timedelta, using the unit specified. Same units as in `allowed_units`
+        apply.
 
     Returns
     -------
@@ -285,6 +290,7 @@ def get_timedelta_converter(
         __call__ = functools.partialmethod(
             type(DictConverter).__call__,
             allowed_units=allowed_units,
+            default_unit=default_unit,
             minimum=minimum,
             maximum=maximum,
         )

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -238,7 +238,7 @@ class TimedeltaConverter(dpy_commands.Converter):
         self.maximum = maximum
 
     async def convert(self, ctx: "Context", argument: str) -> timedelta:
-        if self.default_unit and argument.isdigit():
+        if self.default_unit and argument.isdecimal():
             delta = timedelta(**{self.default_unit: int(argument)})
         else:
             delta = parse_timedelta(


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

This PR adds `default_unit` to the TimedeltaConverter, that let's you specify the default unit to use in cases where user would provide an integer input only. Let's consider this example:

`async def mute(self, ctx, user: discord.Member, minutes: int = 10)`

The command above, made using a standard base and discord converters, presumably lets you mute server members for the amount of time specified by `minutes`. Now, if one would like to mute for couple of hours or days, and generally have more granular and easy to use input, they could use the new TimedeltaConverter to achieve this:

`async def mute(self, ctx, user: discord.Member, time: TimedeltaConverter = timedelta(minutes=10))`

Now, because of this change, doing something like `[p]mute Member 20` will no longer work due to the converter expecting a unit specified right after. With this PR, a `default_unit` can be passed into the converter like so:

`async def mute(self, ctx, user: discord.Member, time: TimedeltaConverter(default_unit="minutes") = timedelta(minutes=10))`

..., making it parse integer-only input as a time duration as well, using the unit specified. This provides backwards compatibility with every command that used seconds, minutes, hours, days or weeks as the input unit, while also allowing to specify the time more precisely than it was possible.

I'm not that good with docs, so any improvement suggestions are welcome. 

Note on the implementation: `.isdigit()` specification ensures that `int()` should never fail to convert the string provided, so should be safe to use here.