### PR TITLE
[Audio] Remove blacklisted architectures

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -37,7 +37,7 @@ class ServerManager:
     _java_version: ClassVar[Optional[Tuple[int, int]]] = None
     _up_to_date: ClassVar[Optional[bool]] = None
 
-    _blacklisted_archs = ["armv6l", "aarch32", "aarch64"]
+    _blacklisted_archs = []
 
     def __init__(self) -> None:
         self.ready = asyncio.Event()


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
With the new Lavalink.jar we're distributing we shouldn't need to blacklist any architectures any more, but the list should be kept available in case we need it in the future.