### PR TITLE
[Audio] Fix console spam caused by `disconnect_timer` if a player is destroyed before the task completes

### DIFF
--- a/changelog.d/audio/3123.bugfix.rst
+++ b/changelog.d/audio/3123.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a console spam caused sometimes when auto disconnect and auto pause are used.

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -6741,8 +6741,10 @@ class Audio(commands.Cog):
                         stop_times.pop(sid)
                         try:
                             await lavalink.get_player(sid).disconnect()
-                        except Exception:
+                        except Exception as err:
                             log.error("Exception raised in Audio's emptydc_timer.", exc_info=True)
+                            if "No such player for that guild" in str(err):
+                                stop_times.pop(sid, None)
                             pass
                 elif (
                     sid in pause_times and await self.config.guild(server_obj).emptypause_enabled()
@@ -6751,7 +6753,9 @@ class Audio(commands.Cog):
                     if (time.time() - pause_times.get(sid)) >= emptypause_timer:
                         try:
                             await lavalink.get_player(sid).pause()
-                        except Exception:
+                        except Exception as err:
+                            if "No such player for that guild" in str(err):
+                                pause_times.pop(sid, None)
                             log.error(
                                 "Exception raised in Audio's emptypause_timer.", exc_info=True
                             )


### PR DESCRIPTION
Remove servers from the auto disconnect/pause list is their players no longer exist...
Prevents a console spam

Signed-off-by: Drapersniper <27962761+drapersniper@users.noreply.github.com>

### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes this 👀 
![image](https://user-images.githubusercontent.com/27962761/68893937-220e5780-071e-11ea-99ad-97681ae4da27.png)
