### PR TITLE
[Admin] Convert set to list before updating config (sets are not JSON serializable)

### DIFF
--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -315,7 +315,7 @@ class Admin(commands.Cog):
         valid_role_ids = set(r.id for r in valid_roles)
 
         if selfrole_ids != valid_role_ids:
-            await self.conf.guild(guild).selfroles.set(valid_role_ids)
+            await self.conf.guild(guild).selfroles.set(list(valid_role_ids))
 
         # noinspection PyTypeChecker
         return valid_roles


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Converts set to list before setting it in Config to prevent errors about sets being not JSON serializable.