### PR TITLE
[Help] Prevent spamming when a user blocks the bot

### DIFF
--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -538,7 +538,7 @@ class RedHelpFormatter:
                     try:
                         await destination.send(embed=page)
                     except discord.Forbidden:
-                        await ctx.send(
+                        return await ctx.send(
                             T_(
                                 "I couldn't send the help message to you in DM. "
                                 "Either you blocked me or you disabled DMs in this server."
@@ -549,7 +549,7 @@ class RedHelpFormatter:
                     try:
                         await destination.send(page)
                     except discord.Forbidden:
-                        await ctx.send(
+                        return await ctx.send(
                             T_(
                                 "I couldn't send the help message to you in DM. "
                                 "Either you blocked me or you disabled DMs in this server."


### PR DESCRIPTION
Currently the bot sends an error message for each page of help, this should make it only send once.