### PR TITLE
[Docs] Link directly to installing Red from installing requirements using chocolatey section

### DIFF
--- a/changelog.d/2995.docs.rst
+++ b/changelog.d/2995.docs.rst
@@ -1,0 +1,1 @@
+Add direct link to "Installing Red" section in "Installing using powershell and chocolatey"

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -29,6 +29,7 @@ Then run each of the following commands:
     choco install git --params "/GitOnlyOnPath /WindowsTerminal" -y
     choco install jre8 python -y; exit
 
+From here, continue onto `installing Red <installing-red-windows>`.
 
 ********************************
 Manually installing dependencies


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Add direct link to "Installing Red" section in "Installing using powershell and chocolatey" as people using chocolatey don't need to manually install dependencies