### PR TITLE
Fix ctx.clean_prefix for *new* discord behavior

### DIFF
--- a/changelog.d/3249.bugfix.rst
+++ b/changelog.d/3249.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``ctx.clean_prefix`` for undocumented changes from discord

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import re
 from typing import Iterable, List, Union
 import discord
 from discord.ext import commands
@@ -248,7 +249,8 @@ class Context(commands.Context):
     def clean_prefix(self) -> str:
         """str: The command prefix, but a mention prefix is displayed nicer."""
         me = self.me
-        return self.prefix.replace(me.mention, f"@{me.display_name}")
+        pattern = re.compile(rf"<@!?{me.id}>")
+        return pattern.sub(f"@{me.display_name}", self.prefix)
 
     @property
     def me(self) -> discord.abc.User:


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Discord made all mentions with the new text boxes use the `<@!` format, instead of following the prior behavior of " `!` is for telling the client to check a nickname for render"

This fixes ctx.clean_prefix which relied on them not changing that without warning.