### PR TITLE
Catch discord.errors.Forbidden when DMing a user the invite message

### DIFF
--- a/changelog.d/2948.bugfix.rst
+++ b/changelog.d/2948.bugfix.rst
@@ -1,1 +1,1 @@
-The [p]invite command no longer erros when a user has the bot blocked or DMs disabled in the server.
+The [p]invite command no longer errors when a user has the bot blocked or DMs disabled in the server.

--- a/changelog.d/2948.bugfix.rst
+++ b/changelog.d/2948.bugfix.rst
@@ -1,0 +1,1 @@
+The [p]invite command no longer erros when a user has the bot blocked or DMs disabled in the server.

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -435,7 +435,13 @@ class Core(commands.Cog, CoreLogic):
     @commands.check(CoreLogic._can_get_invite_url)
     async def invite(self, ctx):
         """Show's Red's invite url"""
-        await ctx.author.send(await self._invite_url())
+        try:
+            await ctx.author.send(await self._invite_url())
+        except discord.errors.Forbidden:
+            await ctx.send(
+                "I couldn't send the invite message to you in DM. "
+                "Either you blocked me or you disabled DMs in this server."
+            )
 
     @commands.group()
     @checks.is_owner()


### PR DESCRIPTION
Uses the same error message as `[p]help`

### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Adds a `try`/`except` to the `[p]invite` command that sends the same warning message as `[p]help` when a user has the bot blocked or DMs disabled in the server.