### PR TITLE
[Docs] Fix driver docs showing twice

### DIFF
--- a/changelog.d/2972.docs.rst
+++ b/changelog.d/2972.docs.rst
@@ -1,0 +1,1 @@
+Driver docs no longer show twice.

--- a/changelog.d/3035.docs.rst
+++ b/changelog.d/3035.docs.rst
@@ -1,0 +1,1 @@
+Add proper docstrings to enums that show in drivers docs.

--- a/docs/framework_config.rst
+++ b/docs/framework_config.rst
@@ -416,7 +416,12 @@ Value
 Driver Reference
 ****************
 
-.. automodule:: redbot.core.drivers
+.. autofunction:: redbot.core.drivers.get_driver
+
+.. autoclass:: redbot.core.drivers.BackendType
+    :members:
+
+.. autoclass:: redbot.core.drivers.ConfigCategory
     :members:
 
 Base Driver
@@ -429,3 +434,7 @@ JSON Driver
 .. autoclass:: redbot.core.drivers.JsonDriver
     :members:
 
+Postgres Driver
+^^^^^^^^^^^^^^^
+.. autoclass:: redbot.core.drivers.PostgresDriver
+    :members:

--- a/redbot/core/drivers/__init__.py
+++ b/redbot/core/drivers/__init__.py
@@ -18,9 +18,13 @@ __all__ = [
 
 
 class BackendType(enum.Enum):
+    """Represents storage backend type."""
+
+    #: JSON storage backend.
     JSON = "JSON"
+    #: Postgres storage backend.
     POSTGRES = "Postgres"
-    # Dead drivrs below retained for error handling.
+    # Dead drivers below retained for error handling.
     MONGOV1 = "MongoDB"
     MONGO = "MongoDBV2"
 

--- a/redbot/core/drivers/base.py
+++ b/redbot/core/drivers/base.py
@@ -6,11 +6,19 @@ __all__ = ["BaseDriver", "IdentifierData", "ConfigCategory"]
 
 
 class ConfigCategory(str, enum.Enum):
+    """Represents config category."""
+
+    #: Global category.
     GLOBAL = "GLOBAL"
+    #: Guild category.
     GUILD = "GUILD"
+    #: Channel category.
     CHANNEL = "TEXTCHANNEL"
+    #: Role category.
     ROLE = "ROLE"
+    #: User category.
     USER = "USER"
+    #: Member category.
     MEMBER = "MEMBER"
 
     @classmethod


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #2972 + improves how `BackendType` and `ConfigCategory` enumerations. If them showing in docs is unintended, let me know and I'll just hide those and revert changes to docstrings.

You can see updated docs here: https://jack1142-red-prs.readthedocs.io/en/v3-issue_2972/framework_config.html#driver-reference