### PR TITLE
Remove a specific f-string usage in the launcher.

### DIFF
--- a/changelog.d/3002.bugfix.rst
+++ b/changelog.d/3002.bugfix.rst
@@ -1,0 +1,1 @@
+remove f-string usage in launcher to prevent our error handling from cauing an error.

--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -451,8 +451,7 @@ def main():
     if not PYTHON_OK:
         print(
             "Python {req_ver} is required to run Red, but you have {sys_ver}!".format(
-                req_ver='.'.join(map(str, MIN_PYTHON_VERSION)),
-                sys_ver=sys.version,
+                req_ver=".".join(map(str, MIN_PYTHON_VERSION)), sys_ver=sys.version
             )
         )  # Don't make an f-string, these may not exist on the python version being rejected!
         sys.exit(1)

--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -450,9 +450,11 @@ def main():
     args, flags_to_pass = parse_cli_args()
     if not PYTHON_OK:
         print(
-            f"Python {'.'.join(map(str, MIN_PYTHON_VERSION))} is required to run Red, but you "
-            f"have {sys.version}! Please update Python."
-        )
+            "Python {req_ver} is required to run Red, but you have {sys_ver}!".format(
+                req_ver='.'.join(map(str, MIN_PYTHON_VERSION)),
+                sys_ver=sys.version,
+            )
+        )  # Don't make an f-string, these may not exist on the python version being rejected!
         sys.exit(1)
     if args.debuginfo:  # Check first since the function triggers an exit
         debug_info()


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Small fix to the launcher logic. There's actually a place where we have an f-string and it can break in the exact way we should expect looking at the condition