### PR TITLE
[Image] Only send one Imgur result and update wording for setting API keys

### DIFF
--- a/changelog.d/image/.bugfix.rst
+++ b/changelog.d/image/.bugfix.rst
@@ -1,0 +1,1 @@
+Correct wording for setting Imgur API keys.

--- a/changelog.d/image/.bugfix.rst
+++ b/changelog.d/image/.bugfix.rst
@@ -1,1 +1,0 @@
-Correct wording for setting Imgur API keys.

--- a/changelog.d/image/3044.bugfix.rst
+++ b/changelog.d/image/3044.bugfix.rst
@@ -1,1 +1,1 @@
-Only send one image from image searches.
+Only send one image from Imgur searches.

--- a/changelog.d/image/3044.bugfix.rst
+++ b/changelog.d/image/3044.bugfix.rst
@@ -1,0 +1,1 @@
+Only send one image from image searches.

--- a/changelog.d/image/3091.bugfix.rst
+++ b/changelog.d/image/3091.bugfix.rst
@@ -1,0 +1,1 @@
+Update setting Imgur and GIPHY API keys.

--- a/changelog.d/image/3091.bugfix.rst
+++ b/changelog.d/image/3091.bugfix.rst
@@ -1,1 +1,1 @@
-Update setting Imgur and GIPHY API keys.
+Update wording for setting Imgur and GIPHY API keys to match the website.

--- a/redbot/cogs/image/image.py
+++ b/redbot/cogs/image/image.py
@@ -148,7 +148,7 @@ class Image(commands.Cog):
             "5. Set the authorization callback URL to `https://localhost`.\n"
             "6. Leave the app website blank.\n"
             "7. Enter a valid email address and a description.\n"
-            "8. Check the captcha box and click next.\n"
+            "8. Check the captcha box and click submit.\n"
             "9. Your Client ID will be on the next page.\n"
             "10. Run the command `{prefix}set api imgur client_id <your_client_id_here>`.\n"
         ).format(prefix=ctx.prefix)

--- a/redbot/cogs/image/image.py
+++ b/redbot/cogs/image/image.py
@@ -232,8 +232,10 @@ class Image(commands.Cog):
             "3. Press *Create an App*.\n"
             "4. Write an app name, example: *Red Bot*.\n"
             "5. Write an app description, example: *Used for Red Bot*.\n"
-            "6. Copy the API key shown.\n"
-            "7. Run the command `{prefix}set api GIPHY api_key <your_api_key_here>`.\n"
+            "6. Select *I only want to use the GIPHY API*."
+            "7. Click *Create New App*"
+            "8. Copy the API key shown.\n"
+            "9. Run the command `{prefix}set api GIPHY api_key <your_api_key_here>`.\n"
         ).format(prefix=ctx.prefix)
 
         await ctx.maybe_send_embed(message)

--- a/redbot/cogs/image/image.py
+++ b/redbot/cogs/image/image.py
@@ -68,9 +68,8 @@ class Image(commands.Cog):
                 return
             shuffle(results)
             msg = _("Search results...\n")
-            for r in results[:3]:
+            for r in results[:1]:
                 msg += r["gifv"] if "gifv" in r else r["link"]
-                msg += "\n"
             await ctx.send(msg)
         else:
             await ctx.send(


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
The title says it all really... I've updated the wording for Imgur and GIPHY API keys to be more accurate.
Also made Imgur search only return one result, instead of three.
I tried not using a for loop... but I couldn't make it work without one. At least the fix works lol.
Closes #3044 