### PR TITLE
Merge 3.1.6

### DIFF
--- a/changelog.d/3069.fix.rst
+++ b/changelog.d/3069.fix.rst
@@ -1,0 +1,1 @@
+Discord.py is updated to 1.2.4 to handle a critical issue with voice connections

--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -173,7 +173,7 @@ class VersionInfo:
         )
 
 
-__version__ = "3.1.5"
+__version__ = "3.1.6"
 version_info = VersionInfo.from_str(__version__)
 
 # Filter fuzzywuzzy slow sequence matcher warning

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     Click==7.0
     colorama==0.4.1
     contextlib2==0.5.5
-    discord.py==1.2.3
+    discord.py==1.2.4
     distro==1.4.0; sys_platform == "linux"
     fuzzywuzzy==0.17.0
     idna==2.8


### PR DESCRIPTION
Merges 3.1.6 into dev with an additional changelog unsuited for 3.1.x (towncrier adoption was after this)


