### PR TITLE
[ModLog] Prevent duplicate kwarg error

### DIFF
--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -463,6 +463,7 @@ class CaseType:
         CaseType
 
         """
+        data.pop(name, None)
         return cls(name=name, **data, **kwargs)
 
 

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -463,8 +463,9 @@ class CaseType:
         CaseType
 
         """
-        data.pop(name, None)
-        return cls(name=name, **data, **kwargs)
+        data_copy = data.copy()
+        data_copy.pop(name, None)
+        return cls(name=name, **data_copy, **kwargs)
 
 
 async def get_next_case_number(guild: discord.Guild) -> int:


### PR DESCRIPTION
The `name` key used to be set in the Config for casetypes.

Resolves this traceback:
```
Traceback (most recent call last):
  File "discord/ext/commands/core.py", line 79, in wrapped
    ret = await coro(*args, **kwargs)
  File "redbot/cogs/mod/kickban.py", line 223, in ban
    user=user, ctx=ctx, days=days, reason=reason, create_modlog_case=True
  File "redbot/cogs/mod/kickban.py", line 114, in ban_user
    channel=None,
  File "redbot/core/modlog.py", line 647, in create_case
    case_type = await get_casetype(action_type, guild)
  File "redbot/core/modlog.py", line 699, in get_casetype
    casetype = CaseType.from_json(name, data)
  File "redbot/core/modlog.py", line 466, in from_json
    return cls(name=name, **data, **kwargs)
TypeError: type object got multiple values for keyword argument 'name'
```
