### PR TITLE
Fixing typo in starwars trivia

### DIFF
--- a/changelog.d/trivia/2909.bugfix.rst
+++ b/changelog.d/trivia/2909.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes a typo in `Ahsoka Tano`'s name in the starwars trivia

--- a/redbot/cogs/trivia/data/lists/starwars.yaml
+++ b/redbot/cogs/trivia/data/lists/starwars.yaml
@@ -425,8 +425,8 @@ What was the cartel family who ruled over Tatooine?:
 What was the cloning planet in Episode II, Attack of the Clones?:
 - Kamino
 "What was the name of Anakin Skywalker's Apprentice in Star Wars: The Clone Wars?":
-- Ashoka
-- Ashoka Tano
+- Ahsoka
+- Ahsoka Tano
 What was the name of Darth Vader's flagship from the Battle of Hoth to the Battle of Endor?:
 - Executor
 "What was the name of General Grievous' Superweapon in Star Wars: The Clone Wars?":


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

As pointed out by kDals#5653, there was a typo in [Ahsoka Tano](https://starwars.fandom.com/wiki/Ahsoka_Tano)'s name.