### PR TITLE
[Mongo] Escape identifiers before extracting value

### DIFF
--- a/redbot/core/drivers/red_mongo.py
+++ b/redbot/core/drivers/red_mongo.py
@@ -119,9 +119,9 @@ class Mongo(BaseDriver):
         mongo_collection = self.get_collection(identifier_data.category)
 
         pkey_filter = self.generate_primary_key_filter(identifier_data)
+        escaped_identifiers = list(map(self._escape_key, identifier_data.identifiers))
         if len(identifier_data.identifiers) > 0:
-            dot_identifiers = ".".join(map(self._escape_key, identifier_data.identifiers))
-            proj = {"_id": False, dot_identifiers: True}
+            proj = {"_id": False, ".".join(escaped_identifiers): True}
 
             partial = await mongo_collection.find_one(filter=pkey_filter, projection=proj)
         else:
@@ -132,7 +132,7 @@ class Mongo(BaseDriver):
         if partial is None:
             raise KeyError("No matching document was found and Config expects a KeyError.")
 
-        for i in identifier_data.identifiers:
+        for i in escaped_identifiers:
             partial = partial[i]
         if isinstance(partial, dict):
             return self._unescape_dict_keys(partial)


### PR DESCRIPTION
This was causing a KeyError to be raised any time the identifiers contained a key containing $ or ., regardless of whether or not the (escaped) key existed in the data.