### PR TITLE
[Core] Search for a cog in core cogs path first

### DIFF
--- a/changelog.d/3011.bugfix.rst
+++ b/changelog.d/3011.bugfix.rst
@@ -1,0 +1,1 @@
+Search for a cog in core cogs path first

--- a/redbot/core/cog_manager.py
+++ b/redbot/core/cog_manager.py
@@ -280,10 +280,10 @@ class CogManager:
 
         """
         with contextlib.suppress(NoSuchCog):
-            return await self._find_ext_cog(name)
+            return await self._find_core_cog(name)
 
         with contextlib.suppress(NoSuchCog):
-            return await self._find_core_cog(name)
+            return await self._find_ext_cog(name)
 
     async def available_modules(self) -> List[str]:
         """Finds the names of all available modules to load."""


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Seems to make more sense to prevent shadowing core cogs by the ones in external cog paths.