### PR TITLE
[Docs] Fix broken docs for `commands.Context.react_quietly`

### DIFF
--- a/changelog.d/3257.docs.rst
+++ b/changelog.d/3257.docs.rst
@@ -1,0 +1,1 @@
+Fix broken docs for :func:`redbot.core.commands.Context.react_quietly`.

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -107,6 +107,7 @@ class Context(commands.Context):
         self, reaction: Union[discord.Emoji, discord.Reaction, discord.PartialEmoji, str]
     ) -> bool:
         """Adds a reaction to to the command message.
+
         Returns
         -------
         bool


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Needs verification that docs are now generated properly (can't check since readthedocs.org builds are failing due to update to python 3.8).
![image](https://user-images.githubusercontent.com/6032823/71685128-ae8cdc00-2d97-11ea-8127-5a87a6e0d7a9.png)
