### PR TITLE
[Core] Fix error message about guild-only command and add dm-only error message

### DIFF
--- a/changelog.d/3057.bugfix.rst
+++ b/changelog.d/3057.bugfix.rst
@@ -1,0 +1,1 @@
+Bot will now properly send a message when the invoked command is guild-only.

--- a/changelog.d/3057.enhance.rst
+++ b/changelog.d/3057.enhance.rst
@@ -1,0 +1,1 @@
+Bot will now send a message when the invoked command is DM-only.

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -234,10 +234,12 @@ def init_events(bot, cli_flags):
         elif isinstance(error, commands.UserFeedbackCheckFailure):
             if error.message:
                 await ctx.send(error.message)
-        elif isinstance(error, commands.CheckFailure):
-            pass
         elif isinstance(error, commands.NoPrivateMessage):
             await ctx.send("That command is not available in DMs.")
+        elif isinstance(error, commands.PrivateMessageOnly):
+            await ctx.send("That command is only available in DMs.")
+        elif isinstance(error, commands.CheckFailure):
+            pass
         elif isinstance(error, commands.CommandOnCooldown):
             await ctx.send(
                 "This command is on cooldown. Try again in {}.".format(


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
"That command is not available in DMs." error message wasn't showing up because of wrong order of `isinstance` calls.

I also decided to add an error message for dm-only messages and figured there's no point in doing 2 separate PRs for a change in practically the same place.