### PR TITLE
[Downloader] Fix `UnboundLocalError` in cog update that happened when cogs were already up-to-date.

### DIFF
--- a/changelog.d/downloader/3229.misc.rst
+++ b/changelog.d/downloader/3229.misc.rst
@@ -1,0 +1,1 @@
+Fix `UnboundLocalError` in cog update that happened when cogs were already up-to-date.

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -859,6 +859,7 @@ class Downloader(commands.Cog):
             pinned_cogs = {cog for cog in cogs_to_check if cog.pinned}
             cogs_to_check -= pinned_cogs
             if not cogs_to_check:
+                cogs_to_update = libs_to_update = ()
                 message += _("There were no cogs to check.")
                 if pinned_cogs:
                     cognames = [cog.name for cog in pinned_cogs]


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #3229 
Used `misc` for changelog as this is a bug that happens only in V3/develop.