### PR TITLE
Remove a large amount of `fetch_user` calls

### DIFF
--- a/changelog.d/2964.enhance.rst
+++ b/changelog.d/2964.enhance.rst
@@ -1,0 +1,1 @@
+Red takes less time to fetch cases, unban members, and list warnings.

--- a/changelog.d/2964.misc.rst
+++ b/changelog.d/2964.misc.rst
@@ -1,0 +1,3 @@
+Red no longer uses bot.fetch_user in core
+    - This is a 1/1s global ratelimit
+    - It really really really should be avoided.

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -374,13 +374,8 @@ class Warnings(commands.Cog):
                 await ctx.send(_("That user has no warnings!"))
             else:
                 for key in user_warnings.keys():
-                    mod = ctx.guild.get_member(user_warnings[key]["mod"])
-                    if mod is None:
-                        mod = discord.utils.get(
-                            self.bot.get_all_members(), id=user_warnings[key]["mod"]
-                        )
-                        if mod is None:
-                            mod = await self.bot.fetch_user(user_warnings[key]["mod"])
+                    mod_id = user_warnings[key]["mod"]
+                    mod = ctx.bot.get_user(mod_id) or _("Unknown Moderator ({})").format(mod_id)
                     msg += _(
                         "{num_points} point warning {reason_name} issued by {user} for "
                         "{description}\n"

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1693,8 +1693,8 @@ class Core(commands.Cog, CoreLogic):
         """
         uid = getattr(user, "id", user)
         async with ctx.bot._config.whitelist() as curr_list:
-            if user.id not in curr_list:
-                curr_list.append(user.id)
+            if uid not in curr_list:
+                curr_list.append(uid)
 
         await ctx.send(_("User added to whitelist."))
 
@@ -1720,9 +1720,9 @@ class Core(commands.Cog, CoreLogic):
         removed = False
         uid = getattr(user, "id", user)
         async with ctx.bot._config.whitelist() as curr_list:
-            if user.id in curr_list:
+            if uid in curr_list:
                 removed = True
-                curr_list.remove(user.id)
+                curr_list.remove(uid)
 
         if removed:
             await ctx.send(_("User has been removed from whitelist."))
@@ -1746,7 +1746,7 @@ class Core(commands.Cog, CoreLogic):
         pass
 
     @blacklist.command(name="add")
-    async def blacklist_add(self, ctx: commands.Context, *, user: discord.User):
+    async def blacklist_add(self, ctx: commands.Context, *, user: Union[discord.Member, int]):
         """
         Adds a user to the blacklist.
         """
@@ -1754,9 +1754,10 @@ class Core(commands.Cog, CoreLogic):
             await ctx.send(_("You cannot blacklist an owner!"))
             return
 
+        uid = getattr(user, "id", user)
         async with ctx.bot._config.blacklist() as curr_list:
-            if user.id not in curr_list:
-                curr_list.append(user.id)
+            if uid not in curr_list:
+                curr_list.append(uid)
 
         await ctx.send(_("User added to blacklist."))
 
@@ -1775,16 +1776,17 @@ class Core(commands.Cog, CoreLogic):
             await ctx.send(box(page))
 
     @blacklist.command(name="remove")
-    async def blacklist_remove(self, ctx: commands.Context, *, user: discord.User):
+    async def blacklist_remove(self, ctx: commands.Context, *, user: Union[discord.Member, int]):
         """
         Removes user from blacklist.
         """
         removed = False
 
+        uid = getattr(user, "id", user)
         async with ctx.bot._config.blacklist() as curr_list:
-            if user.id in curr_list:
+            if uid in curr_list:
                 removed = True
-                curr_list.remove(user.id)
+                curr_list.remove(uid)
 
         if removed:
             await ctx.send(_("User has been removed from blacklist."))
@@ -1810,12 +1812,16 @@ class Core(commands.Cog, CoreLogic):
 
     @localwhitelist.command(name="add")
     async def localwhitelist_add(
-        self, ctx: commands.Context, *, user_or_role: Union[discord.Member, discord.Role]
+        self, ctx: commands.Context, *, user_or_role: Union[discord.Member, discord.Role, int]
     ):
         """
         Adds a user or role to the whitelist.
         """
         user = isinstance(user_or_role, discord.Member)
+        if isinstance(user_or_role, int):
+            user_or_role = discord.Object(id=user_or_role)
+            user = True
+
         async with ctx.bot._config.guild(ctx.guild).whitelist() as curr_list:
             if user_or_role.id not in curr_list:
                 curr_list.append(user_or_role.id)
@@ -1841,12 +1847,15 @@ class Core(commands.Cog, CoreLogic):
 
     @localwhitelist.command(name="remove")
     async def localwhitelist_remove(
-        self, ctx: commands.Context, *, user_or_role: Union[discord.Member, discord.Role]
+        self, ctx: commands.Context, *, user_or_role: Union[discord.Member, discord.Role, int]
     ):
         """
         Removes user or role from whitelist.
         """
         user = isinstance(user_or_role, discord.Member)
+        if isinstance(user_or_role, int):
+            user_or_role = discord.Object(id=user_or_role)
+            user = True
 
         removed = False
         async with ctx.bot._config.guild(ctx.guild).whitelist() as curr_list:
@@ -1884,12 +1893,15 @@ class Core(commands.Cog, CoreLogic):
 
     @localblacklist.command(name="add")
     async def localblacklist_add(
-        self, ctx: commands.Context, *, user_or_role: Union[discord.Member, discord.Role]
+        self, ctx: commands.Context, *, user_or_role: Union[discord.Member, discord.Role, int]
     ):
         """
         Adds a user or role to the blacklist.
         """
         user = isinstance(user_or_role, discord.Member)
+        if isinstance(user_or_role, int):
+            user_or_role = discord.Object(id=user_or_role)
+            user = True
 
         if user and await ctx.bot.is_owner(user_or_role):
             await ctx.send(_("You cannot blacklist an owner!"))
@@ -1920,13 +1932,16 @@ class Core(commands.Cog, CoreLogic):
 
     @localblacklist.command(name="remove")
     async def localblacklist_remove(
-        self, ctx: commands.Context, *, user_or_role: Union[discord.Member, discord.Role]
+        self, ctx: commands.Context, *, user_or_role: Union[discord.Member, discord.Role, int]
     ):
         """
         Removes user or role from blacklist.
         """
         removed = False
         user = isinstance(user_or_role, discord.Member)
+        if isinstance(user_or_role, int):
+            user_or_role = discord.Object(id=user_or_role)
+            user = True
 
         async with ctx.bot._config.guild(ctx.guild).blacklist() as curr_list:
             if user_or_role.id in curr_list:

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1687,10 +1687,11 @@ class Core(commands.Cog, CoreLogic):
         pass
 
     @whitelist.command(name="add")
-    async def whitelist_add(self, ctx, user: discord.User):
+    async def whitelist_add(self, ctx, *, user: Union[discord.Member, int]):
         """
         Adds a user to the whitelist.
         """
+        uid = getattr(user, "id", user)
         async with ctx.bot._config.whitelist() as curr_list:
             if user.id not in curr_list:
                 curr_list.append(user.id)
@@ -1712,12 +1713,12 @@ class Core(commands.Cog, CoreLogic):
             await ctx.send(box(page))
 
     @whitelist.command(name="remove")
-    async def whitelist_remove(self, ctx: commands.Context, *, user: discord.User):
+    async def whitelist_remove(self, ctx: commands.Context, *, user: Union[discord.Member, int]):
         """
         Removes user from whitelist.
         """
         removed = False
-
+        uid = getattr(user, "id", user)
         async with ctx.bot._config.whitelist() as curr_list:
             if user.id in curr_list:
                 removed = True

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -304,7 +304,7 @@ class Case:
             )
 
         if isinstance(self.user, int):
-            user = f"Deleted User#0000 ({self.user})"
+            user = f"[Unknown or Deleted User] ({self.user})"
             avatar_url = None
         else:
             user = escape_spoilers(
@@ -448,12 +448,7 @@ class Case:
                 if user_id is None:
                     user_object = None
                 else:
-                    user_object = bot.get_user(user_id)
-                    if user_object is None:
-                        try:
-                            user_object = await bot.fetch_user(user_id)
-                        except discord.NotFound:
-                            user_object = user_id
+                    user_object = bot.get_user(user_id) or user_id
             user_objects[user_key] = user_object
 
         channel = kwargs.get("channel") or guild.get_channel(data["channel"]) or data["channel"]
@@ -687,12 +682,7 @@ async def get_cases_for_member(
         member_id = member.id
 
     if not member:
-        member = bot.get_user(member_id)
-        if not member:
-            try:
-                member = await bot.fetch_user(member_id)
-            except discord.NotFound:
-                member = member_id
+        member = bot.get_user(member_id) or member_id
 
     try:
         modlog_channel = await get_modlog_channel(guild)


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

Fetch user calls a pretty restricted API endpoint, slowing down a lot of things in the bot. Non bot-owners should not be able to generate these calls.

resolves #2964 
