### PR TITLE
Remove the API from the audio cog

### DIFF
--- a/changelog.d/audio/3152.misc.rst
+++ b/changelog.d/audio/3152.misc.rst
@@ -1,0 +1,1 @@
+remove an undocumented API from audio


### PR DESCRIPTION

### Description of the changes

Removes an undocumented API which was added into the audio cog. This API was not in a release version, nor documented as an addition in 3.2. Additionally it is part of a cog. It's removal should not be breaking anyone, as nobody should feasibly be using this.
Removes a couple of dispatches.

 - API as a part of the cog itself is in direct conflict with goals stated in #2804
 - Features this was intended to enable can be enabled in other more appropriate ways later on
  - The majority of dispatches were retained, as they may be useful as informational messages to enable additional functionality in other cogs