### PR TITLE
[Core] Multiple mod admin roles

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -107,8 +107,11 @@ def main():
     red = Red(
         cli_flags=cli_flags, description=description, dm_help=None, fetch_offline_members=True
     )
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(red.maybe_update_config())
     init_global_checks(red)
     init_events(red, cli_flags)
+
     red.add_cog(Core(red))
     red.add_cog(CogManagerUI())
     if cli_flags.dev:
@@ -117,7 +120,7 @@ def main():
     modlog._init()
     # noinspection PyProtectedMember
     bank._init()
-    loop = asyncio.get_event_loop()
+
     if os.name == "posix":
         loop.add_signal_handler(SIGTERM, lambda: asyncio.ensure_future(sigterm_handler(red, log)))
     tmp_data = {}

--- a/redbot/cogs/bank/bank.py
+++ b/redbot/cogs/bank/bank.py
@@ -43,10 +43,14 @@ def check_global_setting_admin():
                 return False
             if await ctx.bot.is_owner(author):
                 return True
-            permissions = ctx.channel.permissions_for(author)
-            is_guild_owner = author == ctx.guild.owner
-            admin_role = await ctx.bot.db.guild(ctx.guild).admin_role()
-            return admin_role in author.roles or is_guild_owner or permissions.manage_guild
+            if author == ctx.guild.owner:
+                return True
+            if ctx.channel.permissions_for(author).manage_guild:
+                return True
+            admin_roles = set(await ctx.bot.db.guild(ctx.guild).admin_role())
+            for role in author.roles:
+                if role.id in admin_roles:
+                    return True
         else:
             return await ctx.bot.is_owner(author)
 

--- a/redbot/cogs/reports/reports.py
+++ b/redbot/cogs/reports/reports.py
@@ -84,18 +84,14 @@ class Reports(commands.Cog):
             await ctx.send(_("Reporting is now disabled."))
 
     async def internal_filter(self, m: discord.Member, mod=False, perms=None):
-        ret = False
-        if mod:
-            guild = m.guild
-            admin_role = guild.get_role(await self.bot.db.guild(guild).admin_role())
-            mod_role = guild.get_role(await self.bot.db.guild(guild).mod_role())
-            ret |= any(r in m.roles for r in (mod_role, admin_role))
-        if perms:
-            ret |= m.guild_permissions >= perms
+        if perms and m.guild_permissions >= perms:
+            return True
+        if mod and await self.bot.is_mod(m):
+            return True
         # The following line is for consistency with how perms are handled
-        # in Red, though I'm not sure it makse sense to use here.
-        ret |= await self.bot.is_owner(m)
-        return ret
+        # in Red, though I'm not sure it makes sense to use here.
+        if await self.bot.is_owner(m):
+            return True
 
     async def discover_guild(
         self,

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -161,10 +161,10 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
 
             if maybe_mod_role_id:
                 mod_roles.append(maybe_mod_role_id)
-                await self.config.db.guild(guild_obj).mod_role.set(mod_roles)
+                await self.db.guild(guild_obj).mod_role.set(mod_roles)
             if maybe_admin_role_id:
                 admin_roles.append(maybe_admin_role_id)
-                await self.config.db.guild(guild_obj).admin_role.set(admin_roles)
+                await self.db.guild(guild_obj).admin_role.set(admin_roles)
         log.info("Done updating guild configs to support multiple mod/admin roles")
 
     async def send_help_for(

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -136,17 +136,20 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
         self._permissions_hooks: List[commands.CheckPredicate] = []
 
     async def maybe_update_config(self):
-        """ This should be run prior to loading cogs or connecting to discord """
+        """
+        This should be run prior to loading cogs or connecting to discord.
+        """
         schema_version = await self.db.schema_version()
 
         if schema_version == 0:
             await self._schema_0_to_1()
             schema_version += 1
-
-        await self.db.schema_version.set(schema_version)
+            await self.db.schema_version.set(schema_version)
 
     async def _schema_0_to_1(self):
-        """ This contains the migration to allow multiple mod and multiple admin roles """
+        """
+        This contains the migration to allow multiple mod and multiple admin roles.
+        """
 
         log.info("Begin updating guild configs to support multiple mod/admin roles")
         all_guild_data = await self.db.all_guilds()

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -67,14 +67,15 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
             api_tokens={},
             extra_owner_destinations=[],
             owner_opt_out_list=[],
+            schema_version=0,
         )
 
         self.db.register_guild(
             prefix=[],
             whitelist=[],
             blacklist=[],
-            admin_role=None,
-            mod_role=None,
+            admin_role=[],
+            mod_role=[],
             embeds=None,
             use_bot_color=False,
             fuzzy=False,
@@ -134,6 +135,35 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
 
         self._permissions_hooks: List[commands.CheckPredicate] = []
 
+    async def maybe_update_config(self):
+        """ This should be run prior to loading cogs or connecting to discord """
+        schema_version = await self.db.schema_version()
+
+        if schema_version == 0:
+            await self._schema_0_to_1()
+            schema_version += 1
+
+        await self.db.schema_version.set(schema_version)
+
+    async def _schema_0_to_1(self):
+        """ This contains the migration to allow multiple mod and multiple admin roles """
+
+        log.info("Begin updating guild configs to support multiple mod/admin roles")
+        all_guild_data = await self.db.all_guilds()
+        for guild_id, guild_data in all_guild_data.items():
+            guild_obj = discord.Object(id=guild_id)
+            mod_roles, admin_roles = [], []
+            maybe_mod_role_id = guild_data["mod_role"]
+            maybe_admin_role_id = guild_data["admin_role"]
+
+            if maybe_mod_role_id:
+                mod_roles.append(maybe_mod_role_id)
+                await self.config.db.guild(guild_obj).mod_role.set(mod_roles)
+            if maybe_admin_role_id:
+                admin_roles.append(maybe_admin_role_id)
+                await self.config.db.guild(guild_obj).admin_role.set(admin_roles)
+        log.info("Done updating guild configs to support multiple mod/admin roles")
+
     async def send_help_for(
         self, ctx: commands.Context, help_for: Union[commands.Command, commands.GroupMixin, str]
     ):
@@ -191,21 +221,23 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
 
     async def is_admin(self, member: discord.Member):
         """Checks if a member is an admin of their guild."""
-        admin_role = await self.db.guild(member.guild).admin_role()
+        admin_role_ids = set(await self.db.guild(member.guild).admin_role())
         try:
-            if any(role.id == admin_role for role in member.roles):
-                return True
+            for role in member.roles:
+                if role.id in admin_role_ids:
+                    return True
         except AttributeError:  # someone passed a webhook to this
             pass
         return False
 
     async def is_mod(self, member: discord.Member):
         """Checks if a member is a mod or admin of their guild."""
-        mod_role = await self.db.guild(member.guild).mod_role()
-        admin_role = await self.db.guild(member.guild).admin_role()
+        mod_role_ids = set(await self.db.guild(member.guild).mod_role())
+        mod_role_ids.update(await self.db.guild(member.guild).admin_role())
         try:
-            if any(role.id in (mod_role, admin_role) for role in member.roles):
-                return True
+            for role in member.roles:
+                if role.id in mod_role_ids:
+                    return True
         except AttributeError:  # someone passed a webhook to this
             pass
         return False

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -224,10 +224,10 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
 
     async def is_admin(self, member: discord.Member):
         """Checks if a member is an admin of their guild."""
-        admin_role_ids = set(await self.db.guild(member.guild).admin_role())
         try:
-            for role in member.roles:
-                if role.id in admin_role_ids:
+            member_snowflakes = member._roles  # DEP-WARN
+            for snowflake in await self.db.guild(member.guild).admin_role():
+                if member_snowflakes.has(snowflake):  # Dep-WARN
                     return True
         except AttributeError:  # someone passed a webhook to this
             pass
@@ -235,11 +235,13 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
 
     async def is_mod(self, member: discord.Member):
         """Checks if a member is a mod or admin of their guild."""
-        mod_role_ids = set(await self.db.guild(member.guild).mod_role())
-        mod_role_ids.update(await self.db.guild(member.guild).admin_role())
         try:
-            for role in member.roles:
-                if role.id in mod_role_ids:
+            member_snowflakes = member._roles  # DEP-WARN
+            for snowflake in await self.db.guild(member.guild).admin_role():
+                if member_snowflakes.has(snowflake):  # DEP-WARN
+                    return True
+            for snowflake in await self.db.guild(member.guild).mod_role():
+                if member_snowflakes.has(snowflake):  # DEP-WARN
                     return True
         except AttributeError:  # someone passed a webhook to this
             pass

--- a/redbot/core/commands/requires.py
+++ b/redbot/core/commands/requires.py
@@ -126,13 +126,13 @@ class PrivilegeLevel(enum.IntEnum):
         # The following is simply an optimised way to check if the user has the
         # admin or mod role.
         guild_settings = ctx.bot.db.guild(ctx.guild)
-        admin_role_id = await guild_settings.admin_role()
-        mod_role_id = await guild_settings.mod_role()
+        admin_role_ids = set(await guild_settings.admin_role())
+        mod_role_ids = set(await guild_settings.mod_role())
         is_mod = False
         for role in ctx.author.roles:
-            if role.id == admin_role_id:
+            if role.id in admin_role_ids:
                 return cls.ADMIN
-            elif role.id == mod_role_id:
+            elif role.id in mod_role_ids:
                 is_mod = True
         if is_mod:
             return cls.MOD

--- a/redbot/core/commands/requires.py
+++ b/redbot/core/commands/requires.py
@@ -127,12 +127,12 @@ class PrivilegeLevel(enum.IntEnum):
         # admin or mod role.
         guild_settings = ctx.bot.db.guild(ctx.guild)
 
-        snowflakes = ctx.author._roles  # DEP-WARN
+        member_snowflakes = ctx.author._roles  # DEP-WARN
         for snowflake in await guild_settings.admin_role():
-            if snowflakes.has(snowflake):  # DEP-WARN
+            if member_snowflakes.has(snowflake):  # DEP-WARN
                 return cls.ADMIN
         for snowflake in await guild_settings.mod_role():
-            if snowflakes.has(snowflake):  # DEP-WARN
+            if member_snowflakes.has(snowflake):  # DEP-WARN
                 return cls.MOD
 
         return cls.NONE

--- a/redbot/core/commands/requires.py
+++ b/redbot/core/commands/requires.py
@@ -126,16 +126,14 @@ class PrivilegeLevel(enum.IntEnum):
         # The following is simply an optimised way to check if the user has the
         # admin or mod role.
         guild_settings = ctx.bot.db.guild(ctx.guild)
-        admin_role_ids = set(await guild_settings.admin_role())
-        mod_role_ids = set(await guild_settings.mod_role())
-        is_mod = False
-        for role in ctx.author.roles:
-            if role.id in admin_role_ids:
+
+        snowflakes = ctx.author._roles  # DEP-WARN
+        for snowflake in await guild_settings.admin_role():
+            if snowflakes.has(snowflake):  # DEP-WARN
                 return cls.ADMIN
-            elif role.id in mod_role_ids:
-                is_mod = True
-        if is_mod:
-            return cls.MOD
+        for snowflake in await guild_settings.mod_role():
+            if snowflakes.has(snowflake):  # DEP-WARN
+                return cls.MOD
 
         return cls.NONE
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -706,10 +706,10 @@ class Core(commands.Cog, CoreLogic):
             if ctx.guild:
                 guild = ctx.guild
                 admin_role_ids = await ctx.bot.db.guild(ctx.guild).admin_role()
-                admin_roles = [r for r in guild.roles if r.id in admin_role_ids]
-                admin_roles_str = humanize_list(admin_roles) if admin_roles else "Not Set."
-                mod_roles = [r for r in guild.roles if r.id in admin_role_ids]
-                mod_roles_str = humanize_list(mod_roles) if mod_roles else "Not Set."
+                admin_role_names = [r.name for r in guild.roles if r.id in admin_role_ids]
+                admin_roles_str = humanize_list(admin_role_names) if admin_roles else "Not Set."
+                mod_role_names = [r.name for r in guild.roles if r.id in admin_role_ids]
+                mod_roles_str = humanize_list(mod_role_names) if mod_roles else "Not Set."
                 prefixes = await ctx.bot.db.guild(ctx.guild).prefix()
                 guild_settings = _("Admin roles: {admin}\nMod roles: {mod}\n").format(
                     admin=admin_roles_str, mod=mod_roles_str

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -707,9 +707,9 @@ class Core(commands.Cog, CoreLogic):
                 guild = ctx.guild
                 admin_role_ids = await ctx.bot.db.guild(ctx.guild).admin_role()
                 admin_role_names = [r.name for r in guild.roles if r.id in admin_role_ids]
-                admin_roles_str = humanize_list(admin_role_names) if admin_roles else "Not Set."
+                admin_roles_str = humanize_list(admin_role_names) if admin_role_names else "Not Set."
                 mod_role_names = [r.name for r in guild.roles if r.id in admin_role_ids]
-                mod_roles_str = humanize_list(mod_role_names) if mod_roles else "Not Set."
+                mod_roles_str = humanize_list(mod_role_names) if mod_role_names else "Not Set."
                 prefixes = await ctx.bot.db.guild(ctx.guild).prefix()
                 guild_settings = _("Admin roles: {admin}\nMod roles: {mod}\n").format(
                     admin=admin_roles_str, mod=mod_roles_str

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -707,7 +707,9 @@ class Core(commands.Cog, CoreLogic):
                 guild = ctx.guild
                 admin_role_ids = await ctx.bot.db.guild(ctx.guild).admin_role()
                 admin_role_names = [r.name for r in guild.roles if r.id in admin_role_ids]
-                admin_roles_str = humanize_list(admin_role_names) if admin_role_names else "Not Set."
+                admin_roles_str = (
+                    humanize_list(admin_role_names) if admin_role_names else "Not Set."
+                )
                 mod_role_ids = await ctx.bot.db.guild(ctx.guild).mod_role()
                 mod_role_names = [r.name for r in guild.roles if r.id in mod_role_ids]
                 mod_roles_str = humanize_list(mod_role_names) if mod_role_names else "Not Set."

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -733,7 +733,8 @@ class Core(commands.Cog, CoreLogic):
                 guild_settings=guild_settings,
                 locale=locale,
             )
-            await ctx.send(box(settings))
+            for page in pagify(settings):
+                await ctx.send(box(page))
 
     @_set.command()
     @checks.guildowner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -739,45 +739,53 @@ class Core(commands.Cog, CoreLogic):
     @checks.guildowner()
     @commands.guild_only()
     async def addadminrole(self, ctx: commands.Context, *, role: discord.Role):
-        """ Adds an admin role for this guild """
+        """
+        Adds an admin role for this guild.
+        """
         async with ctx.bot.db.guild(ctx.guild).admin_role() as roles:
             if role.id in roles:
-                return await ctx.send(_("This is already an admin role."))
+                return await ctx.send(_("This role is already an admin role."))
             roles.append(role.id)
-        await ctx.send(_("That role was added as an admin role for this guild."))
+        await ctx.send(_("That role is now considered an admin role."))
 
     @_set.command()
     @checks.guildowner()
     @commands.guild_only()
     async def addmodrole(self, ctx: commands.Context, *, role: discord.Role):
-        """ Adds a mod role for this guild """
+        """
+        Adds a mod role for this guild.
+        """
         async with ctx.bot.db.guild(ctx.guild).mod_role() as roles:
             if role.id in roles:
-                return await ctx.send(_("This is already a mod role."))
+                return await ctx.send(_("This role is already a mod role."))
             roles.append(role.id)
-        await ctx.send(_("That role was added as a mod role for this guild."))
+        await ctx.send(_("That role is now considered a mod role."))
 
-    @_set.command(aliases=["remadmindrole"])
+    @_set.command(aliases=["remadmindrole", "deladminrole", "deleteadminrole"])
     @checks.guildowner()
     @commands.guild_only()
     async def removeadminrole(self, ctx: commands.Context, *, role: discord.Role):
-        """ Removes an admin role for this guild """
+        """
+        Removes an admin role for this guild.
+        """
         async with ctx.bot.db.guild(ctx.guild).admin_role() as roles:
             if role.id not in roles:
-                return await ctx.send(_("This was not an admin role."))
+                return await ctx.send(_("That role was not an admin role to begin with."))
             roles.remove(role.id)
-        await ctx.send(_("That role was removed as an admin role for this guild."))
+        await ctx.send(_("That role is no longer considered an admin role."))
 
-    @_set.command(aliases=["remmodrole"])
+    @_set.command(aliases=["remmodrole", "delmodrole", "deletemodrole"])
     @checks.guildowner()
     @commands.guild_only()
     async def removemodrole(self, ctx: commands.Context, *, role: discord.Role):
-        """ Removes a mod role for this guild """
+        """
+        Removes a mod role for this guild.
+        """
         async with ctx.bot.db.guild(ctx.guild).mod_role() as roles:
             if role.id not in roles:
-                return await ctx.send(_("That was not a mod role."))
+                return await ctx.send(_("That role was not a mod role to begin with."))
             roles.remove(role.id)
-        await ctx.send(_("That role was removes as a mod role for this guild."))
+        await ctx.send(_("That role is no longer considered a mod role."))
 
     @_set.command(aliases=["usebotcolor"])
     @checks.guildowner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -708,7 +708,8 @@ class Core(commands.Cog, CoreLogic):
                 admin_role_ids = await ctx.bot.db.guild(ctx.guild).admin_role()
                 admin_role_names = [r.name for r in guild.roles if r.id in admin_role_ids]
                 admin_roles_str = humanize_list(admin_role_names) if admin_role_names else "Not Set."
-                mod_role_names = [r.name for r in guild.roles if r.id in admin_role_ids]
+                mod_role_ids = await ctx.bot.db.guild(ctx.guild).mod_role()
+                mod_role_names = [r.name for r in guild.roles if r.id in mod_role_ids]
                 mod_roles_str = humanize_list(mod_role_names) if mod_role_names else "Not Set."
                 prefixes = await ctx.bot.db.guild(ctx.guild).prefix()
                 guild_settings = _("Admin roles: {admin}\nMod roles: {mod}\n").format(

--- a/redbot/core/utils/mod.py
+++ b/redbot/core/utils/mod.py
@@ -123,29 +123,25 @@ async def is_mod_or_superior(
         If the wrong type of ``obj`` was passed.
 
     """
-    user = None
     if isinstance(obj, discord.Message):
         user = obj.author
     elif isinstance(obj, discord.Member):
         user = obj
     elif isinstance(obj, discord.Role):
-        pass
+        if obj.id in await bot.db.guild(obj.guild).mod_role():
+            return True
+        if await bot.db.guild(obj.guild).admin_role():
+            return True
+        return False
     else:
         raise TypeError("Only messages, members or roles may be passed")
 
-    server = obj.guild
-    admin_role_id = await bot.db.guild(server).admin_role()
-    mod_role_id = await bot.db.guild(server).mod_role()
-
-    if isinstance(obj, discord.Role):
-        return obj.id in [admin_role_id, mod_role_id]
-
     if await bot.is_owner(user):
         return True
-    elif discord.utils.find(lambda r: r.id in (admin_role_id, mod_role_id), user.roles):
+    if await bot.is_mod(user):
         return True
-    else:
-        return False
+
+    return False
 
 
 def strfdelta(delta: timedelta):
@@ -208,27 +204,21 @@ async def is_admin_or_superior(
         If the wrong type of ``obj`` was passed.
 
     """
-    user = None
     if isinstance(obj, discord.Message):
         user = obj.author
     elif isinstance(obj, discord.Member):
         user = obj
     elif isinstance(obj, discord.Role):
-        pass
+        return obj.id in await bot.db.guild(obj.guild).admin_role()
     else:
         raise TypeError("Only messages, members or roles may be passed")
 
-    admin_role_id = await bot.db.guild(obj.guild).admin_role()
-
-    if isinstance(obj, discord.Role):
-        return obj.id == admin_role_id
-
-    if user and await bot.is_owner(user):
+    if await bot.is_owner(user):
         return True
-    elif discord.utils.get(user.roles, id=admin_role_id):
+    if await bot.is_admin(user):
         return True
-    else:
-        return False
+
+    return False
 
 
 async def check_permissions(ctx: "Context", perms: Dict[str, bool]) -> bool:

--- a/redbot/core/utils/mod.py
+++ b/redbot/core/utils/mod.py
@@ -130,7 +130,7 @@ async def is_mod_or_superior(
     elif isinstance(obj, discord.Role):
         if obj.id in await bot.db.guild(obj.guild).mod_role():
             return True
-        if await bot.db.guild(obj.guild).admin_role():
+        if obj.id in await bot.db.guild(obj.guild).admin_role():
             return True
         return False
     else:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

This allows multiple mod and admin roles to be used.

I've updated everywhere which uses it directly.

If cog developers are expected to be allowed to interact with the bot's settings directly, this is also a breaking change.