### PR TITLE
[Downloader] Actually use disabled key in updates

### DIFF
--- a/changelog.d/downloader/3173.misc.rst
+++ b/changelog.d/downloader/3173.misc.rst
@@ -1,0 +1,1 @@
+Downloader will no longer show update for a cog if the latest version is disabled through ``info.json`` file.

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -252,7 +252,7 @@ class Downloader(commands.Cog):
                 continue
             # marking cog for update if there's no commit data saved (back-compat, see GH-2571)
             last_cog_occurrence = await cog.repo.get_last_module_occurrence(cog.name)
-            if last_cog_occurrence is not None:
+            if last_cog_occurrence is not None and not last_cog_occurrence.disabled:
                 cogs_to_update.add(last_cog_occurrence)
 
         # Reduces diff requests to a single dict with no repeats
@@ -277,7 +277,8 @@ class Downloader(commands.Cog):
                 else:
                     modified_module = modified[index]
                     if modified_module.type == InstallableType.COG:
-                        cogs_to_update.add(modified_module)
+                        if not modified_module.disabled:
+                            cogs_to_update.add(modified_module)
                     elif modified_module.type == InstallableType.SHARED_LIBRARY:
                         libraries_to_update.add(modified_module)
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
WIP - needs testing and I also have alternative solution that detects disabled cogs in `Repo`'s methods, instead of `Downloader`'s methods in case it could work better for this.

Fixes #3173