### PR TITLE
[WIP] [Downloader] Set repo's folder path as cwd when installing requirements

### DIFF
--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -946,7 +946,8 @@ class Repo(RepoJSONMixin):
         p = await self._run(
             ProcessFormatter().format(
                 self.PIP_INSTALL, python=executable, target_dir=target_dir, reqs=requirements
-            )
+            ),
+            cwd=self.folder_path,
         )
 
         if p.returncode != 0:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
I haven't tested this, I didn't think about this very thoroughly either, but this should allow cog creators to install pip package directly from their already downloaded repo. 