### PR TITLE
Makes bot.send_filtered return the message that is sent

### DIFF
--- a/changelog.d/3052.enhance.rst
+++ b/changelog.d/3052.enhance.rst
@@ -1,0 +1,1 @@
+``bot.send_filtered`` now returns the message that is sent.

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -690,6 +690,10 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
         This should realistically only be used for responding using user provided
         input. (unfortunately, including usernames)
         Manually crafted messages which dont take any user input have no need of this
+        
+        Returns
+        -------
+        discord.Message
         """
 
         content = kwargs.pop("content", None)
@@ -702,7 +706,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
             if filter_all_links:
                 content = common_filters.filter_urls(content)
 
-        await destination.send(content=content, **kwargs)
+        return await destination.send(content=content, **kwargs)
 
     def add_cog(self, cog: commands.Cog):
         if not isinstance(cog, commands.Cog):

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -694,6 +694,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
         Returns
         -------
         discord.Message
+            The message that was sent.
         """
 
         content = kwargs.pop("content", None)


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Most messageables (`ctx.send`, `channel.send`) return the sent message for convenience. This PR makes `bot.send_filtered` follow this behavior.