### PR TITLE
[Converters] Always raise BadArgument with parse_timedelta

### DIFF
--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -49,7 +49,7 @@ def parse_timedelta(
     maximum: Optional[timedelta] = None,
     minimum: Optional[timedelta] = None,
     allowed_units: Optional[List[str]] = None,
-) -> Optional[timedelta]:
+) -> timedelta:
     """
     This converts a user provided string into a timedelta
 
@@ -71,14 +71,14 @@ def parse_timedelta(
 
     Returns
     -------
-    Optional[timedelta]
-        If matched, the timedelta which was parsed. This can return `None`
+    timedelta
+        The timedelta which was parsed.
 
     Raises
     ------
     BadArgument
-        If the argument passed uses a unit not allowed, but understood
-        or if the value is out of bounds.
+        If the argument passed uses a unit not allowed but understood, if the value is
+        out of bounds or if the value can't be converted.
     """
     matches = TIME_RE.match(argument)
     allowed_units = allowed_units or ["weeks", "days", "hours", "minutes", "seconds"]
@@ -104,7 +104,12 @@ def parse_timedelta(
                     ).format(minimum=humanize_timedelta(timedelta=minimum))
                 )
             return delta
-    return None
+    raise BadArgument(
+        _(
+            "The format is incorrect. Here are some examples of the format: "
+            '`"1 week"`, `"2 days"`, `12h`, `2h30m`'
+        )
+    )
 
 
 class GuildConverter(discord.Guild):


### PR DESCRIPTION
### Type

- [x] Bugfix (I guess)
- [ ] Enhancement
- [ ] New feature

### Description of the changes

When using `redbot.core.commands.converter.parse_timedelta`, if the format given is incorrect, the converter doesn't raise `BadArgument` but returns `None` instead. This behaviour is a problem when using `typing.Optional` or `commands.Greedy` since the commands module doesn't know the converstion failed.

The case that made me create this pull request is the following: I'm trying to make a mute command with an optional duration (`[p]mymute <members> [time] <reason>`) using `typing.Optional`
```py
from typing import Optional
from redbot.core.commands.converter import parse_timedelta

@commands.command()
async def mymute(self, ctx, member: discord.Member, duration: Optional[parse_timedelta], *, reason: str):
    pass
```
Here if the user tries this: `[p]mymute @Laggron a potato reason`, the length of the mute will be undefined, as desired, but the reason will be "potato reason" (instead of "a potato reason"). By returning `None` instead of raising `BadArgument`, the commands module will consider that the convertion succeeded, therefore removing the first word of the reason. 