### PR TITLE
[Trivia] Overwatch - Remove a blank answer

### DIFF
--- a/changelog.d/trivia/2996.bugfix.rst
+++ b/changelog.d/trivia/2996.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a question in Overwatch accepting blank responses.

--- a/redbot/cogs/trivia/data/lists/overwatch.yaml
+++ b/redbot/cogs/trivia/data/lists/overwatch.yaml
@@ -395,7 +395,6 @@ What is the name of D.Va's "Cute Spray" achievement?:
 What is the name of D.Va's default voice line?:
 - Love, D.Va
 - love d.va
-- ""
 What is the name of Genji's default voice line?:
 - A Steady blade
 What is the name of Hanzo's default voice line?:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Removes an answer that accepts a blank input. Such an input can be provided by posting an image with no text.