### PR TITLE
Quotes in helpset tagline for clarity

### DIFF
--- a/changelog.d/3010.bugfix.rst
+++ b/changelog.d/3010.bugfix.rst
@@ -1,0 +1,1 @@
+Add quotation marks to helpset tagline's response so two consecutive full stops don't appear

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1289,7 +1289,7 @@ class Core(commands.Cog, CoreLogic):
             return
 
         await ctx.bot._config.help.tagline.set(tagline)
-        await ctx.send(_("The tagline has been set to {}.").format(tagline[:1900]))
+        await ctx.send(_("The tagline has been set to "{}".").format(tagline[:1900]))
 
     @commands.command()
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1289,7 +1289,7 @@ class Core(commands.Cog, CoreLogic):
             return
 
         await ctx.bot._config.help.tagline.set(tagline)
-        await ctx.send(_('The tagline has been set to "{}".').format(tagline[:1900]))
+        await ctx.send(_("The tagline has been set."))
 
     @commands.command()
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1289,7 +1289,7 @@ class Core(commands.Cog, CoreLogic):
             return
 
         await ctx.bot._config.help.tagline.set(tagline)
-        await ctx.send(_("The tagline has been set to \"{}\".").format(tagline[:1900]))
+        await ctx.send(_('The tagline has been set to "{}".').format(tagline[:1900]))
 
     @commands.command()
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1289,7 +1289,7 @@ class Core(commands.Cog, CoreLogic):
             return
 
         await ctx.bot._config.help.tagline.set(tagline)
-        await ctx.send(_("The tagline has been set to "{}".").format(tagline[:1900]))
+        await ctx.send(_("The tagline has been set to \"{}\".").format(tagline[:1900]))
 
     @commands.command()
     @checks.is_owner()


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Add quotation marks to helpset tagline's response so two consecutive full stops don't appear. This will prevent Red replying
> I'm a wonderful tagline!.

which may create confusion over as to whether a full stop was automatically inserted. Instead, this PR makes it
> The tagline has been set to "I'm a wonderful tagline!".

### Possible alterations
> The tagline has been set to `I'm a wonderful tagline!`.

> The tagline has been set to: I'm a wonderful tagline!