### PR TITLE
[Tunnel] Add `use_cached` and `images_only` kwargs to `files_from_attach`

### DIFF
--- a/changelog.d/2885.misc.rst
+++ b/changelog.d/2885.misc.rst
@@ -1,0 +1,1 @@
+[Tunnel] Added ``use_cached`` and ``images_only`` kwargs to `redbot.core.utils.Tunnel.files_from_attach`

--- a/redbot/core/utils/tunnel.py
+++ b/redbot/core/utils/tunnel.py
@@ -133,7 +133,7 @@ class Tunnel(metaclass=TunnelMeta):
 
     @staticmethod
     async def files_from_attach(
-        m: discord.Message, *, use_cached: bool = False
+        m: discord.Message, *, use_cached: bool = False, images_only: bool = False
     ) -> List[discord.File]:
         """
         makes a list of file objects from a message
@@ -146,6 +146,8 @@ class Tunnel(metaclass=TunnelMeta):
             A message to get attachments from
         use_cached: `bool`
             Whether to use ``proxy_url`` rather than ``url`` when downloading the attachment
+        images_only: `bool`
+            Whether only image attachments should be added to returned list
 
         Returns
         -------
@@ -157,8 +159,16 @@ class Tunnel(metaclass=TunnelMeta):
         max_size = 8 * 1000 * 1000
         if m.attachments and sum(a.size for a in m.attachments) <= max_size:
             for a in m.attachments:
+                if images_only and a.height is None:
+                    # if this is None, it's not an image
+                    continue
                 _fp = io.BytesIO()
-                await a.save(_fp, use_cached=use_cached)
+                try:
+                    await a.save(_fp, use_cached=use_cached)
+                except discord.HTTPException as e:
+                    # this is required, because animated webp files aren't cached
+                    if not (e.status == 415 and images_only and use_cached):
+                        raise
                 files.append(discord.File(_fp, filename=a.filename))
         return files
 

--- a/redbot/core/utils/tunnel.py
+++ b/redbot/core/utils/tunnel.py
@@ -132,7 +132,9 @@ class Tunnel(metaclass=TunnelMeta):
         return rets
 
     @staticmethod
-    async def files_from_attach(m: discord.Message) -> List[discord.File]:
+    async def files_from_attach(
+        m: discord.Message, *, use_cached: bool = False
+    ) -> List[discord.File]:
         """
         makes a list of file objects from a message
         returns an empty list if none, or if the sum of file sizes
@@ -142,6 +144,8 @@ class Tunnel(metaclass=TunnelMeta):
         ---------
         m: `discord.Message`
             A message to get attachments from
+        use_cached: `bool`
+            Whether to use ``proxy_url`` rather than ``url`` when downloading the attachment
 
         Returns
         -------
@@ -154,7 +158,7 @@ class Tunnel(metaclass=TunnelMeta):
         if m.attachments and sum(a.size for a in m.attachments) <= max_size:
             for a in m.attachments:
                 _fp = io.BytesIO()
-                await a.save(_fp)
+                await a.save(_fp, use_cached=use_cached)
                 files.append(discord.File(_fp, filename=a.filename))
         return files
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
re #2885