### PR TITLE
[Mod] add role mentions to userinfo and reverse role sorting

### DIFF
--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -91,7 +91,7 @@ class ModInfo(MixinMeta):
         special_date = datetime(2016, 1, 10, 6, 8, 4, 443000)
         is_special = user.id == 96130341705637888 and guild.id == 133049272517001216
 
-        roles = sorted(user.roles, reverse=True)[:-1]
+        roles = user.roles[-1:1:-1]
         names, nicks = await self.get_names_and_nicks(user)
 
         joined_at = user.joined_at if not is_special else special_date

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -91,7 +91,7 @@ class ModInfo(MixinMeta):
         special_date = datetime(2016, 1, 10, 6, 8, 4, 443000)
         is_special = user.id == 96130341705637888 and guild.id == 133049272517001216
 
-        roles = sorted(user.roles)[1:]
+        roles = sorted(user.roles, reverse=True)[:-1]
         names, nicks = await self.get_names_and_nicks(user)
 
         joined_at = user.joined_at if not is_special else special_date
@@ -125,7 +125,7 @@ class ModInfo(MixinMeta):
             activity = _("Watching {}").format(user.activity.name)
 
         if roles:
-            roles = ", ".join([x.name for x in roles])
+            roles = ", ".join([x.mention for x in roles])
         else:
             roles = None
 

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -91,7 +91,7 @@ class ModInfo(MixinMeta):
         special_date = datetime(2016, 1, 10, 6, 8, 4, 443000)
         is_special = user.id == 96130341705637888 and guild.id == 133049272517001216
 
-        roles = user.roles[-1:1:-1]
+        roles = user.roles[-1:0:-1]
         names, nicks = await self.get_names_and_nicks(user)
 
         joined_at = user.joined_at if not is_special else special_date


### PR DESCRIPTION
This small PR adds the role mentions to userinfo and reverses the sorting so that the top most role of a user is at the left of the embed

### Type

- [ ] Bugfix
- [x ] Enhancement
- [ ] New feature

### Description of the changes
Adds role mentions to userinfo and reverses sort to have the top most role of a user to the left of the embed