### PR TITLE
[Automation] Skip assigning "Needs triage" label if issue already has a status label

### DIFF
--- a/.github/workflows/auto_labeler.yml
+++ b/.github/workflows/auto_labeler.yml
@@ -13,9 +13,14 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
+            const is_status_label = (label) => label.name.startsWith('Status: ');
+            if (context.payload.issue.labels.some(is_status_label)) {
+                console.log('Issue already has Status label, skipping...');
+                return;
+            }
             github.issues.addLabels({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               labels: ['Status: Needs Triage']
-            })
+            });


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Useful for people in org who assign labels right when they create issues.