### PR TITLE
[Audio] Catch unhandled internal folder types

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -1211,6 +1211,8 @@ class Audio(commands.Cog):
     async def _folder_list(self, ctx, folder):
         if not await self._localtracks_check(ctx):
             return
+        if not os.path.isdir(os.getcwd() + folder):
+            return
         allowed_files = (".mp3", ".flac", ".ogg")
         folder_list = sorted(
             (
@@ -1236,6 +1238,8 @@ class Audio(commands.Cog):
 
     async def _folder_tracks(self, ctx, player, folder):
         if not await self._localtracks_check(ctx):
+            return
+        if not os.path.isdir(os.getcwd() + folder):
             return
         local_tracks = []
         for local_file in await self._all_folder_tracks(ctx, folder):

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -1211,7 +1211,7 @@ class Audio(commands.Cog):
     async def _folder_list(self, ctx, folder):
         if not await self._localtracks_check(ctx):
             return
-        if not os.path.isdir(os.getcwd() + folder):
+        if not os.path.isdir(os.getcwd() + "/localtracks/{}/".format(folder)):
             return
         allowed_files = (".mp3", ".flac", ".ogg")
         folder_list = sorted(
@@ -1239,7 +1239,7 @@ class Audio(commands.Cog):
     async def _folder_tracks(self, ctx, player, folder):
         if not await self._localtracks_check(ctx):
             return
-        if not os.path.isdir(os.getcwd() + folder):
+        if not os.path.isdir(os.getcwd() + "/localtracks/{}/".format(folder)):
             return
         local_tracks = []
         for local_file in await self._all_folder_tracks(ctx, folder):


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This resolves #2818.

The `folder:` and `localfolder:` prefixes are used internally with some localtracks strings to define what to do with the item when it's cycled through the search function. Users theoretically should have never seen this issue as [p]search is used on the user side for YouTube and Soundcloud searching and not local searching, but this handles the issue where a folder is being passed to these functions that doesn't exist.