### PR TITLE
Add `pip-wheel-metadata` folder to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ parts/
 sdist/
 var/
 wheels/
+pip-wheel-metadata/
 *.egg-info/
 .installed.cfg
 *.egg

--- a/changelog.d/2941.misc.rst
+++ b/changelog.d/2941.misc.rst
@@ -1,0 +1,1 @@
+Add `pip-wheel-metadata` folder to `.gitignore` file - pip creates it when installing Red in venv


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Add `pip-wheel-metadata` folder to `.gitignore` - pip creates it when installing Red in venv due to PEP-517: https://github.com/pypa/pip/blob/63639bfc0f6daa5cf18580db71d44e37d2a3b682/src/pip/_internal/req/req_install.py#L599