### PR TITLE
[Audio] Expose FriendlyException on play command

### DIFF
--- a/changelog.d/audio/3085.enhance.1.rst
+++ b/changelog.d/audio/3085.enhance.1.rst
@@ -1,0 +1,1 @@
+Expose FriendlyExceptions to users on the play command.

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -2835,6 +2835,8 @@ class Audio(commands.Cog):
             if not tracks:
                 self._play_lock(ctx, False)
                 embed = discord.Embed(title=_("Nothing found."), colour=await ctx.embed_colour())
+                if result.exception_message:
+                    embed.set_footer(text=result.exception_message)
                 if await self.config.use_external_lavalink() and query.is_local:
                     embed.description = _(
                         "Local tracks will not work "


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This change will expose the Lavalink.jar FriendlyException text to the users when they use the play command and the resulting request is a broken video: on YouTube this could be region locked videos, copyright claims by the original owners, etc. Provides a bit more information to the user besides just "Nothing found."