### PR TITLE
[Warnings] Make [p]warnings usable on base of permissions

### DIFF
--- a/changelog.d/warnings/2900.enhance.rst
+++ b/changelog.d/warnings/2900.enhance.rst
@@ -1,2 +1,2 @@
-[p]warning can now be used by users that have the permission to use it from the Permissions cog, in order to check another user's warnings.
-[p]mywarnings can now be used by any user (instead of [p]warnings previously) to check their own warnings.
+``[p]warnings`` can now be used by users that have the permission to use it from the Permissions cog, in order to check another user's warnings.
+``[p]mywarnings`` can now be used by any user (instead of ``[p]warnings`` previously) to check their own warnings.

--- a/changelog.d/warnings/2900.enhance.rst
+++ b/changelog.d/warnings/2900.enhance.rst
@@ -1,0 +1,2 @@
+[p]warning can now be used by users that have the permission to use it from the Permissions cog, in order to check another user's warnings.
+[p]mywarn can now be used by any user (instead of [p]warnings previously) to check their own warnings.

--- a/changelog.d/warnings/2900.enhance.rst
+++ b/changelog.d/warnings/2900.enhance.rst
@@ -1,2 +1,2 @@
 [p]warning can now be used by users that have the permission to use it from the Permissions cog, in order to check another user's warnings.
-[p]mywarn can now be used by any user (instead of [p]warnings previously) to check their own warnings.
+[p]mywarnings can now be used by any user (instead of [p]warnings previously) to check their own warnings.

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -370,14 +370,14 @@ class Warnings(commands.Cog):
                 await ctx.send_interactive(
                     pagify(msg, shorten_by=58), box_lang=_("Warnings for {user}").format(user=user)
                 )
-                
+
     @commands.command()
     @commands.guild_only()
     async def mywarnings(self, ctx: commands.Context):
         """List warnings for yourself."""
-        
+
         user = ctx.author
-        
+
         msg = ""
         member_settings = self.config.member(user)
         async with member_settings.warnings() as user_warnings:

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -345,6 +345,13 @@ class Warnings(commands.Cog):
     async def warnings(self, ctx: commands.Context, user: Union[discord.Member, int]):
         """List the warnings for the specified user."""
 
+        try:
+            userid: int = user.id
+        except AttributeError:
+            userid: int = user
+            user = ctx.guild.get_member(userid)
+            user = user or namedtuple("Member", "id guild")(userid, ctx.guild)
+
         msg = ""
         member_settings = self.config.member(user)
         async with member_settings.warnings() as user_warnings:
@@ -377,14 +384,6 @@ class Warnings(commands.Cog):
         msg = ""
         member_settings = self.config.member(user)
         async with member_settings.warnings() as user_warnings:
-
-            try:
-                userid: int = user.id
-            except AttributeError:
-                userid: int = user
-                user = ctx.guild.get_member(userid)
-                user = user or namedtuple("Member", "id guild")(userid, ctx.guild)
-
             if not user_warnings.keys():  # no warnings for the user
                 await ctx.send(_("You have no warnings!"))
             else:

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -12,7 +12,6 @@ from redbot.cogs.warnings.helpers import (
 from redbot.core import Config, checks, commands, modlog
 from redbot.core.bot import Red
 from redbot.core.i18n import Translator, cog_i18n
-from redbot.core.utils.mod import is_admin_or_superior
 from redbot.core.utils.chat_formatting import warning, pagify
 from redbot.core.utils.menus import menu, DEFAULT_CONTROLS
 
@@ -342,36 +341,48 @@ class Warnings(commands.Cog):
 
     @commands.command()
     @commands.guild_only()
+    @checks.admin()
     async def warnings(
         self, ctx: commands.Context, user: Optional[Union[discord.Member, int]] = None
     ):
-        """List the warnings for the specified user.
-
-        Omit `<user>` to see your own warnings.
-
-        Note that showing warnings for users other than yourself requires
-        appropriate permissions.
-        """
+        """List the warnings for the specified user."""
         if user is None:
-            user = ctx.author
-        else:
-            if not await is_admin_or_superior(self.bot, ctx.author):
-                return await ctx.send(
-                    warning(_("You are not allowed to check warnings for other users!"))
-                )
-
-            try:
-                userid: int = user.id
-            except AttributeError:
-                userid: int = user
-                user = ctx.guild.get_member(userid)
-                user = user or namedtuple("Member", "id guild")(userid, ctx.guild)
+            await ctx.send(_("Please provide a user you want to check the warnings for."))
 
         msg = ""
         member_settings = self.config.member(user)
         async with member_settings.warnings() as user_warnings:
             if not user_warnings.keys():  # no warnings for the user
                 await ctx.send(_("That user has no warnings!"))
+            else:
+                for key in user_warnings.keys():
+                    mod_id = user_warnings[key]["mod"]
+                    mod = ctx.bot.get_user(mod_id) or _("Unknown Moderator ({})").format(mod_id)
+                    msg += _(
+                        "{num_points} point warning {reason_name} issued by {user} for "
+                        "{description}\n"
+                    ).format(
+                        num_points=user_warnings[key]["points"],
+                        reason_name=key,
+                        user=mod,
+                        description=user_warnings[key]["description"],
+                    )
+                await ctx.send_interactive(
+                    pagify(msg, shorten_by=58), box_lang=_("Warnings for {user}").format(user=user)
+                )
+                
+    @commands.command()
+    @commands.guild_only()
+    async def mywarnings(self, ctx: commands.Context):
+        """List warnings for yourself."""
+        
+        user = ctx.author
+        
+        msg = ""
+        member_settings = self.config.member(user)
+        async with member_settings.warnings() as user_warnings:
+            if not user_warnings.keys():  # no warnings for the user
+                await ctx.send(_("You have no warnings!"))
             else:
                 for key in user_warnings.keys():
                     mod_id = user_warnings[key]["mod"]

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -342,12 +342,8 @@ class Warnings(commands.Cog):
     @commands.command()
     @commands.guild_only()
     @checks.admin()
-    async def warnings(
-        self, ctx: commands.Context, user: Optional[Union[discord.Member, int]] = None
-    ):
+    async def warnings(self, ctx: commands.Context, user: Union[discord.Member, int]):
         """List the warnings for the specified user."""
-        if user is None:
-            await ctx.send(_("Please provide a user you want to check the warnings for."))
 
         msg = ""
         member_settings = self.config.member(user)
@@ -381,6 +377,14 @@ class Warnings(commands.Cog):
         msg = ""
         member_settings = self.config.member(user)
         async with member_settings.warnings() as user_warnings:
+
+            try:
+                userid: int = user.id
+            except AttributeError:
+                userid: int = user
+                user = ctx.guild.get_member(userid)
+                user = user or namedtuple("Member", "id guild")(userid, ctx.guild)
+
             if not user_warnings.keys():  # no warnings for the user
                 await ctx.send(_("You have no warnings!"))
             else:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Makes [p]warnings work with permissions and introduces [p]mywarnings with the functionality described in #2900 