### PR TITLE
 [ModLog] Use custom scopes for ModLog Config

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -116,7 +116,6 @@ def main():
     red.add_cog(CogManagerUI())
     if cli_flags.dev:
         red.add_cog(Dev())
-    loop = asyncio.get_event_loop()
     # noinspection PyProtectedMember
     loop.run_until_complete(modlog._init())
     # noinspection PyProtectedMember

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -113,11 +113,11 @@ def main():
     red.add_cog(CogManagerUI())
     if cli_flags.dev:
         red.add_cog(Dev())
+    loop = asyncio.get_event_loop()
     # noinspection PyProtectedMember
-    modlog._init()
+    loop.run_until_complete(modlog._init())
     # noinspection PyProtectedMember
     bank._init()
-    loop = asyncio.get_event_loop()
     if os.name == "posix":
         loop.add_signal_handler(SIGTERM, lambda: asyncio.ensure_future(sigterm_handler(red, log)))
     tmp_data = {}

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -852,22 +852,9 @@ class Config:
             custom_group_data=self.custom_groups,
             is_custom=is_custom,
         )
-
-        if category == self.GLOBAL:
-            primary_key_len = 0
-        elif category == self.MEMBER:
-            primary_key_len = 2
-        elif is_custom:
-            primary_key_len = self.custom_groups[category]
-        else:
-            primary_key_len = 1
-        if len(primary_keys) < primary_key_len:
-            defaults = {}
-        else:
-            defaults = self.defaults.get(category, {})
         return Group(
             identifier_data=identifier_data,
-            defaults=defaults,
+            defaults=self.defaults.get(category, {}),
             driver=self.driver,
             force_registration=self.force_registration,
         )
@@ -988,7 +975,6 @@ class Config:
         """
         group = self._get_base_group(scope)
         ret = {}
-        defaults = self.defaults.get(scope, {})
 
         try:
             dict_ = await self.driver.get(group.identifier_data)
@@ -996,7 +982,7 @@ class Config:
             pass
         else:
             for k, v in dict_.items():
-                data = deepcopy(defaults)
+                data = group.defaults
                 data.update(v)
                 ret[int(k)] = data
 
@@ -1070,11 +1056,11 @@ class Config:
         """
         return await self._all_from_scope(self.USER)
 
-    def _all_members_from_guild(self, group: Group, guild_data: dict) -> dict:
+    @staticmethod
+    def _all_members_from_guild(group: Group, guild_data: dict) -> dict:
         ret = {}
-        defaults = self.defaults.get(self.MEMBER, {})
         for member_id, member_data in guild_data.items():
-            new_member_data = deepcopy(defaults)
+            new_member_data = group.defaults
             new_member_data.update(member_data)
             ret[int(member_id)] = new_member_data
         return ret

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -852,9 +852,22 @@ class Config:
             custom_group_data=self.custom_groups,
             is_custom=is_custom,
         )
+
+        if category == self.GLOBAL:
+            primary_key_len = 0
+        elif category == self.MEMBER:
+            primary_key_len = 2
+        elif is_custom:
+            primary_key_len = self.custom_groups[category]
+        else:
+            primary_key_len = 1
+        if len(primary_keys) < primary_key_len:
+            defaults = {}
+        else:
+            defaults = self.defaults.get(category, {})
         return Group(
             identifier_data=identifier_data,
-            defaults=self.defaults.get(category, {}),
+            defaults=defaults,
             driver=self.driver,
             force_registration=self.force_registration,
         )
@@ -975,6 +988,7 @@ class Config:
         """
         group = self._get_base_group(scope)
         ret = {}
+        defaults = self.defaults.get(scope, {})
 
         try:
             dict_ = await self.driver.get(group.identifier_data)
@@ -982,7 +996,7 @@ class Config:
             pass
         else:
             for k, v in dict_.items():
-                data = group.defaults
+                data = deepcopy(defaults)
                 data.update(v)
                 ret[int(k)] = data
 
@@ -1056,11 +1070,11 @@ class Config:
         """
         return await self._all_from_scope(self.USER)
 
-    @staticmethod
-    def _all_members_from_guild(group: Group, guild_data: dict) -> dict:
+    def _all_members_from_guild(self, group: Group, guild_data: dict) -> dict:
         ret = {}
+        defaults = self.defaults.get(self.MEMBER, {})
         for member_id, member_data in guild_data.items():
-            new_member_data = group.defaults
+            new_member_data = deepcopy(defaults)
             new_member_data.update(member_data)
             ret[int(member_id)] = new_member_data
         return ret

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -477,7 +477,7 @@ async def get_next_case_number(guild: discord.Guild) -> int:
     if not case_numbers:
         return 1
     else:
-        return int(max(case_numbers)) + 1
+        return max(map(int, case_numbers)) + 1
 
 
 async def get_case(case_number: int, guild: discord.Guild, bot: Red) -> Case:

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -40,7 +40,8 @@ _SCHEMA_VERSION = 2
 async def _init():
     global _conf
     _conf = Config.get_conf(None, 1354799444, cog_name="ModLog")
-    _conf.register_guild(mod_log=None, casetypes={}, schema_version=1)
+    _conf.register_global(schema_version=1)
+    _conf.register_guild(mod_log=None, casetypes={})
     _conf.init_custom(_CASETYPES, 1)
     _conf.init_custom(_CASES, 2)
     _conf.register_custom(

--- a/redbot/pytest/mod.py
+++ b/redbot/pytest/mod.py
@@ -5,11 +5,11 @@ __all__ = ["mod"]
 
 
 @pytest.fixture
-def mod(config, monkeypatch):
+async def mod(config, monkeypatch):
     from redbot.core import Config
 
     with monkeypatch.context() as m:
         m.setattr(Config, "get_conf", lambda *args, **kwargs: config)
 
-        modlog._init()
+        await modlog._init()
         return modlog


### PR DESCRIPTION
Modlog is currently the biggest culprit for seriously large documents in the MongoDB backend, since it stores all cases as nested dicts in the guild scope. So, for example, on the Fortnite server, the guild document for @Kowlin's bot has exceeded 8MB. 

This PR gives each case its own document. It also does the same for casetypes. Not only does it remove the possibility of the document exceeding the maximum size in MongoDB, it's also just more efficient for all backends.

### Other changes
#### Config Bug
These changes highlighted a bug in Config, which I've fixed here but will probably open a new PR for: when a custom scope uses more than one primary key, but does this with a partial primary key: `conf.custom(SCOPE, primary_key_1).all()`, the defaults will be mixed in with the top-level of the returned dict, even though the actual documents are nested further in.

#### General ModLog improvements
Fixed a bunch of type-hints, and also added more support for when an object related to a case (user, moderator, channel etc.) can't be found (because it was deleted or something rather)