### PR TITLE
Prevent error on empty install message.

### DIFF
--- a/changelog.d/3024.bugfix.rst
+++ b/changelog.d/3024.bugfix.rst
@@ -1,0 +1,1 @@
+cog install will no longer error if a cog creator has an empty install message

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -345,7 +345,7 @@ class Downloader(commands.Cog):
                 "Cog `{cog_name}` successfully installed. You can load it with `{prefix}load {cog_name}`"
             ).format(cog_name=cog_name, prefix=ctx.prefix)
         )
-        if cog.install_msg is not None:
+        if cog.install_msg:
             await ctx.send(cog.install_msg.replace("[p]", ctx.prefix))
 
     @cog.command(name="uninstall", usage="<cogs>")


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Prevents an error on installing cogs with an empty but not null install message in info.json