### PR TITLE
add apsw-wheels to deps

### DIFF
--- a/changelog.d/3192.misc.rst
+++ b/changelog.d/3192.misc.rst
@@ -1,0 +1,1 @@
+Add ``apsw-wheels`` to dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     aiohttp-json-rpc==0.12.1
     aiosqlite==0.10.0
     appdirs==1.4.3
+    apsw-wheels==3.30.1.post1
     async-timeout==3.0.1
     attrs==19.1.0
     Babel==2.7.0

--- a/tools/primary_deps.ini
+++ b/tools/primary_deps.ini
@@ -10,6 +10,7 @@ install_requires =
     aiohttp-json-rpc
     aiosqlite
     appdirs
+    apsw-wheels
     babel
     click
     colorama


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Adds `apsw-wheels` to our dependencies for cog creator availability (and future planned core usage)