### PR TITLE
[Core] Give friendly error when provided instance name doesn't exist.

### DIFF
--- a/changelog.d/2968.bugfix.rst
+++ b/changelog.d/2968.bugfix.rst
@@ -1,0 +1,1 @@
+Give friendly error when provided instance name doesn't exist.

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -91,14 +91,20 @@ def load_basic_configuration(instance_name_: str):
     try:
         with config_file.open(encoding="utf-8") as fs:
             config = json.load(fs)
-    except (FileNotFoundError, KeyError):
+    except FileNotFoundError:
         print(
             "You need to configure the bot instance using `redbot-setup`"
             " prior to running the bot."
         )
         sys.exit(1)
-    else:
+    try:
         basic_config = config[instance_name]
+    except KeyError:
+        print(
+            "Instance with this name doesn't exist."
+            " You can create new instance using `redbot-setup` prior to running the bot."
+        )
+        sys.exit(1)
 
 
 def _base_data_path() -> Path:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #2968