### PR TITLE
Help delete pages delay feature

### DIFF
--- a/changelog.d/3433.feature.rst
+++ b/changelog.d/3433.feature.rst
@@ -1,0 +1,1 @@
+Added a ``[p]helpset deletedelay`` command, that lets you set a delay (in seconds) after which help messages / pages will be deleted.

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -88,6 +88,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
             custom_info=None,
             help__page_char_limit=1000,
             help__max_pages_in_guild=2,
+            help__delete_delay=0,
             help__use_menus=False,
             help__show_hidden=False,
             help__verify_checks=True,
@@ -186,9 +187,9 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
     def before_invoke(self, coro: T_BIC) -> T_BIC:
         """
         Overridden decorator method for Red's ``before_invoke`` behavior.
-        
+
         This can safely be used purely functionally as well.
-        
+
         3rd party cogs should remove any hooks which they register at unload
         using `remove_before_invoke_hook`
 
@@ -199,12 +200,12 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
             only called if all checks and argument parsing procedures pass
             without error. If any check or argument parsing procedures fail
             then the hooks are not called.
-        
+
         Parameters
         ----------
         coro: Callable[[commands.Context], Awaitable[Any]]
             The coroutine to register as the pre-invoke hook.
-        
+
         Raises
         ------
         TypeError
@@ -298,7 +299,7 @@ class RedBase(commands.GroupMixin, commands.bot.BotBase, RPCMixin):  # pylint: d
         ------
         TypeError
             Did not provide ``who`` or ``who_id``
-            
+
         Returns
         -------
         bool

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -662,7 +662,7 @@ class RedHelpFormatter:
                 not use_DMs  # we're not in DMs
                 and delete_delay > 0  # delete delay is enabled
                 and channel_permissions.manage_messages  # we can manage messages here
-                and len(pages) < 100  # there's less than 100 pages to delete
+                and len(messages) <= 100  # there's no more than 100 messages to delete
             ):
 
                 # We need to wrap this in a task to not block after-sending-help interactions.

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -660,11 +660,14 @@ class RedHelpFormatter:
             if delete_delay is not None:
 
                 # We need to wrap this in a task to not block after-sending-help interactions.
-                async def _delete_delay_help(bot, messages: List[discord.Message], delay: int):
+                # The channel has to be TextChannel as we can't bulk-delete from DMs
+                async def _delete_delay_help(
+                    channel: discord.TextChannel, messages: List[discord.Message], delay: int
+                ):
                     await asyncio.sleep(delay)
-                    await bot.delete_messages(messages)
+                    await channel.delete_messages(messages)
 
-                asyncio.create_task(_delete_delay_help(ctx.bot, messages, delete_delay))
+                asyncio.create_task(_delete_delay_help(destination, messages, delete_delay))
         else:
             # Specifically ensuring the menu's message is sent prior to returning
             m = await (ctx.send(embed=pages[0]) if embed else ctx.send(pages[0]))

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -44,6 +44,7 @@ from . import commands
 from .context import Context
 from ..i18n import Translator
 from ..utils import menus
+from ..utils.mod import mass_purge
 from ..utils._internal_utils import fuzzy_command_search, format_fuzzy_results
 from ..utils.chat_formatting import box, pagify
 
@@ -662,7 +663,6 @@ class RedHelpFormatter:
                 not use_DMs  # we're not in DMs
                 and delete_delay > 0  # delete delay is enabled
                 and channel_permissions.manage_messages  # we can manage messages here
-                and len(messages) <= 100  # there's no more than 100 messages to delete
             ):
 
                 # We need to wrap this in a task to not block after-sending-help interactions.
@@ -671,7 +671,7 @@ class RedHelpFormatter:
                     channel: discord.TextChannel, messages: List[discord.Message], delay: int
                 ):
                     await asyncio.sleep(delay)
-                    await channel.delete_messages(messages)
+                    await mass_purge(messages, channel)
 
                 asyncio.create_task(_delete_delay_help(destination, messages, delete_delay))
         else:

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -634,7 +634,7 @@ class RedHelpFormatter:
 
             max_pages_in_guild = await ctx.bot._config.help.max_pages_in_guild()
             use_DMs = len(pages) > max_pages_in_guild
-            destination = ctx.author if use_DMs else ctx
+            destination = ctx.author if use_DMs else ctx.channel
             delete_delay = await ctx.bot._config.help.delete_delay()
             if delete_delay == 0 or use_DMs:
                 # This feature is disabled when we're sending to DMs or setting is 0

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1378,6 +1378,9 @@ class Core(commands.Cog, CoreLogic):
         if seconds < 0:
             await ctx.send(_("You must give a value of zero or greater!"))
             return
+        if seconds > 60 * 60 * 24 * 14:  # 14 days
+            await ctx.send(_("The delay cannot be longer than 14 days!"))
+            return
 
         await ctx.bot._config.help.delete_delay.set(seconds)
         if seconds == 0:

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1380,7 +1380,10 @@ class Core(commands.Cog, CoreLogic):
             return
 
         await ctx.bot._config.help.delete_delay.set(seconds)
-        await ctx.send(_("Done. The delete delay has been set to {} seconds.").format(seconds))
+        if seconds == 0:
+            await ctx.send(_("Done. Help messages will not be deleted now."))
+        else:
+            await ctx.send(_("Done. The delete delay has been set to {} seconds.").format(seconds))
 
     @helpset.command(name="tagline")
     async def helpset_tagline(self, ctx: commands.Context, *, tagline: str = None):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1369,6 +1369,7 @@ class Core(commands.Cog, CoreLogic):
         await ctx.send(_("Done. The page limit has been set to {}.").format(pages))
 
     @helpset.command(name="deletedelay")
+    @commands.bot_has_permissions(manage_messages=True)
     async def helpset_deletedelay(self, ctx: commands.Context, seconds: int):
         """Set the delay after which help pages will be deleted.
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1372,8 +1372,11 @@ class Core(commands.Cog, CoreLogic):
     async def helpset_deletedelay(self, ctx: commands.Context, seconds: int):
         """Set the delay after which help pages will be deleted.
 
-        The setting is disabled by default, and only applies to non-menu help.
+        The setting is disabled by default, and only applies to non-menu help,
+        sent in server text channels.
         Setting the delay to 0 disables this feature.
+
+        The bot has to have MANAGE_MESSAGES permission for this to work.
         """
         if seconds < 0:
             await ctx.send(_("You must give a value of zero or greater!"))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1368,6 +1368,20 @@ class Core(commands.Cog, CoreLogic):
         await ctx.bot._config.help.max_pages_in_guild.set(pages)
         await ctx.send(_("Done. The page limit has been set to {}.").format(pages))
 
+    @helpset.command(name="deletedelay")
+    async def helpset_deletedelay(self, ctx: commands.Context, seconds: int):
+        """Set the delay after which help pages will be deleted.
+
+        The setting is disabled by default, and only applies to non-menu help.
+        Setting the delay to 0 disables this feature.
+        """
+        if seconds < 0:
+            await ctx.send(_("You must give a value of zero or greater!"))
+            return
+
+        await ctx.bot._config.help.delete_delay.set(seconds)
+        await ctx.send(_("Done. The delete delay has been set to {} seconds.").format(seconds))
+
     @helpset.command(name="tagline")
     async def helpset_tagline(self, ctx: commands.Context, *, tagline: str = None):
         """


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes

This PR adds a feature that allows you to set a delay after which the help messages / pages will be deleted after using a help command. Disabled by default. Doesn't affect embed-menu-based help since that's handled differently. Doesn't delete when sending to DMs, nor does it delete the issued help command message itself. Handles code blocks and embed-based help. Uses bulk delete. Tested on code-blocks help only, but should work for embed type too.

It addresses one of the future plans in #2667, however the current help config structure doesn't seem to support per-guild settings easily, so this has been implemented as a global bot setting. Should be good enough though.