### PR TITLE
[Docs] Git Install Updates, note about launcher deprecation, capitalise some words

### DIFF
--- a/changelog.d/2998.docs.rst
+++ b/changelog.d/2998.docs.rst
@@ -1,1 +1,1 @@
-Update Git PATH install (Windows) and capitalise some words
+Update Git PATH install (Windows), capitalise some words, don't mention to launcher

--- a/changelog.d/2998.docs.rst
+++ b/changelog.d/2998.docs.rst
@@ -1,0 +1,1 @@
+Update Git PATH install (Windows) and capitalise some words

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -318,8 +318,9 @@ You can find out how to obtain a token with
 section "Creating a Bot Account".
 
 You may also run Red via the launcher, which allows you to restart the bot
-from discord, and enable auto-restart. You may also update the bot from the
-launcher menu. Use the following command to run the launcher:
+from discord, and enable auto-restart. Please note the launcher will be
+deprecated soon. You may also update the bot from the launcher menu. Use
+the following command to run the launcher:
 
 .. code-block:: none
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -316,13 +316,3 @@ It will walk through the initial setup, asking for your token and a prefix.
 You can find out how to obtain a token with
 `this guide <https://discordpy.readthedocs.io/en/v1.0.1/discord.html#creating-a-bot-account>`_,
 section "Creating a Bot Account".
-
-You may also run Red via the launcher, which allows you to restart the bot
-from discord, and enable auto-restart. Please note the launcher will be
-deprecated soon. You may also update the bot from the launcher menu. Use
-the following command to run the launcher:
-
-.. code-block:: none
-
-    redbot-launcher
-

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -18,8 +18,8 @@ Please install the pre-requirements using the commands listed for your operating
 
 The pre-requirements are:
  - Python 3.7.0 or greater
- - pip 9.0 or greater
- - git
+ - Pip 9.0 or greater
+ - Git
  - Java Runtime Environment 8 or later (for audio support)
 
 We also recommend installing some basic compiler tools, in case our dependencies don't provide

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -120,12 +120,3 @@ It will walk through the initial setup, asking for your token and a prefix.
 You can find out how to obtain a token with
 `this guide <https://discordpy.readthedocs.io/en/v1.0.1/discord.html#creating-a-bot-account>`_,
 section "Creating a Bot Account".
-
-You may also run Red via the launcher, which allows you to restart the bot
-from discord, and enable auto-restart. Please note the launcher will be
-deprecated soon. You may also update the bot from the launcher menu. Use
-the following command to run the launcher:
-
-.. code-block:: none
-
-    redbot-launcher

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -8,8 +8,8 @@ Installing Red on Windows
 Needed Software
 ---------------
 
-The following software dependencies can all be installed quickly and easily through powershell,
-using a trusted package manager for windows called `Chocolatey <https://chocolatey.org>`_
+The following software dependencies can all be installed quickly and easily through PowerShell,
+using a trusted package manager for Windows called `Chocolatey <https://chocolatey.org>`_
 
 We also provide instructions for manually installing all of the dependencies.
 
@@ -17,7 +17,7 @@ We also provide instructions for manually installing all of the dependencies.
 Installing using powershell and chocolatey
 ******************************************
 
-To install via powershell, search "powershell" in the windows start menu,
+To install via PowerShell, search "powershell" in the Windows start menu,
 right-click on it and then click "Run as administrator"
 
 Then run each of the following commands:
@@ -41,7 +41,7 @@ Manually installing dependencies
 
 * `Git <https://git-scm.com/download/win>`_
 
-.. attention:: Please choose the option to "Run Git from the Windows Command Prompt" in Git's setup.
+.. attention:: Please choose the option to "Git from the command line and also from 3rd-party software" in Git's setup.
 
 * `Java <https://java.com/en/download/manual.jsp>`_ - needed for Audio
 
@@ -122,8 +122,9 @@ You can find out how to obtain a token with
 section "Creating a Bot Account".
 
 You may also run Red via the launcher, which allows you to restart the bot
-from discord, and enable auto-restart. You may also update the bot from the
-launcher menu. Use the following command to run the launcher:
+from discord, and enable auto-restart. Please note the launcher will be
+deprecated soon. You may also update the bot from the launcher menu. Use
+the following command to run the launcher:
 
 .. code-block:: none
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Git updated the title they gave to the add to PATH option during setup for Windows from "Run Git from the Windows Command Prompt" to "Git from the command line and also from 3rd-party software", as we found out in [#support](https://discordapp.com/channels/133049272517001216/387398816317440000/622096446333911061). I have also checked this is correct.
This PR also corrects some capitalisation and a note about launcher deprecation.