### PR TITLE
Catches `discord.NotFound` in `utils.mod.mass_purge`

### DIFF
--- a/changelog.d/3378.bugfix.rst
+++ b/changelog.d/3378.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an error when ``redbot.core.utils.mod.mass_purge`` is passed ``COUNT % 100 == 1`` messages AND the last message in the list does not exist.

--- a/redbot/core/utils/mod.py
+++ b/redbot/core/utils/mod.py
@@ -38,12 +38,13 @@ async def mass_purge(messages: List[discord.Message], channel: discord.TextChann
 
     """
     while messages:
-        if len(messages) > 1:
+        # discord.NotFound can be raised when `len(messages) == 1` and the message does not exist.
+        # As a result of this obscure behavior, this error needs to be caught just in case.
+        try:
             await channel.delete_messages(messages[:100])
-            messages = messages[100:]
-        else:
-            await messages[0].delete()
-            messages = []
+        except discord.errors.HTTPException:
+            pass
+        messages = messages[100:]
         await asyncio.sleep(1.5)
 
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixed an error when `redbot.core.utils.mod.mass_purge` is passed `COUNT % 100 == 1` messages AND the last message in the list does not exist.
Fixes #3378