### PR TITLE
[Core] Don't change type of exception during cog load

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -300,10 +300,10 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
                 await lib.setup(self)
             else:
                 lib.setup(self)
-        except Exception as e:
+        except Exception:
             self._remove_module_references(lib.__name__)
             self._call_module_finalizers(lib, name)
-            raise errors.CogLoadError(e) from e
+            raise
         else:
             self._BotBase__extensions[name] = lib
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This will prevent `[p]load` from suppressing tracebacks for all exceptions made by cog during load.
It still allows devs to use `redbot.core.errors.CogLoadError` if they want to show the "This package could not be loaded for the following reason" message, but now it doesn't throw at user all kinds of exceptions and doesn't swallow the traceback in console.