### PR TITLE
[Modlog API] Add resolution for people inpacted by bad casetypes

### DIFF
--- a/redbot/cogs/modlog/modlog.py
+++ b/redbot/cogs/modlog/modlog.py
@@ -29,7 +29,8 @@ class ModLog(commands.Cog):
     @checks.is_owner()
     @modlogset.command(hidden=True, name="fixcasetypes")
     async def reapply_audittype_migration(self, ctx: commands.Context):
-        """Command to fix misbehaving casetypes"""
+        """Command to fix misbehaving casetypes."""
+        await ctx.send(_("Fixing up the casetypes, this may take a moment."))
         await modlog.handle_auditype_key()
         await ctx.tick()
 

--- a/redbot/cogs/modlog/modlog.py
+++ b/redbot/cogs/modlog/modlog.py
@@ -26,6 +26,13 @@ class ModLog(commands.Cog):
         """Manage modlog settings."""
         pass
 
+    @checks.is_owner()
+    @modlogset.command(hidden=True, name="fixcasetypes")
+    async def reapply_audittype_migration(self, ctx: commands.Context):
+        """Command to fix misbehaving casetypes"""
+        await modlog.handle_auditype_key()
+        await ctx.tick()
+
     @modlogset.command()
     @commands.guild_only()
     async def modlog(self, ctx: commands.Context, channel: discord.TextChannel = None):

--- a/redbot/cogs/modlog/modlog.py
+++ b/redbot/cogs/modlog/modlog.py
@@ -30,7 +30,6 @@ class ModLog(commands.Cog):
     @modlogset.command(hidden=True, name="fixcasetypes")
     async def reapply_audittype_migration(self, ctx: commands.Context):
         """Command to fix misbehaving casetypes."""
-        await ctx.send(_("Fixing up the casetypes, this may take a moment."))
         await modlog.handle_auditype_key()
         await ctx.tick()
 

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -512,7 +512,7 @@ class CaseType:
         self.guild = guild
         if kwargs:
             log.warning(
-                "Fix this using the hidden command: `modlogset fixcasetypes`:  "
+                "Fix this using the hidden command: `modlogset fixcasetypes` in Discord: "
                 "Got unexpected key(s) in casetype %s",
                 ",".join(kwargs.keys()),
             )

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -142,6 +142,18 @@ async def _init(bot: Red):
     bot.add_listener(on_member_unban)
 
 
+async def handle_auditype_key():
+    all_casetypes = {
+        casetype_name: {
+            inner_key: inner_value
+            for inner_key, inner_value in casetype_data.items()
+            if inner_key != "audit_type"
+        }
+        for casetype_name, casetype_data in (await _conf.custom(_CASETYPES).all()).items()
+    }
+    await _conf.custom(_CASETYPES).set(all_casetypes)
+
+
 async def _migrate_config(from_version: int, to_version: int):
     if from_version == to_version:
         return
@@ -170,16 +182,7 @@ async def _migrate_config(from_version: int, to_version: int):
             await _conf.guild(cast(discord.Guild, discord.Object(id=guild_id))).clear_raw("cases")
 
     if from_version < 3 <= to_version:
-        all_casetypes = {
-            casetype_name: {
-                inner_key: inner_value
-                for inner_key, inner_value in casetype_data.items()
-                if inner_key != "audit_type"
-            }
-            for casetype_name, casetype_data in (await _conf.custom(_CASETYPES).all()).items()
-        }
-
-        await _conf.custom(_CASETYPES).set(all_casetypes)
+        await handle_auditype_key()
         await _conf.schema_version.set(3)
 
     if from_version < 4 <= to_version:
@@ -508,7 +511,11 @@ class CaseType:
         self.case_str = case_str
         self.guild = guild
         if kwargs:
-            log.warning("Got unexpected keys in case %s", ",".join(kwargs.keys()))
+            log.warning(
+                "Fix this using the hidden command: `modlogset fixcasetypes`:  "
+                "Got unexpected key(s) in casetype %s",
+                ",".join(kwargs.keys()),
+            )
 
     async def to_json(self):
         """Transforms the case type into a dict and saves it"""

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -510,12 +510,15 @@ class CaseType:
         self.image = image
         self.case_str = case_str
         self.guild = guild
-        if kwargs:
+
+        if "audit_type" in kwargs:
+            kwargs.pop("audit_type", None)
             log.warning(
                 "Fix this using the hidden command: `modlogset fixcasetypes` in Discord: "
-                "Got unexpected key(s) in casetype %s",
-                ",".join(kwargs.keys()),
+                "Got outdated key in casetype: audit_type"
             )
+        if kwargs:
+            log.warning("Got unexpected key(s) in casetype: %s", ",".join(kwargs.keys()))
 
     async def to_json(self):
         """Transforms the case type into a dict and saves it"""


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

The worst case right now is just some log spam, but people who migrated from mongo don't have a great resolution for this without it.

The command is hidden, informed about in logging, and does not add a new top-level command to prevent polluting the top level command namespace.