### PR TITLE
[Core] Add `redbot --debuginfo` flag

### DIFF
--- a/changelog.d/3183.enhance.rst
+++ b/changelog.d/3183.enhance.rst
@@ -1,0 +1,1 @@
+Add ``redbot --debuginfo`` flag that shows useful information for debugging.

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -80,11 +80,11 @@ def debug_info():
     """Shows debug information useful for debugging."""
     if sys.platform == "linux":
         import distro  # pylint: disable=import-error
-    
+
     IS_WINDOWS = os.name == "nt"
     IS_MAC = sys.platform == "darwin"
     IS_LINUX = sys.platform == "linux"
-    
+
     pyver = sys.version
     pipver = pip.__version__
     redver = __version__
@@ -111,6 +111,7 @@ def debug_info():
     )
     print(info)
     sys.exit(0)
+
 
 def edit_instance(red, cli_flags):
     no_prompt = cli_flags.no_prompt

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -103,6 +103,7 @@ def debug_info():
         "Debug Info for Red\n\n"
         + "Red version: {}\n".format(redver)
         + "Python version: {}\n".format(pyver)
+        + "Python executable: {}\n".format(sys.executable)
         + "Discord.py version: {}\n".format(dpy_version)
         + "Pip version: {}\n".format(pipver)
         + "OS version: {}\n".format(osver)

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -3,9 +3,12 @@
 # Discord Version check
 
 import asyncio
+import getpass
 import json
 import logging
 import os
+import pip
+import platform
 import shutil
 import sys
 from copy import deepcopy
@@ -16,7 +19,7 @@ import discord
 # Set the event loop policies here so any subsequent `get_event_loop()`
 # calls, in particular those as a result of the following imports,
 # return the correct loop object.
-from redbot import _update_event_loop_policy
+from redbot import _update_event_loop_policy, __version__
 
 _update_event_loop_policy()
 
@@ -72,6 +75,42 @@ def list_instances():
         print(text)
         sys.exit(0)
 
+
+def debug_info():
+    """Shows debug information useful for debugging."""
+    if sys.platform == "linux":
+        import distro  # pylint: disable=import-error
+    
+    IS_WINDOWS = os.name == "nt"
+    IS_MAC = sys.platform == "darwin"
+    IS_LINUX = sys.platform == "linux"
+    
+    pyver = sys.version
+    pipver = pip.__version__
+    redver = __version__
+    dpy_version = discord.__version__
+    if IS_WINDOWS:
+        os_info = platform.uname()
+        osver = "{} {} (version {})".format(os_info.system, os_info.release, os_info.version)
+    elif IS_MAC:
+        os_info = platform.mac_ver()
+        osver = "Mac OSX {} {}".format(os_info[0], os_info[2])
+    else:
+        os_info = distro.linux_distribution()
+        osver = "{} {}".format(os_info[0], os_info[1]).strip()
+    user_who_ran = getpass.getuser()
+    info = (
+        "Debug Info for Red\n\n"
+        + "Red version: {}\n".format(redver)
+        + "Python version: {}\n".format(pyver)
+        + "Discord.py version: {}\n".format(dpy_version)
+        + "Pip version: {}\n".format(pipver)
+        + "OS version: {}\n".format(osver)
+        + "System arch: {}\n".format(platform.machine())
+        + "User: {}\n".format(user_who_ran)
+    )
+    print(info)
+    sys.exit(0)
 
 def edit_instance(red, cli_flags):
     no_prompt = cli_flags.no_prompt
@@ -231,6 +270,8 @@ def main():
         print(description)
         print("Current Version: {}".format(__version__))
         sys.exit(0)
+    elif cli_flags.debuginfo:
+        debug_info()
     elif not cli_flags.instance_name and (not cli_flags.no_instance or cli_flags.edit):
         print("Error: No instance name was provided!")
         sys.exit(1)

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -73,6 +73,7 @@ def parse_cli_flags(args):
         description="Red - Discord Bot", usage="redbot <instance_name> [arguments]"
     )
     parser.add_argument("--version", "-V", action="store_true", help="Show Red's current version")
+    parser.add_argument("--debuginfo", action="store_true", help="Show debug information.")
     parser.add_argument(
         "--list-instances",
         action="store_true",


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
A somewhat cool feature from `redbot-launcher` put in `redbot`

// I'm putting those imports at the top since it looks like `redbot.core.core_commands` 
 would import those anyway.