### PR TITLE
Fixed broken link in set color help message

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -850,7 +850,7 @@ class Core(commands.Cog, CoreLogic):
 
         Acceptable values for the colour parameter can be found at:
 
-        https://discordpy.readthedocs.io/en/v1.0.1/ext/commands/api.html#discord.ext.commands.ColourConverter
+        https://discordpy.readthedocs.io/en/stable/ext/commands/api.html#discord.ext.commands.ColourConverter
         """
         if colour is None:
             ctx.bot.color = discord.Color.red()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -850,7 +850,7 @@ class Core(commands.Cog, CoreLogic):
 
         Acceptable values for the colour parameter can be found at:
 
-        https://discordpy.readthedocs.io/en/latest/ext/commands/api.html#discord.ext.commands.ColourConverter
+        https://discordpy.readthedocs.io/en/v1.0.1/ext/commands/api.html#discord.ext.commands.ColourConverter
         """
         if colour is None:
             ctx.bot.color = discord.Color.red()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -850,7 +850,7 @@ class Core(commands.Cog, CoreLogic):
 
         Acceptable values for the colour parameter can be found at:
 
-        http://discordpy.readthedocs.io/en/rewrite/ext/commands/api.html#discord.ext.commands.ColourConverter
+        https://discordpy.readthedocs.io/en/latest/ext/commands/api.html#discord.ext.commands.ColourConverter
         """
         if colour is None:
             ctx.bot.color = discord.Color.red()


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
In response to issue #2715 
I fixed the broken link in `/redbot/core/core_commands.py` on line 853. Couldn't find a corresponding page with values on the Red documentation which would have been the ideal, but this is better than nothing.
EDIT: At the suggestion of @jack1142 the link now takes you to the discord.py v1.0.1 documentation for color converter.