### PR TITLE
[Streams] Fix TypeError in TwitchStream class and change stream_alert function for Twitch

### DIFF
--- a/changelog.d/streams/3042.bugfix.rst
+++ b/changelog.d/streams/3042.bugfix.rst
@@ -1,1 +1,1 @@
-Fix a TypeError in TwitchStream class when calling Twitch client_id from Red shared APIs tokens.
+Fix a TypeError in TwitchStream class when calling Twitch client_id from Red shared APIs tokens and also changed the stream_alert function for Twitch alerts to make it works with how TwitchStream class works now.

--- a/changelog.d/streams/3042.bugfix.rst
+++ b/changelog.d/streams/3042.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a TypeError in TwitchStream class when calling Twitch client_id from Red shared APIs tokens.

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -275,8 +275,11 @@ class Streams(commands.Cog):
         if not stream:
             token = await self.bot.get_shared_api_tokens(_class.token_name)
             is_yt = _class.__name__ == "YoutubeStream"
+            is_twitch = _class.__name__ == "TwitchStream"
             if is_yt and not self.check_name_or_id(channel_name):
                 stream = _class(id=channel_name, token=token)
+            elif is_twitch:
+                stream = _class(name=channel_name, token=token.get("client_id"))
             else:
                 stream = _class(name=channel_name, token=token)
             try:

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -163,7 +163,7 @@ class TwitchStream(Stream):
 
         url = TWITCH_STREAMS_ENDPOINT + self.id
         header = {
-            "Client-ID": str(self._token["client_id"]),
+            "Client-ID": str(self._token),
             "Accept": "application/vnd.twitchtv.v5+json",
         }
 
@@ -188,7 +188,7 @@ class TwitchStream(Stream):
 
     async def fetch_id(self):
         header = {
-            "Client-ID": str(self._token["client_id"]),
+            "Client-ID": str(self._token),
             "Accept": "application/vnd.twitchtv.v5+json",
         }
         url = TWITCH_ID_ENDPOINT + self.name

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -162,10 +162,7 @@ class TwitchStream(Stream):
             self.id = await self.fetch_id()
 
         url = TWITCH_STREAMS_ENDPOINT + self.id
-        header = {
-            "Client-ID": str(self._token),
-            "Accept": "application/vnd.twitchtv.v5+json",
-        }
+        header = {"Client-ID": str(self._token), "Accept": "application/vnd.twitchtv.v5+json"}
 
         async with aiohttp.ClientSession() as session:
             async with session.get(url, headers=header) as r:
@@ -187,10 +184,7 @@ class TwitchStream(Stream):
             raise APIError()
 
     async def fetch_id(self):
-        header = {
-            "Client-ID": str(self._token),
-            "Accept": "application/vnd.twitchtv.v5+json",
-        }
+        header = {"Client-ID": str(self._token), "Accept": "application/vnd.twitchtv.v5+json"}
         url = TWITCH_ID_ENDPOINT + self.name
 
         async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This PR fix a TypeError in TwitchStream class when calling Twitch client_id from Red shared APIs tokens and also changed the stream_alert function for Twitch alerts to make it works with how TwitchStream class works now.