### PR TITLE
Added a warning about modifying the PATH variable

### DIFF
--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -39,8 +39,6 @@ Manually installing dependencies
 .. note:: Please make sure that the box to add Python to PATH is CHECKED, otherwise
           you may run into issues when trying to run Red.
 
-.. attention:: A restart might be required for the PATH changes to take an effect.
-
 * `Git <https://git-scm.com/download/win>`_
 
 .. attention:: Please choose the option to "Run Git from the Windows Command Prompt" in Git's setup.
@@ -54,6 +52,9 @@ Manually installing dependencies
 --------------
 Installing Red
 --------------
+
+.. attention:: You may need to restart your computer after installing dependencies
+               for the PATH changes to take effect.
 
 1. Open a command prompt (open Start, search for "command prompt", then click it)
 2. Create and activate a virtual environment (strongly recommended), see the section `using-venv`

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -37,15 +37,17 @@ Manually installing dependencies
 * `Python <https://www.python.org/downloads/>`_ - Red needs Python 3.7.0 or greater
 
 .. note:: Please make sure that the box to add Python to PATH is CHECKED, otherwise
-          you may run into issues when trying to run Red
+          you may run into issues when trying to run Red.
+
+.. attention:: A restart might be required for the PATH changes to take an effect.
 
 * `Git <https://git-scm.com/download/win>`_
 
-.. attention:: Please choose the option to "Run Git from the Windows Command Prompt" in Git's setup
+.. attention:: Please choose the option to "Run Git from the Windows Command Prompt" in Git's setup.
 
 * `Java <https://java.com/en/download/manual.jsp>`_ - needed for Audio
 
-.. attention:: Please choose the "Windows Online" installer
+.. attention:: Please choose the "Windows Online" installer.
 
 .. _installing-red-windows:
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature
- [x] Docs only

### Description of the changes

Modifying the PATH variable on Windows usually requires a restart to take an effect. Even with the option checked and a completely new command prompt, it might say that the `python` executable couldn't be found.

This PR adds a warning about this possibility, guiding the user to restart their computer before proceeding.