### PR TITLE
Fixed [p]announce failing due to errors messaging the owner.

### DIFF
--- a/changelog.d/admin/3166.bugfix.rst
+++ b/changelog.d/admin/3166.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``[p]announce`` failing after encountering an error attempting to message the bot owner.

--- a/redbot/cogs/admin/announcer.py
+++ b/redbot/cogs/admin/announcer.py
@@ -53,7 +53,6 @@ class Announcer:
 
     async def announcer(self):
         guild_list = self.ctx.bot.guilds
-        bot_owner = (await self.ctx.bot.application_info()).owner
         for g in guild_list:
             if not self.active:
                 return
@@ -66,7 +65,7 @@ class Announcer:
             try:
                 await channel.send(self.message)
             except discord.Forbidden:
-                await bot_owner.send(
+                await self.ctx.bot.send_to_owners(
                     _("I could not announce to server: {server.id}").format(server=g)
                 )
             await asyncio.sleep(0.5)

--- a/redbot/cogs/admin/announcer.py
+++ b/redbot/cogs/admin/announcer.py
@@ -70,9 +70,11 @@ class Announcer:
                 failed.append(str(g.id))
             await asyncio.sleep(0.5)
 
-        await self.ctx.bot.send_to_owners(
-            _("I could not announce to the following servers: {}").format(
-                humanize_list(tuple(map(inline, failed)))
-            )
+        msg = (
+            _("I could not announce to the following server: ")
+            if len(failed) == 1
+            else _("I could not announce to the following servers: ")
         )
+        msg += humanize_list(tuple(map(inline, failed)))
+        await self.ctx.bot.send_to_owners(msg)
         self.active = False

--- a/redbot/cogs/admin/announcer.py
+++ b/redbot/cogs/admin/announcer.py
@@ -3,6 +3,7 @@ import asyncio
 import discord
 from redbot.core import commands
 from redbot.core.i18n import Translator
+from redbot.core.utils.chat_formatting import humanize_list, inline
 
 _ = Translator("Announcer", __file__)
 
@@ -53,6 +54,7 @@ class Announcer:
 
     async def announcer(self):
         guild_list = self.ctx.bot.guilds
+        failed = []
         for g in guild_list:
             if not self.active:
                 return
@@ -65,9 +67,12 @@ class Announcer:
             try:
                 await channel.send(self.message)
             except discord.Forbidden:
-                await self.ctx.bot.send_to_owners(
-                    _("I could not announce to server: {server.id}").format(server=g)
-                )
+                failed.append(str(g.id))
             await asyncio.sleep(0.5)
 
+        await self.ctx.bot.send_to_owners(
+            _("I could not announce to the following servers: {}").format(
+                humanize_list(tuple(map(inline, failed)))
+            )
+        )
         self.active = False


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
If the bot belongs to team or the owner has blocked the bot, `bot_owner.send` will throw an exception, stopping the announcement from continuing. This PR changes this warning to use `bot.send_to_owners` (which has built in error handling) to properly send to the designated owners.

Fixes #3161