### PR TITLE
[Docs] Do not overwrite rst_prolog

### DIFF
--- a/changelog.d/3082.docs.rst
+++ b/changelog.d/3082.docs.rst
@@ -1,0 +1,1 @@
+Do not overwrite the docs/prolog.txt file in conf.py.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,7 +99,7 @@ with open("prolog.txt", "r") as file:
     rst_prolog = file.read()
 
 # Adds d.py version to available substitutions in all files
-rst_prolog = f"\n.. |DPY_VERSION| replace:: {dpy_version}"
+rst_prolog += f"\n.. |DPY_VERSION| replace:: {dpy_version}"
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

This addition was overwriting all contents in `prolog.txt`.