### PR TITLE
Allow a small bit of extra async cleanup, without preventing cog unload.

### DIFF
--- a/changelog.d/2474.feature.rst
+++ b/changelog.d/2474.feature.rst
@@ -1,0 +1,2 @@
+New method: ``bot.submit_for_close``.
+Can pass an object with a coroutine method ``close`` to be closed by the bot asynchronously from synchronous cleanup code (such as ``cog_unload``)

--- a/changelog.d/audio/2474.bugfix.rst
+++ b/changelog.d/audio/2474.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent some console noise on audio unload

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -6931,9 +6931,9 @@ class Audio(commands.Cog):
                 pass
 
     def cog_unload(self):
+        self.bot.submit_for_close(self.session)
         if not self._cleaned_up:
             self.bot.dispatch("red_audio_unload", self)
-            self.session.detach()
             self.bot.loop.create_task(self._close_database())
             if self._disconnect_task:
                 self._disconnect_task.cancel()

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -473,7 +473,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
 
         Examples
         --------
-        >>> bot.submit_for_close(asyncio_client_session)  # in cog_unload
+        >>> bot.submit_for_close(aiohttp_client_session)  # in cog_unload
         """
         self._close_queue.put_nowait(obj)
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -401,7 +401,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
             try:
                 await to_close.close()
             except Exception as exc:
-                log.exception("Failed to a close object %r", to_close, exc_info=exc)
+                log.exception("Failed to close object %r", to_close, exc_info=exc)
 
     async def pre_flight(self, cli_flags):
         """


### PR DESCRIPTION
### Type

- [X] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

Adds a new method to the bot for use by cogs: ``submit_for_close``

Passing this an object which implements a coroutine ``close`` which can be called with no arguments, will have the bot handle cleaning up the object asynchronously from synchronous code.

Designed with things such as aiohttp client sessions needing to be closed in `cog_unload` in mind, but allows any object with a similar close method to be passed.

Also has Audio use it, which resolves #2474 