### PR TITLE
Fix duplicate commands in fuzzy help

### DIFF
--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -450,7 +450,7 @@ class RedHelpFormatter:
         """
         Sends an error, fuzzy help, or stays quiet based on settings
         """
-        coms = [c async for c in self.help_filter_func(ctx, ctx.bot.walk_commands())]
+        coms = {c async for c in self.help_filter_func(ctx, ctx.bot.walk_commands())}
         fuzzy_commands = await fuzzy_command_search(ctx, help_for, commands=coms, min_score=75)
         use_embeds = await ctx.embed_requested()
         if fuzzy_commands:

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -417,8 +417,9 @@ class RedHelpFormatter:
             pages = [box(p) for p in pagify(to_page)]
             await self.send_pages(ctx, pages, embed=False)
 
+    @staticmethod
     async def help_filter_func(
-        self, ctx, objects: Iterable[SupportsCanSee], bypass_hidden=False
+        ctx, objects: Iterable[SupportsCanSee], bypass_hidden=False
     ) -> AsyncIterator[SupportsCanSee]:
         """
         This does most of actual filtering.

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -13,6 +13,7 @@ import pkg_resources
 from colorama import Fore, Style, init
 from pkg_resources import DistributionNotFound
 
+from redbot.core.commands import RedHelpFormatter
 from .. import __version__ as red_version, version_info as red_version_info, VersionInfo
 from . import commands
 from .config import get_latest_confs
@@ -201,7 +202,12 @@ def init_events(bot, cli_flags):
             bot._last_exception = exception_log
             await ctx.send(inline(message))
         elif isinstance(error, commands.CommandNotFound):
-            fuzzy_commands = await fuzzy_command_search(ctx)
+            fuzzy_commands = await fuzzy_command_search(
+                ctx,
+                commands={
+                    c async for c in RedHelpFormatter.help_filter_func(ctx, bot.walk_commands())
+                },
+            )
             if not fuzzy_commands:
                 pass
             elif await ctx.embed_requested():


### PR DESCRIPTION
Resolves #2797.

The `commands` argument of `fuzzy_command_search` should now take a `set` of `commands.Command` objects instead of some other sequence.