### PR TITLE
Allow pre_invoke to be used by 3rd party cogs safely.

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -164,10 +164,10 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
 
     async def _red_before_invoke_method(self, ctx):
         await self.wait_until_red_ready()
-        exceptions_cancel = not isinstance(ctx.command, commands.commands._AlwaysAvailableCommand)
+        return_exceptions = not isinstance(ctx.command, commands.commands._AlwaysAvailableCommand)
         await asyncio.gather(
             *(coro(ctx) for coro in self._red_before_invoke_objs),
-            return_exceptions=exceptions_cancel,
+            return_exceptions=return_exceptions,
         )
 
     def remove_before_invoke_hook(self, coro: Coroutine):

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -10,7 +10,19 @@ from datetime import datetime
 from enum import IntEnum
 from importlib.machinery import ModuleSpec
 from pathlib import Path
-from typing import Optional, Union, List, Dict, NoReturn, Set, Coroutine, TypeVar
+from typing import (
+    Optional,
+    Union,
+    List,
+    Dict,
+    NoReturn,
+    Set,
+    Coroutine,
+    TypeVar,
+    Callable,
+    Awaitable,
+    Any,
+)
 from types import MappingProxyType
 
 import discord
@@ -35,7 +47,9 @@ log = logging.getLogger("redbot")
 __all__ = ["RedBase", "Red", "ExitCodes"]
 
 NotMessage = namedtuple("NotMessage", "guild")
-T_BIC = TypeVar("T_BIC")
+
+PreInvokeCoroutine = Callable[[commands.Context], Awaitable[Any]]
+T_BIC = TypeVar("T_BIC", bound=PreInvokeCoroutine)
 
 
 def _is_submodule(parent, child):
@@ -151,7 +165,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
 
         self._permissions_hooks: List[commands.CheckPredicate] = []
         self._red_ready = asyncio.Event()
-        self._red_before_invoke_objs: Set[Coroutine] = set()
+        self._red_before_invoke_objs: Set[PreInvokeCoroutine] = set()
 
     @property
     def _before_invoke(self):
@@ -171,7 +185,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
                 return_exceptions=return_exceptions,
             )
 
-    def remove_before_invoke_hook(self, coro: Coroutine):
+    def remove_before_invoke_hook(self, coro: PreInvokeCoroutine):
         """
         Functional method to remove a before_invoke hooks
         """

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -185,9 +185,9 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
                 return_exceptions=return_exceptions,
             )
 
-    def remove_before_invoke_hook(self, coro: PreInvokeCoroutine):
+    def remove_before_invoke_hook(self, coro: PreInvokeCoroutine) -> None:
         """
-        Functional method to remove a ``before_invoke`` hook.
+        Functional method to remove a `before_invoke` hook.
         """
         self._red_before_invoke_objs.discard(coro)
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -35,7 +35,7 @@ log = logging.getLogger("redbot")
 __all__ = ["RedBase", "Red", "ExitCodes"]
 
 NotMessage = namedtuple("NotMessage", "guild")
-T_BIC = TypeVar("T_BIC", Coroutine)
+T_BIC = TypeVar("T_BIC")
 
 
 def _is_submodule(parent, child):

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -173,7 +173,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
 
     @_before_invoke.setter
     def _before_invoke(self, val):
-        """Prevent this from being overwriten in super().__init__"""
+        """Prevent this from being overwritten in super().__init__"""
         pass
 
     async def _red_before_invoke_method(self, ctx):
@@ -187,30 +187,30 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
 
     def remove_before_invoke_hook(self, coro: PreInvokeCoroutine):
         """
-        Functional method to remove a before_invoke hooks
+        Functional method to remove a ``before_invoke`` hook.
         """
         self._red_before_invoke_objs.discard(coro)
 
     def before_invoke(self, coro: T_BIC) -> T_BIC:
         """
-        Overriden Decorator method for Red's before_invoke behavior
+        Overridden decorator method for Red's ``before_invoke`` behavior.
         
         This can safely be used purely functionally as well.
         
         3rd party cogs should remove any hooks which they register at unload
-        Using `remove_before_invoke_hook`
+        using `remove_before_invoke_hook`
 
-        Below behavior shared with Discord.py:
+        Below behavior shared with discord.py:
 
         .. note::
-            The before_invoke hooks are
+            The ``before_invoke`` hooks are
             only called if all checks and argument parsing procedures pass
             without error. If any check or argument parsing procedures fail
             then the hooks are not called.
         
         Parameters
         ----------
-        coro:
+        coro: Callable[[commands.Context], Awaitable[Any]]
             The coroutine to register as the pre-invoke hook.
         
         Raises

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -159,7 +159,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
 
     @_before_invoke.setter
     def _before_invoke(self, val):
-        """ Prevent this from being overwriten in super().__init__ """
+        """Prevent this from being overwriten in super().__init__"""
         pass
 
     async def _red_before_invoke_method(self, ctx):
@@ -194,11 +194,12 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
             then the hooks are not called.
         
         Parameters
-        -----------
+        ----------
         coro:
             The coroutine to register as the pre-invoke hook.
+        
         Raises
-        -------
+        ------
         TypeError
             The coroutine passed is not actually a coroutine.
         """

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -165,10 +165,11 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
     async def _red_before_invoke_method(self, ctx):
         await self.wait_until_red_ready()
         return_exceptions = not isinstance(ctx.command, commands.commands._AlwaysAvailableCommand)
-        await asyncio.gather(
-            *(coro(ctx) for coro in self._red_before_invoke_objs),
-            return_exceptions=return_exceptions,
-        )
+        if self._red_before_invoke_objs:
+            await asyncio.gather(
+                *(coro(ctx) for coro in self._red_before_invoke_objs),
+                return_exceptions=return_exceptions,
+            )
 
     def remove_before_invoke_hook(self, coro: Coroutine):
         """

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -178,7 +178,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
 
     async def _red_before_invoke_method(self, ctx):
         await self.wait_until_red_ready()
-        return_exceptions = not isinstance(ctx.command, commands.commands._AlwaysAvailableCommand)
+        return_exceptions = isinstance(ctx.command, commands.commands._AlwaysAvailableCommand)
         if self._red_before_invoke_objs:
             await asyncio.gather(
                 *(coro(ctx) for coro in self._red_before_invoke_objs),

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -168,11 +168,11 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
         self._red_before_invoke_objs: Set[PreInvokeCoroutine] = set()
 
     @property
-    def _before_invoke(self):
+    def _before_invoke(self):  # DEP-WARN
         return self._red_before_invoke_method
 
     @_before_invoke.setter
-    def _before_invoke(self, val):
+    def _before_invoke(self, val):  # DEP-WARN
         """Prevent this from being overwritten in super().__init__"""
         pass
 

--- a/redbot/core/global_checks.py
+++ b/redbot/core/global_checks.py
@@ -14,14 +14,6 @@ def init_global_checks(bot):
         return ctx.channel.permissions_for(ctx.me).send_messages
 
     @bot.check_once
-    def actually_up(ctx) -> bool:
-        """ 
-        Uptime is set during the initial startup process.
-        If this hasn't been set, we should assume the bot isn't ready yet. 
-        """
-        return ctx.bot.uptime is not None
-
-    @bot.check_once
     async def whiteblacklist_checks(ctx) -> bool:
         return await ctx.bot.allowed_by_whitelist_blacklist(ctx.author)
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Okay, so there's a lot in this diff, but the idea is to actually be able to allow 3rd party cogs to use pre_invoke globally without conflicting eachother, or disrupting other goals with the bot.