### PR TITLE
Replaces more `.db` -> `._config`

### DIFF
--- a/changelog.d/3003.misc.rst
+++ b/changelog.d/3003.misc.rst
@@ -1,0 +1,1 @@
+Replaced two instances of .db -> ._config in the interactive config that were missed due to being called red.db rather than bot.db. 

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -21,7 +21,7 @@ def interactive_config(red, token_set, prefix_set):
                 print("That doesn't look like a valid token.")
                 token = ""
             if token:
-                loop.run_until_complete(red.db.token.set(token))
+                loop.run_until_complete(red._config.token.set(token))
 
     if not prefix_set:
         prefix = ""
@@ -39,7 +39,7 @@ def interactive_config(red, token_set, prefix_set):
                 if not confirm("> "):
                     prefix = ""
             if prefix:
-                loop.run_until_complete(red.db.prefix.set([prefix]))
+                loop.run_until_complete(red._config.prefix.set([prefix]))
 
     return token
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Two `.db` -> `._config`s were missed because they are called `red.db` rather than `bot.db`. This PR replaces them accordingly.