### PR TITLE
[Downloader] Make `Repo.clean_url` work with relative urls.

### DIFF
--- a/changelog.d/downloader/3141.bugfix.rst
+++ b/changelog.d/downloader/3141.bugfix.rst
@@ -1,0 +1,1 @@
+Make :attr:`redbot.cogs.downloader.repo_manager.Repo.clean_url` work with relative urls. This property uses `str` type now.

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -149,11 +149,13 @@ class Repo(RepoJSONMixin):
         self._loop = loop if loop is not None else asyncio.get_event_loop()
 
     @property
-    def clean_url(self):
+    def clean_url(self) -> str:
         """Sanitized repo URL (with removed HTTP Basic Auth)"""
         url = yarl.URL(self.url)
-        clean_url = url.with_user(None)
-        return clean_url
+        try:
+            return url.with_user(None).human_repr()
+        except ValueError:
+            return self.url
 
     @classmethod
     async def convert(cls, ctx: commands.Context, argument: str) -> Repo:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #3141 