### PR TITLE
Stop special casing help in bot.embed_requested

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -622,9 +622,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
         bool
             :code:`True` if an embed is requested
         """
-        if isinstance(channel, discord.abc.PrivateChannel) or (
-            command and command == self.get_command("help")
-        ):
+        if isinstance(channel, discord.abc.PrivateChannel):
             user_setting = await self._config.user(user).embeds()
             if user_setting is not None:
                 return user_setting
@@ -632,6 +630,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
             guild_setting = await self._config.guild(channel.guild).embeds()
             if guild_setting is not None:
                 return guild_setting
+
         global_setting = await self._config.embeds()
         return global_setting
 


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

- help is no longer special-cased in bot.embed_requested
- help no longer abnormally has guild setting ignored in bot.embed_requested

### For people looking at this later with questions

The original purpose for this predates the new help formatter, and is no longer directly relevant.

At this point, this special casing is more confusing than helpful, but leaving the signature alone both to not break callers, and to leave this open to further improvements in the future.
