### PR TITLE
[Core] Removed redundant event loop check

### DIFF
--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -181,9 +181,7 @@ class VersionInfo:
 
 
 def _update_event_loop_policy():
-    if _sys.platform == "win32":
-        _asyncio.set_event_loop_policy(_asyncio.WindowsProactorEventLoopPolicy())
-    elif _sys.implementation.name == "cpython":
+    if _sys.implementation.name == "cpython":
         # Let's not force this dependency, uvloop is much faster on cpython
         try:
             import uvloop as _uvloop


### PR DESCRIPTION
Removed redundant check.

### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Removed a check that forced windows to use ProactorEventLoop. As of Python 3.8, it now uses ProactorEventLoop by default.