### PR TITLE
Make Requires.verify() wait until rules are loaded

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -10,6 +10,22 @@ import sys
 
 import discord
 
+# Set the event loop policies here so any subsequent `get_event_loop()`
+# calls, in particular those as a result of the following imports,
+# return the correct loop object.
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+else:
+    # Let's not force this dependency, uvloop is much faster on cpython
+    if sys.implementation.name == "cpython":
+        try:
+            import uvloop
+        except ImportError:
+            uvloop = None
+            pass
+        else:
+            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
 import redbot.logging
 from redbot.core.bot import Red, ExitCodes
 from redbot.core.cog_manager import CogManagerUI
@@ -21,18 +37,6 @@ from redbot.core.dev_commands import Dev
 from redbot.core import __version__, modlog, bank, data_manager
 from signal import SIGTERM
 
-# Let's not force this dependency, uvloop is much faster on cpython
-if sys.implementation.name == "cpython":
-    try:
-        import uvloop
-    except ImportError:
-        uvloop = None
-        pass
-    else:
-        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
-
-if sys.platform == "win32":
-    asyncio.set_event_loop(asyncio.ProactorEventLoop())
 
 log = logging.getLogger("red.main")
 

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -15,16 +15,15 @@ import discord
 # return the correct loop object.
 if sys.platform == "win32":
     asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
-else:
+elif sys.implementation.name == "cpython":
     # Let's not force this dependency, uvloop is much faster on cpython
-    if sys.implementation.name == "cpython":
-        try:
-            import uvloop
-        except ImportError:
-            uvloop = None
-            pass
-        else:
-            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+    try:
+        import uvloop
+    except ImportError:
+        uvloop = None
+        pass
+    else:
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
 import redbot.logging
 from redbot.core.bot import Red, ExitCodes

--- a/redbot/cogs/permissions/__init__.py
+++ b/redbot/cogs/permissions/__init__.py
@@ -8,6 +8,7 @@ async def setup(bot):
     # the permissions commands themselves have rules added.
     # Automatic listeners being added in add_cog happen in arbitrary
     # order, so we want to circumvent that.
-    bot.add_listener(cog.red_cog_added, "on_cog_add")
-    bot.add_listener(cog.red_command_added, "on_command_add")
+    await cog.on_cog_add(cog)
+    for command in cog.walk_commands():
+        await cog.on_command_add(command)
     bot.add_cog(cog)

--- a/redbot/cogs/permissions/__init__.py
+++ b/redbot/cogs/permissions/__init__.py
@@ -4,11 +4,9 @@ from .permissions import Permissions
 async def setup(bot):
     cog = Permissions(bot)
     await cog.initialize()
-    # It's important that these listeners are added prior to load, so
-    # the permissions commands themselves have rules added.
-    # Automatic listeners being added in add_cog happen in arbitrary
-    # order, so we want to circumvent that.
-    await cog.on_cog_add(cog)
-    for command in cog.walk_commands():
-        await cog.on_command_add(command)
+    # We should add the rules for the Permissions cog and its own commands *before* adding the cog.
+    # The actual listeners ought to skip the ones we're passing here.
+    await cog._on_cog_add(cog)
+    for command in cog.__cog_commands__:
+        await cog._on_command_add(command)
     bot.add_cog(cog)

--- a/redbot/cogs/permissions/permissions.py
+++ b/redbot/cogs/permissions/permissions.py
@@ -445,11 +445,7 @@ class Permissions(commands.Cog):
         if cog is self:
             # This cog has its rules loaded manually in setup()
             return
-        self._load_rules_for(
-            cog_or_command=cog,
-            rule_dict=await self.config.custom(COG, cog.__class__.__name__).all(),
-        )
-        cog.requires.ready_event.set()
+        await self._on_cog_add(cog)
 
     @commands.Cog.listener()
     async def on_command_add(self, command: commands.Command) -> None:
@@ -460,6 +456,16 @@ class Permissions(commands.Cog):
         if command.cog is self:
             # This cog's commands have their rules loaded manually in setup()
             return
+        await self._on_command_add(command)
+
+    async def _on_cog_add(self, cog: commands.Cog) -> None:
+        self._load_rules_for(
+            cog_or_command=cog,
+            rule_dict=await self.config.custom(COG, cog.__class__.__name__).all(),
+        )
+        cog.requires.ready_event.set()
+
+    async def _on_command_add(self, command: commands.Command) -> None:
         self._load_rules_for(
             cog_or_command=command,
             rule_dict=await self.config.custom(COMMAND, command.qualified_name).all(),

--- a/redbot/cogs/permissions/permissions.py
+++ b/redbot/cogs/permissions/permissions.py
@@ -712,8 +712,6 @@ class Permissions(commands.Cog):
                     cog_or_command.deny_to(model_id, guild_id=guild_id)
 
     def cog_unload(self) -> None:
-        self.bot.remove_listener(self.red_cog_added, "on_cog_add")
-        self.bot.remove_listener(self.red_command_added, "on_command_add")
         self.bot.loop.create_task(self._unload_all_rules())
 
     async def _unload_all_rules(self) -> None:

--- a/redbot/cogs/permissions/permissions.py
+++ b/redbot/cogs/permissions/permissions.py
@@ -436,31 +436,35 @@ class Permissions(commands.Cog):
             await self._clear_rules(guild_id=ctx.guild.id)
             await ctx.tick()
 
-    async def red_cog_added(self, cog: commands.Cog) -> None:
+    @commands.Cog.listener()
+    async def on_cog_add(self, cog: commands.Cog) -> None:
         """Event listener for `cog_add`.
 
         This loads rules whenever a new cog is added.
-
-        Do not convert to using Cog.listener decorator !!
-        This *must* be added manually prior to cog load, and removed at unload
         """
+        if cog is self:
+            # This cog has its rules loaded manually in setup()
+            return
         self._load_rules_for(
             cog_or_command=cog,
             rule_dict=await self.config.custom(COG, cog.__class__.__name__).all(),
         )
+        cog.requires.ready_event.set()
 
-    async def red_command_added(self, command: commands.Command) -> None:
+    @commands.Cog.listener()
+    async def on_command_add(self, command: commands.Command) -> None:
         """Event listener for `command_add`.
 
         This loads rules whenever a new command is added.
-
-        Do not convert to using Cog.listener decorator !!
-        This *must* be added manually prior to cog load, and removed at unload
         """
+        if command.cog is self:
+            # This cog's commands have their rules loaded manually in setup()
+            return
         self._load_rules_for(
             cog_or_command=command,
             rule_dict=await self.config.custom(COMMAND, command.qualified_name).all(),
         )
+        command.requires.ready_event.set()
 
     async def _add_rule(
         self, rule: bool, cog_or_cmd: CogOrCommand, model_id: int, guild_id: int

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -454,7 +454,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
         if permissions_not_loaded:
             command.requires.ready_event.set()
         if isinstance(command, commands.Group):
-            for subcommand in command.__cog_commands__:
+            for subcommand in set(command.walk_commands()):
                 self.dispatch("command_add", subcommand)
                 if permissions_not_loaded:
                     command.requires.ready_event.set()
@@ -463,7 +463,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
         command = super().remove_command(name)
         command.requires.reset()
         if isinstance(command, commands.Group):
-            for subcommand in command.__cog_commands__:
+            for subcommand in set(command.walk_commands()):
                 subcommand.requires.reset()
 
     def clear_permission_rules(self, guild_id: Optional[int]) -> None:

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -454,7 +454,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
         if permissions_not_loaded:
             command.requires.ready_event.set()
         if isinstance(command, commands.Group):
-            for subcommand in command.walk_commands():
+            for subcommand in command.__cog_commands__:
                 self.dispatch("command_add", subcommand)
                 if permissions_not_loaded:
                     command.requires.ready_event.set()
@@ -463,7 +463,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
         command = super().remove_command(name)
         command.requires.reset()
         if isinstance(command, commands.Group):
-            for subcommand in command.walk_commands():
+            for subcommand in command.__cog_commands__:
                 subcommand.requires.reset()
 
     def clear_permission_rules(self, guild_id: Optional[int]) -> None:

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -322,6 +322,8 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
 
         super().remove_cog(cogname)
 
+        cog.requires.reset()
+
         for meth in self.rpc_handlers.pop(cogname.upper(), ()):
             self.unregister_rpc_handler(meth)
 
@@ -424,21 +426,10 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
                     self.add_permissions_hook(hook)
                     added_hooks.append(hook)
 
-            for command in cog.__cog_commands__:
-
-                if not isinstance(command, commands.Command):
-                    raise RuntimeError(
-                        f"The {cog.__class__.__name__} cog in the {cog.__module__} package,"
-                        " is not using Red's command module, and cannot be added. "
-                        "If this is your cog, please use `from redbot.core import commands`"
-                        "in place of `from discord.ext import commands`. For more details on "
-                        "this requirement, see this page: "
-                        "http://red-discordbot.readthedocs.io/en/v3-develop/framework_commands.html"
-                    )
             super().add_cog(cog)
             self.dispatch("cog_add", cog)
-            for command in cog.__cog_commands__:
-                self.dispatch("command_add", command)
+            if "permissions" not in self.extensions:
+                cog.requires.ready_event.set()
         except Exception:
             for hook in added_hooks:
                 try:
@@ -451,6 +442,29 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
                     )
             del cog
             raise
+
+    def add_command(self, command: commands.Command) -> None:
+        if not isinstance(command, commands.Command):
+            raise RuntimeError("Commands must be instances of `redbot.core.commands.Command`")
+
+        super().add_command(command)
+
+        permissions_not_loaded = "permissions" not in self.extensions
+        self.dispatch("command_add", command)
+        if permissions_not_loaded:
+            command.requires.ready_event.set()
+        if isinstance(command, commands.Group):
+            for subcommand in command.walk_commands():
+                self.dispatch("command_add", subcommand)
+                if permissions_not_loaded:
+                    command.requires.ready_event.set()
+
+    def remove_command(self, name: str) -> None:
+        command = super().remove_command(name)
+        command.requires.reset()
+        if isinstance(command, commands.Group):
+            for subcommand in command.walk_commands():
+                subcommand.requires.reset()
 
     def clear_permission_rules(self, guild_id: Optional[int]) -> None:
         """Clear all permission overrides in a scope.


### PR DESCRIPTION
This gives every `Requires` object an `asyncio.Event` object to wait on until all of its rules are loaded.

Also ensures `Requires` objects are reset when unloaded, particularly in case a `Command` object manages to stay in memory between cog unload and load, and its permissions rules change between those events.

Also, this PR re-ordered some of the event loop policy stuff, because it was required that the event loop policy be set before creating any `Requires` objects. This may or may not have an effect on other `get_event_loop()` calls elsewhere (either in our code, a dependency's, or asyncio's). Either way, these effects would be a *correction*, and any bugs that arise from it are likely to have been occurring silently beforehand.

Also sets the event loop *policy* on Windows to `WindowsProactorEventLoopPolicy` instead of directly setting the loop object. The reason this wasn't done originally was because the policy was only made available in Python 3.7.0 (see the last dot point [here](https://docs.python.org/3/whatsnew/3.7.html#asyncio)).

This PR is an alternative to #2853.