### PR TITLE
[Core/Downloader] Add 3rd-party lib folder to `sys.path` before loading cogs

### DIFF
--- a/changelog.d/3036.bugfix.rst
+++ b/changelog.d/3036.bugfix.rst
@@ -1,0 +1,1 @@
+Add 3rd-party lib folder to ``sys.path`` before loading cogs. This prevents issues with 3rd-party cogs failing to load without loaded Downloader due to unavailable requirements.

--- a/changelog.d/3062.bugfix.rst
+++ b/changelog.d/3062.bugfix.rst
@@ -1,0 +1,1 @@
+Always append 3rd-party lib folder to the end of ``sys.path`` to avoid shadowing Red's dependencies.

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -119,6 +119,13 @@ def main():
     init_global_checks(red)
     init_events(red, cli_flags)
 
+    # lib folder has to be in sys.path before trying to load any 3rd-party cog (GH-3061)
+    # We might want to change handling of requirements in Downloader at later date
+    LIB_PATH = data_manager.cog_data_path(raw_name="Downloader") / "lib"
+    LIB_PATH.mkdir(parents=True, exist_ok=True)
+    if str(LIB_PATH) not in sys.path:
+        sys.path.insert(1, str(LIB_PATH))
+
     red.add_cog(Core(red))
     red.add_cog(CogManagerUI())
     if cli_flags.dev:

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -124,7 +124,7 @@ def main():
     LIB_PATH = data_manager.cog_data_path(raw_name="Downloader") / "lib"
     LIB_PATH.mkdir(parents=True, exist_ok=True)
     if str(LIB_PATH) not in sys.path:
-        sys.path.insert(1, str(LIB_PATH))
+        sys.path.append(str(LIB_PATH))
 
     red.add_cog(Core(red))
     red.add_cog(CogManagerUI())

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -43,14 +43,10 @@ class Downloader(commands.Cog):
         self.SHAREDLIB_PATH = self.LIB_PATH / "cog_shared"
         self.SHAREDLIB_INIT = self.SHAREDLIB_PATH / "__init__.py"
 
-        self.LIB_PATH.mkdir(parents=True, exist_ok=True)
         self.SHAREDLIB_PATH.mkdir(parents=True, exist_ok=True)
         if not self.SHAREDLIB_INIT.exists():
             with self.SHAREDLIB_INIT.open(mode="w", encoding="utf-8") as _:
                 pass
-
-        if str(self.LIB_PATH) not in syspath:
-            syspath.insert(1, str(self.LIB_PATH))
 
         self._repo_manager = RepoManager()
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #3036.
+now the code will append the lib to the end of `sys.path` to avoid shadowing Red's dependencies.

I've put changelog files in main folder cause it seemed more appropriate.
