### PR TITLE
[Downloader] Fix `[p]findcog` not working with different levels of imports

### DIFF
--- a/changelog.d/downloader/3177.bugfix.rst
+++ b/changelog.d/downloader/3177.bugfix.rst
@@ -1,0 +1,1 @@
+``[p]findcog`` now properly works for cogs with less typical folder structure.

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1179,7 +1179,7 @@ class Downloader(commands.Cog):
 
         """
         splitted = instance.__module__.split(".")
-        return splitted[-2]
+        return splitted[0]
 
     @commands.command()
     async def findcog(self, ctx: commands.Context, command_name: str) -> None:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #3177 

If #2446 gets merged, this method might need some changes again.