### PR TITLE
[Tests] Ignore pylint's ImportErrors for `distro` package on non-linux systems

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1652,7 +1652,7 @@ class Core(commands.Cog, CoreLogic):
         """Shows debug information useful for debugging.."""
 
         if sys.platform == "linux":
-            import distro
+            import distro  # pylint: disable=import-error
 
         IS_WINDOWS = os.name == "nt"
         IS_MAC = sys.platform == "darwin"

--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -20,7 +20,7 @@ from redbot.core import __version__, version_info as red_version_info, VersionIn
 from redbot.core.cli import confirm
 
 if sys.platform == "linux":
-    import distro
+    import distro  # pylint: disable=import-error
 
 INTERACTIVE_MODE = not len(sys.argv) > 1  # CLI flags = non-interactive
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
