### PR TITLE
[Audio] Add a local cache to reduce API calls

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -33,6 +33,7 @@ from urllib.parse import urlparse
 from .equalizer import Equalizer
 from .manager import ServerManager
 from .errors import LavalinkDownloadFailed
+from .localcache import music_cache
 
 _ = Translator("Audio", __file__)
 
@@ -1801,8 +1802,9 @@ class Audio(commands.Cog):
                 song_info = "{} {}".format(i["name"], i["artists"][0]["name"])
             else:
                 song_info = "{} {}".format(i["track"]["name"], i["track"]["artists"][0]["name"])
+
             try:
-                track_url = await self._youtube_api_search(yt_key, song_info)
+                track_url = await music_cache.get_url(yt_key, song_info, self.session)
             except (RuntimeError, aiohttp.client_exceptions.ServerDisconnectedError):
                 error_embed = discord.Embed(
                     colour=await ctx.embed_colour(),
@@ -1810,7 +1812,6 @@ class Audio(commands.Cog):
                 )
                 await playlist_msg.edit(embed=error_embed)
                 return None
-                pass
             try:
                 yt_track = await player.get_tracks(track_url)
             except (RuntimeError, aiohttp.client_exceptions.ServerDisconnectedError):
@@ -4181,21 +4182,6 @@ class Audio(commands.Cog):
         else:
             return False
 
-    async def _youtube_api_search(self, yt_key, query):
-        params = {"q": query, "part": "id", "key": yt_key, "maxResults": 1, "type": "video"}
-        yt_url = "https://www.googleapis.com/youtube/v3/search"
-        try:
-            async with self.session.request("GET", yt_url, params=params) as r:
-                if r.status == 400:
-                    return None
-                else:
-                    search_response = await r.json()
-        except RuntimeError:
-            return None
-        for search_result in search_response.get("items", []):
-            if search_result["id"]["kind"] == "youtube#video":
-                return "https://www.youtube.com/watch?v={}".format(search_result["id"]["videoId"])
-
     # Spotify-related methods below are originally from: https://github.com/Just-Some-Bots/MusicBot/blob/master/musicbot/spotify.py
 
     async def _check_token(self, token):
@@ -4280,6 +4266,7 @@ class Audio(commands.Cog):
             self.bot.loop.create_task(lavalink.close())
             if self._manager is not None:
                 self.bot.loop.create_task(self._manager.shutdown())
+            music_cache._save_cache()  # Saves cache upon unload
             self._cleaned_up = True
 
     __del__ = cog_unload

--- a/redbot/cogs/audio/localcache.py
+++ b/redbot/cogs/audio/localcache.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+import asyncio
+import atexit
+import json
+import os.path
+from typing import Dict, Tuple, Union
+
+import aiofiles
+
+from appdirs import AppDirs
+
+__all__ = ["music_cache"]
+PRETTY: Dict[str, Union[int, bool, Tuple[str, str]]] = {
+    "indent": 4,
+    "sort_keys": False,
+    "separators": (",", " : "),
+}
+dirs = AppDirs("Red-DiscordBot", "Audio")
+CACHE_FILE = str(os.path.join(dirs.user_data_dir, "audio.cache"))
+
+
+class YouTubeCacheConfigClass(object):
+    def __init__(self):
+        self.cache = None
+        self._file_name = CACHE_FILE
+
+    async def get_file_cache(self):
+        async with aiofiles.open(self._file_name, mode="r") as stream:
+            return json.loads(await stream.read())
+
+    def save_to_file(self, settings=None, unload=False):
+        if settings is None:
+            settings = PRETTY
+
+        async def save_file_cache():
+            async with aiofiles.open(YouTubeCacheConfig._file_name, mode="w") as stream:
+                if self.cache is not None:
+                    await stream.write(json.dumps(self.cache, **settings))
+
+        if not unload:
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(save_file_cache())
+        else:
+            return save_file_cache
+
+    async def get_cache(self):
+        if self.cache is None:
+            try:
+                self.cache = await self.get_file_cache()
+            except (IOError, ValueError):
+                self.cache = {}
+
+            atexit.register(lambda: self.save_to_file())
+        return self.cache
+
+    async def get_song(self, song_info):
+        if self.cache is None:
+            self.cache = await self.get_cache()
+        if song_info in self.cache:
+            return self.cache[song_info]
+        else:
+            return False
+
+    async def update_cache(self, song_info, url):
+        if self.cache is None:
+            self.cache = await self.get_cache()
+        self.cache[song_info] = url
+
+    @staticmethod
+    async def youtube_api_search(yt_key, query, session):
+        params = {"q": query, "part": "id", "key": yt_key, "maxResults": 1, "type": "video"}
+        yt_url = "https://www.googleapis.com/youtube/v3/search"
+        async with session.request("GET", yt_url, params=params) as r:
+            if r.status == 400:
+                return None
+            else:
+                search_response = await r.json()
+        for search_result in search_response.get("items", []):
+            if search_result["id"]["kind"] == "youtube#video":
+                return f"https://www.youtube.com/watch?v={search_result['id']['videoId']}"
+
+
+YouTubeCacheConfig = YouTubeCacheConfigClass()
+
+
+class music_cache(object):
+    @classmethod
+    async def get_url(cls, yt_key, song_info, session):
+        song_data = await YouTubeCacheConfig.get_song(song_info)
+        if song_data is False:
+            url = await YouTubeCacheConfig.youtube_api_search(yt_key, song_info, session)
+            if url:
+                await YouTubeCacheConfig.update_cache(song_info, url)
+            return url
+        else:
+            return song_data
+
+    @staticmethod
+    def _save_cache():
+        return YouTubeCacheConfig.save_to_file(unload=True)

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -1,6 +1,6 @@
 import asyncio
 import contextlib
-from typing import Iterable, List, Union
+from typing import Iterable, List
 import discord
 from discord.ext import commands
 
@@ -83,30 +83,6 @@ class Context(commands.Context):
             await self.message.add_reaction(TICK)
         except discord.HTTPException:
             return False
-        else:
-            return True
-
-    async def react_quietly(
-        self, reaction: Union[discord.Emoji, discord.Reaction, discord.PartialEmoji, bool, str]
-    ) -> bool:
-        """Adds a reaction to to the command message.
-
-        Returns
-        -------
-        bool
-            :code:`True` if adding the reaction succeeded.
-
-        """
-        if reaction is True:
-            reaction = TICK
-        elif reaction is False:
-            reaction = "\N{CROSS MARK}"
-        try:
-            await self.message.add_reaction(reaction)
-        except (discord.HTTPException, discord.NotFound, discord.Forbidden):
-            return False
-        except discord.InvalidArgument:
-            return False  # Possibly raise error here?
         else:
             return True
 

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -1,6 +1,6 @@
 import asyncio
 import contextlib
-from typing import Iterable, List
+from typing import Iterable, List, Union
 import discord
 from discord.ext import commands
 
@@ -83,6 +83,30 @@ class Context(commands.Context):
             await self.message.add_reaction(TICK)
         except discord.HTTPException:
             return False
+        else:
+            return True
+
+    async def react_quietly(
+        self, reaction: Union[discord.Emoji, discord.Reaction, discord.PartialEmoji, bool, str]
+    ) -> bool:
+        """Adds a reaction to to the command message.
+
+        Returns
+        -------
+        bool
+            :code:`True` if adding the reaction succeeded.
+
+        """
+        if reaction is True:
+            reaction = TICK
+        elif reaction is False:
+            reaction = "\N{CROSS MARK}"
+        try:
+            await self.message.add_reaction(reaction)
+        except (discord.HTTPException, discord.NotFound, discord.Forbidden):
+            return False
+        except discord.InvalidArgument:
+            return False  # Possibly raise error here?
         else:
             return True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
 packages = find_namespace:
 python_requires = >=3.7
 install_requires =
+    aiofiles==0.4.0
     aiohttp==3.5.4
     aiohttp-json-rpc==0.12.1
     appdirs==1.4.3

--- a/tools/primary_deps.ini
+++ b/tools/primary_deps.ini
@@ -6,6 +6,7 @@
 
 [options]
 install_requires =
+    aiofiles
     aiohttp
     aiohttp-json-rpc
     appdirs


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [X] New feature

### Description of the changes
This PR adds a local cache to the Audio cog

This cache will be loaded in memory on cog load and will only write to memory on Cog unload/bot crash
This is to avoid killing your back-end with reads and write operations

This will allows the user to play Spotify songs that have been played in the past even if they run out of their YouTube API quota