### PR TITLE
Fixes errors on repo add from empty string values for `install_msg`

### DIFF
--- a/changelog.d/downloader/3153.bugfix.rst
+++ b/changelog.d/downloader/3153.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an error on repo add from empty string values for the `install_msg` info.json field.

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -462,7 +462,7 @@ class Downloader(commands.Cog):
             )
         else:
             await ctx.send(_("Repo `{name}` successfully added.").format(name=name))
-            if repo.install_msg is not None:
+            if repo.install_msg:
                 await ctx.send(repo.install_msg.replace("[p]", ctx.prefix))
 
     @repo.command(name="delete", aliases=["remove", "del"], usage="<repo_name>")


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes an issue when the value of `install_msg` was set to an empty string value (such as ""), causing it to not be `None`. Attempting to send this empty string in discord would throw an error. There probably needs to be more checks to the install messages to prevent errors (2k chars, etc), but this PR does not handle that.