### PR TITLE
[commands] Implement `__call__` to `commands.Command`

### DIFF
--- a/changelog.d/3241.misc.rst
+++ b/changelog.d/3241.misc.rst
@@ -1,0 +1,1 @@
+implements ``__call__`` for commands

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -157,6 +157,13 @@ class Command(CogCommandMixin, commands.Command):
 
     """
 
+    def __call__(self, *args, **kwargs):
+        if self.cog:
+            # We need to inject cog as self here
+            return self.callback(self.cog, *args, **kwargs)
+        else:
+            return self.callback(*args, **kwargs)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._help_override = kwargs.pop("help_override", None)
@@ -593,7 +600,7 @@ class CogMixin(CogGroupMixin, CogCommandMixin):
     @property
     def all_commands(self) -> Dict[str, Command]:
         """
-        This does not have identical behavior to 
+        This does not have identical behavior to
         Group.all_commands but should return what you expect
         """
         return {cmd.name: cmd for cmd in self.__cog_commands__}
@@ -609,7 +616,7 @@ class CogMixin(CogGroupMixin, CogCommandMixin):
         """
         This really just exists to allow easy use with other methods using can_run
         on commands and groups such as help formatters.
-        
+
         kwargs used in that won't apply here as they don't make sense to,
         but will be swallowed silently for a compatible signature for ease of use.
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

This is technically awesome, but let's not document it for public use rn.

Improves our ability to write tests without convoluting code to do it.

May incidentally make mypy happier about some decorators :eyes: 