### PR TITLE
[Audio] Check for player when not connected

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -2848,7 +2848,8 @@ class Audio(commands.Cog):
         await self._embed_msg(
             ctx, _("Repeat tracks: {true_or_false}.").format(true_or_false=not repeat)
         )
-        await self._data_check(ctx)
+        if self._player_check(ctx):
+            await self._data_check(ctx)
 
     @commands.command()
     @commands.guild_only()
@@ -3278,7 +3279,8 @@ class Audio(commands.Cog):
         await self._embed_msg(
             ctx, _("Shuffle tracks: {true_or_false}.").format(true_or_false=not shuffle)
         )
-        await self._data_check(ctx)
+        if self._player_check(ctx):
+            await self._data_check(ctx)
 
     @commands.command()
     @commands.guild_only()


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
The changes introduced with #2812 needed to have a player check before attempting to send the values to the player. Using [p]shuffle or [p]repeat right now while the bot is not connected will result in an error otherwise.