### PR TITLE
[Docs] Fix `which` cmd for pyenv in systemd docs

### DIFF
--- a/docs/autostart_systemd.rst
+++ b/docs/autostart_systemd.rst
@@ -14,11 +14,11 @@ In order to create the service file, you will first need the location of your :c
 
     # If redbot is installed in a virtualenv
     source redenv/bin/activate
+    which python
 
     # If you are using pyenv
     pyenv shell <name>
-
-    which python
+    pyenv which python
 
 Then create the new service file:
 


### PR DESCRIPTION
### Type

- [X] Docs

### Description of the changes
Using `which python` when using a pyenv venv returns one of pyenv's shims (e.g. `/home/zephyrkul/.pyenv/shims/python`), which won't work in systemd when using the docs-recommended `pyenv shell` setting.
Rather, `pyenv which python` should be used instead.