### PR TITLE
Audio playlist capitalisation changes

### DIFF
--- a/changelog.d/audio/3047.bugfix.rst
+++ b/changelog.d/audio/3047.bugfix.rst
@@ -1,1 +1,1 @@
-Unify capitalisation in `help playlist`
+Unify capitalisation in `[p]help playlist`.

--- a/changelog.d/audio/3047.bugfix.rst
+++ b/changelog.d/audio/3047.bugfix.rst
@@ -1,0 +1,1 @@
+Unify capitalisation in `help playlist`

--- a/changelog.d/audio/3047.bugfix.rst
+++ b/changelog.d/audio/3047.bugfix.rst
@@ -1,1 +1,0 @@
-Unify capitalisation in `[p]help playlist`.

--- a/changelog.d/audio/3048.bugfix.rst
+++ b/changelog.d/audio/3048.bugfix.rst
@@ -1,0 +1,1 @@
+Unify capitalisation in ``[p]help playlist``.

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -3266,8 +3266,8 @@ class Audio(commands.Cog):
         ​ ​ ​ ​ ​ ​ ​ ​ Only editable by bot owner.
         ​ ​ ​ ​ **Guild**:
         ​ ​ ​ ​ ​ ​ ​ ​ Visible to all users in this guild.
-        ​ ​ ​ ​ ​ ​ ​ ​ Editable By Bot Owner, Guild Owner, Guild Admins,
-        ​ ​ ​ ​ ​ ​ ​ ​ Guild Mods, DJ Role and playlist creator.
+        ​ ​ ​ ​ ​ ​ ​ ​ Editable by bot owner, guild owner, guild admins,
+        ​ ​ ​ ​ ​ ​ ​ ​ guild mods, DJ role and playlist creator.
         ​ ​ ​ ​ **User**:
         ​ ​ ​ ​ ​ ​ ​ ​ Visible to all bot users, if --author is passed.
         ​ ​ ​ ​ ​ ​ ​ ​ Editable by bot owner and creator.


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Make all the people be lower case in `[p]help playlist`
This fits in with other commands in audio.