### PR TITLE
Add autostart documentation for venv users

### DIFF
--- a/changelog.d/3005.docs.rst
+++ b/changelog.d/3005.docs.rst
@@ -1,0 +1,1 @@
+Adds autostart documentation for Red users who installed it inside a virtual environment.

--- a/docs/autostart_systemd.rst
+++ b/docs/autostart_systemd.rst
@@ -8,11 +8,23 @@ Setting up auto-restart using systemd on Linux
 Creating the service file
 -------------------------
 
-Create the new service file:
+In order to create the service file, you will first need the location of your :code:`redbot` binary.
+
+.. code-block:: bash
+
+    # If redbot is installed in a virtualenv
+    source path/to/venv/bin/activate
+
+    # If you are using pyenv
+    pyenv shell <name>
+
+    which redbot
+
+Then create the new service file:
 
 :code:`sudo -e /etc/systemd/system/red@.service`
 
-Paste the following and replace all instances of :code:`username` with the username your bot is running under (hopefully not root):
+Paste the following and replace all instances of :code:`username` with the username, and :code:`path` with the location you obtained above:
 
 .. code-block:: none
 
@@ -21,7 +33,7 @@ Paste the following and replace all instances of :code:`username` with the usern
     After=multi-user.target
 
     [Service]
-    ExecStart=/home/username/.local/bin/redbot %I --no-prompt
+    ExecStart=path %I --no-prompt
     User=username
     Group=username
     Type=idle

--- a/docs/autostart_systemd.rst
+++ b/docs/autostart_systemd.rst
@@ -13,7 +13,7 @@ In order to create the service file, you will first need the location of your :c
 .. code-block:: bash
 
     # If redbot is installed in a virtualenv
-    source path/to/venv/bin/activate
+    source redenv/bin/activate
 
     # If you are using pyenv
     pyenv shell <name>


### PR DESCRIPTION
Resolves #3005

- [x] Enhancement

Adds autostart documentation for Red users who installed it inside a virtual environment.