### PR TITLE
[Downloader] findcog no longer attempts to find cogs for commands without them

### DIFF
--- a/changelog.d/downloader/2902.bugfix.rst
+++ b/changelog.d/downloader/2902.bugfix.rst
@@ -1,0 +1,1 @@
+findcog no longer attempts to find a cog for commands without one.

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -600,6 +600,6 @@ class Downloader(commands.Cog):
                 # Assume it's in a base cog
                 msg = self.format_findcog_info(command_name, cog)
         else:
-            msg = _("This command is not provided by a cog")
+            msg = _("This command is not provided by a cog.")
 
         await ctx.send(box(msg))

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -590,12 +590,16 @@ class Downloader(commands.Cog):
             return
 
         # Check if in installed cogs
-        cog_name = self.cog_name_from_instance(command.cog)
-        installed, cog_installable = await self.is_installed(cog_name)
-        if installed:
-            msg = self.format_findcog_info(command_name, cog_installable)
+        cog = command.cog
+        if cog:
+            cog_name = self.cog_name_from_instance(cog)
+            installed, cog_installable = await self.is_installed(cog_name)
+            if installed:
+                msg = self.format_findcog_info(command_name, cog_installable)
+            else:
+                # Assume it's in a base cog
+                msg = self.format_findcog_info(command_name, cog)
         else:
-            # Assume it's in a base cog
-            msg = self.format_findcog_info(command_name, command.cog)
+            msg = _("This command is not provided by a cog")
 
         await ctx.send(box(msg))


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Fixes #2902 