### PR TITLE
[Audio] Update equalizer permissions

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -913,7 +913,7 @@ class Audio(commands.Cog):
         header_author = _("Author")
         header = box(
             "[{header_name}]{space}[{header_author}]\n".format(
-                header_name=header_name, space=space*9, header_author=header_author
+                header_name=header_name, space=space * 9, header_author=header_author
             ),
             lang="ini",
         )

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -909,7 +909,14 @@ class Audio(commands.Cog):
             return await self._embed_msg(ctx, _("No saved equalizer presets."))
 
         space = "\N{EN SPACE}"
-        header = box(f"[Preset Name]{space*9}[Author]\n", lang="ini")
+        header_name = _("Preset Name")
+        header_author = _("Author")
+        header = box(
+            "[{header_name}]{space}[{header_author}]\n".format(
+                header_name=header_name, space=space*9, header_author=header_author
+            ),
+            lang="ini",
+        )
         preset_list = ""
         for preset, bands in eq_presets.items():
             try:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Changed the equalizer permissions to be more in line with the rest of Audio's permission mechanics. The DJ role is now used to restrict access to the eq instead of using a mod/admin bot role or the administrator guild permission.

* All users will be able to manage the eq if DJ role is off and there are no restrictions on subcommand use.
* If the DJ role is on, and the user does not have the role, they will only be able to view the current eq.
* Deleting eq presets now follows the same permissions style as playlist deletion. If the person is a bot mod/admin, bot owner, or other generally exempt user, they will be able to delete any eq setting. There is now an author field on eq settings, and if a pleb tries to delete someone else's setting they will not be able to.
* If someone was using the dev version before these changes were made and they have saved eq settings, there are a few lines to handle that previous eq data storage file arrangement. Since there is no author, the mods/admins will need to be the ones to delete those settings as they will be the only user with authorization to do so.
* The eq list command output has changed to show author and has a slightly different format.
