### PR TITLE
Increased clarity of wording in info command

### DIFF
--- a/changelog.d/3121.enhance.rst
+++ b/changelog.d/3121.enhance.rst
@@ -1,3 +1,1 @@
-Use the bot's username in ``[p]info`` instead of "This"
-- Before: "This is an..."
-- Now: "Bot's Username is an..."
+Change ``[p]info`` to say "This bot is an..." instead of "This is an..." for clarity.

--- a/changelog.d/3121.enhance.rst
+++ b/changelog.d/3121.enhance.rst
@@ -1,0 +1,3 @@
+Use the bot's username in ``[p]info`` instead of "This"
+- Before: "This is an..."
+- Now: "Bot's Username is an..."

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -287,19 +287,20 @@ class Core(commands.Cog, CoreLogic):
         app_info = await self.bot.application_info()
         owner = app_info.owner
         custom_info = await self.bot._config.custom_info()
+        bot_nick = ctx.bot.user.name
 
         async with aiohttp.ClientSession() as session:
             async with session.get("{}/json".format(red_pypi)) as r:
                 data = await r.json()
         outdated = VersionInfo.from_str(data["info"]["version"]) > red_version_info
         about = _(
-            "This is an instance of [Red, an open source Discord bot]({}) "
+            "{} is an instance of [Red, an open source Discord bot]({}) "
             "created by [Twentysix]({}) and [improved by many]({}).\n\n"
             "Red is backed by a passionate community who contributes and "
             "creates content for everyone to enjoy. [Join us today]({}) "
             "and help us improve!\n\n"
             "(c) Cog Creators"
-        ).format(red_repo, author_repo, org_repo, support_server_url)
+        ).format(bot_name, red_repo, author_repo, org_repo, support_server_url)
 
         embed = discord.Embed(color=(await ctx.embed_colour()))
         embed.add_field(name=_("Instance owned by"), value=str(owner))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -287,20 +287,19 @@ class Core(commands.Cog, CoreLogic):
         app_info = await self.bot.application_info()
         owner = app_info.owner
         custom_info = await self.bot._config.custom_info()
-        bot_name = ctx.bot.user.name
 
         async with aiohttp.ClientSession() as session:
             async with session.get("{}/json".format(red_pypi)) as r:
                 data = await r.json()
         outdated = VersionInfo.from_str(data["info"]["version"]) > red_version_info
         about = _(
-            "{} is an instance of [Red, an open source Discord bot]({}) "
+            "This bot is an instance of [Red, an open source Discord bot]({}) "
             "created by [Twentysix]({}) and [improved by many]({}).\n\n"
             "Red is backed by a passionate community who contributes and "
             "creates content for everyone to enjoy. [Join us today]({}) "
             "and help us improve!\n\n"
             "(c) Cog Creators"
-        ).format(bot_name, red_repo, author_repo, org_repo, support_server_url)
+        ).format(red_repo, author_repo, org_repo, support_server_url)
 
         embed = discord.Embed(color=(await ctx.embed_colour()))
         embed.add_field(name=_("Instance owned by"), value=str(owner))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -287,7 +287,7 @@ class Core(commands.Cog, CoreLogic):
         app_info = await self.bot.application_info()
         owner = app_info.owner
         custom_info = await self.bot._config.custom_info()
-        bot_nick = ctx.bot.user.name
+        bot_name = ctx.bot.user.name
 
         async with aiohttp.ClientSession() as session:
             async with session.get("{}/json".format(red_pypi)) as r:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
[Draper's variation](https://discordapp.com/channels/133049272517001216/133049878837329920/644274713853427720) of ClearlyElevated's [origianal suggestion](https://discordapp.com/channels/133049272517001216/133049878837329920/644272849758060556) in #feature-ideas, Discord.
Replaces "This is an..." with "Example Bot Username is an...".
Possible variation: use the bot's nick instead of name.