### PR TITLE
[Audio] Stop player before destroying on emptydisconnect

### DIFF
--- a/changelog.d/audio/3050.bugfix.rst
+++ b/changelog.d/audio/3050.bugfix.rst
@@ -1,0 +1,1 @@
+Bot's status is now properly cleared on emptydisconnect.

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -6740,7 +6740,9 @@ class Audio(commands.Cog):
                     if (time.time() - stop_times[sid]) >= emptydc_timer:
                         stop_times.pop(sid)
                         try:
-                            await lavalink.get_player(sid).disconnect()
+                            player = lavalink.get_player(sid)
+                            await player.stop()
+                            await player.disconnect()
                         except Exception:
                             log.error("Exception raised in Audio's emptydc_timer.", exc_info=True)
                             pass


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #3050 