### PR TITLE
Fix typo '.foramt()' -> '.format()' in cogs/admin/admin.py

### DIFF
--- a/changelog.d/3255.misc.rst
+++ b/changelog.d/3255.misc.rst
@@ -1,0 +1,1 @@
+Fixes typo '.foramt()' to '.format()' in .redbot/cogs/admin/admin.py

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -145,7 +145,7 @@ class Admin(commands.Cog):
         if member is None:
             member = ctx.author
         if not self.pass_user_hierarchy_check(ctx, role):
-            await ctx.send(_(USER_HIERARCHY_ISSUE_REMOVE).foramt(role=role, member=member))
+            await ctx.send(_(USER_HIERARCHY_ISSUE_REMOVE).format(role=role, member=member))
             return
         if not self.pass_hierarchy_check(ctx, role):
             await ctx.send(_(HIERARCHY_ISSUE_REMOVE).format(role=role, member=member))


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Fixes a typo on line 148 in `./redbot/cogs/admin/admin.py`.
