### PR TITLE
[Core] Add `redbot --edit` cli flag (replacement for `[p]set owner&token`)

### DIFF
--- a/changelog.d/3060.enhance.rst
+++ b/changelog.d/3060.enhance.rst
@@ -1,0 +1,1 @@
+All ``y/n`` confirmations in cli commands are now unified.

--- a/changelog.d/3060.feature.rst
+++ b/changelog.d/3060.feature.rst
@@ -1,1 +1,1 @@
-Add `redbot --edit` cli flag that allows to edit instance name, token, owner and datapath.
+Add ``redbot --edit`` cli flag that allows to edit instance name, token, owner and datapath.

--- a/changelog.d/3060.feature.rst
+++ b/changelog.d/3060.feature.rst
@@ -1,1 +1,1 @@
-Add ``redbot --edit`` cli flag that allows to edit instance name, token, owner and datapath.
+Added ``redbot --edit`` cli flag that can be used to edit instance name, token, owner and datapath.

--- a/changelog.d/3060.feature.rst
+++ b/changelog.d/3060.feature.rst
@@ -1,0 +1,1 @@
+Add `redbot --edit` cli flag that allows to edit instance name, token, owner and datapath.

--- a/changelog.d/3060.fix.rst
+++ b/changelog.d/3060.fix.rst
@@ -1,0 +1,1 @@
+Arguments ``--co-owner`` and ``--load-cogs`` now properly require at least one argument to be passed.

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -118,6 +118,12 @@ def edit_instance(red, cli_flags):
 
 def _edit_token(red, token, no_prompt):
     if token:
+        if not len(token) >= 50:
+            print(
+                "The provided token doesn't look a valid Discord bot token."
+                " Instance's token will remain unchanged.\n"
+            )
+            return
         red.loop.run_until_complete(red._config.token.set(token))
     elif not no_prompt and confirm("Would you like to change instance's token?", default=False):
         interactive_config(red, False, True, print_header=False)
@@ -149,6 +155,7 @@ def _edit_owner(red, owner, no_prompt):
                     continue
                 owner_id = int(owner_id)
                 red.loop.run_until_complete(red._config.owner.set(owner_id))
+                print("Owner updated.")
                 break
         else:
             print("Instance's owner will remain unchanged.")
@@ -161,10 +168,8 @@ def _edit_instance_name(old_name, new_name, confirm_overwrite, no_prompt):
         if name in _get_instance_names() and not confirm_overwrite:
             name = old_name
             print(
-                "An instance already exists with this name."
-                " Continuing would overwrite the existing instance config.\n"
-                "Instance name will remain unchanged.\n"
-                "If you want to replace existing instance,"
+                "An instance with this name already exists.\n"
+                "If you want to remove the existing instance and replace it with this one,"
                 " run this command with --overwrite-existing-instance flag."
             )
     elif not no_prompt and confirm("Would you like to change the instance name?", default=False):
@@ -180,6 +185,8 @@ def _edit_instance_name(old_name, new_name, confirm_overwrite, no_prompt):
             ):
                 print("Instance name will remain unchanged.")
                 name = old_name
+            else:
+                print("Instance name updated.")
             print()
     else:
         name = old_name
@@ -202,6 +209,8 @@ def _edit_data_path(data, data_path, copy_data, no_prompt):
             if not confirm("Do you still want to use the new data location?"):
                 data["DATA_PATH"] = data_manager.basic_config["DATA_PATH"]
                 print("Data location will remain unchanged.")
+            else:
+                print("Data location updated.")
 
 
 def _copy_data(data):

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -195,10 +195,9 @@ def _edit_data_path(data, data_path, copy_data, no_prompt):
             data["DATA_PATH"] = data_manager.basic_config["DATA_PATH"]
     elif not no_prompt and confirm("Would you like to change the data location?", default=False):
         data["DATA_PATH"] = get_data_dir()
-        if (
-            confirm("Do you want to copy the data from old location?", default=True)
-            and not _copy_data(data)
-        ):
+        if confirm(
+            "Do you want to copy the data from old location?", default=True
+        ) and not _copy_data(data):
             print("Can't copy the data to non-empty location.")
             if not confirm("Do you still want to use the new data location?"):
                 data["DATA_PATH"] = data_manager.basic_config["DATA_PATH"]

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -91,6 +91,12 @@ def parse_cli_flags(args):
         help="New name for the instance. This argument only works with --edit argument passed.",
     )
     parser.add_argument(
+        "--overwrite-existing-instance",
+        action="store_true",
+        help="Confirm overwriting of existing instance when changing name."
+        " This argument only works with --edit argument passed.",
+    )
+    parser.add_argument(
         "--edit-data-path",
         type=str,
         help=(

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import logging
+import sys
 from typing import Optional
 
 
@@ -15,7 +16,11 @@ def confirm(text: str, default: Optional[bool] = None) -> bool:
         raise TypeError(f"expected bool, not {type(default)}")
 
     while True:
-        value = input(f"{text}: [{options}] ").lower().strip()
+        try:
+            value = input(f"{text}: [{options}] ").lower().strip()
+        except (KeyboardInterrupt, EOFError):
+            print("\nAborted!")
+            sys.exit(1)
         if value in ("y", "yes"):
             return True
         if value in ("n", "no"):

--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -264,7 +264,8 @@ async def reset_red():
         print("Cancelling...")
         return
 
-    if confirm("\nDo you want to create a backup for an instance? (y/n) "):
+    print("")
+    if confirm("Do you want to create a backup for an instance?"):
         for index, instance in instances.items():
             print("\nRemoving {}...".format(index))
             await create_backup(index)

--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -264,8 +264,7 @@ async def reset_red():
         print("Cancelling...")
         return
 
-    print("")
-    if confirm("Do you want to create a backup for an instance?"):
+    if confirm("\nDo you want to create a backup for an instance?"):
         for index, instance in instances.items():
             print("\nRemoving {}...".format(index))
             await create_backup(index)

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -158,9 +158,7 @@ def basic_setup():
             "WARNING: An instance already exists with this name. "
             "Continuing will overwrite the existing instance config."
         )
-        if not click.confirm(
-            "Are you absolutely certain you want to continue?", default=False
-        ):
+        if not click.confirm("Are you absolutely certain you want to continue?", default=False):
             print("Not continuing")
             sys.exit(0)
     save_config(name, default_dirs)


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [x] New feature

### Description of the changes
This PR adds `redbot --edit` cli flag that allows to edit instance name, token, owner and datapath. It's supposed to be a replacement for `[p]set owner` and `[p]set token` that were removed due to being potentially dangerous.

I used the occasion to unify all confirmation prompts in Red's cli commands and also fixed a small bug that allowed user to pass no arguments to `--co-owner` and `--load-cogs`

Flags that can be used with `redbot --edit`:
`--no-prompt` - disables everything interactive in the command, if it's not passed the command will ask for everything that wasn't passed with other flags
`--token` - can be used to change token
`--owner` - can be used to change owner
`--edit-instance-name` - can be used to change instance name
`--overwrite-existing-instance` - can be used with `--edit-instance-name` to allow Red to overwrite existing instance when changing name
`--edit-data-path` - can be used to change data path
`--copy-data` - can be used with `--edit-data-path` to make Red copy data from old data path to new one

This might be considered breaking as I did change function signature for `confirm()` and `interactive_config()` that are under `redbot.core.cli` module but I didn't make changelog entries for that and I'm waiting for response whether I should add changelog entries, make this change non-breaking in that regard or don't change anything at all.
