### PR TITLE
[CustomCom] Use humanize_list for iterable arguments

### DIFF
--- a/changelog.d/customcom/3277.enhance.rst
+++ b/changelog.d/customcom/3277.enhance.rst
@@ -1,0 +1,1 @@
+Use humanize_list utility for iterable parameter results, e.g. :code:`{#:Role.members}`.

--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -11,7 +11,7 @@ import discord
 from redbot.core import Config, checks, commands
 from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils import menus
-from redbot.core.utils.chat_formatting import box, pagify, escape
+from redbot.core.utils.chat_formatting import box, pagify, escape, humanize_list
 from redbot.core.utils.predicates import MessagePredicate
 
 _ = Translator("CustomCommands", __file__)
@@ -608,12 +608,21 @@ class CustomCommands(commands.Cog):
     def transform_arg(result, attr, obj) -> str:
         attr = attr[1:]  # strip initial dot
         if not attr:
-            return str(obj)
+            return self.maybe_humanize_list(obj)
         raw_result = "{" + result + "}"
         # forbid private members and nested attr lookups
         if attr.startswith("_") or "." in attr:
             return raw_result
-        return str(getattr(obj, attr, raw_result))
+        return self.maybe_humanize_list(getattr(obj, attr, raw_result))
+
+    @staticmethod
+    def maybe_humanize_list(thing) -> str:
+        if isinstance(thing, str):
+            return thing
+        try:
+            return humanize_list(list(map(str, thing)))
+        except TypeError:
+            return str(thing)
 
     @staticmethod
     def transform_parameter(result, message) -> str:

--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -604,16 +604,16 @@ class CustomCommands(commands.Cog):
         # only update cooldowns if the command isn't on cooldown
         self.cooldowns.update(new_cooldowns)
 
-    @staticmethod
-    def transform_arg(result, attr, obj) -> str:
+    @classmethod
+    def transform_arg(cls, result, attr, obj) -> str:
         attr = attr[1:]  # strip initial dot
         if not attr:
-            return self.maybe_humanize_list(obj)
+            return cls.maybe_humanize_list(obj)
         raw_result = "{" + result + "}"
         # forbid private members and nested attr lookups
         if attr.startswith("_") or "." in attr:
             return raw_result
-        return self.maybe_humanize_list(getattr(obj, attr, raw_result))
+        return cls.maybe_humanize_list(getattr(obj, attr, raw_result))
 
     @staticmethod
     def maybe_humanize_list(thing) -> str:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Some parameter attributes (like `{#:Role.members}`) return iterables, which can result in poor-looking CCs:
![Screenshot](https://cdn.discordapp.com/attachments/492050319241379871/663822477314752592/unknown.png)

This applies `humanize_list` in such cases, resulting in more human-understandable CCs:
![Screenshot](https://cdn.discordapp.com/attachments/492050319241379871/663822987568349185/unknown.png)