### PR TITLE
Preemptive patch for discord.py changes

### DIFF
--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -323,14 +323,25 @@ class Command(CogCommandMixin, commands.Command):
             if not change_permission_state:
                 ctx.permission_state = original_state
 
-    async def _verify_checks(self, ctx):
+    async def prepare(self, ctx):
+        ctx.command = self
+
         if not self.enabled:
             raise commands.DisabledCommand(f"{self.name} command is disabled")
 
-        if not (await self.can_run(ctx, change_permission_state=True)):
+        if not await self.can_run(ctx, change_permission_state=True):
             raise commands.CheckFailure(
                 f"The check functions for command {self.qualified_name} failed."
             )
+
+        if self.cooldown_after_parsing:
+            await self._parse_arguments(ctx)
+            self._prepare_cooldowns(ctx)
+        else:
+            self._prepare_cooldowns(ctx)
+            await self._parse_arguments(ctx)
+
+        await self.call_before_hooks(ctx)
 
     async def do_conversion(
         self, ctx: "Context", converter, argument: str, param: inspect.Parameter
@@ -618,14 +629,14 @@ class Group(GroupMixin, Command, CogGroupMixin, commands.Group):
 
         if ctx.invoked_subcommand is None or self == ctx.invoked_subcommand:
             if self.autohelp and not self.invoke_without_command:
-                await self._verify_checks(ctx)
+                await self.can_run(ctx, change_permission_state=True)
                 await ctx.send_help()
         elif self.invoke_without_command:
             # So invoke_without_command when a subcommand of this group is invoked
             # will skip the the invokation of *this* command. However, because of
             # how our permissions system works, we don't want it to skip the checks
             # as well.
-            await self._verify_checks(ctx)
+            await self.can_run(ctx, change_permission_state=True)
             # this is actually why we don't prepare earlier.
 
         await super().invoke(ctx)
@@ -770,7 +781,4 @@ class _AlwaysAvailableCommand(Command):
             raise TypeError("This command may not be added to a cog")
 
     async def can_run(self, ctx, *args, **kwargs) -> bool:
-        return not ctx.author.bot
-
-    async def _verify_checks(self, ctx) -> bool:
         return not ctx.author.bot

--- a/redbot/core/commands/requires.py
+++ b/redbot/core/commands/requires.py
@@ -758,14 +758,42 @@ class _RulesDict(Dict[Union[int, str], PermState]):
 
 def _validate_perms_dict(perms: Dict[str, bool]) -> None:
     for perm, value in perms.items():
-        try:
-            attr = getattr(discord.Permissions, perm)
-        except AttributeError:
-            attr = None
 
-        if attr is None or not isinstance(attr, property):
-            # We reject invalid permissions
-            raise TypeError(f"Unknown permission name '{perm}'")
+        # DEP-WARN: This one needs to be changed when formally updating to d.py 1.3
+        # This is to prevent users who upgrade now from breaking.
+        if perm not in (
+            "add_reactions",
+            "administrator",
+            "attach_files",
+            "ban_members",
+            "change_nickname",
+            "connect",
+            "create_instant_invite",
+            "deafen_members",
+            "embed_links",
+            "external_emojis",
+            "kick_members",
+            "manage_channels",
+            "manage_emojis",
+            "manage_guild",
+            "manage_messages",
+            "manage_nicknames",
+            "manage_roles",
+            "manage_webhooks",
+            "mention_everyone",
+            "move_members",
+            "mute_members",
+            "priority_speaker",
+            "read_message_history",
+            "read_messages",
+            "send_messages",
+            "send_tts_messages",
+            "speak",
+            "stream",
+            "use_voice_activation",
+            "view_audit_log",
+        ):
+            raise TypeError(f"Unknown perm {perm}")
 
         if value is not True:
             # We reject any permission not specified as 'True', since this is the only value which


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

Patch here is to make it safer to use\* the development version of discord.py without dropping support for 1.2.5 (latest stable) Some of this should be and is marked for further change at 1.3

\* As the changes for 1.3 are not yet finalized, this only handles the known issues in a way which won't break 1.2.5 users

I repeat: This is not a "go ahead and use the dev version of discord.py", this merely allows us to start testing 1.3 internally.