### PR TITLE
[Warnings] Allow the permissions cog to allow mods to check other user's warnings

### DIFF
--- a/changelog.d/2900.bugfix.rst
+++ b/changelog.d/2900.bugfix.rst
@@ -1,1 +1,1 @@
-Add in ``[p]warncheck`` to remove a `is_admin_or_superior` check so the permissions cog can change who can check other user's warnings.
+Add in ``[p]warncheck`` to remove a ``is_admin_or_superior`` check so the permissions cog can change who can check other user's warnings.

--- a/changelog.d/2900.bugfix.rst
+++ b/changelog.d/2900.bugfix.rst
@@ -1,0 +1,1 @@
+Add in ``[p]warncheck`` to remove a `is_admin_or_superior` check so the permissions cog can change who can check other user's warnings.

--- a/changelog.d/2900.bugfix.rst
+++ b/changelog.d/2900.bugfix.rst
@@ -1,1 +1,2 @@
-Add in ``[p]warncheck`` to remove a ``is_admin_or_superior`` check so the permissions cog can change who can check other user's warnings.
+Add in ``[p]mywarnings`` to remove a ``is_admin_or_superior`` check so the permissions cog can change who can check other user's warnings
+Also makes ``[p]warnings`` not be able to check user's own warnings.

--- a/changelog.d/2900.bugfix.rst
+++ b/changelog.d/2900.bugfix.rst
@@ -1,2 +1,3 @@
-Add in ``[p]mywarnings`` to remove a ``is_admin_or_superior`` check so the permissions cog can change who can check other user's warnings
-Also makes ``[p]warnings`` not be able to check user's own warnings.
+Remove a ``is_admin_or_superior`` check so the permissions cog can change who can check other user's warnings.
+- Changes ``[p]warnings`` to be admin or higher, and now ``[p]warnings`` is **only** used for other user's warnings.
+- Adds in ``[p]mwarnings`` as a substitute for ``[p]warnings`` not allowing users to check their own warnings.

--- a/changelog.d/warnings/2900.bugfix.rst
+++ b/changelog.d/warnings/2900.bugfix.rst
@@ -1,3 +1,3 @@
 Remove a ``is_admin_or_superior`` check so the permissions cog can change who can check other user's warnings.
 - Changes ``[p]warnings`` to be admin or higher, and now ``[p]warnings`` is **only** used for other user's warnings.
-- Adds in ``[p]mwarnings`` as a substitute for ``[p]warnings`` not allowing users to check their own warnings.
+- Adds in ``[p]mywarnings`` as a substitute for ``[p]warnings`` not allowing users to check their own warnings.

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -12,7 +12,7 @@ from redbot.cogs.warnings.helpers import (
 from redbot.core import Config, checks, commands, modlog
 from redbot.core.bot import Red
 from redbot.core.i18n import Translator, cog_i18n
-from redbot.core.utils.mod import is_admin_or_superior
+from redbot.core.utils.mod import is_admin_or_superior, is_mod_or_superior
 from redbot.core.utils.chat_formatting import warning, pagify
 from redbot.core.utils.menus import menu, DEFAULT_CONTROLS
 
@@ -355,7 +355,7 @@ class Warnings(commands.Cog):
         if user is None:
             user = ctx.author
         else:
-            if not await is_admin_or_superior(self.bot, ctx.author):
+            if not await is_mod_or_superior(self.bot, ctx.author):
                 return await ctx.send(
                     warning(_("You are not allowed to check warnings for other users!"))
                 )

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -343,7 +343,7 @@ class Warnings(commands.Cog):
     @commands.command()
     @commands.guild_only()
     @checks.admin_or_permissions(ban_members=True)
-    async def warnings(self, ctx: commands.Context, user: Union[discord.Member, int] = None):
+    async def warnings(self, ctx: commands.Context, user: discord.Member):
         """List the warnings for the specified user."""
         msg = ""
         member_settings = self.config.member(user)
@@ -357,8 +357,6 @@ class Warnings(commands.Cog):
                         mod = discord.utils.get(
                             self.bot.get_all_members(), id=user_warnings[key]["mod"]
                         )
-                        if mod is None:
-                            mod = await self.bot.fetch_user(user_warnings[key]["mod"])
                     msg += _(
                         "{num_points} point warning {reason_name} issued by {user} for "
                         "{description}\n"
@@ -395,8 +393,6 @@ class Warnings(commands.Cog):
                         mod = discord.utils.get(
                             self.bot.get_all_members(), id=user_warnings[key]["mod"]
                         )
-                        if mod is None:
-                            mod = await self.bot.fetch_user(user_warnings[key]["mod"])
                     msg += _(
                         "{num_points} point warning {reason_name} issued by {user} for "
                         "{description}\n"

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -348,15 +348,17 @@ class Warnings(commands.Cog):
         """Check your own warnings."""
         if user is None:
             user = ctx.author
-        else: #TODO: remove this else statement in a release after 3.3.0 (will allow users time start using [p]warncheck)
+        else:  # TODO: remove this else statement in a release after 3.3.0 (will allow users time start using [p]warncheck)
             if not await is_admin_or_superior(self.bot, ctx.author):
                 return await ctx.send(
                     warning(_("You are not allowed to check warnings for other users!"))
                 )
             else:
-                return await ctx.send(_(
-                    "Checking other user's warnings has moved to `{prefix}warncheck`."
-                ).format(prefix=ctx.prefix))
+                return await ctx.send(
+                    _("Checking other user's warnings has moved to `{prefix}warncheck`.").format(
+                        prefix=ctx.prefix
+                    )
+                )
 
         msg = ""
         member_settings = self.config.member(user)
@@ -387,9 +389,7 @@ class Warnings(commands.Cog):
 
     @commands.command()
     @commands.guild_only()
-    async def warncheck(
-        self, ctx: commands.Context, user: discord.Member
-    ):
+    async def warncheck(self, ctx: commands.Context, user: discord.Member):
         """Check other user's warnings."""
         msg = ""
         member_settings = self.config.member(user)

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -342,8 +342,8 @@ class Warnings(commands.Cog):
 
     @commands.command()
     @commands.guild_only()
-    @checks.admin_or_permissions(ban_members=True)
-    async def warnings(self, ctx: commands.Context, user: discord.Member):
+    @checks.admin()
+    async def warnings(self, ctx: commands.Context, user: Union[discord.Member, int] = None):
         """List the warnings for the specified user."""
         msg = ""
         member_settings = self.config.member(user)
@@ -355,7 +355,7 @@ class Warnings(commands.Cog):
                     mod = ctx.guild.get_member(user_warnings[key]["mod"])
                     if mod is None:
                         mod = discord.utils.get(
-                            self.bot.get_all_members(), id=user_warnings[key]["mod"]
+                            ctx.guild.get_member(), id=user_warnings[key]["mod"]
                         )
                     msg += _(
                         "{num_points} point warning {reason_name} issued by {user} for "


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This changes `[p]warnings` to only check other user's warnings and adds `[p]mywarnings` so that the Permissions cog can dictate who can check other's warnings, instead of an unchangeable `is_admin_or_superior` check.
This fixes the duplicate issue #3086.
Closes #2900.