### PR TITLE
[Downloader] Ensure consistent output from git commands

### DIFF
--- a/changelog.d/downloader/3160.misc.rst
+++ b/changelog.d/downloader/3160.misc.rst
@@ -1,0 +1,1 @@
+Ensure consistent output from git commands for purpose of parsing.

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -513,6 +513,12 @@ class Repo(RepoJSONMixin):
         """
         env = os.environ.copy()
         env["GIT_TERMINAL_PROMPT"] = "0"
+        # attempt to force all output to plain ascii english
+        # some methods that parse output may expect it
+        # according to gettext manual both variables have to be set:
+        # https://www.gnu.org/software/gettext/manual/gettext.html#Locale-Environment-Variables
+        env["LC_ALL"] = "C"
+        env["LANGUAGE"] = "C"
         kwargs["env"] = env
         async with self._repo_lock:
             p: CompletedProcess = await self._loop.run_in_executor(


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Git support localisation so output may vary by language causing parsing to fail.
This PR ensures that git will always use English for output.

~~// note: I actually haven't been able to run git in non-English language and this fix is based solely on what I've seen in git's source (and gettext's manual).~~
okay, I've managed to run git in non-English language, I didn't install language pack 😄 