### PR TITLE
Fixes the strings of `[p]set usebotcolor`

### DIFF
--- a/changelog.d/2974.bugfix.rst
+++ b/changelog.d/2974.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the help text and response of `[p]set usebotcolor` to accurately reflect what the command is doing.

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -853,14 +853,14 @@ class Core(commands.Cog, CoreLogic):
         """
         Toggle whether to use the bot owner-configured colour for embeds.
 
-        Default is to not use the bot's configured colour, in which case the
-        colour used will be the colour of the bot's top role.
+        Default is to use the bot's configured colour.
+        Otherwise, the colour used will be the colour of the bot's top role.
         """
         current_setting = await ctx.bot._config.guild(ctx.guild).use_bot_color()
         await ctx.bot._config.guild(ctx.guild).use_bot_color.set(not current_setting)
         await ctx.send(
             _("The bot {} use its configured color for embeds.").format(
-                _("will not") if current_setting else _("will")
+                _("will not") if not current_setting else _("will")
             )
         )
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Right now, the help text and response of `[p]set usebotcolor` say the opposite of what actually happens. This fixes the strings to have accurate descriptions of what they are doing.

Wording the help text was pretty hard, so I am open to suggestions on wording.