### PR TITLE
[Setup] Use instance name in default data path

### DIFF
--- a/changelog.d/3171.bugfix.rst
+++ b/changelog.d/3171.bugfix.rst
@@ -1,0 +1,1 @@
+Handle invalid folder names for data path gracefully in ``redbot-setup`` and ``redbot --edit``.

--- a/changelog.d/3171.enhance.1.rst
+++ b/changelog.d/3171.enhance.1.rst
@@ -1,0 +1,1 @@
+``redbot-setup`` will now use instance name in default data path to avoid creating second instance with same data path.

--- a/changelog.d/3171.enhance.2.rst
+++ b/changelog.d/3171.enhance.2.rst
@@ -1,0 +1,1 @@
+Instance names can now only include characters A-z, numbers, underscores, and hyphens. Old instances are unaffected by this change.

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import sys
+import re
 from copy import deepcopy
 from pathlib import Path
 from typing import Dict, Any, Optional
@@ -59,26 +60,35 @@ def save_config(name, data, remove=False):
         json.dump(_config, fs, indent=4)
 
 
-def get_data_dir():
-    default_data_dir = Path(appdir.user_data_dir)
+def get_data_dir(instance_name: str):
+    data_path = Path(appdir.user_data_dir) / "data" / instance_name
 
+    print()
     print(
         "We've attempted to figure out a sane default data location which is printed below."
         " If you don't want to change this default please press [ENTER],"
         " otherwise input your desired data location."
     )
     print()
-    print("Default: {}".format(default_data_dir))
+    print("Default: {}".format(data_path))
 
-    new_path = input("> ")
+    data_path_input = input("> ")
 
-    if new_path != "":
-        new_path = Path(new_path)
-        default_data_dir = new_path
+    if data_path_input != "":
+        data_path = Path(data_path_input)
 
-    if not default_data_dir.exists():
+    try:
+        exists = data_path.exists()
+    except OSError:
+        print(
+            "We were unable to check your chosen directory."
+            " Provided path may contain an invalid character."
+        )
+        sys.exit(1)
+
+    if not exists:
         try:
-            default_data_dir.mkdir(parents=True, exist_ok=True)
+            data_path.mkdir(parents=True, exist_ok=True)
         except OSError:
             print(
                 "We were unable to create your chosen directory."
@@ -87,11 +97,11 @@ def get_data_dir():
             )
             sys.exit(1)
 
-    print("You have chosen {} to be your data directory.".format(default_data_dir))
+    print("You have chosen {} to be your data directory.".format(data_path))
     if not click.confirm("Please confirm", default=True):
         print("Please start the process over.")
         sys.exit(0)
-    return str(default_data_dir.resolve())
+    return str(data_path.resolve())
 
 
 def get_storage_type():
@@ -113,16 +123,20 @@ def get_storage_type():
     return storage
 
 
-def get_name():
+def get_name() -> str:
     name = ""
     while len(name) == 0:
-        print()
         print(
-            "Please enter a name for your instance, this name cannot include spaces"
-            " and it will be used to run your bot from here on out."
+            "Please enter a name for your instance,"
+            " it will be used to run your bot from here on out.\n"
+            "This name can only include characters A-z, numbers, underscores, and hyphens."
         )
         name = input("> ")
-        if " " in name:
+        if re.fullmatch(r"[a-zA-Z0-9_\-]*", name) is None:
+            print(
+                "ERROR: Instance name can only include"
+                " characters A-z, numbers, underscores, and hyphens!"
+            )
             name = ""
     return name
 
@@ -134,11 +148,11 @@ def basic_setup():
     """
 
     print(
-        "Hello! Before we begin the full configuration process we need to"
-        " gather some initial information about where you'd like us"
-        " to store your bot's data."
+        "Hello! Before we begin, we need to gather some initial information for the new instance."
     )
-    default_data_dir = get_data_dir()
+    name = get_name()
+
+    default_data_dir = get_data_dir(name)
 
     default_dirs = deepcopy(data_manager.basic_config_default)
     default_dirs["DATA_PATH"] = default_data_dir
@@ -151,7 +165,6 @@ def basic_setup():
     driver_cls = drivers.get_driver_class(storage_type)
     default_dirs["STORAGE_DETAILS"] = driver_cls.get_config_details()
 
-    name = get_name()
     if name in instance_data:
         print(
             "WARNING: An instance already exists with this name. "

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -129,7 +129,8 @@ def get_name() -> str:
         print(
             "Please enter a name for your instance,"
             " it will be used to run your bot from here on out.\n"
-            "This name can only include characters A-z, numbers, underscores, and hyphens."
+            "This name is case-sensitive and can only include characters"
+            " A-z, numbers, underscores, and hyphens."
         )
         name = input("> ")
         if re.fullmatch(r"[a-zA-Z0-9_\-]*", name) is None:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
- instance names can now only include characters A-z, numbers, underscores, and hyphens - this isn't strictly required - we *could* have checks for invalid characters in Windows folder names, but supporting all sorts of characters could possibly be troublesome in other cases too
- ``redbot-setup`` will now use instance name in default data path to avoid creating second instance with same data path - the new datapath should typically (everything before `Red-DiscordBot` is dependent on what `appdirs` gives us as it was before) be as follows:
    - Mac OS X: `~/Library/Application Support/Red-DiscordBot/data/<instance_name>`
    - Unix: `~/.local/share/Red-DiscordBot/data/<instance_name>`
    - Win: `C:\Users\<username>\AppData\Local\Red-DiscordBot\Red-DiscordBot\data\<instance_name>`
- ``redbot-setup`` and ``redbot --edit`` should now gracefully handle invalid folder names for data path
- few small changes in ``redbot --edit` (consistency)