### PR TITLE
[Trivia] Greek Myth: Caduceus Typo

### DIFF
--- a/changelog.d/trivia/2994.bugfix.rst
+++ b/changelog.d/trivia/2994.bugfix.rst
@@ -1,0 +1,1 @@
+Fix typo in the Greek mythology trivia regarding Hermes' staff

--- a/redbot/cogs/trivia/data/lists/greekmyth.yaml
+++ b/redbot/cogs/trivia/data/lists/greekmyth.yaml
@@ -55,7 +55,7 @@ Which god is associated with prophecy?:
 - Apollo
 Which god is associated with the anvil?:
 - Hephaestus
-Which god is associated with the cadaceus?:
+Which god is associated with the caduceus?:
 - Hermes
 Which god is associated with the dolphin?:
 - Poseidon


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Very minor typo I spotted whilst playing. Actual word: https://en.wikipedia.org/wiki/Caduceus