### PR TITLE
Fix docs building

### DIFF
--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -29,7 +29,7 @@ INTRO = "==========================\nRed Discord Bot - Launcher\n===============
 IS_WINDOWS = os.name == "nt"
 IS_MAC = sys.platform == "darwin"
 
-PYTHON_OK = sys.version_info >= MIN_PYTHON_VERSION
+PYTHON_OK = sys.version_info >= MIN_PYTHON_VERSION or os.getenv("READTHEDOCS", False)
 
 
 def is_venv():

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,8 @@
 from setuptools import setup
+import os
 
-# Metadata and options defined in setup.cfg
-setup()
+if os.getenv("READTHEDOCS", False):
+    setup(python_requires=">=3.7")
+else:
+    # Metadata and options defined in setup.cfg
+    setup()


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

This sidesteps an issue on RTD for now. We won't be able to use `:=` in core until RTD has python3.8 support, but we still benefit from the bugfix which prompted the bump.

3rd party cog creators are free to use such features.