### PR TITLE
Alternative fix for reaction issue

### DIFF
--- a/changelog.d/2944.removal.rst
+++ b/changelog.d/2944.removal.rst
@@ -1,0 +1,1 @@
+Removed ``Context.react_quietly``

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -1,6 +1,6 @@
 import asyncio
 import contextlib
-from typing import Iterable, List, Union
+from typing import Iterable, List, Union, Optional
 import discord
 from discord.ext import commands
 
@@ -70,37 +70,19 @@ class Context(commands.Context):
         command = command or self.command
         await self.bot.send_help_for(self, command)
 
-    async def tick(self) -> bool:
-        """Add a tick reaction to the command message.
+    async def tick(self) -> Optional[discord.Message]:
+        """Sends a check mark as a message. This is usually used to indicate success.
 
         Returns
         -------
-        bool
-            :code:`True` if adding the reaction succeeded.
+        discord.Message:
+            The message which was sent if sent.   
 
         """
         try:
-            await self.message.add_reaction(TICK)
+            return await self.send(TICK)
         except discord.HTTPException:
-            return False
-        else:
-            return True
-
-    async def react_quietly(
-        self, reaction: Union[discord.Emoji, discord.Reaction, discord.PartialEmoji, str]
-    ) -> bool:
-        """Adds a reaction to to the command message.
-        Returns
-        -------
-        bool
-            :code:`True` if adding the reaction succeeded.
-        """
-        try:
-            await self.message.add_reaction(reaction)
-        except discord.HTTPException:
-            return False
-        else:
-            return True
+            return None
 
     async def send_interactive(
         self, messages: Iterable[str], box_lang: str = None, timeout: int = 15


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Removes `Context.react_quietly()`
Changes `Context.tick()` to just send a message instead.

This is mostly in replacement of #2934 

I don't think the changes in #2934 are the right direction for addressing the problem.

The `Context.send` change in that PR also seems like a non-issue if people check for permissions before doing things. The only case where it wouldn't be is DMs and if someone can make the context channel a DM channel, then the bot should be able to return the DM.