### PR TITLE
[Utils] Stop using `:` in backup's filename - Windows doesn't accept it

### DIFF
--- a/changelog.d/2954.bugfix.rst
+++ b/changelog.d/2954.bugfix.rst
@@ -1,0 +1,1 @@
+Stop using `:` character in backup's filename - Windows doesn't accept it

--- a/redbot/core/utils/__init__.py
+++ b/redbot/core/utils/__init__.py
@@ -410,7 +410,7 @@ async def create_backup(dest: Path = Path.home()) -> Optional[Path]:
         return
 
     dest.mkdir(parents=True, exist_ok=True)
-    timestr = datetime.utcnow().isoformat(timespec="minutes")
+    timestr = datetime.utcnow().strftime("%Y-%m-%dT%H-%M-%S")
     backup_fpath = dest / f"redv3_{data_manager.instance_name}_{timestr}.tar.gz"
 
     to_backup = []


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #2954 