### PR TITLE
[Core] Fix missing ``await`` in code of ``redbot --edit``.

### DIFF
--- a/changelog.d/3256.misc.rst
+++ b/changelog.d/3256.misc.rst
@@ -1,0 +1,1 @@
+Fix missing ``await`` in code of ``redbot --edit``.

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -282,7 +282,7 @@ async def run_bot(red: Red, cli_flags: Namespace):
 
     if cli_flags.edit:
         try:
-            edit_instance(red, cli_flags)
+            await edit_instance(red, cli_flags)
         except (KeyboardInterrupt, EOFError):
             print("Aborted!")
         finally:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
