### PR TITLE
[Core] Various fixes to `redbot-setup delete`

### DIFF
--- a/changelog.d/2955.bugfix.rst
+++ b/changelog.d/2955.bugfix.rst
@@ -1,0 +1,1 @@
+``redbot-setup delete`` no longer errors about "unexpected keyword argument"

--- a/changelog.d/2956.bugfix.rst
+++ b/changelog.d/2956.bugfix.rst
@@ -1,0 +1,1 @@
+``redbot-setup delete`` no longer prompts about backup when user passes ``--no-prompt`` option

--- a/changelog.d/2958.enhance.1.rst
+++ b/changelog.d/2958.enhance.1.rst
@@ -1,0 +1,1 @@
+``--[no-]backup``, ``--[no-]drop-db`` and ``--[no-]remove-datapath`` in ``redbot-setup delete`` command are now on/off flags.

--- a/changelog.d/2958.enhance.2.rst
+++ b/changelog.d/2958.enhance.2.rst
@@ -1,0 +1,1 @@
+Confirmation prompts in ``redbot-setup`` now have default values for user convenience.

--- a/changelog.d/2958.enhance.rst
+++ b/changelog.d/2958.enhance.rst
@@ -1,1 +1,0 @@
-User can now pass ``--create-backup`` flag to ``redbot-setup delete`` to create backup without prompting (or to replace default behavior of ``--no-prompt``)

--- a/changelog.d/2958.enhance.rst
+++ b/changelog.d/2958.enhance.rst
@@ -1,0 +1,1 @@
+User can now pass ``--create-backup`` flag to ``redbot-setup delete`` to create backup without prompting (or to replace default behavior of ``--no-prompt``)

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -368,47 +368,49 @@ def cli(ctx, debug):
 
 @cli.command()
 @click.argument("instance", type=click.Choice(instance_list))
-@click.option("--no-prompt", default=False, help="Don't ask for user input during the process.")
 @click.option(
-    "--create-backup",
+    "--no-prompt",
+    "interactive",
+    is_flag=True,
+    default=True,
+    help="Don't ask for user input during the process.",
+)
+@click.option(
+    "--backup/--no-backup",
     "_create_backup",
-    type=bool,
+    is_flag=True,
     default=None,
     help=(
         "Create backup of this instance's data. "
-        "If this option and --no-prompt are omitted, you will be asked about this."
+        "If these options and --no-prompt are omitted, you will be asked about this."
     ),
 )
 @click.option(
-    "--drop-db",
-    type=bool,
+    "--drop-db/--no-drop-db",
+    is_flag=True,
     default=None,
     help=(
         "Drop the entire database constaining this instance's data. Has no effect on JSON "
-        "instances. If this option and --no-prompt are omitted, you will be asked about this."
+        "instances. If these options and --no-prompt are omitted, you will be asked about this."
     ),
 )
 @click.option(
-    "--remove-datapath",
-    type=bool,
+    "--remove-datapath/--no-remove-datapath",
+    is_flag=True,
     default=None,
     help=(
-        "Remove this entire instance's datapath. If this option and --no-prompt are omitted, you "
-        "will be asked about this."
+        "Remove this entire instance's datapath. If these options and --no-prompt are omitted, "
+        "you will be asked about this."
     ),
 )
 def delete(
     instance: str,
-    no_prompt: Optional[bool],
+    interactive: bool,
     _create_backup: Optional[bool],
     drop_db: Optional[bool],
     remove_datapath: Optional[bool],
 ):
     loop = asyncio.get_event_loop()
-    if no_prompt is None:
-        interactive = False
-    else:
-        interactive = not no_prompt
     loop.run_until_complete(
         remove_instance(instance, interactive, _create_backup, drop_db, remove_datapath)
     )

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -12,7 +12,6 @@ import appdirs
 import click
 
 import redbot.logging
-from redbot.core.cli import confirm
 from redbot.core.utils import safe_delete, create_backup as red_create_backup
 from redbot.core import config, data_manager, drivers
 from redbot.core.drivers import BackendType, IdentifierData
@@ -59,7 +58,9 @@ def save_config(name, data, remove=False):
                 "WARNING: An instance already exists with this name. "
                 "Continuing will overwrite the existing instance config."
             )
-            if not confirm("Are you absolutely certain you want to continue? (y/n) "):
+            if not click.confirm(
+                "Are you absolutely certain you want to continue?", default=False
+            ):
                 print("Not continuing")
                 sys.exit(0)
         _config[name] = data
@@ -100,7 +101,7 @@ def get_data_dir():
             sys.exit(1)
 
     print("You have chosen {} to be your data directory.".format(default_data_dir))
-    if not confirm("Please confirm (y/n): "):
+    if not click.confirm("Please confirm", default=True):
         print("Please start the process over.")
         sys.exit(0)
     return default_data_dir
@@ -258,18 +259,18 @@ async def edit_instance():
 
     current_data_dir = Path(_instance_data["DATA_PATH"])
     print("You have selected '{}' as the instance to modify.".format(selected))
-    if not confirm("Please confirm (y/n): "):
+    if not click.confirm("Please confirm", default=True):
         print("Ok, we will not continue then.")
         return
 
     print("Ok, we will continue on.")
     print()
-    if confirm("Would you like to change the instance name? (y/n) "):
+    if click.confirm("Would you like to change the instance name?", default=False):
         name = get_name()
     else:
         name = selected
 
-    if confirm("Would you like to change the data location? (y/n) "):
+    if click.confirm("Would you like to change the data location?", default=False):
         default_data_dir = get_data_dir()
         default_dirs["DATA_PATH"] = str(default_data_dir.resolve())
     else:
@@ -307,8 +308,8 @@ async def remove_instance(
     data_manager.load_basic_configuration(instance)
 
     if interactive is True and _create_backup is None:
-        _create_backup = confirm(
-            "Would you like to make a backup of the data for this instance? (y/n) "
+        _create_backup = click.confirm(
+            "Would you like to make a backup of the data for this instance?", default=False
         )
 
     if _create_backup is True:
@@ -323,8 +324,8 @@ async def remove_instance(
     await driver_cls.delete_all_data(interactive=interactive, drop_db=drop_db)
 
     if interactive is True and remove_datapath is None:
-        remove_datapath = confirm(
-            "Would you like to delete the instance's entire datapath? (y/n) "
+        remove_datapath = click.confirm(
+            "Would you like to delete the instance's entire datapath?", default=False
         )
 
     if remove_datapath is True:

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -395,7 +395,7 @@ def delete(
 ):
     loop = asyncio.get_event_loop()
     if no_prompt is None:
-        interactive = None
+        interactive = False
     else:
         interactive = not no_prompt
     loop.run_until_complete(remove_instance(instance, interactive, drop_db, remove_datapath))

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -387,13 +387,18 @@ def cli(ctx, debug):
         "will be asked about this."
     ),
 )
-def delete(instance: str, no_prompt: Optional[bool], drop_db: Optional[bool]):
+def delete(
+    instance: str,
+    no_prompt: Optional[bool],
+    drop_db: Optional[bool],
+    remove_datapath: Optional[bool],
+):
     loop = asyncio.get_event_loop()
     if no_prompt is None:
         interactive = None
     else:
         interactive = not no_prompt
-    loop.run_until_complete(remove_instance(instance, interactive, drop_db))
+    loop.run_until_complete(remove_instance(instance, interactive, drop_db, remove_datapath))
 
 
 @cli.command()

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -13,7 +13,7 @@ import click
 
 import redbot.logging
 from redbot.core.cli import confirm
-from redbot.core.utils import safe_delete, create_backup as _create_backup
+from redbot.core.utils import safe_delete, create_backup as red_create_backup
 from redbot.core import config, data_manager, drivers
 from redbot.core.drivers import BackendType, IdentifierData
 
@@ -290,7 +290,7 @@ async def create_backup(instance: str) -> None:
     elif backend_type != BackendType.JSON:
         await do_migration(backend_type, BackendType.JSON)
     print("Backing up the instance's data...")
-    backup_fpath = await _create_backup()
+    backup_fpath = await red_create_backup()
     if backup_fpath is not None:
         print(f"A backup of {instance} has been made. It is at {backup_fpath}")
     else:
@@ -370,6 +370,16 @@ def cli(ctx, debug):
 @click.argument("instance", type=click.Choice(instance_list))
 @click.option("--no-prompt", default=False, help="Don't ask for user input during the process.")
 @click.option(
+    "--create-backup",
+    "_create_backup",
+    type=bool,
+    default=None,
+    help=(
+        "Create backup of this instance's data. "
+        "If this option and --no-prompt are omitted, you will be asked about this."
+    ),
+)
+@click.option(
     "--drop-db",
     type=bool,
     default=None,
@@ -390,6 +400,7 @@ def cli(ctx, debug):
 def delete(
     instance: str,
     no_prompt: Optional[bool],
+    _create_backup: Optional[bool],
     drop_db: Optional[bool],
     remove_datapath: Optional[bool],
 ):
@@ -398,7 +409,9 @@ def delete(
         interactive = False
     else:
         interactive = not no_prompt
-    loop.run_until_complete(remove_instance(instance, interactive, drop_db, remove_datapath))
+    loop.run_until_complete(
+        remove_instance(instance, interactive, _create_backup, drop_db, remove_datapath)
+    )
 
 
 @cli.command()

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -59,7 +59,7 @@ def save_config(name, data, remove=False):
                 "WARNING: An instance already exists with this name. "
                 "Continuing will overwrite the existing instance config."
             )
-            if not confirm("Are you absolutely certain you want to continue (y/n)? "):
+            if not confirm("Are you absolutely certain you want to continue? (y/n) "):
                 print("Not continuing")
                 sys.exit(0)
         _config[name] = data
@@ -100,7 +100,7 @@ def get_data_dir():
             sys.exit(1)
 
     print("You have chosen {} to be your data directory.".format(default_data_dir))
-    if not confirm("Please confirm (y/n):"):
+    if not confirm("Please confirm (y/n): "):
         print("Please start the process over.")
         sys.exit(0)
     return default_data_dir
@@ -258,18 +258,18 @@ async def edit_instance():
 
     current_data_dir = Path(_instance_data["DATA_PATH"])
     print("You have selected '{}' as the instance to modify.".format(selected))
-    if not confirm("Please confirm (y/n):"):
+    if not confirm("Please confirm (y/n): "):
         print("Ok, we will not continue then.")
         return
 
     print("Ok, we will continue on.")
     print()
-    if confirm("Would you like to change the instance name? (y/n)"):
+    if confirm("Would you like to change the instance name? (y/n) "):
         name = get_name()
     else:
         name = selected
 
-    if confirm("Would you like to change the data location? (y/n)"):
+    if confirm("Would you like to change the data location? (y/n) "):
         default_data_dir = get_data_dir()
         default_dirs["DATA_PATH"] = str(default_data_dir.resolve())
     else:
@@ -300,12 +300,18 @@ async def create_backup(instance: str) -> None:
 async def remove_instance(
     instance,
     interactive: bool = False,
+    _create_backup: Optional[bool] = None,
     drop_db: Optional[bool] = None,
     remove_datapath: Optional[bool] = None,
 ):
     data_manager.load_basic_configuration(instance)
 
-    if confirm("Would you like to make a backup of the data for this instance? (y/n)"):
+    if interactive is True and _create_backup is None:
+        _create_backup = confirm(
+            "Would you like to make a backup of the data for this instance? (y/n) "
+        )
+
+    if _create_backup is True:
         await create_backup(instance)
 
     backend = get_current_backend(instance)
@@ -317,7 +323,9 @@ async def remove_instance(
     await driver_cls.delete_all_data(interactive=interactive, drop_db=drop_db)
 
     if interactive is True and remove_datapath is None:
-        remove_datapath = confirm("Would you like to delete the instance's entire datapath? (y/n)")
+        remove_datapath = confirm(
+            "Would you like to delete the instance's entire datapath? (y/n) "
+        )
 
     if remove_datapath is True:
         data_path = data_manager.core_data_path().parent


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
- ``redbot-setup delete`` no longer errors about "unexpected keyword argument" (fix #2955)
- ``redbot-setup delete`` no longer prompts about backup when user passes ``--no-prompt`` option (fix #2956)
- ``--[no-]backup``, ``--[no-]drop-db`` and ``--[no-]remove-datapath`` in ``redbot-setup delete`` command are now on/off flags. ``--no-prompt`` was changed to flag too, but it doesn't have ``--prompt`` equivalent as there's no much point in having it
- ``redbot-setup`` now uses `click.confirm` for confirmation prompts and thy now also have default values for user convenience
