### PR TITLE
[Changelogs] Remove info about branch support in revision argument

### DIFF
--- a/changelog.d/downloader/2527.feature.2.rst
+++ b/changelog.d/downloader/2527.feature.2.rst
@@ -1,1 +1,1 @@
-Added ``[p]cog installversion <repo_name> <revision> <cogs>`` command that allows you to install cogs from specified revision (commit, tag, branch) of given repo. When using this command, cog will automatically be pinned.
+Added ``[p]cog installversion <repo_name> <revision> <cogs>`` command that allows you to install cogs from specified revision (commit, tag) of given repo. When using this command, cog will automatically be pinned.

--- a/changelog.d/downloader/2527.feature.2.rst
+++ b/changelog.d/downloader/2527.feature.2.rst
@@ -1,1 +1,1 @@
-Added ``[p]cog installversion <repo_name> <revision> <cogs>`` command that allows you to install cogs from specified revision (commit, tag) of given repo. When using this command, cog will automatically be pinned.
+Added ``[p]cog installversion <repo_name> <revision> <cogs>`` command that allows you to install cogs from specified revision (commit, tag) of given repo. When using this command, the cog will automatically be pinned.


### PR DESCRIPTION
Remove info about branch support in revision argument since we confirmed during review of #2571 that it isn't possible yet and can be improved at a later date.