### PR TITLE
[Downloader] Catch OSErrors from invalid repo names

### DIFF
--- a/changelog.d/downloader/2827.bugfix.rst
+++ b/changelog.d/downloader/2827.bugfix.rst
@@ -1,1 +1,1 @@
-Invalid repo names no longer cause an error.
+Repo names can now only contain the characters listed in the help text (A-Z, 0-9, underscores, and hyphens).

--- a/changelog.d/downloader/2827.bugfix.rst
+++ b/changelog.d/downloader/2827.bugfix.rst
@@ -1,1 +1,1 @@
-Repo names can now only contain the characters listed in the help text (A-Z, 0-9, and underscores).
+Invalid repo names no longer cause an error.

--- a/changelog.d/downloader/2827.bugfix.rst
+++ b/changelog.d/downloader/2827.bugfix.rst
@@ -1,0 +1,1 @@
+Repo names can now only contain the characters listed in the help text (A-Z, 0-9, and underscores).

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -222,11 +223,16 @@ class Downloader(commands.Cog):
     async def _repo_add(self, ctx, name: str, repo_url: str, branch: str = None):
         """Add a new repo.
 
-        We recommend using only A-z, numbers and underscores in the repo name for compatibility.
+        Repo names can only contain characters A-z, numbers, underscores, and hyphens.
         The branch will be the default branch if not specified.
         """
         agreed = await do_install_agreement(ctx)
         if not agreed:
+            return
+        if re.match("^[a-zA-Z0-9_\-]*$", name) is None:
+            await ctx.send(
+                _("Repo names can only contain characters A-z, numbers, underscores, and hyphens.")
+            )
             return
         try:
             # noinspection PyTypeChecker

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -227,6 +228,11 @@ class Downloader(commands.Cog):
         """
         agreed = await do_install_agreement(ctx)
         if not agreed:
+            return
+        if re.match("^[a-zA-Z0-9_]*$", name) is None:
+            await ctx.send(
+                _("Repo names can only contain characters A-z, numbers and underscores.")
+            )
             return
         try:
             # noinspection PyTypeChecker

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -243,7 +243,9 @@ class Downloader(commands.Cog):
             )
         except OSError:
             await ctx.send(
-                _("Something went wrong trying to add that repo. Your repo name might have an invalid character.")
+                _(
+                    "Something went wrong trying to add that repo. Your repo name might have an invalid character."
+                )
             )
         else:
             await ctx.send(_("Repo `{name}` successfully added.").format(name=name))

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1,7 +1,6 @@
 import asyncio
 import contextlib
 import os
-import re
 import shutil
 import sys
 from pathlib import Path
@@ -223,16 +222,11 @@ class Downloader(commands.Cog):
     async def _repo_add(self, ctx, name: str, repo_url: str, branch: str = None):
         """Add a new repo.
 
-        The name can only contain characters A-z, numbers and underscores.
+        We recommend using only A-z, numbers and underscores in the repo name for compatibility.
         The branch will be the default branch if not specified.
         """
         agreed = await do_install_agreement(ctx)
         if not agreed:
-            return
-        if re.match("^[a-zA-Z0-9_]*$", name) is None:
-            await ctx.send(
-                _("Repo names can only contain characters A-z, numbers and underscores.")
-            )
             return
         try:
             # noinspection PyTypeChecker
@@ -246,6 +240,10 @@ class Downloader(commands.Cog):
                 repo_url,
                 branch,
                 exc_info=err,
+            )
+        except OSError:
+            await ctx.send(
+                _("Something went wrong trying to add that repo. Your repo name might have an invalid character.")
             )
         else:
             await ctx.send(_("Repo `{name}` successfully added.").format(name=name))


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
~~Prevents repo names from containing anything except for a-z, 0-9, and underscores.
This fix might need to happen at a lower level, this PR only addresses the command `[p]repo add`~~
~~Catches OSErrors from invalid repo names, pretty much only on Windows. Also recommends users only use safe characters in the docstring.~~
Prevents repo names from containing anything except for a-z, 0-9, underscores, and hyphens.

Fixes #2999, Fixes #2827