### PR TITLE
[Docs] Add missing descriptions for function returns

### DIFF
--- a/changelog.d/3054.docs.rst
+++ b/changelog.d/3054.docs.rst
@@ -1,0 +1,1 @@
+Add missing descriptions for function returns.

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -612,7 +612,7 @@ class RepoManager:
         Returns
         -------
         `tuple` of `str`
-
+            Repo names.
         """
         # noinspection PyTypeChecker
         return tuple(self._repos.keys())

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -287,7 +287,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
         ----------
         guild : Optional[discord.Guild]
             The guild you want prefixes for. Omit (or pass None) for the DM prefixes
-        
+
         Returns
         -------
         List[str]
@@ -303,10 +303,12 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
         Parameters
         ----------
         location : `discord.abc.Messageable`
-
+            Location to check embed color for.
+        
         Returns
         -------
         discord.Color
+            Embed color for the provided location.
         """
 
         guild = getattr(location, "guild", None)
@@ -493,6 +495,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
         Parameters
         ----------
         service_name: str
+            The service to get tokens for.
 
         Returns
         -------

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -1275,6 +1275,7 @@ class Config:
         Returns
         -------
         asyncio.Lock
+            A lock for all guild data.
         """
         return self.get_custom_lock(self.GUILD)
 
@@ -1284,6 +1285,7 @@ class Config:
         Returns
         -------
         asyncio.Lock
+            A lock for all channels data.
         """
         return self.get_custom_lock(self.CHANNEL)
 
@@ -1293,6 +1295,7 @@ class Config:
         Returns
         -------
         asyncio.Lock
+            A lock for all roles data.
         """
         return self.get_custom_lock(self.ROLE)
 
@@ -1302,6 +1305,7 @@ class Config:
         Returns
         -------
         asyncio.Lock
+            A lock for all user data.
         """
         return self.get_custom_lock(self.USER)
 
@@ -1317,6 +1321,9 @@ class Config:
         Returns
         -------
         asyncio.Lock
+            A lock for all member data for the given guild.
+            If ``guild`` is omitted this will give a lock
+            for all data for all members in all guilds.
         """
         if guild is None:
             return self.get_custom_lock(self.GUILD)
@@ -1342,6 +1349,7 @@ class Config:
         Returns
         -------
         asyncio.Lock
+            A lock for all data in a custom scope with given group identifier.
         """
         try:
             pkey_len, is_custom = ConfigCategory.get_pkey_info(

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -214,6 +214,7 @@ def storage_type() -> str:
     Returns
     -------
     str
+        Storage type.
     """
     try:
         return basic_config["STORAGE_TYPE"]
@@ -229,5 +230,6 @@ def storage_details() -> dict:
     Returns
     -------
     dict
+        Storage details.
     """
     return basic_config.get("STORAGE_DETAILS", {})

--- a/redbot/core/drivers/mongo.py
+++ b/redbot/core/drivers/mongo.py
@@ -113,6 +113,7 @@ class MongoDriver(BaseDriver):
         attributes of :py:class:`core.config.Config`.
 
         :param str category:
+            The group identifier of a category.
         :return:
             PyMongo collection object.
         """

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -561,7 +561,7 @@ class CaseType:
         Returns
         -------
         CaseType
-
+            The case type object created from given data.
         """
         data_copy = data.copy()
         data_copy.pop("name", None)
@@ -808,6 +808,7 @@ async def get_casetype(name: str, guild: Optional[discord.Guild] = None) -> Opti
     Returns
     -------
     Optional[CaseType]
+        Case type with provided name. If such case type doesn't exist this will be `None`.
     """
     data = await _conf.custom(_CASETYPES, name).all()
     if not data:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
I think it makes sense to have description for function returns everywhere in docs + for some reason sphinx decides to generate "Returns: " field when there's only function return type anyway.
I used grep to help myself out so every function should now have description for return 👍 