### PR TITLE
[Docs] Add a copy button to code blocks

### DIFF
--- a/docs/_static/copybutton.css
+++ b/docs/_static/copybutton.css
@@ -1,0 +1,62 @@
+/*
+ CSS rules for the copy button modified to work on the theme "sphinx_rtd_theme"
+ Original: https://github.com/choldgraf/sphinx-copybutton/blob/master/sphinx_copybutton/_static/copybutton.css
+*/
+
+/* Copy buttons */
+a.copybtn {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    width: 1.6em;
+    height: 1em;
+    padding: .3em;
+	opacity: .3;
+    transition: opacity 0.5s;
+}
+
+div.highlight  {
+    position: relative;
+}
+
+.highlight:hover .copybtn {
+	opacity: 1;
+}
+
+/**
+ * A minimal CSS-only tooltip copied from:
+ *   https://codepen.io/mildrenben/pen/rVBrpK
+ *
+ * To use, write HTML like the following:
+ *
+ * <p class="o-tooltip--left" data-tooltip="Hey">Short</p>
+ */
+ .o-tooltip--left {
+  position: relative;
+ }
+
+ .o-tooltip--left:after {
+    opacity: 0;
+    visibility: hidden;
+    position: absolute;
+    content: attr(data-tooltip);
+    padding: 2px;
+    top: 6px;
+    left: 0;
+    background: grey;
+    font-size: 1rem;
+    color: white;
+    white-space: nowrap;
+    z-index: 2;
+    border-radius: 2px;
+    transform: translateX(-102%) translateY(0);
+    transition: opacity 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), transform 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
+}
+
+.o-tooltip--left:hover:after {
+    display: block;
+    opacity: 1;
+    visibility: visible;
+    transform: translateX(-100%) translateY(0);
+    transition: opacity 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), transform 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.doctest",
     "sphinxcontrib_trio",
+    "sphinx_copybutton",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,5 @@
 # We still need this because RTD is special
 setuptools==40.8.0
+
+# copy button for code blocks
+sphinx-copybutton

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,7 @@ docs =
     six==1.12.0
     snowballstemmer==1.9.0
     Sphinx==2.1.2
+    sphinx-copybutton==0.2.5
     sphinx-rtd-theme==0.4.3
     sphinxcontrib-applehelp==1.0.1
     sphinxcontrib-devhelp==1.0.1

--- a/tools/primary_deps.ini
+++ b/tools/primary_deps.ini
@@ -28,6 +28,7 @@ install_requires =
 [options.extras_require]
 docs =
     Sphinx
+    sphinx-copybutton
     sphinx_rtd_theme
     sphinxcontrib-trio
     towncrier


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes

This includes the [sphinx_copybutton](https://github.com/choldgraf/sphinx-copybutton/) extension to the docs with modified CSS rules to work with our theme (thanks to @Eznel).

![2019-07-23 13 45 16](https://user-images.githubusercontent.com/23153234/61710149-34205080-ad51-11e9-9e42-a7787d9a941d.gif)
