### PR TITLE
Fixes the logic of MessagePredicate.greater and MessagePredicate.less

### DIFF
--- a/changelog.d/3004.bugfix.rst
+++ b/changelog.d/3004.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed MessagePredicate.greater and MessagePredicate.less allowing any valid int instead of only valid ints/floats that are greater/less than the given value.

--- a/redbot/core/utils/predicates.py
+++ b/redbot/core/utils/predicates.py
@@ -574,7 +574,7 @@ class MessagePredicate(Callable[[discord.Message], bool]):
         """
         valid_int = cls.valid_int(ctx, channel, user)
         valid_float = cls.valid_float(ctx, channel, user)
-        return cls(lambda self, m: valid_int(m) or valid_float(m) and float(m.content) < value)
+        return cls(lambda self, m: (valid_int(m) or valid_float(m)) and float(m.content) < value)
 
     @classmethod
     def greater(
@@ -605,7 +605,7 @@ class MessagePredicate(Callable[[discord.Message], bool]):
         """
         valid_int = cls.valid_int(ctx, channel, user)
         valid_float = cls.valid_float(ctx, channel, user)
-        return cls(lambda self, m: valid_int(m) or valid_float(m) and float(m.content) > value)
+        return cls(lambda self, m: (valid_int(m) or valid_float(m)) and float(m.content) > value)
 
     @classmethod
     def length_less(


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Currently, any valid int will cause `MessagePredicate.greater` and `MessagePredicate.less` to pass due to some incorrect boolean logic. `bool or bool and bool` is interpreted as `bool or (bool and bool)`, which causes the statement `valid_int(m) or valid_float(m) and float(m.content) > value` to allow any valid int to be accepted. This PR adds explicit parenthesis to ensure that only values greater or less than the given value are accepted.