### PR TITLE
[3.2.3][Audio] Enforce a Cog wide check that return false until audio is ready

### DIFF
--- a/changelog.d/audio/3389.bugfix.1.rst
+++ b/changelog.d/audio/3389.bugfix.1.rst
@@ -1,0 +1,1 @@
+Disable Audio commands until startup has completed.

--- a/redbot/cogs/audio/playlists.py
+++ b/redbot/cogs/audio/playlists.py
@@ -54,7 +54,6 @@ def _pass_config_to_playlist(config: Config, bot: Red):
 
 
 def get_playlist_database() -> Optional[PlaylistInterface]:
-    global database
     return database
 
 


### PR DESCRIPTION
Fixes #3389 by adding a global cog check that disables all audio commands until the cog is ready to be used ... 