### PR TITLE
Clarifies what `[p]backup` does

### DIFF
--- a/changelog.d/3172.enhance.rst
+++ b/changelog.d/3172.enhance.rst
@@ -1,0 +1,1 @@
+Clarified that ``[p]backup`` saves the **bot's** data in the help text.

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1323,8 +1323,9 @@ class Core(commands.Cog, CoreLogic):
     @commands.command()
     @checks.is_owner()
     async def backup(self, ctx: commands.Context, *, backup_dir: str = None):
-        """Creates a backup of all data for the instance.
+        """Creates a backup of all data for this bot instance.
 
+        This backs up the bot's data and settings.
         You may provide a path to a directory for the backup archive to
         be placed in. If the directory does not exist, the bot will
         attempt to create it.


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
After some issues in #support, this change further emphasizes what the `[p]backup` command does, backup the bot's data.