### PR TITLE
[Downloader/Core] RepoManager: don't load repos in `__init__`

### DIFF
--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -540,9 +540,6 @@ class RepoManager:
     def __init__(self):
         self._repos = {}
 
-        loop = asyncio.get_event_loop()
-        loop.create_task(self._load_repos(set=True))  # str_name: Repo
-
     async def initialize(self):
         await self._load_repos(set=True)
 

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -409,8 +409,9 @@ async def create_backup(instance):
             from redbot.cogs.downloader.repo_manager import RepoManager
 
             repo_mgr = RepoManager()
+            await repo_mgr.initialize()
             repo_output = []
-            for _, repo in repo_mgr._repos:
+            for repo in repo_mgr._repos.values():
                 repo_output.append({"url": repo.url, "name": repo.name, "branch": repo.branch})
             repo_filename = pth / "cogs" / "RepoManager" / "repos.json"
             with open(str(repo_filename), "w") as f:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
*Yeah, this commit stood for a long time in the big fella Downloader PR, and I completely forgot about it. So, here it is:*
Loading repos is already done in `initialize()` method.
This could actually turn out badly if both of git processes would touch the same repo at the same time (and locks wouldn't stop that as they're separate between each `Repo` instance, no matter if the directory to the git repo is the same).

This also fixes `create_backup()` in setup.py - now it properly generates `repos.json` file, that might come useful to restore repos (even if it's not currently done by Red)