### PR TITLE
fixup docs

### DIFF
--- a/changelog.d/3148.misc.1.rst
+++ b/changelog.d/3148.misc.1.rst
@@ -1,1 +1,0 @@
-Cache prefixes rather than lookup from config each time

--- a/changelog.d/3224.enhance.rst
+++ b/changelog.d/3224.enhance.rst
@@ -1,1 +1,0 @@
-Adds server IDs to servers command.

--- a/changelog.d/3306.docs.rst
+++ b/changelog.d/3306.docs.rst
@@ -1,1 +1,0 @@
-Add "Fork me on GitHub" ribbon in top right corner of the docs page.

--- a/changelog.d/3335.enhance.rst
+++ b/changelog.d/3335.enhance.rst
@@ -1,1 +1,0 @@
-make typehints accessible to cog developers

--- a/changelog.d/3368.docs.rst
+++ b/changelog.d/3368.docs.rst
@@ -1,1 +1,0 @@
-Update modlog documentation example to show "action_type" instead of "action".

--- a/changelog.d/3390.misc.rst
+++ b/changelog.d/3390.misc.rst
@@ -1,1 +1,0 @@
-Fixes a typo in redbot/core/commands/requires.py.

--- a/changelog.d/audio/3140.enhance.1.rst
+++ b/changelog.d/audio/3140.enhance.1.rst
@@ -1,1 +1,0 @@
-Update the help strings for ``[p]audioset emptydisconnect``.

--- a/changelog.d/audio/3328.hotfix.1.rst
+++ b/changelog.d/audio/3328.hotfix.1.rst
@@ -1,1 +1,0 @@
-Fixed an attribute error that can be raised on play commands for spotify tracks.

--- a/changelog.d/audio/3328.hotfix.2.rst
+++ b/changelog.d/audio/3328.hotfix.2.rst
@@ -1,1 +1,0 @@
-Check data before it is inserted into the database to avoid corruption.

--- a/changelog.d/audio/3337.misc.1.rst
+++ b/changelog.d/audio/3337.misc.1.rst
@@ -1,1 +1,0 @@
-Removed a duplication of track search prefixes.

--- a/changelog.d/audio/3337.misc.2.rst
+++ b/changelog.d/audio/3337.misc.2.rst
@@ -1,1 +1,0 @@
-Changed and handled  the `V2_COMPACT` LoadType to use the correct `V2_COMPAT` type.

--- a/changelog.d/audio/3342.enhance.1.rst
+++ b/changelog.d/audio/3342.enhance.1.rst
@@ -1,2 +1,0 @@
-Reduce some cooldowns on playlist commands and stop them triggering before command parsing.
-

--- a/changelog.d/audio/3344.enhance.1.rst
+++ b/changelog.d/audio/3344.enhance.1.rst
@@ -1,1 +1,0 @@
-Fixes the messages for playlists.

--- a/changelog.d/audio/3345.enhance.1.rst
+++ b/changelog.d/audio/3345.enhance.1.rst
@@ -1,1 +1,0 @@
-Fix an issues with the formatting of non existing local tracks.

--- a/changelog.d/audio/3349.bugfix.1.rst
+++ b/changelog.d/audio/3349.bugfix.1.rst
@@ -1,1 +1,0 @@
-Fixed a bug where ``[p]audioset dc`` didn't disconnect the bot.

--- a/changelog.d/audio/3373.bugfix.1.rst
+++ b/changelog.d/audio/3373.bugfix.1.rst
@@ -1,1 +1,0 @@
-``[p]bumpplay`` now shows the current remaining time until the bumped track is played.

--- a/changelog.d/warnings/2900.enhance.rst
+++ b/changelog.d/warnings/2900.enhance.rst
@@ -1,2 +1,0 @@
-``[p]warnings`` can now be used by users that have the permission to use it from the Permissions cog, in order to check another user's warnings.
-``[p]mywarnings`` can now be used by any user (instead of ``[p]warnings`` previously) to check their own warnings.

--- a/docs/framework_commands.rst
+++ b/docs/framework_commands.rst
@@ -15,6 +15,7 @@ extend functionlities used throughout the bot, as outlined below.
 
 .. autoclass:: redbot.core.commands.Command
     :members:
+    :inherited-members: format_help_for_context
 
 .. autoclass:: redbot.core.commands.Group
     :members:


### PR DESCRIPTION
### Type
Fixes a missing item from command reference which is intended to be documented.
Also removes the old changelog fragments