### PR TITLE
Reserves command names

### DIFF
--- a/changelog.d/2973.breaking.rst
+++ b/changelog.d/2973.breaking.rst
@@ -1,1 +1,1 @@
-Reserves some command names for internal Red use. These are available programatically as ``redbot.core.commands.RESERVED_COMMAND_QUALNAMES``
+Reserves some command names for internal Red use. These are available programatically as ``redbot.core.commands.RESERVED_COMMAND_NAMES``

--- a/changelog.d/2973.breaking.rst
+++ b/changelog.d/2973.breaking.rst
@@ -1,0 +1,1 @@
+Reserves some command names for internal Red use. These are available programatically as ``redbot.core.commands.RESERVED_COMMAND_QUALNAMES``

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -90,7 +90,7 @@ class Alias(commands.Cog):
 
     def is_command(self, alias_name: str) -> bool:
         command = self.bot.get_command(alias_name)
-        return command is not None
+        return command is not None and alias_name not in commands.RESERVED_COMMAND_QUALNAMES
 
     @staticmethod
     def is_valid_alias_name(alias_name: str) -> bool:

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -89,8 +89,12 @@ class Alias(commands.Cog):
         return False, None
 
     def is_command(self, alias_name: str) -> bool:
+        """
+        The logic here is that if this returns true, the name shouldnt be used for an alias
+        The function name can be changed when alias is reworked
+        """
         command = self.bot.get_command(alias_name)
-        return command is not None and alias_name not in commands.RESERVED_COMMAND_NAMES
+        return command is not None or alias_name in commands.RESERVED_COMMAND_NAMES
 
     @staticmethod
     def is_valid_alias_name(alias_name: str) -> bool:

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -90,7 +90,7 @@ class Alias(commands.Cog):
 
     def is_command(self, alias_name: str) -> bool:
         command = self.bot.get_command(alias_name)
-        return command is not None and alias_name not in commands.RESERVED_COMMAND_QUALNAMES
+        return command is not None and alias_name not in commands.RESERVED_COMMAND_NAMES
 
     @staticmethod
     def is_valid_alias_name(alias_name: str) -> bool:

--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -102,9 +102,10 @@ class CommandObj:
     async def create(self, ctx: commands.Context, command: str, *, response):
         """Create a custom command"""
         # Check if this command is already registered as a customcommand
-        if command in commands.RESERVED_COMMAND_NAMES or await self.db(
-            ctx.guild
-        ).commands.get_raw(command, default=None):
+        if (
+            await self.db(ctx.guild).commands.get_raw(command, default=None)
+            or command in commands.RESERVED_COMMAND_NAMES
+        ):
             raise AlreadyExists()
         # test to raise
         ctx.cog.prepare_args(response if isinstance(response, str) else response[0])

--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -102,7 +102,9 @@ class CommandObj:
     async def create(self, ctx: commands.Context, command: str, *, response):
         """Create a custom command"""
         # Check if this command is already registered as a customcommand
-        if await self.db(ctx.guild).commands.get_raw(command, default=None):
+        if command in commands.RESERVED_COMMAND_QUALNAMES or await self.db(
+            ctx.guild
+        ).commands.get_raw(command, default=None):
             raise AlreadyExists()
         # test to raise
         ctx.cog.prepare_args(response if isinstance(response, str) else response[0])

--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -102,7 +102,7 @@ class CommandObj:
     async def create(self, ctx: commands.Context, command: str, *, response):
         """Create a custom command"""
         # Check if this command is already registered as a customcommand
-        if command in commands.RESERVED_COMMAND_QUALNAMES or await self.db(
+        if command in commands.RESERVED_COMMAND_NAMES or await self.db(
             ctx.guild
         ).commands.get_raw(command, default=None):
             raise AlreadyExists()

--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -102,10 +102,7 @@ class CommandObj:
     async def create(self, ctx: commands.Context, command: str, *, response):
         """Create a custom command"""
         # Check if this command is already registered as a customcommand
-        if (
-            await self.db(ctx.guild).commands.get_raw(command, default=None)
-            or command in commands.RESERVED_COMMAND_NAMES
-        ):
+        if await self.db(ctx.guild).commands.get_raw(command, default=None):
             raise AlreadyExists()
         # test to raise
         ctx.cog.prepare_args(response if isinstance(response, str) else response[0])
@@ -224,6 +221,9 @@ class CustomCommands(commands.Cog):
 
         Note: This command is interactive.
         """
+        if command in (*self.bot.all_commands, *commands.RESERVED_COMMAND_NAMES):
+            await ctx.send(_("There already exists a bot command with the same name."))
+            return
         responses = await self.commandobj.get_responses(ctx=ctx)
         try:
             await self.commandobj.create(ctx=ctx, command=command, response=responses)
@@ -243,7 +243,7 @@ class CustomCommands(commands.Cog):
         Example:
         - `[p]customcom create simple yourcommand Text you want`
         """
-        if command in self.bot.all_commands:
+        if command in (*self.bot.all_commands, *commands.RESERVED_COMMAND_NAMES):
             await ctx.send(_("There already exists a bot command with the same name."))
             return
         try:

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -28,7 +28,13 @@ __all__ = [
     "GroupMixin",
     "command",
     "group",
+    "RESERVED_COMMAND_QUALNAMES",
 ]
+
+#: The following names are reserved for various reasons
+RESERVED_COMMAND_QUALNAMES = (
+    "cancel",  # reserved due to use in ``redbot.core.utils.MessagePredicate``
+)
 
 _ = Translator("commands.commands", __file__)
 
@@ -155,6 +161,12 @@ class Command(CogCommandMixin, commands.Command):
         super().__init__(*args, **kwargs)
         self._help_override = kwargs.pop("help_override", None)
         self.translator = kwargs.pop("i18n", None)
+        if self.parent is None:
+            for name in (self.name, *self.aliases):
+                if name in RESERVED_COMMAND_QUALNAMES:
+                    raise RuntimeError(
+                        f"The name `{name}` cannot be set as a command name. It is reserved for internal use."
+                    )
 
     def _ensure_assignment_on_copy(self, other):
         super()._ensure_assignment_on_copy(other)

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -28,11 +28,11 @@ __all__ = [
     "GroupMixin",
     "command",
     "group",
-    "RESERVED_COMMAND_QUALNAMES",
+    "RESERVED_COMMAND_NAMES",
 ]
 
 #: The following names are reserved for various reasons
-RESERVED_COMMAND_QUALNAMES = (
+RESERVED_COMMAND_NAMES = (
     "cancel",  # reserved due to use in ``redbot.core.utils.MessagePredicate``
 )
 
@@ -163,7 +163,7 @@ class Command(CogCommandMixin, commands.Command):
         self.translator = kwargs.pop("i18n", None)
         if self.parent is None:
             for name in (self.name, *self.aliases):
-                if name in RESERVED_COMMAND_QUALNAMES:
+                if name in RESERVED_COMMAND_NAMES:
                     raise RuntimeError(
                         f"The name `{name}` cannot be set as a command name. It is reserved for internal use."
                     )


### PR DESCRIPTION
 
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

Resolves #2973 

  - Currently, only reserving ``cancel``
  - This should only impact matching command names
  - This only impacts top level commands (and groups), not subcommands.
  - This also checks aliases
  - This makes cc and alias use the new module constant with info about
  this
  - Module constant is available for use by 3rd party cogs which may
  dynamically create responses.

### Notes

Adding anything to this constant should constitute a breaking change, as it may break 3rd party cogs, and can't be fixed by unloading the cog with a conflicting command (there wont be one)

The constant is exposed for programmatic use, and should not break cogs which use it for responses, but could still break if we need to reserve a name in use by a cog for non-user generated commands and/or responses.

This is used alternatively to adding no-op commands for a a few reasons.

1. No-op commands will still be shown in help, even if disabled and hidden based on user settings for help
2. No additional dispatches.
3. Prevents someone from replacing a dummy command with a real one.

The current use case for this is our use of `[p]cancel` in MessagePredicate.

This pattern should be used sparingly. Adding to this constant needs to be done with caution and thought behind why we want to add to it.