### PR TITLE
[3.2.0] dep update

### DIFF
--- a/changelog.d/3279.enhance.rst
+++ b/changelog.d/3279.enhance.rst
@@ -1,0 +1,2 @@
+``[p]playlist download`` will now compress playlists larger than
+the server attachment limit and attempt to send that.

--- a/changelog.d/3288.dep.rst
+++ b/changelog.d/3288.dep.rst
@@ -1,0 +1,1 @@
+bumps dependency versions

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,49 +26,51 @@ classifiers =
 packages = find_namespace:
 python_requires = >=3.8.1
 install_requires =
-    aiohttp==3.5.4
+    aiohttp==3.6.2
     aiohttp-json-rpc==0.12.1
-    aiosqlite==0.10.0
+    aiosqlite==0.11.0
     appdirs==1.4.3
-    apsw-wheels==3.30.1.post1
+    # No source_dist for apsw-wheels rn, consider changing later.
+    apsw-wheels==3.30.1.post1; platform_machine != "aarch64"
+    reddist-apsw==3.30.1.post1; platform_machine == "aarch64"
     async-timeout==3.0.1
-    attrs==19.1.0
-    Babel==2.7.0
+    attrs==19.3.0
+    Babel==2.8.0
     chardet==3.0.4
     Click==7.0
-    colorama==0.4.1
+    colorama==0.4.3
     contextlib2==0.5.5
     discord.py==1.2.5
     distro==1.4.0; sys_platform == "linux"
     fuzzywuzzy==0.17.0
     idna==2.8
-    multidict==4.5.2
+    multidict==4.7.3
     python-Levenshtein-wheels==0.13.1
-    pytz==2019.2
-    PyYAML==5.1.2
+    pytz==2019.3
+    PyYAML==5.3
     Red-Lavalink==0.4.0
-    schema==0.7.0
-    tqdm==4.35.0
+    schema==0.7.1
+    tqdm==4.41.1
     uvloop==0.14.0; sys_platform != "win32" and platform_python_implementation == "CPython"
     websockets==6.0
-    yarl==1.3.0
+    yarl==1.4.2
 
 [options.extras_require]
 docs =
     alabaster==0.7.12
-    certifi==2019.6.16
+    certifi==2019.11.28
     docutils==0.15.2
-    imagesize==1.1.0
+    imagesize==1.2.0
     incremental==17.5.0
-    Jinja2==2.10.1
+    Jinja2==2.10.3
     MarkupSafe==1.1.1
-    packaging==19.1
-    Pygments==2.4.2
-    pyparsing==2.4.2
+    packaging==20.0
+    Pygments==2.5.2
+    pyparsing==2.4.6
     requests==2.22.0
-    six==1.12.0
-    snowballstemmer==1.9.0
-    Sphinx==2.2.0
+    six==1.13.0
+    snowballstemmer==2.0.0
+    Sphinx==2.3.1
     sphinx-rtd-theme==0.4.3
     sphinxcontrib-applehelp==1.0.1
     sphinxcontrib-devhelp==1.0.1
@@ -79,30 +81,31 @@ docs =
     sphinxcontrib-trio==1.1.0
     toml==0.10.0
     towncrier==19.2.0
-    urllib3==1.25.3
+    urllib3==1.25.7
 postgres =
-    asyncpg==0.18.3
+    asyncpg==0.20.0
 style =
-    black==19.3b0
+    black==19.10b0
+    pathspec==0.7.0
+    regex==2020.1.8
     toml==0.10.0
+    typed-ast==1.4.0
 test =
     astroid==2.3.3
-    atomicwrites==1.3.0
     isort==4.3.21
-    lazy-object-proxy==1.4.2
+    lazy-object-proxy==1.4.3
     mccabe==0.6.1
-    more-itertools==7.2.0
-    packaging==19.1
-    pluggy==0.12.0
-    py==1.8.0
-    pylint==2.3.1
-    pyparsing==2.4.2
+    more-itertools==8.0.2
+    packaging==20.0
+    pluggy==0.13.1
+    py==1.8.1
+    pylint==2.4.4
+    pyparsing==2.4.6
     pytest==5.3.2
     pytest-asyncio==0.10.0
-    pytest-mock==1.13.0
-    six==1.12.0
-    typed-ast==1.4.0
-    wcwidth==0.1.7
+    pytest-mock==2.0.0
+    six==1.13.0
+    wcwidth==0.1.8
     wrapt==1.11.2
     zipp==0.6.0
 


### PR DESCRIPTION
### Description of the changes

This needs to be one of the last things we merge for 3.2

(temporarily) resolves #3272 (until we have ci-buildwheels for aarch64) 