### PR TITLE
[Docs] Remove API Reference for downloader, add page about publishing cogs

### DIFF
--- a/changelog.d/3234.docs.rst
+++ b/changelog.d/3234.docs.rst
@@ -1,0 +1,1 @@
+Added "Publishing cogs for V3" document explaining how to make user's cogs work with Downloader.

--- a/changelog.d/downloader/3234.docs.rst
+++ b/changelog.d/downloader/3234.docs.rst
@@ -1,0 +1,1 @@
+Remove API Reference for Downloader cog.

--- a/docs/changelog_3_1_0.rst
+++ b/docs/changelog_3_1_0.rst
@@ -110,7 +110,7 @@ Downloader
  * ``[p]cog uninstall`` allows to uninstall multiple cogs now (`#2592`_)
  * ``[p]cog uninstall`` will now remove cog from installed cogs even if it can't find the cog in install path anymore (`#2595`_)
  * ``[p]cog install`` will not allow to install cogs which aren't suitable for installed version of Red anymore (`#2605`_)
- * Cog Developers now have to use ``min_bot_version`` in form of version string instead of ``bot_version`` in info.json and they can also use ``max_bot_version`` to specify maximum version of Red, more in :doc:`framework_downloader`. (`#2605`_)
+ * Cog Developers now have to use ``min_bot_version`` in form of version string instead of ``bot_version`` in info.json and they can also use ``max_bot_version`` to specify maximum version of Red, more in :ref:`info-json-format`. (`#2605`_)
 
 ------
 Filter

--- a/docs/cog_downloader.rst
+++ b/docs/cog_downloader.rst
@@ -1,9 +1,0 @@
-.. Downloader Cog Reference
-
-Downloader Cog Reference
-========================
-
-.. automodule:: redbot.cogs.downloader
-
-.. autoclass:: redbot.cogs.downloader.downloader.Downloader
-    :members:

--- a/docs/guide_cog_creation.rst
+++ b/docs/guide_cog_creation.rst
@@ -3,9 +3,9 @@
 .. role:: python(code)
     :language: python
 
-====================
-Creating cogs for V3
-====================
+========================
+Creating cogs for Red V3
+========================
 
 This guide serves as a tutorial on creating cogs for Red V3.
 It will cover the basics of setting up a package for your
@@ -135,6 +135,12 @@ have successfully created a cog!
     to load them
     
     You can also take a look at `our cookiecutter <https://github.com/Cog-Creators/cog-cookiecutter>`_, for help creating the right structure.
+
+-------------------
+Publishing your cog
+-------------------
+
+Go to :doc:`/guide_publish_cogs`
 
 --------------------
 Additional resources

--- a/docs/guide_migration.rst
+++ b/docs/guide_migration.rst
@@ -3,9 +3,9 @@
 .. role:: python(code)
     :language: python
 
-====================
-Migrating Cogs to V3
-====================
+==========================
+Migrating cogs from Red V2
+==========================
 
 First, be sure to read :dpy_docs:`discord.py's migration guide <migrating.html>`
 as that covers all of the changes to discord.py that will affect the migration process

--- a/docs/guide_publish_cogs.rst
+++ b/docs/guide_publish_cogs.rst
@@ -1,10 +1,35 @@
-.. downloader framework reference
+.. Publishing cogs for V3
 
-Downloader Framework
-====================
+Publishing cogs for Red V3
+==========================
 
-Info.json
-*********
+Users of Red install 3rd-party cogs using Downloader cog. To make your cog available
+to install for others, you will have to create a git repository
+and publish it on git repository hosting (for example `GitHub <https://github.com>`_)
+
+Repository Template
+-------------------
+
+We have standardized what a repository's structure should look like to better assist
+our Downloader system and provide essential information to the Red portal.
+
+The main repository should contain at a minimum:
+
+ - :ref:`An info.json file <info-json-format>`
+ - One folder for each cog package in the repository
+
+   - refer to :doc:`/guide_cog_creation` for information on how to create a valid cog package
+   - you should also put :ref:`info.json file <info-json-format>` inside each cog folder
+
+We also recommend adding a license and README file with general information about the repository.
+
+For a simple example of what this might look like when finished,
+take a look at `our example template <https://github.com/Cog-Creators/Applications>`_.
+
+.. _info-json-format:
+
+Info.json format
+----------------
 
 The optional info.json file may exist inside every package folder in the repo, 
 as well as in the root of the repo. The following sections describe the valid 
@@ -16,7 +41,7 @@ Keys common to both repo and cog info.json (case sensitive)
 - ``author`` (list of strings) - list of names of authors of the cog or repo.
 
 - ``description`` (string) - A long description of the cog or repo. For cogs, this 
-  is displayed when a user executes ``!cog info``.
+  is displayed when a user executes ``[p]cog info``.
 
 - ``install_msg`` (string) - The message that gets displayed when a cog 
   is installed or a repo is added
@@ -25,7 +50,7 @@ Keys common to both repo and cog info.json (case sensitive)
       used for installing.
 
 - ``short`` (string) - A short description of the cog or repo. For cogs, this info 
-  is displayed when a user executes ``!cog list``
+  is displayed when a user executes ``[p]cog list``
 
 Keys specific to the cog info.json (case sensitive)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -57,46 +82,4 @@ Keys specific to the cog info.json (case sensitive)
 
 .. warning::
     Shared libraries are deprecated since version 3.2 and are marked for removal in version 3.3.
-
-API Reference
-*************
-
-.. automodule:: redbot.cogs.downloader.json_mixins
-
-.. autoclass RepoJSONMixin
-    :members
-
-.. automodule:: redbot.cogs.downloader.installable
-
-Installable
-^^^^^^^^^^^
-
-.. autoclass:: Installable
-    :members:
-
-InstalledModule
-^^^^^^^^^^^^^^^
-
-.. autoclass:: InstalledModule
-    :members:
-
-.. automodule:: redbot.cogs.downloader.repo_manager
-
-Repo
-^^^^
-
-.. autoclass:: Repo
-    :members:
-
-Repo Manager
-^^^^^^^^^^^^
-
-.. autoclass:: RepoManager
-    :members:
-
-Exceptions
-^^^^^^^^^^
-
-.. automodule:: redbot.cogs.downloader.errors
-    :members:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,6 @@ Welcome to Red - Discord Bot's documentation!
     :caption: Cog Reference:
 
     cog_customcom
-    cog_downloader
     cog_permissions
 
 .. toctree::
@@ -38,6 +37,7 @@ Welcome to Red - Discord Bot's documentation!
 
     guide_migration
     guide_cog_creation
+    guide_publish_cogs
     framework_apikeys
     framework_bank
     framework_bot
@@ -46,7 +46,6 @@ Welcome to Red - Discord Bot's documentation!
     framework_commands
     framework_config
     framework_datamanager
-    framework_downloader
     framework_events
     framework_i18n
     framework_modlog


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
https://jack1142-red-prs.readthedocs.io/en/v3-remove_downloader_reference/guide_publish_cogs.html

Due to changes to our version guarantees and privatization, we shouldn't encourage users to use Downloader's API as it isn't guaranteed to stay this way.

This also adds a "Publishing cogs for V3" document explaining how to make user's cogs work with Downloader.

Took some parts from RJM's docs, so added him as co-author.