### PR TITLE
 Fixed remove_command error when trying to remove a non-existent command 

### DIFF
--- a/changelog.d/2888.bugfix.rst
+++ b/changelog.d/2888.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed remove_command error when trying to remove a non-existent command

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -461,6 +461,8 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
 
     def remove_command(self, name: str) -> None:
         command = super().remove_command(name)
+        if not command:
+            return
         command.requires.reset()
         if isinstance(command, commands.Group):
             for subcommand in set(command.walk_commands()):


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Resolves #2888.