### PR TITLE
[Docs] Add awaits and missing imports in usage examples

### DIFF
--- a/docs/framework_bank.rst
+++ b/docs/framework_bank.rst
@@ -16,7 +16,8 @@ Basic Usage
 
 .. code-block:: python
 
-    from redbot.core import bank
+    from redbot.core import bank, commands
+    import discord
 
     class MyCog:
         @commands.command()

--- a/docs/framework_bank.rst
+++ b/docs/framework_bank.rst
@@ -20,11 +20,11 @@ Basic Usage
 
     class MyCog:
         @commands.command()
-        async def balance(self, ctx, user: discord.Member=None):
+        async def balance(self, ctx, user: discord.Member = None):
             if user is None:
                 user = ctx.author
-            bal = bank.get_balance(user)
-            currency = bank.get_currency_name(ctx.guild)
+            bal = await bank.get_balance(user)
+            currency = await bank.get_currency_name(ctx.guild)
             await ctx.send(
                 "{}'s balance is {} {}".format(
                     user.display_name, bal, currency

--- a/docs/framework_bank.rst
+++ b/docs/framework_bank.rst
@@ -19,7 +19,7 @@ Basic Usage
     from redbot.core import bank, commands
     import discord
 
-    class MyCog:
+    class MyCog(commands.Cog):
         @commands.command()
         async def balance(self, ctx, user: discord.Member = None):
             if user is None:

--- a/docs/framework_modlog.rst
+++ b/docs/framework_modlog.rst
@@ -25,8 +25,8 @@ Basic Usage
         async def ban(self, ctx, user: discord.Member, reason: str = None):
             await ctx.guild.ban(user)
             case = await modlog.create_case(
-                ctx.bot, ctx.guild, ctx.message.created_at, "ban", user,
-                moderator=ctx.author, reason=reason
+                ctx.bot, ctx.guild, ctx.message.created_at, action="ban",
+                user=user, moderator=ctx.author, reason=reason
             )
             await ctx.send("Done. It was about time.")
 
@@ -83,10 +83,7 @@ it from your setup function:
                     "audit_type": "kick"
                 }
             ]
-            try:
-                await modlog.register_casetypes(new_types)
-            except RuntimeError:
-                pass
+            await modlog.register_casetypes(new_types)
 
 .. code-block:: python
 

--- a/docs/framework_modlog.rst
+++ b/docs/framework_modlog.rst
@@ -35,7 +35,7 @@ Basic Usage
 Registering Case types
 **********************
 
-To register case types, use an asynchronous `initialize()` method and call
+To register case types, use an asynchronous ``initialize()`` method and call
 it from your setup function:
 
 .. code-block:: python

--- a/docs/framework_modlog.rst
+++ b/docs/framework_modlog.rst
@@ -16,7 +16,7 @@ Basic Usage
 
 .. code-block:: python
 
-    from redbot.core import modlog
+    from redbot.core import commands, modlog
     import discord
 
     class MyCog:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Well, the modlog examples had to be changed a lot, because `await` obviously won't work in regular method. I used the same way as it's done in core code.