### PR TITLE
Use a metaclass for config's singletons

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -907,10 +907,10 @@ class Config(metaclass=ConfigMeta):
         """
         Initializes a custom group for usage. This method must be called first!
         """
-        if group_identifier in self.custom_groups:
-            raise ValueError(f"Group identifier already registered: {group_identifier}")
-
-        self.custom_groups[group_identifier] = identifier_count
+        if identifier_count != self.custom_groups.setdefault(group_identifier, identifier_count):
+            raise ValueError(
+                f"Cannot change identifier count of already registered group: {group_identifier}"
+            )
 
     def _get_base_group(self, category: str, *primary_keys: str) -> Group:
         """

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -30,6 +30,33 @@ _config_cache = weakref.WeakValueDictionary()
 _retrieved = weakref.WeakSet()
 
 
+class ConfigMeta(type):
+    """
+    We want to prevent re-initializing existing config instances while having a singleton
+    """
+
+    def __call__(
+        cls,
+        cog_name: str,
+        unique_identifier: str,
+        driver: BaseDriver,
+        force_registration: bool = False,
+        defaults: dict = None,
+    ):
+        if cog_name is None:
+            raise ValueError("You must provide either the cog instance or a cog name.")
+
+        key = (cog_name, unique_identifier)
+        if key in _config_cache:
+            return _config_cache[key]
+
+        instance = super(ConfigMeta, cls).__call__(
+            cog_name, unique_identifier, driver, force_registration, defaults
+        )
+        _config_cache[key] = instance
+        return instance
+
+
 def get_latest_confs() -> Tuple["Config"]:
     global _retrieved
     ret = set(_config_cache.values()) - set(_retrieved)
@@ -562,7 +589,7 @@ class Group(Value):
         await self.driver.set(identifier_data, value=value)
 
 
-class Config:
+class Config(metaclass=ConfigMeta):
     """Configuration manager for cogs and Red.
 
     You should always use `get_conf` to instantiate a Config object. Use
@@ -604,19 +631,6 @@ class Config:
     ROLE = "ROLE"
     USER = "USER"
     MEMBER = "MEMBER"
-
-    def __new__(cls, cog_name, unique_identifier, *args, **kwargs):
-        key = (cog_name, unique_identifier)
-
-        if key[0] is None:
-            raise ValueError("You must provide either the cog instance or a cog name.")
-
-        if key in _config_cache:
-            conf = _config_cache[key]
-        else:
-            conf = object.__new__(cls)
-            _config_cache[key] = conf
-        return conf
 
     def __init__(
         self,


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

This is technically a fix. This closes #3136 

#3136 isn't what we had in mind when handling config as a singleton (and we don't intend for people to think accessing other cog's data should be done without that cog being designed for it), but we should be preventing reinitialization of existing config objects from this.

This also removes the potential for an error to be raised in a safe case of using `init_group` multiple times in the same config object, allowing multiple cogs to more safely share a config object if related. 

It will still error if you try to change the identifier count of a group as this would be unsafe.