### PR TITLE
[Docs] Update windows deps instructions

### DIFF
--- a/changelog.d/3188.docs.rst
+++ b/changelog.d/3188.docs.rst
@@ -1,0 +1,1 @@
+update windows docs with up to date dependency instructions

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -52,7 +52,12 @@ Manually installing dependencies
 
 * `Python <https://www.python.org/downloads/>`_ - Red needs Python 3.7.2 or greater
 
+.. attention:: Please make sure that the box to add Python to PATH is CHECKED, otherwise
+               you may run into issues when trying to run Red.
+
 * `Git <https://git-scm.com/download/win>`_
+
+.. attention:: Please choose the option to "Git from the command line and also from 3rd-party software" in Git's setup.
 
 * `Java <https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=hotspot>`_ - needed for Audio
 

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -27,14 +27,14 @@ Then run each of the following commands:
     Set-ExecutionPolicy Bypass -Scope Process -Force
     iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
     choco install git --params "/GitOnlyOnPath /WindowsTerminal" -y
-    choco install visualstudio2019buildtools --package-parameters "--allWorkloads --includeRecommended --includeOptional --passive --locale en-US"
-    choco install python3 --version=3.7.5
+    choco install choco install visualstudio2019-workload-vctools -y
+    choco install python3 --version=3.7.5 -y
 
 For Audio support, you should also run the following command before exiting:
 
 .. code-block:: none
 
-    choco install choco install adoptopenjdk11jre --installarguments "ADDLOCAL=FeatureMain,FeatureJarFileRunWith,FeatureEnvironment,FeatureJavaHome,FeatureOracleJavaSoft INSTALLDIR=%ProgramFiles%\AdoptOpenJDK\"
+    choco install choco install adoptopenjdk11jre --installarguments "ADDLOCAL=FeatureMain,FeatureJarFileRunWith,FeatureEnvironment,FeatureJavaHome,FeatureOracleJavaSoft INSTALLDIR=%ProgramFiles%\AdoptOpenJDK\" -y
 
 
 From here, continue onto `installing Red <installing-red-windows>`.

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -37,7 +37,7 @@ For Audio support, you should also run the following command before exiting:
     choco install choco install adoptopenjdk11jre --installarguments "ADDLOCAL=FeatureMain,FeatureJarFileRunWith,FeatureEnvironment,FeatureJavaHome,FeatureOracleJavaSoft INSTALLDIR=%ProgramFiles%\AdoptOpenJDK\" -y
 
 
-From here, continue onto `installing Red <installing-red-windows>`.
+From here, exit the prompt then continue onto `installing Red <installing-red-windows>`.
 
 ********************************
 Manually installing dependencies

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -27,7 +27,15 @@ Then run each of the following commands:
     Set-ExecutionPolicy Bypass -Scope Process -Force
     iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
     choco install git --params "/GitOnlyOnPath /WindowsTerminal" -y
-    choco install jre8 python -y; exit
+    choco install visualstudio2019buildtools --package-parameters "--allWorkloads --includeRecommended --includeOptional --passive --locale en-US"
+    choco install python3 --version=3.7.5
+
+For Audio support, you should also run the following command before exiting:
+
+.. code-block:: none
+
+    choco install choco install adoptopenjdk11jre --installarguments "ADDLOCAL=FeatureMain,FeatureJarFileRunWith,FeatureEnvironment,FeatureJavaHome,FeatureOracleJavaSoft INSTALLDIR=%ProgramFiles%\AdoptOpenJDK\"
+
 
 From here, continue onto `installing Red <installing-red-windows>`.
 

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -43,18 +43,19 @@ From here, continue onto `installing Red <installing-red-windows>`.
 Manually installing dependencies
 ********************************
 
-* `Python <https://www.python.org/downloads/>`_ - Red needs Python 3.7.0 or greater
+.. attention:: There are additional configuration steps required which are
+               not documented for installing dependencies manually.
+               These dependencies are only listed seperately here for
+               reference purposes.
 
-.. attention:: Please make sure that the box to add Python to PATH is CHECKED, otherwise
-               you may run into issues when trying to run Red.
+* `MSVC Build tools <https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019>`_
+
+* `Python <https://www.python.org/downloads/>`_ - Red needs Python 3.7.2 or greater
 
 * `Git <https://git-scm.com/download/win>`_
 
-.. attention:: Please choose the option to "Git from the command line and also from 3rd-party software" in Git's setup.
+* `Java <https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=hotspot>`_ - needed for Audio
 
-* `Java <https://java.com/en/download/manual.jsp>`_ - needed for Audio
-
-.. attention:: Please choose the "Windows Online" installer.
 
 .. _installing-red-windows:
 

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -34,7 +34,7 @@ For Audio support, you should also run the following command before exiting:
 
 .. code-block:: none
 
-    choco install adoptopenjdk11jre --installarguments "ADDLOCAL=FeatureMain,FeatureJarFileRunWith,FeatureEnvironment,FeatureJavaHome,FeatureOracleJavaSoft INSTALLDIR=%ProgramFiles%\AdoptOpenJDK\" -y
+    choco install adoptopenjdk11jre -y
 
 
 From here, exit the prompt then continue onto `installing Red <installing-red-windows>`.

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -27,14 +27,14 @@ Then run each of the following commands:
     Set-ExecutionPolicy Bypass -Scope Process -Force
     iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
     choco install git --params "/GitOnlyOnPath /WindowsTerminal" -y
-    choco install choco install visualstudio2019-workload-vctools -y
+    choco install visualstudio2019-workload-vctools -y
     choco install python3 --version=3.7.5 -y
 
 For Audio support, you should also run the following command before exiting:
 
 .. code-block:: none
 
-    choco install choco install adoptopenjdk11jre --installarguments "ADDLOCAL=FeatureMain,FeatureJarFileRunWith,FeatureEnvironment,FeatureJavaHome,FeatureOracleJavaSoft INSTALLDIR=%ProgramFiles%\AdoptOpenJDK\" -y
+    choco install adoptopenjdk11jre --installarguments "ADDLOCAL=FeatureMain,FeatureJarFileRunWith,FeatureEnvironment,FeatureJavaHome,FeatureOracleJavaSoft INSTALLDIR=%ProgramFiles%\AdoptOpenJDK\" -y
 
 
 From here, exit the prompt then continue onto `installing Red <installing-red-windows>`.


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

This updates the Windows portion of our install documentation based on discussions about certain changes needed in 3.2

* This does not make the corresponding changes for other OSes
* This includes installing build tools for greater package support
* This uses adoptopenjdk11, but also clearly denotes this is only for audio support now.
* This does not add additional extras under current internal consideration.