### PR TITLE
Print quickstart guide at the end of `redbot-setup`

### DIFF
--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -181,7 +181,9 @@ def basic_setup():
     print()
     print(
         "Your basic configuration has been saved. Please run `redbot <name>` to"
-        " continue your setup process and to run the bot."
+        " continue your setup process and to run the bot.\n\n"
+        "First time? Read the quickstart guide:\n"
+        "https://docs.discord.red/en/latest/getting_started.html"
     )
 
 

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -183,7 +183,7 @@ def basic_setup():
         "Your basic configuration has been saved. Please run `redbot <name>` to"
         " continue your setup process and to run the bot.\n\n"
         "First time? Read the quickstart guide:\n"
-        "https://docs.discord.red/en/latest/getting_started.html"
+        "https://docs.discord.red/en/stable/getting_started.html"
     )
 
 


### PR DESCRIPTION
- [x] Enhancement

Just prints the link to the recently added [quickstart guide](https://docs.discord.red/en/latest/getting_started.html).

Edit: This does not resolve the linked issue. ~~ @Kowlin 