### PR TITLE
[Downloader] Discard local changes when updating repo or checking out commit

### DIFF
--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -104,7 +104,7 @@ class Repo(RepoJSONMixin):
     )
     GIT_FETCH = "git -c credential.helper= -c core.askpass= -C {path} fetch -q"
     GIT_SUBMODULE_UPDATE = (
-        "git -c credential.helper= -c core.askpass= -C {path} submodule update --init -q"
+        "git -c credential.helper= -c core.askpass= -C {path} submodule update --init -q --force"
     )
     GIT_DIFF_FILE_STATUS = (
         "git -C {path} diff-tree --no-commit-id --name-status"

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -104,7 +104,8 @@ class Repo(RepoJSONMixin):
     )
     GIT_FETCH = "git -c credential.helper= -c core.askpass= -C {path} fetch -q"
     GIT_SUBMODULE_UPDATE = (
-        "git -c credential.helper= -c core.askpass= -C {path} submodule update --init -q --force"
+        "git -c credential.helper= -c core.askpass= -C {path}"
+        " submodule update --init --recursive --force -q"
     )
     GIT_DIFF_FILE_STATUS = (
         "git -C {path} diff-tree --no-commit-id --name-status"

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -112,7 +112,7 @@ class Repo(RepoJSONMixin):
     )
     GIT_LOG = "git -C {path} log --relative-date --reverse {old_rev}.. {relative_file_path}"
     GIT_DISCOVER_REMOTE_URL = "git -C {path} config --get remote.origin.url"
-    GIT_CHECKOUT = "git -C {path} checkout {rev}"
+    GIT_CHECKOUT = "git -C {path} checkout --force {rev}"
     GIT_GET_FULL_SHA1 = "git -C {path} rev-parse --verify {rev}^{{commit}}"
     GIT_IS_ANCESTOR = (
         "git -C {path} merge-base --is-ancestor {maybe_ancestor_rev} {descendant_rev}"


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
WIP

---
Observations (noticed issues, possible improvements):
- there are no unit tests for git submodules support
- if `git clone` fails, git leaves a partially cloned repo folder and Downloader doesn't remove it (unrelated to this PR, but possibly related to recursing submodules)
- there's a cool flag in `git fetch` - [`--jobs=<n>`](https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt---jobsltngt) which allows parallel fetching of submodules
- using git submodule from some older revision of repo most likely ends up with it being borked in the cog install