### PR TITLE
[Audio] Show correct time remaining for bumped tracks

### DIFF
--- a/changelog.d/audio/3373.bugfix.1.rst
+++ b/changelog.d/audio/3373.bugfix.1.rst
@@ -1,0 +1,1 @@
+``[p]bumpplay`` now shows the current remaining time until the bumped track is played.

--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -2954,8 +2954,7 @@ class Audio(commands.Cog):
             return await self._embed_msg(ctx, embed=embed)
         elif isinstance(tracks, discord.Message):
             return
-        queue_dur = await queue_duration(ctx)
-        lavalink.utils.format_time(queue_dur)
+        queue_dur = await track_remaining_duration(ctx)
         index = query.track_index
         seek = 0
         if query.start_time:

--- a/redbot/cogs/audio/audio_dataclasses.py
+++ b/redbot/cogs/audio/audio_dataclasses.py
@@ -211,7 +211,7 @@ class LocalPath:
 
     def tracks_in_tree(self):
         tracks = []
-        for track in self.multirglob(*[f"*{ext}" for ext in self._all_music_ext]):
+        for track in self.multirglob(*[f"{ext}" for ext in self._all_music_ext]):
             if track.exists() and track.is_file() and track.parent != self.localtrack_folder:
                 tracks.append(Query.process_input(LocalPath(str(track.absolute()))))
         return sorted(tracks, key=lambda x: x.to_string_user().lower())

--- a/redbot/cogs/audio/utils.py
+++ b/redbot/cogs/audio/utils.py
@@ -43,6 +43,7 @@ __all__ = [
     "CacheLevel",
     "format_playlist_picker_data",
     "get_track_description_unformatted",
+    "track_remaining_duration",
     "Notifier",
     "PlaylistScope",
 ]
@@ -124,6 +125,20 @@ async def queue_duration(ctx) -> int:
         remain = 0
     queue_total_duration = remain + queue_dur
     return queue_total_duration
+
+
+async def track_remaining_duration(ctx) -> int:
+    player = lavalink.get_player(ctx.guild.id)
+    if not player.current:
+        return 0
+    try:
+        if not player.current.is_stream:
+            remain = player.current.length - player.position
+        else:
+            remain = 0
+    except AttributeError:
+        remain = 0
+    return remain
 
 
 async def draw_time(ctx) -> str:


### PR DESCRIPTION
# Description of the changes

``[p]bumpplay`` now shows the current remaining time until the bumped track is played.

Fixes #3373 