### PR TITLE
[Permissions] Possible solution for clearing out usage of commands with <who_or_what>

### DIFF
--- a/changelog.d/permissions/2991.enhance.rst
+++ b/changelog.d/permissions/2991.enhance.rst
@@ -1,0 +1,1 @@
+Clear out usage of commands with ``<who_or_what>`` argument.

--- a/redbot/cogs/permissions/permissions.py
+++ b/redbot/cogs/permissions/permissions.py
@@ -277,7 +277,9 @@ class Permissions(commands.Cog):
         await self._permissions_acl_set(ctx, guild_id=ctx.guild.id, update=True)
 
     @checks.is_owner()
-    @permissions.command(name="addglobalrule")
+    @permissions.command(
+        name="addglobalrule", usage="<allow_or_deny> <cog_or_command> <who_or_what>..."
+    )
     async def permissions_addglobalrule(
         self,
         ctx: commands.Context,
@@ -308,7 +310,11 @@ class Permissions(commands.Cog):
 
     @commands.guild_only()
     @checks.guildowner_or_permissions(administrator=True)
-    @permissions.command(name="addserverrule", aliases=["addguildrule"])
+    @permissions.command(
+        name="addserverrule",
+        usage="<allow_or_deny> <cog_or_command> <who_or_what>...",
+        aliases=["addguildrule"],
+    )
     async def permissions_addguildrule(
         self,
         ctx: commands.Context,
@@ -338,7 +344,7 @@ class Permissions(commands.Cog):
         await ctx.send(_("Rule added."))
 
     @checks.is_owner()
-    @permissions.command(name="removeglobalrule")
+    @permissions.command(name="removeglobalrule", usage="<cog_or_command> <who_or_what>...")
     async def permissions_removeglobalrule(
         self,
         ctx: commands.Context,
@@ -361,7 +367,9 @@ class Permissions(commands.Cog):
 
     @commands.guild_only()
     @checks.guildowner_or_permissions(administrator=True)
-    @permissions.command(name="removeserverrule", aliases=["removeguildrule"])
+    @permissions.command(
+        name="removeserverrule", usage="<cog_or_command> <who_or_what>...", aliases=["removeguildrule"]
+    )
     async def permissions_removeguildrule(
         self,
         ctx: commands.Context,

--- a/redbot/cogs/permissions/permissions.py
+++ b/redbot/cogs/permissions/permissions.py
@@ -368,7 +368,9 @@ class Permissions(commands.Cog):
     @commands.guild_only()
     @checks.guildowner_or_permissions(administrator=True)
     @permissions.command(
-        name="removeserverrule", usage="<cog_or_command> <who_or_what>...", aliases=["removeguildrule"]
+        name="removeserverrule",
+        usage="<cog_or_command> <who_or_what>...",
+        aliases=["removeguildrule"],
     )
     async def permissions_removeguildrule(
         self,


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #2991 assuming it really needs solving, d.py doesn't offer way to indicate that the command accept one or more arguments instead of zero or more.