### PR TITLE
[Audio] Move playlist from the Config Driver to their own SQL table

### DIFF
--- a/changelog.d/audio/3195.misc.1.rst
+++ b/changelog.d/audio/3195.misc.1.rst
@@ -1,0 +1,1 @@
+Migrate Playlists to its dedicated playlist table and remove them from the Config driver.

--- a/changelog.d/audio/3199.feature.1.rst
+++ b/changelog.d/audio/3199.feature.1.rst
@@ -1,1 +1,0 @@
-Add self managed daily playlists in the GUILD scope, these are called "Daily playlist - YYYY-MM-DD" and auto delete after 7 days.

--- a/changelog.d/audio/3199.feature.1.rst
+++ b/changelog.d/audio/3199.feature.1.rst
@@ -1,0 +1,1 @@
+Add self managed daily playlists in the GUILD scope, these are called "Daily playlist - YYYY-MM-DD" and auto delete after 7 days.

--- a/redbot/cogs/audio/apis.py
+++ b/redbot/cogs/audio/apis.py
@@ -40,6 +40,9 @@ from .utils import CacheLevel, Notifier, is_allowed, queue_duration, track_limit
 log = logging.getLogger("red.audio.cache")
 _ = Translator("Audio", __file__)
 
+# TODO: https://github.com/Cog-Creators/Red-DiscordBot/pull/3195#issuecomment-567821701
+# Thanks a lot Sinbad!
+
 _DROP_YOUTUBE_TABLE = "DROP TABLE youtube;"
 
 _CREATE_YOUTUBE_TABLE = """

--- a/redbot/cogs/audio/apis.py
+++ b/redbot/cogs/audio/apis.py
@@ -40,8 +40,6 @@ from .utils import CacheLevel, Notifier, is_allowed, queue_duration, track_limit
 log = logging.getLogger("red.audio.cache")
 _ = Translator("Audio", __file__)
 
-# TODO: https://github.com/Cog-Creators/Red-DiscordBot/pull/3195#issuecomment-567821701
-# Thanks a lot Sinbad!
 
 _DROP_YOUTUBE_TABLE = "DROP TABLE youtube;"
 

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -274,7 +274,7 @@ class Audio(commands.Cog):
                 ).clear_raw("playlists")
         if from_version < 3 <= to_version:
             for scope in PlaylistScope.list():
-                scope_playlist = await get_all_playlist_for_migration23(scope)
+                scope_playlist = await get_all_playlist_for_migration23(scope, self.bot)
                 for p in scope_playlist:
                     await p.save()
                 await self.config.custom(scope).clear()

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -38,6 +38,7 @@ from . import audio_dataclasses
 from .apis import _ERROR, HAS_SQL, MusicCache
 from .checks import can_have_caching
 from .converters import ComplexScopeParser, ScopeParser, get_lazy_converter, get_playlist_converter
+from .databases import database_connection
 from .equalizer import Equalizer
 from .errors import (
     DatabaseError,
@@ -7014,7 +7015,6 @@ class Audio(commands.Cog):
     async def _close_database(self):
         await self.music_cache.run_all_pending_tasks()
         await self.music_cache.close()
-        if database:
-            database.close()
+        database_connection.close()
 
     __del__ = cog_unload

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -34,11 +34,11 @@ from redbot.core.utils.menus import (
 )
 from redbot.core.utils.predicates import MessagePredicate, ReactionPredicate
 
+import redbot.cogs.audio.databases
 from . import audio_dataclasses
 from .apis import _ERROR, HAS_SQL, MusicCache
 from .checks import can_have_caching
 from .converters import ComplexScopeParser, ScopeParser, get_lazy_converter, get_playlist_converter
-from .databases import database_connection
 from .equalizer import Equalizer
 from .errors import (
     DatabaseError,
@@ -56,7 +56,6 @@ from .playlists import (
     get_all_playlist,
     get_playlist,
     humanize_scope,
-    database,
     get_all_playlist_for_migration23,
 )
 from .utils import (
@@ -230,7 +229,9 @@ class Audio(commands.Cog):
             await self._migrate_config(
                 from_version=await self.config.schema_version(), to_version=_SCHEMA_VERSION
             )
-            database.delete_scheduled()
+            import redbot.cogs.audio.playlists
+
+            redbot.cogs.audio.playlists.database.delete_scheduled()
             self._restart_connect()
             self._disconnect_task = self.bot.loop.create_task(self.disconnect_timer())
             lavalink.register_event_listener(self.event_handler)
@@ -7015,6 +7016,6 @@ class Audio(commands.Cog):
     async def _close_database(self):
         await self.music_cache.run_all_pending_tasks()
         await self.music_cache.close()
-        database_connection.close()
+        redbot.cogs.audio.databases.database_connection.close()
 
     __del__ = cog_unload

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -274,7 +274,7 @@ class Audio(commands.Cog):
                 ).clear_raw("playlists")
         if from_version < 3 <= to_version:
             for scope in PlaylistScope.list():
-                scope_playlist = await get_all_playlist_for_migration23(scope, self.bot)
+                scope_playlist = await get_all_playlist_for_migration23(scope)
                 for p in scope_playlist:
                     await p.save()
                 await self.config.custom(scope).clear()

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -229,6 +229,7 @@ class Audio(commands.Cog):
             await self._migrate_config(
                 from_version=await self.config.schema_version(), to_version=_SCHEMA_VERSION
             )
+            database.delete_scheduled()
             self._restart_connect()
             self._disconnect_task = self.bot.loop.create_task(self.disconnect_timer())
             lavalink.register_event_listener(self.event_handler)

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -3229,9 +3229,21 @@ class Audio(commands.Cog):
                 ]
             else:
                 correct_scope_matches = [p for p in correct_scope_matches]
+
+        match_count = len(correct_scope_matches)
+        if match_count > 1:
+            correct_scope_matches2 = [
+                p for p in correct_scope_matches if p.name == str(original_input).strip()
+            ]
+            if correct_scope_matches2:
+                correct_scope_matches = correct_scope_matches2
+            elif original_input.isnumeric():
+                arg = int(original_input)
+                correct_scope_matches3 = [p for p in correct_scope_matches if p.id == arg]
+                if correct_scope_matches3:
+                    correct_scope_matches = correct_scope_matches3
         match_count = len(correct_scope_matches)
         # We done all the trimming we can with the info available time to ask the user
-        print("correct_scope_matches", correct_scope_matches)
         if match_count > 10:
             if original_input.isnumeric():
                 arg = int(original_input)
@@ -3950,16 +3962,8 @@ class Audio(commands.Cog):
                 track["info"]["uri"] for track in playlist.tracks
             ]
             # TODO: Keep new playlists backwards compatible, Remove me in a few releases
-            playlist_data[
-                "playlist"
-            ] = (
-                playlist_songs_backwards_compatible
-            )
-            playlist_data[
-                "link"
-            ] = (
-                playlist.url
-            )
+            playlist_data["playlist"] = playlist_songs_backwards_compatible
+            playlist_data["link"] = playlist.url
             file_name = playlist.id
         playlist_data.update({"schema": schema, "version": version})
         playlist_data = json.dumps(playlist_data)

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -56,7 +56,8 @@ from .playlists import (
     get_playlist,
     humanize_scope,
     database,
-    get_all_playlist_for_migration23)
+    get_all_playlist_for_migration23,
+)
 from .utils import *
 
 

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -50,7 +50,6 @@ from .manager import ServerManager
 from .playlists import (
     FakePlaylist,
     Playlist,
-    PlaylistScope,
     create_playlist,
     delete_playlist,
     get_all_playlist,
@@ -69,7 +68,6 @@ from .utils import (
     is_allowed,
     match_url,
     match_yt_playlist,
-    pass_config_to_dependencies,
     queue_duration,
     remove_react,
     rgetattr,
@@ -78,7 +76,9 @@ from .utils import (
     track_limit,
     url_check,
     userlimit,
+    PlaylistScope,
 )
+from .config import pass_config_to_dependencies
 
 _ = Translator("Audio", __file__)
 
@@ -224,8 +224,8 @@ class Audio(commands.Cog):
         try:
             await self.bot.wait_until_ready()
             # Unlike most cases, we want the cache to exit before migration.
-            await self.music_cache.initialize(self.config)
             pass_config_to_dependencies(self.config, self.bot, await self.config.localpath())
+            await self.music_cache.initialize(self.config)
             await self._migrate_config(
                 from_version=await self.config.schema_version(), to_version=_SCHEMA_VERSION
             )

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -226,9 +226,9 @@ class Audio(commands.Cog):
                     for page in pagify(error_message):
                         await self.bot.send_to_owners(page)
                 log.critical(error_message)
-        except Exception as e:
-            log.exception("Error on audio init", exc_info=e)
-            raise e
+        except Exception as err:
+            log.exception("Audio failed to start up, please report this issue.", exc_info=err)
+            raise err
 
         self._ready_event.set()
         self.bot.dispatch("red_audio_initialized", self)

--- a/redbot/cogs/audio/config.py
+++ b/redbot/cogs/audio/config.py
@@ -1,0 +1,15 @@
+from redbot.core import Config
+from redbot.core.bot import Red
+from .audio_dataclasses import _pass_config_to_dataclasses
+from .converters import _pass_config_to_converters
+from .databases import _pass_config_to_databases
+from .playlists import _pass_config_to_playlist
+from .utils import _pass_config_to_utils
+
+
+def pass_config_to_dependencies(config: Config, bot: Red, localtracks_folder: str):
+    _pass_config_to_playlist(config, bot)
+    _pass_config_to_converters(config, bot)
+    _pass_config_to_dataclasses(config, bot, localtracks_folder)
+    _pass_config_to_databases(config, bot)
+    _pass_config_to_utils(config, bot)

--- a/redbot/cogs/audio/config.py
+++ b/redbot/cogs/audio/config.py
@@ -8,8 +8,8 @@ from .utils import _pass_config_to_utils
 
 
 def pass_config_to_dependencies(config: Config, bot: Red, localtracks_folder: str):
+    _pass_config_to_databases(config, bot)
+    _pass_config_to_utils(config, bot)
     _pass_config_to_playlist(config, bot)
     _pass_config_to_converters(config, bot)
     _pass_config_to_dataclasses(config, bot, localtracks_folder)
-    _pass_config_to_databases(config, bot)
-    _pass_config_to_utils(config, bot)

--- a/redbot/cogs/audio/converters.py
+++ b/redbot/cogs/audio/converters.py
@@ -63,7 +63,6 @@ class PlaylistConverter(commands.Converter):
         user_matches = await get_all_playlist_converter(
             PlaylistScope.USER.value, _bot, arg, guild=ctx.guild, author=ctx.author
         )
-
         if not user_matches and not guild_matches and not global_matches:
             raise commands.BadArgument(_("Could not match '{}' to a playlist.").format(arg))
         return {

--- a/redbot/cogs/audio/converters.py
+++ b/redbot/cogs/audio/converters.py
@@ -10,7 +10,8 @@ from redbot.core import Config, commands
 from redbot.core.bot import Red
 from redbot.core.i18n import Translator
 
-from .playlists import PlaylistScope, standardize_scope, get_all_playlist_converter
+from .playlists import standardize_scope, get_all_playlist_converter
+from .utils import PlaylistScope
 
 _ = Translator("Audio", __file__)
 

--- a/redbot/cogs/audio/converters.py
+++ b/redbot/cogs/audio/converters.py
@@ -8,7 +8,7 @@ from redbot.core import Config, commands
 from redbot.core.bot import Red
 from redbot.core.i18n import Translator
 
-from .playlists import PlaylistScope, standardize_scope
+from .playlists import PlaylistScope, standardize_scope, get_all_playlist_converter
 
 _ = Translator("Audio", __file__)
 
@@ -22,8 +22,8 @@ __all__ = [
     "get_playlist_converter",
 ]
 
-_config = None
-_bot = None
+_config: Config = None
+_bot: Red = None
 
 _SCOPE_HELP = """
 Scope must be a valid version of one of the following:
@@ -54,29 +54,18 @@ def _pass_config_to_converters(config: Config, bot: Red):
 
 class PlaylistConverter(commands.Converter):
     async def convert(self, ctx: commands.Context, arg: str) -> dict:
-        global_scope = await _config.custom(PlaylistScope.GLOBAL.value).all()
-        guild_scope = await _config.custom(PlaylistScope.GUILD.value).all()
-        user_scope = await _config.custom(PlaylistScope.USER.value).all()
-        user_matches = [
-            (uid, pid, pdata)
-            for uid, data in user_scope.items()
-            for pid, pdata in data.items()
-            if arg == pid or arg.lower() in pdata.get("name", "").lower()
-        ]
-        guild_matches = [
-            (gid, pid, pdata)
-            for gid, data in guild_scope.items()
-            for pid, pdata in data.items()
-            if arg == pid or arg.lower() in pdata.get("name", "").lower()
-        ]
-        global_matches = [
-            (None, pid, pdata)
-            for pid, pdata in global_scope.items()
-            if arg == pid or arg.lower() in pdata.get("name", "").lower()
-        ]
+        global_matches = await get_all_playlist_converter(
+            PlaylistScope.GLOBAL.value, _bot, arg, guild=ctx.guild, author=ctx.author
+        )
+        guild_matches = await get_all_playlist_converter(
+            PlaylistScope.GUILD.value, _bot, arg, guild=ctx.guild, author=ctx.author
+        )
+        user_matches = await get_all_playlist_converter(
+            PlaylistScope.USER.value, _bot, arg, guild=ctx.guild, author=ctx.author
+        )
+
         if not user_matches and not guild_matches and not global_matches:
             raise commands.BadArgument(_("Could not match '{}' to a playlist.").format(arg))
-
         return {
             PlaylistScope.GLOBAL.value: global_matches,
             PlaylistScope.GUILD.value: guild_matches,

--- a/redbot/cogs/audio/databases.py
+++ b/redbot/cogs/audio/databases.py
@@ -162,7 +162,7 @@ _CREATE_INDEX = """
 CREATE INDEX IF NOT EXISTS name_index ON playlists (scope_type, playlist_id, playlist_name, scope_id);
 """
 
-_con: apsw.Connection = None
+database_connection: apsw.Connection = None
 _config: Config = None
 _bot: Red = None
 
@@ -178,26 +178,25 @@ class SQLFetchResult:
 
 
 def _pass_config_to_databases(config: Config, bot: Red):
-    global _config, _bot, _con
+    global _config, _bot, database_connection
     if _config is None:
         _config = config
     if _bot is None:
         _bot = bot
-    if _con is None:
-        _con = apsw.Connection(str(cog_data_path(_bot.get_cog("Audio")) / "Audio.db"))
+    if database_connection is None:
+        database_connection = apsw.Connection(
+            str(cog_data_path(_bot.get_cog("Audio")) / "Audio.db")
+        )
 
 
-class Playlist_Interface:
+class PlaylistInterface:
     def __init__(self):
-        self.cursor = _con.cursor()
+        self.cursor = database_connection.cursor()
         self.cursor.execute(_PRAGMA_UPDATE_temp_store)
         self.cursor.execute(_PRAGMA_UPDATE_journal_mode)
         self.cursor.execute(_PRAGMA_UPDATE_read_uncommitted)
         self.cursor.execute(_CREATE_TABLE)
         self.cursor.execute(_CREATE_INDEX)
-
-    def close(self):
-        self._database.close()
 
     @staticmethod
     def get_scope_type(scope: str) -> int:

--- a/redbot/cogs/audio/databases.py
+++ b/redbot/cogs/audio/databases.py
@@ -1,5 +1,6 @@
+import json
 from dataclasses import dataclass, field
-from typing import List, Optional, Mapping
+from typing import List, Optional
 
 import apsw
 
@@ -174,7 +175,11 @@ class SQLFetchResult:
     scope_id: int
     author_id: int
     playlist_url: Optional[str] = None
-    tracks: List[Mapping] = field(default_factory=lambda: [])
+    tracks: List[dict] = field(default_factory=lambda: [])
+
+    def __post_init__(self):
+        if isinstance(self.tracks, str):
+            self.tracks = json.loads(self.tracks)
 
 
 def _pass_config_to_databases(config: Config, bot: Red):
@@ -292,7 +297,7 @@ class PlaylistInterface:
                     "scope_id": int(scope_id),
                     "author_id": int(author_id),
                     "playlist_url": playlist_url,
-                    "tracks": tracks,
+                    "tracks": json.dumps(tracks),
                 }
             ),
         )

--- a/redbot/cogs/audio/databases.py
+++ b/redbot/cogs/audio/databases.py
@@ -1,0 +1,299 @@
+from dataclasses import dataclass, field
+from typing import List, Optional, Mapping
+
+import apsw
+
+from redbot.core import Config
+from redbot.core.bot import Red
+from redbot.core.data_manager import cog_data_path
+
+from .utils import PlaylistScope
+
+# TODO: https://github.com/Cog-Creators/Red-DiscordBot/pull/3195#issuecomment-567821701
+# Thanks a lot Sinbad!
+
+_PRAGMA_UPDATE_temp_store = """
+PRAGMA temp_store = 2;
+"""
+_PRAGMA_UPDATE_journal_mode = """
+PRAGMA journal_mode = wal;
+"""
+_PRAGMA_UPDATE_read_uncommitted = """
+PRAGMA read_uncommitted = 1;
+"""
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS playlists ( 
+    scope_type INTEGER NOT NULL, 
+    playlist_id INTEGER NOT NULL, 
+    playlist_name TEXT NOT NULL, 
+    scope_id INTEGER NOT NULL, 
+    author_id INTEGER NOT NULL, 
+    deleted BOOLEAN DEFAULT false,
+    playlist_url TEXT, 
+    tracks JSON, 
+    PRIMARY KEY (playlist_id, scope_id, scope_type)
+);
+"""
+
+_DELETE = """
+UPDATE playlists
+    SET
+        deleted = true
+WHERE
+    (
+        scope_type = :scope_type 
+        AND playlist_id = :playlist_id 
+        AND scope_id = :scope_id 
+    )
+;
+"""
+_DELETE_SCOPE = """
+DELETE
+FROM
+    playlists 
+WHERE
+    scope_type = :scope_type ;
+"""
+
+_DELETE_SCHEDULED = """
+DELETE
+FROM
+    playlists 
+WHERE
+    deleted = true;
+"""
+
+_FETCH_ALL = """
+SELECT
+    playlist_id,
+    playlist_name,
+    scope_id,
+    author_id,
+    playlist_url,
+    tracks 
+FROM
+    playlists 
+WHERE
+    scope_type = :scope_type 
+    AND scope_id = :scope_id
+    AND deleted = false
+    ;
+"""
+
+_FETCH_ALL_WITH_FILTER = """
+SELECT
+    playlist_id,
+    playlist_name,
+    scope_id,
+    author_id,
+    playlist_url,
+    tracks 
+FROM
+    playlists 
+WHERE
+    (
+        scope_type = :scope_type 
+        AND scope_id = :scope_id
+        AND author_id = :author_id 
+        AND deleted = false
+    )
+;
+"""
+
+_FETCH_ALL_CONVERTER = """
+SELECT
+    playlist_id,
+    playlist_name,
+    scope_id,
+    author_id,
+    playlist_url,
+    tracks 
+FROM
+    playlists 
+WHERE
+    (
+        scope_type = :scope_type 
+        AND
+        (
+        playlist_id = :playlist_id
+        OR
+        LOWER(playlist_name) LIKE "%" || COALESCE(LOWER(:playlist_name), "") || "%"
+        )
+        AND deleted = false
+    )
+;
+"""
+
+_FETCH = """
+SELECT
+    playlist_id,
+    playlist_name,
+    scope_id,
+    author_id,
+    playlist_url,
+    tracks 
+FROM
+    playlists 
+WHERE
+    (
+        scope_type = :scope_type 
+        AND playlist_id = :playlist_id 
+        AND scope_id = :scope_id 
+        AND deleted = false
+    )
+"""
+
+_UPSET = """
+INSERT INTO
+    playlists ( scope_type, playlist_id, playlist_name, scope_id, author_id, playlist_url, tracks ) 
+VALUES
+    (
+        :scope_type, :playlist_id, :playlist_name, :scope_id, :author_id, :playlist_url, :tracks 
+    )
+    ON CONFLICT (scope_type, playlist_id, scope_id) DO 
+    UPDATE
+    SET
+        playlist_name = excluded.playlist_name, 
+        playlist_url = excluded.playlist_url, 
+        tracks = excluded.tracks;
+"""
+_CREATE_INDEX = """
+CREATE INDEX IF NOT EXISTS name_index ON playlists (scope_type, playlist_id, playlist_name, scope_id);
+"""
+
+_con: apsw.Connection = None
+_config: Config = None
+_bot: Red = None
+
+
+@dataclass
+class SQLFetchResult:
+    playlist_id: int
+    playlist_name: str
+    scope_id: int
+    author_id: int
+    playlist_url: Optional[str] = None
+    tracks: List[Mapping] = field(default_factory=lambda: [])
+
+
+def _pass_config_to_databases(config: Config, bot: Red):
+    global _config, _bot, _con
+    if _config is None:
+        _config = config
+    if _bot is None:
+        _bot = bot
+    if _con is None:
+        _con = apsw.Connection(str(cog_data_path(_bot.get_cog("Audio")) / "Audio.db"))
+
+
+class Playlist_Interface:
+    def __init__(self):
+        self.cursor = _con.cursor()
+        self.cursor.execute(_PRAGMA_UPDATE_temp_store)
+        self.cursor.execute(_PRAGMA_UPDATE_journal_mode)
+        self.cursor.execute(_PRAGMA_UPDATE_read_uncommitted)
+        self.cursor.execute(_CREATE_TABLE)
+        self.cursor.execute(_CREATE_INDEX)
+
+    def close(self):
+        self._database.close()
+
+    @staticmethod
+    def get_scope_type(scope: str) -> int:
+        if scope == PlaylistScope.GLOBAL.value:
+            table = 1
+        elif scope == PlaylistScope.USER.value:
+            table = 3
+        else:
+            table = 2
+        return table
+
+    def fetch(self, scope: str, playlist_id: int, scope_id: int) -> SQLFetchResult:
+        scope_type = self.get_scope_type(scope)
+        row = (
+            self.cursor.execute(
+                _FETCH,
+                ({"playlist_id": playlist_id, "scope_id": scope_id, "scope_type": scope_type}),
+            ).fetchone()
+            or []
+        )
+
+        return SQLFetchResult(*row) if row else None
+
+    def fetch_all(self, scope: str, scope_id: int, author_id=None) -> List[SQLFetchResult]:
+        scope_type = self.get_scope_type(scope)
+        if author_id is not None:
+            output = self.cursor.execute(
+                _FETCH_ALL_WITH_FILTER,
+                ({"scope_type": scope_type, "scope_id": scope_id, "author_id": author_id}),
+            ).fetchall()
+        else:
+            output = self.cursor.execute(
+                _FETCH_ALL, ({"scope_type": scope_type, "scope_id": scope_id})
+            ).fetchall()
+        return [SQLFetchResult(*row) for row in output] if output else []
+
+    def fetch_all_converter(self, scope: str, playlist_name, playlist_id) -> List[SQLFetchResult]:
+        scope_type = self.get_scope_type(scope)
+        try:
+            playlist_id = int(playlist_id)
+        except:
+            playlist_id = -1
+        output = (
+            self.cursor.execute(
+                _FETCH_ALL_CONVERTER,
+                (
+                    {
+                        "scope_type": scope_type,
+                        "playlist_name": playlist_name,
+                        "playlist_id": playlist_id,
+                    }
+                ),
+            ).fetchall()
+            or []
+        )
+        return [SQLFetchResult(*row) for row in output] if output else []
+
+    def delete(self, scope: str, playlist_id: int, scope_id: int):
+        scope_type = self.get_scope_type(scope)
+        return self.cursor.execute(
+            _DELETE, ({"playlist_id": playlist_id, "scope_id": scope_id, "scope_type": scope_type})
+        )
+
+    def delete_scheduled(self):
+        return self.cursor.execute(_DELETE_SCHEDULED)
+
+    def drop(self, scope: str):
+        scope_type = self.get_scope_type(scope)
+        return self.cursor.execute(_DELETE_SCOPE, ({"scope_type": scope_type}))
+
+    def create_table(self, scope: str):
+        scope_type = self.get_scope_type(scope)
+        return self.cursor.execute(_CREATE_TABLE, ({"scope_type": scope_type}))
+
+    def upsert(
+        self,
+        scope: str,
+        playlist_id: int,
+        playlist_name: str,
+        scope_id: int,
+        author_id: int,
+        playlist_url: str,
+        tracks: List[dict],
+    ):
+        scope_type = self.get_scope_type(scope)
+        self.cursor.execute(
+            _UPSET,
+            (
+                {
+                    "scope_type": str(scope_type),
+                    "playlist_id": int(playlist_id),
+                    "playlist_name": str(playlist_name),
+                    "scope_id": int(scope_id),
+                    "author_id": int(author_id),
+                    "playlist_url": playlist_url,
+                    "tracks": tracks,
+                }
+            ),
+        )

--- a/redbot/cogs/audio/playlists.py
+++ b/redbot/cogs/audio/playlists.py
@@ -200,8 +200,7 @@ class PlaylistMigration23:  # TODO: remove me in a future version ?
 
 
 async def get_all_playlist_for_migration23(  # TODO: remove me in a future version ?
-    scope: str,
-    guild: Union[discord.Guild, int] = None,
+    scope: str, guild: Union[discord.Guild, int] = None,
 ) -> List[PlaylistMigration23]:
     """
     Gets all playlist for the specified scope.

--- a/redbot/cogs/audio/playlists.py
+++ b/redbot/cogs/audio/playlists.py
@@ -202,7 +202,6 @@ class PlaylistMigration23:  # TODO: remove me in a future version ?
 async def get_all_playlist_for_migration23(  # TODO: remove me in a future version ?
     scope: str,
     guild: Union[discord.Guild, int] = None,
-    author: Union[discord.abc.User, int] = None,
 ) -> List[PlaylistMigration23]:
     """
     Gets all playlist for the specified scope.
@@ -212,12 +211,6 @@ async def get_all_playlist_for_migration23(  # TODO: remove me in a future versi
         The custom config scope. One of 'GLOBALPLAYLIST', 'GUILDPLAYLIST' or 'USERPLAYLIST'.
     guild: discord.Guild
         The guild to get the playlist from if scope is GUILDPLAYLIST.
-    author: int
-        The ID of the user to get the playlist from if scope is USERPLAYLIST.
-    bot: Red
-        The bot's instance
-    specified_user:bool
-        Whether or not user ID was passed as an argparse.
     Returns
     -------
     list

--- a/redbot/cogs/audio/playlists.py
+++ b/redbot/cogs/audio/playlists.py
@@ -139,7 +139,7 @@ WHERE
         (
         playlist_id = :playlist_id
         OR
-        playlist_name = :playlist_name
+        LOWER(playlist_name) LIKE "%" || COALESCE(LOWER(:playlist_name), "") || "%"
         )
     )
 ;

--- a/redbot/cogs/audio/playlists.py
+++ b/redbot/cogs/audio/playlists.py
@@ -44,14 +44,8 @@ PRAGMA temp_store = 2;
 _PRAGMA_UPDATE_journal_mode = """
 PRAGMA journal_mode = wal;
 """
-_PRAGMA_UPDATE_wal_autocheckpoint = """
-PRAGMA wal_autocheckpoint;
-"""
 _PRAGMA_UPDATE_read_uncommitted = """
 PRAGMA read_uncommitted = 1;
-"""
-_PRAGMA_UPDATE_optimize = """
-PRAGMA optimize = 1;
 """
 
 _CREATE_TABLE = """
@@ -173,7 +167,9 @@ VALUES
     ON CONFLICT (scope_type, playlist_id, scope_id) DO 
     UPDATE
     SET
-        playlist_name = excluded.playlist_name, playlist_url = excluded.playlist_url, tracks = excluded.tracks;
+        playlist_name = excluded.playlist_name, 
+        playlist_url = excluded.playlist_url, 
+        tracks = excluded.tracks;
 """
 
 
@@ -207,12 +203,10 @@ class Database:
         self.cursor = self._database.cursor()
         self.cursor.execute(_PRAGMA_UPDATE_temp_store)
         self.cursor.execute(_PRAGMA_UPDATE_journal_mode)
-        self.cursor.execute(_PRAGMA_UPDATE_wal_autocheckpoint)
         self.cursor.execute(_PRAGMA_UPDATE_read_uncommitted)
         self.cursor.execute(_CREATE_TABLE)
 
     def close(self):
-        self.cursor.execute(_PRAGMA_UPDATE_optimize)
         self._database.close()
 
     @staticmethod

--- a/redbot/cogs/audio/playlists.py
+++ b/redbot/cogs/audio/playlists.py
@@ -55,121 +55,99 @@ PRAGMA optimize = 1;
 """
 
 _CREATE_TABLE = """
-CREATE TABLE IF NOT EXISTS playlists (
-  scope_type INTEGER NOT NULL,
-  playlist_id INTEGER NOT NULL,
-  playlist_name TEXT NOT NULL,
-  scope_id INTEGER NOT NULL,
-  author_id INTEGER NOT NULL,
-  playlist_url TEXT,
-  tracks BLOB,
-  PRIMARY KEY (playlist_id, scope_id, scope_type)
+CREATE TABLE IF NOT EXISTS playlists ( 
+    scope_type INTEGER NOT NULL, 
+    playlist_id INTEGER NOT NULL, 
+    playlist_name TEXT NOT NULL, 
+    scope_id INTEGER NOT NULL, 
+    author_id INTEGER NOT NULL, 
+    playlist_url TEXT, 
+    tracks BLOB, 
+    PRIMARY KEY (playlist_id, scope_id, scope_type)
 );
 """
 
 _DELETE = """
-DELETE FROM playlists
-WHERE 
-  (
-    scope_type = :scope_type
-  AND
-    playlist_id = :playlist_id
-  AND
-    scope_id = :scope_id
-  )
+DELETE
+FROM
+    playlists 
+WHERE
+    (
+        scope_type = :scope_type 
+        AND playlist_id = :playlist_id 
+        AND scope_id = :scope_id 
+    )
 ;
 """
 _DELETE_SCOPE = """
-DELETE FROM playlists
-WHERE 
-  scope_type = :scope_type
-;
+DELETE
+FROM
+    playlists 
+WHERE
+    scope_type = :scope_type ;
 """
 
 _FETCH_ALL = """
 SELECT
-playlist_id,
-playlist_name,
-scope_id,
-author_id,
-playlist_url,
-tracks
-FROM playlists
-WHERE
-  scope_type = :scope_type
-;
-"""
-
-_FETCH_ALL_WITH_FILTER = """
-SELECT
-playlist_id,
-playlist_name,
-scope_id,
-author_id,
-playlist_url,
-tracks
-FROM playlists
-WHERE
-  (
-    scope_type = :scope_type
-  AND
-    author_id = :author_id
-  )
-;
-"""
-
-_FETCH = """
-SELECT
-playlist_id,
-playlist_name,
-scope_id,
-author_id,
-playlist_url,
-tracks
-FROM playlists
-WHERE 
-  (
-    scope_type = :scope_type
-  AND
-    playlist_id = :playlist_id
-  AND
-    scope_id = :scope_id
-  )
-"""
-
-_UPSET = """INSERT INTO 
-playlists 
-  (
-    scope_type
     playlist_id,
     playlist_name,
     scope_id,
     author_id,
     playlist_url,
-    tracks
-  ) 
-VALUES 
-  (
-    :scope_type,
-    :playlist_id,
-    :playlist_name,
-    :scope_id,
-    :author_id,
-    :playlist_url,
-    :tracks
-  )
-ON CONFLICT
-  (
-  scope_type,
-  playlist_id, 
-  scope_id
-  )
-DO UPDATE 
-  SET 
-    playlist_name = excluded.playlist_name, 
-    playlist_url = excluded.playlist_url, 
-    tracks = excluded.tracks
+    tracks 
+FROM
+    playlists 
+WHERE
+    scope_type = :scope_type ;
+"""
+
+_FETCH_ALL_WITH_FILTER = """
+SELECT
+    playlist_id,
+    playlist_name,
+    scope_id,
+    author_id,
+    playlist_url,
+    tracks 
+FROM
+    playlists 
+WHERE
+    (
+        scope_type = :scope_type 
+        AND author_id = :author_id 
+    )
 ;
+"""
+
+_FETCH = """
+SELECT
+    playlist_id,
+    playlist_name,
+    scope_id,
+    author_id,
+    playlist_url,
+    tracks 
+FROM
+    playlists 
+WHERE
+    (
+        scope_type = :scope_type 
+        AND playlist_id = :playlist_id 
+        AND scope_id = :scope_id 
+    )
+"""
+
+_UPSET = """
+INSERT INTO
+    playlists ( scope_type, playlist_id, playlist_name, scope_id, author_id, playlist_url, tracks ) 
+VALUES
+    (
+        :scope_type, :playlist_id, :playlist_name, :scope_id, :author_id, :playlist_url, :tracks 
+    )
+    ON CONFLICT (scope_type, playlist_id, scope_id) DO 
+    UPDATE
+    SET
+        playlist_name = excluded.playlist_name, playlist_url = excluded.playlist_url, tracks = excluded.tracks;
 """
 
 

--- a/redbot/cogs/audio/playlists.py
+++ b/redbot/cogs/audio/playlists.py
@@ -1,18 +1,23 @@
+import json
+import os
 from collections import namedtuple
 from enum import Enum, unique
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Tuple
 
+import apsw
 import discord
 import lavalink
 
 from redbot.core import Config, commands
 from redbot.core.bot import Red
+from redbot.core.data_manager import cog_data_path
 from redbot.core.i18n import Translator
 from redbot.core.utils.chat_formatting import humanize_list
 from .errors import InvalidPlaylistScope, MissingAuthor, MissingGuild, NotAllowed
 
-_config = None
-_bot = None
+_config: Config = None
+_bot: Red = None
+_database: "Database" = None
 
 __all__ = [
     "Playlist",
@@ -31,6 +36,105 @@ FakePlaylist = namedtuple("Playlist", "author scope")
 
 _ = Translator("Audio", __file__)
 
+_PRAGMA_UPDATE_temp_store = """
+PRAGMA temp_store = 2;
+"""
+_PRAGMA_UPDATE_journal_mode = """
+PRAGMA journal_mode = wal;
+"""
+_PRAGMA_UPDATE_wal_autocheckpoint = """
+PRAGMA wal_autocheckpoint;
+"""
+_PRAGMA_UPDATE_read_uncommitted = """
+PRAGMA read_uncommitted = 1;
+"""
+_PRAGMA_UPDATE_optimize = """
+PRAGMA optimize = 1;
+"""
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS GLOBAL (
+playlist_id INTEGER PRIMARY KEY,
+playlist_name TEXT NOT NULL,
+scope_id INTEGER NOT NULL,
+author_id INTEGER NOT NULL,
+playlist_url TEXT,
+tracks BLOB);
+"""
+
+_DROP = """
+DROP TABLE {table};
+"""
+_DELETE = """
+DELETE FROM {table}
+WHERE 
+    (
+      playlist_id = :playlist_id
+    AND
+      scope_id = :scope_id
+    )
+;
+"""
+_FETCH_ALL = """
+SELECT
+playlist_id,
+playlist_name,
+scope_id,
+author_id,
+playlist_url,
+tracks
+FROM {table};
+"""
+
+_FETCH = """
+SELECT
+playlist_id,
+playlist_name,
+scope_id,
+author_id,
+playlist_url,
+tracks
+FROM {table}
+WHERE 
+    (
+      playlist_id = :playlist_id
+    AND
+      scope_id = :scope_id
+    )
+"""
+
+_UPSET = """INSERT INTO 
+{table} 
+  (
+    playlist_id,
+    playlist_name,
+    scope_id,
+    author_id,
+    playlist_url,
+    tracks
+  ) 
+VALUES 
+  (
+    :playlist_id,
+    :playlist_name,
+    :scope_id,
+    :author_id,
+    :playlist_url,
+    :tracks
+  )
+ON CONFLICT
+  (
+  playlist_id, 
+  scope_id
+  )
+DO UPDATE 
+  SET 
+    playlist_name = :playlist_name,
+    playlist_url = :playlist_url,
+    tracks = :tracks
+;
+"""
+
 
 @unique
 class PlaylistScope(Enum):
@@ -46,12 +150,89 @@ class PlaylistScope(Enum):
         return list(map(lambda c: c.value, PlaylistScope))
 
 
+class Database:
+    def __init__(self):
+        self._database = apsw.Connection(
+            str(cog_data_path(_bot.get_cog("Audio")) / "playlists.db")
+        )
+        self.cursor = self._database.cursor()
+        self.cursor.execute(_PRAGMA_UPDATE_temp_store)
+        self.cursor.execute(_PRAGMA_UPDATE_journal_mode)
+        self.cursor.execute(_PRAGMA_UPDATE_wal_autocheckpoint)
+        self.cursor.execute(_PRAGMA_UPDATE_read_uncommitted)
+        for t in ["GLOBAL", "GUILD", "USER"]:
+            self.cursor.execute(_CREATE_TABLE.format(table=t))
+
+    @staticmethod
+    def parse_query(scope: PlaylistScope, query: str):
+        if scope == PlaylistScope.GLOBAL.value:
+            table = "GLOBAL"
+        elif scope == PlaylistScope.GUILD.value:
+            table = "GUILD"
+        elif scope == PlaylistScope.USER.value:
+            table = "USER"
+        else:
+            raise
+        return query.format(table=table)
+
+    def fetch(
+        self, scope: PlaylistScope, playlist_id: int, scope_id: int
+    ) -> Tuple[int, str, int, int, str, str]:
+        query = self.parse_query(scope, _FETCH)
+        return self.cursor.execute(
+            query, ({"playlist_id": playlist_id, "scope_id": scope_id})
+        ).fetchone()
+
+    def delete(self, scope: PlaylistScope, playlist_id: int, scope_id: int):
+        query = self.parse_query(scope, _DELETE)
+        return self.cursor.execute(query, ({"playlist_id": playlist_id, "scope_id": scope_id}))
+
+    def fetch_all(self, scope: PlaylistScope) -> List[Tuple[int, str, int, int, str, str]]:
+        query = self.parse_query(scope, _FETCH_ALL)
+        return self.cursor.execute(query).fetchall()
+
+    def drop(self, scope: PlaylistScope):
+        query = self.parse_query(scope, _DROP)
+        return self.cursor.execute(query)
+
+    def create_table(self, scope: PlaylistScope):
+        query = self.parse_query(scope, _CREATE_TABLE)
+        return self.cursor.execute(query)
+
+    def upsert(
+        self,
+        scope: PlaylistScope,
+        playlist_id: int,
+        playlist_name: str,
+        scope_id: int,
+        author_id: int,
+        playlist_url: str,
+        tracks: List[dict],
+    ):
+        query = self.parse_query(scope, _UPSET)
+        self.cursor.execute(
+            query,
+            (
+                {
+                    "playlist_id": playlist_id,
+                    "playlist_name": playlist_name,
+                    "scope_id": scope_id,
+                    "author_id": author_id,
+                    "playlist_url": playlist_url,
+                    "tracks": json.dumps(tracks),
+                }
+            ),
+        )
+
+
 def _pass_config_to_playlist(config: Config, bot: Red):
-    global _config, _bot
+    global _config, _bot, _database
     if _config is None:
         _config = config
     if _bot is None:
         _bot = bot
+    if _database is None:
+        _database = Database()
 
 
 def standardize_scope(scope) -> str:
@@ -92,15 +273,15 @@ def _prepare_config_scope(
     scope = standardize_scope(scope)
 
     if scope == PlaylistScope.GLOBAL.value:
-        config_scope = [PlaylistScope.GLOBAL.value]
+        config_scope = [PlaylistScope.GLOBAL.value, _bot.user.id]
     elif scope == PlaylistScope.USER.value:
         if author is None:
             raise MissingAuthor("Invalid author for user scope.")
-        config_scope = [PlaylistScope.USER.value, str(getattr(author, "id", author))]
+        config_scope = [PlaylistScope.USER.value, getattr(author, "id", author)]
     else:
         if guild is None:
             raise MissingGuild("Invalid guild for guild scope.")
-        config_scope = [PlaylistScope.GUILD.value, str(getattr(guild, "id", guild))]
+        config_scope = [PlaylistScope.GUILD.value, getattr(guild, "id", guild)]
     return config_scope
 
 
@@ -132,6 +313,14 @@ class Playlist:
         self.tracks = tracks or []
         self.tracks_obj = [lavalink.Track(data=track) for track in self.tracks]
 
+    def _get_scope_id(self):
+        if self.scope == PlaylistScope.GLOBAL.value:
+            return self.bot.user.id
+        elif self.scope == PlaylistScope.USER.value:
+            return self.author
+        else:
+            return self.guild.id
+
     async def edit(self, data: dict):
         """
         Edits a Playlist.
@@ -146,8 +335,22 @@ class Playlist:
 
         for item in list(data.keys()):
             setattr(self, item, data[item])
+        await self.save()
 
-        await _config.custom(*self.config_scope, str(self.id)).set(self.to_json())
+    async def save(self):
+        """
+        Saves a Playlist.
+        """
+        scope, scope_id = self.config_scope
+        _database.upsert(
+            scope,
+            playlist_id=int(self.id),
+            playlist_name=self.name,
+            scope_id=scope_id,
+            author_id=self.author,
+            playlist_url=self.url,
+            tracks=self.tracks,
+        )
 
     def to_json(self) -> dict:
         """Transform the object to a dict.
@@ -216,7 +419,7 @@ class Playlist:
         )
 
 
-async def get_playlist(
+async def get_playlist( # TODO: convert to SQL
     playlist_number: int,
     scope: str,
     bot: Red,
@@ -262,7 +465,7 @@ async def get_playlist(
     )
 
 
-async def get_all_playlist(
+async def get_all_playlist( # TODO: convert to SQL
     scope: str,
     bot: Red,
     guild: Union[discord.Guild, int] = None,
@@ -360,10 +563,7 @@ async def create_playlist(
     playlist = Playlist(
         ctx.bot, scope, author.id, ctx.message.id, playlist_name, playlist_url, tracks, ctx.guild
     )
-
-    await _config.custom(*_prepare_config_scope(scope, author, guild), str(ctx.message.id)).set(
-        playlist.to_json()
-    )
+    await playlist.save()
     return playlist
 
 
@@ -393,7 +593,9 @@ async def reset_playlist(
     `MissingAuthor`
         Trying to access the User scope without an user id.
     """
-    await _config.custom(*_prepare_config_scope(scope, author, guild)).clear()
+    scope, scope_id = _prepare_config_scope(scope, author, guild)
+    _database.drop(scope)
+    _database.create_table(scope)
 
 
 async def delete_playlist(
@@ -425,4 +627,5 @@ async def delete_playlist(
         `MissingAuthor`
             Trying to access the User scope without an user id.
         """
-    await _config.custom(*_prepare_config_scope(scope, author, guild), str(playlist_id)).clear()
+    scope, scope_id = _prepare_config_scope(scope, author, guild)
+    _database.delete(scope, int(playlist_id), scope_id)

--- a/redbot/cogs/audio/playlists.py
+++ b/redbot/cogs/audio/playlists.py
@@ -215,12 +215,10 @@ class Database:
     def get_scope_type(scope: str) -> int:
         if scope == PlaylistScope.GLOBAL.value:
             table = 1
-        elif scope == PlaylistScope.GUILD.value:
-            table = 2
         elif scope == PlaylistScope.USER.value:
             table = 3
         else:
-            raise
+            table = 2
         return table
 
     def fetch(self, scope: str, playlist_id: int, scope_id: int) -> SQLFetchResult:

--- a/redbot/cogs/audio/playlists.py
+++ b/redbot/cogs/audio/playlists.py
@@ -200,7 +200,7 @@ class PlaylistMigration23:  # TODO: remove me in a future version ?
 
 
 async def get_all_playlist_for_migration23(  # TODO: remove me in a future version ?
-    scope: str, guild: Union[discord.Guild, int] = None,
+    scope: str, guild: Union[discord.Guild, int] = None
 ) -> List[PlaylistMigration23]:
     """
     Gets all playlist for the specified scope.

--- a/redbot/cogs/audio/playlists.py
+++ b/redbot/cogs/audio/playlists.py
@@ -171,6 +171,9 @@ VALUES
         playlist_url = excluded.playlist_url, 
         tracks = excluded.tracks;
 """
+_CREATE_INDEX = """
+CREATE INDEX IF NOT EXISTS name_index ON playlists (scope_type, playlist_id, playlist_name, scope_id);
+"""
 
 
 @dataclass
@@ -205,6 +208,7 @@ class Database:
         self.cursor.execute(_PRAGMA_UPDATE_journal_mode)
         self.cursor.execute(_PRAGMA_UPDATE_read_uncommitted)
         self.cursor.execute(_CREATE_TABLE)
+        self.cursor.execute(_CREATE_INDEX)
 
     def close(self):
         self._database.close()

--- a/redbot/cogs/audio/playlists.py
+++ b/redbot/cogs/audio/playlists.py
@@ -325,7 +325,7 @@ class Database:
                     "scope_id": int(scope_id),
                     "author_id": int(author_id),
                     "playlist_url": playlist_url,
-                    "tracks": json.dumps(tracks),
+                    "tracks": tracks,
                 }
             ),
         )

--- a/redbot/cogs/audio/playlists.py
+++ b/redbot/cogs/audio/playlists.py
@@ -8,13 +8,13 @@ from redbot.core import Config, commands
 from redbot.core.bot import Red
 from redbot.core.i18n import Translator
 from redbot.core.utils.chat_formatting import humanize_list
-from .databases import Playlist_Interface, SQLFetchResult
+from .databases import PlaylistInterface, SQLFetchResult
 from .errors import InvalidPlaylistScope, MissingAuthor, MissingGuild, NotAllowed
 from .utils import PlaylistScope
 
 _config: Config = None
 _bot: Red = None
-database: Playlist_Interface = None
+database: PlaylistInterface = None
 
 __all__ = [
     "Playlist",
@@ -42,7 +42,7 @@ def _pass_config_to_playlist(config: Config, bot: Red):
     if _bot is None:
         _bot = bot
     if database is None:
-        database = Playlist_Interface()
+        database = PlaylistInterface()
 
 
 def standardize_scope(scope) -> str:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

Okay so this should in theory significantly improve audio performance across the border for folks that use the playlist function

@PredaaA using Mart on dev which has #2921 (which significantly reduces JSON size went from 50+MB prior to #2921 to 18.6MB prior to this PR)

With this PR his audio config went from 18.6MB to 287.12 KB... (and say we want to also migrate the EQUALIZER scope to an SQL table ... his config was reduced to 42.97 KB) which should significantly reduce write times and overall make audio commands feel speedier.