### PR TITLE
Add a command to set the bot description

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -76,6 +76,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
             help__verify_checks=True,
             help__verify_exists=False,
             help__tagline="",
+            description="Red V3",
             invite_public=False,
             invite_perm=0,
             disabled_commands=[],
@@ -400,6 +401,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
         This should only be run once, prior to connecting to discord.
         """
         await self._maybe_update_config()
+        self.description = await self._config.description()
 
         init_global_checks(self)
         init_events(self, cli_flags)

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -198,7 +198,7 @@ class RedHelpFormatter:
             emb = {"embed": {"title": "", "description": ""}, "footer": {"text": ""}, "fields": []}
 
             if description:
-                emb["embed"]["title"] = f"*{description[:2044]}*"
+                emb["embed"]["title"] = f"*{description[:250]}*"
 
             emb["footer"]["text"] = tagline
             emb["embed"]["description"] = signature
@@ -209,7 +209,7 @@ class RedHelpFormatter:
                 value = "\n\n".join(splitted[1:]).replace("[p]", ctx.clean_prefix)
                 if not value:
                     value = EMPTY_STRING
-                field = EmbedField(name[:252], value[:1024], False)
+                field = EmbedField(name[:250], value[:1024], False)
                 emb["fields"].append(field)
 
             if subcommands:
@@ -442,7 +442,7 @@ class RedHelpFormatter:
 
             emb["footer"]["text"] = tagline
             if description:
-                emb["embed"]["title"] = f"*{description[:2044]}*"
+                emb["embed"]["title"] = f"*{description[:250]}*"
 
             for cog_name, data in coms:
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -873,6 +873,25 @@ class Core(commands.Cog, CoreLogic):
             for page in pagify(settings):
                 await ctx.send(box(page))
 
+    @checks.is_owner()
+    @_set.command(name="description")
+    async def setdescription(self, ctx: commands.Context, *, description: str = ""):
+        """
+        Sets the bot's description.
+        Use without a description to reset.
+        This is shown in a few locations, including the help menu.
+
+        The default is "Red V3"
+        """
+        if not description:
+            await ctx.bot._config.description.clear()
+            ctx.bot.description = "Red V3"
+            await ctx.send(_("Description reset."))
+        else:
+            await ctx.bot._config.description.set(description)
+            ctx.bot.description = description
+            await ctx.tick()
+
     @_set.command()
     @checks.guildowner()
     @commands.guild_only()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -887,6 +887,13 @@ class Core(commands.Cog, CoreLogic):
             await ctx.bot._config.description.clear()
             ctx.bot.description = "Red V3"
             await ctx.send(_("Description reset."))
+        elif len(description) > 250:  # While the limit is 256, we bold it adding characters.
+            await ctx.send(
+                _(
+                    "This description is too long to properly display. "
+                    "Please try again with below 250 characters"
+                )
+            )
         else:
             await ctx.bot._config.description.set(description)
             ctx.bot.description = description


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [X] New feature

### Description of the changes

Does what it says on the tin.

Follow up from the license info command which was added as a compromise with users on which parts of the bot could be customized while still retaining proper license details.