### PR TITLE
[CI/CE] Replacing Travis with GH Actions

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -1,0 +1,23 @@
+name: Python application
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install tox
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+    - name: Run Tox... Duh..
+      env:
+        TOXENV: py,docs,style
+      run: tox

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -1,4 +1,4 @@
-name: Python application
+name: Tests
 
 on: [push]
 
@@ -17,7 +17,22 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox
-    - name: Run Tox... Duh..
+    - name: Cache
+      uses: actions/cache@v1.0.0
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Tox test - Py
       env:
-        TOXENV: py,docs,style
+        TOXENV: py
+      run: tox
+    - name: Tox test - Style
+      env:
+        TOXENV: style
+      run: tox
+    - name: Tox test - Docs
+      env:
+        TOXENV: docs
       run: tox

--- a/.github/workflows/toxtests.yml
+++ b/.github/workflows/toxtests.yml
@@ -28,6 +28,11 @@ jobs:
     needs: [build]
     runs-on: [ubuntu-latest]
     steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
     - name: Cache
       uses: actions/cache@v1.0.0
       with:
@@ -43,6 +48,11 @@ jobs:
     needs: [build]
     runs-on: [ubuntu-latest]
     steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
     - name: Cache
       uses: actions/cache@v1.0.0
       with:
@@ -58,6 +68,11 @@ jobs:
     needs: [build]
     runs-on: [ubuntu-latest]
     steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
     - name: Cache
       uses: actions/cache@v1.0.0
       with:

--- a/.github/workflows/toxtests.yml
+++ b/.github/workflows/toxtests.yml
@@ -3,10 +3,30 @@ name: Tests
 on: [push]
 
 jobs:
-  build:
 
+  tox-py:
     runs-on: [ubuntu-latest]
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8']
+    name: Python ${{ matrix.python-version }}
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install tox
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+    - name: Tox test - Py
+      env:
+        TOXENV: py
+      run: tox
 
+  tox-style:
+    runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
@@ -17,55 +37,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox
-    - name: Cache
-      uses: actions/cache@v1.0.0
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-  toxpy:
-    needs: [build]
-    runs-on: [ubuntu-latest]
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Cache
-      uses: actions/cache@v1.0.0
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-    - name: Tox test - Py
-      env:
-        TOXENV: py
-      run: tox
-  toxstyle:
-    needs: [build]
-    runs-on: [ubuntu-latest]
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Cache
-      uses: actions/cache@v1.0.0
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
     - name: Tox test - Style
       env:
         TOXENV: style
       run: tox
-  toxdocs:
-    needs: [build]
+
+  tox-docs:
     runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v1
@@ -73,13 +50,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
-    - name: Cache
-      uses: actions/cache@v1.0.0
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
     - name: Tox test - Docs
       env:
         TOXENV: docs

--- a/.github/workflows/toxtests.yml
+++ b/.github/workflows/toxtests.yml
@@ -9,7 +9,8 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8']
-    name: Python ${{ matrix.python-version }}
+      fail-fast: false
+    name: Tox tests - Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -20,13 +21,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox
-    - name: Tox test - Py
+    - name: Tox test
       env:
         TOXENV: py
       run: tox
 
   tox-style:
     runs-on: [ubuntu-latest]
+    name: Tox Style
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
@@ -37,20 +39,25 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox
-    - name: Tox test - Style
+    - name: Tox test
       env:
         TOXENV: style
       run: tox
 
   tox-docs:
     runs-on: [ubuntu-latest]
+    name: Tox Docs
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
-    - name: Tox test - Docs
+    - name: Install tox
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+    - name: Tox test
       env:
         TOXENV: docs
       run: tox

--- a/.github/workflows/toxtests.yml
+++ b/.github/workflows/toxtests.yml
@@ -68,6 +68,8 @@ jobs:
       with:
         postgresql version: '11'
         postgresql db: 'red_db'
+        postgresql user: 'postgres'
+        postgresql password: 'postgres'
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
@@ -80,4 +82,9 @@ jobs:
     - name: Tox test
       env:
         TOXENV: postgres
+        PGHOST: localhost
+        PGPORT: 5432
+        PGUSER: postgres
+        PGPASSWORD: postgres
+        PGDATABASE: red_db
       run: tox

--- a/.github/workflows/toxtests.yml
+++ b/.github/workflows/toxtests.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v1
@@ -24,14 +24,26 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
         restore-keys: |
           ${{ runner.os }}-pip-
+  toxpy:
+    needs: [build]
+    runs-on: [ubuntu-latest]
+    steps:
     - name: Tox test - Py
       env:
         TOXENV: py
       run: tox
+  toxstyle:
+    needs: [build]
+    runs-on: [ubuntu-latest]
+    steps:
     - name: Tox test - Style
       env:
         TOXENV: style
       run: tox
+  toxdocs:
+    needs: [build]
+    runs-on: [ubuntu-latest]
+    steps:
     - name: Tox test - Docs
       env:
         TOXENV: docs

--- a/.github/workflows/toxtests.yml
+++ b/.github/workflows/toxtests.yml
@@ -59,3 +59,25 @@ jobs:
       env:
         TOXENV: docs
       run: tox
+
+  tox-postgres:
+    runs-on: [ubuntu-latest]
+    name: Tox Postgres
+    steps:
+    - uses: harmon758/postgresql-action@v1
+      with:
+        postgresql version: '11'
+        postgresql db: 'red_db'
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install tox
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+    - name: Tox test
+      env:
+        TOXENV: postgres
+      run: tox

--- a/.github/workflows/toxtests.yml
+++ b/.github/workflows/toxtests.yml
@@ -28,6 +28,13 @@ jobs:
     needs: [build]
     runs-on: [ubuntu-latest]
     steps:
+    - name: Cache
+      uses: actions/cache@v1.0.0
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Tox test - Py
       env:
         TOXENV: py
@@ -36,6 +43,13 @@ jobs:
     needs: [build]
     runs-on: [ubuntu-latest]
     steps:
+    - name: Cache
+      uses: actions/cache@v1.0.0
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Tox test - Style
       env:
         TOXENV: style
@@ -44,6 +58,13 @@ jobs:
     needs: [build]
     runs-on: [ubuntu-latest]
     steps:
+    - name: Cache
+      uses: actions/cache@v1.0.0
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/tox.ini') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Tox test - Docs
       env:
         TOXENV: docs

--- a/.github/workflows/toxtests.yml
+++ b/.github/workflows/toxtests.yml
@@ -1,16 +1,14 @@
 name: Tests
-
-on: [push]
+on: [push, pull_request]
 
 jobs:
-
   tox-py:
     runs-on: [ubuntu-latest]
     strategy:
       matrix:
         python-version: ['3.7', '3.8']
       fail-fast: false
-    name: Tox tests - Python ${{ matrix.python-version }}
+    name: Tox Tests - Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/autolabler.yml
+++ b/autolabler.yml
@@ -1,0 +1,18 @@
+name: Auto Labeler
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Apply Triage Label
+        uses: actions/github@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: label Status: Needs Triage

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,7 +90,7 @@ style =
 test =
     astroid==2.2.5
     atomicwrites==1.3.0
-    importlib-metadata==0.19
+    importlib-metadata==0.23; python_version<"3.8"
     isort==4.3.21
     lazy-object-proxy==1.4.2
     mccabe==0.6.1


### PR DESCRIPTION
Now this is gonna be a long one. this is **exploring** the option of using GitHub Actions instead of Travis. And I want some proper discussion on this PR for if or when we want to replace Travis with native GitHub actions.

Things that are working so far:
* Matrix builds for tests against 3.7 and 3.8 (and more)
* Tox docs tests
* Tox py tests (Running in above described matrix)
* Tox style tests (Running on 3.7)

Things that aren't working/not yet implemented:
* Automated publishing to PyPi (there are prebuild actions for those 👍)
* Postgres tests (on my todo)
* Uploading to Crowdin
* Caching (although I don't think that caching on Travis ever worked)