### PR TITLE
Prevent abuse cases with qualname length

### DIFF
--- a/changelog.d/3223.misc.rst
+++ b/changelog.d/3223.misc.rst
@@ -1,0 +1,1 @@
+qualified command names are limited to a maximum of 60 characters

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -167,6 +167,11 @@ class Command(CogCommandMixin, commands.Command):
                     raise RuntimeError(
                         f"The name `{name}` cannot be set as a command name. It is reserved for internal use."
                     )
+        if len(self.qualified_name) > 60:
+            raise RuntimeError(
+                f"This command ({self.qualified_name}) has an excessively long qualified name, "
+                "and will not be added to the bot to prevent breaking tools and menus. (limit 60)"
+            )
 
     def _ensure_assignment_on_copy(self, other):
         super()._ensure_assignment_on_copy(other)


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Prevents absurdities with long command names.