### PR TITLE
[Downloader] Log errors from initialization task

### DIFF
--- a/changelog.d/downloader/3444.misc.rst
+++ b/changelog.d/downloader/3444.misc.rst
@@ -1,0 +1,1 @@
+ Log errors that may happen in initialization task.

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -89,7 +89,6 @@ class Downloader(commands.Cog):
                 )
                 self._ready_raised = True
                 self._ready.set()
-                
 
         self._init_task = asyncio.create_task(self.initialize())
         self._init_task.add_done_callback(_done_callback)

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -68,12 +68,12 @@ class Downloader(commands.Cog):
     async def cog_before_invoke(self, ctx: commands.Context) -> None:
         async with ctx.typing():
             await self._ready.wait()
-            if self._ready_raised:
-                await ctx.send(
-                    "There was an error during Downloader's initialization."
-                    " Check logs for more information."
-                )
-                raise commands.CheckFailure()
+        if self._ready_raised:
+            await ctx.send(
+                "There was an error during Downloader's initialization."
+                " Check logs for more information."
+            )
+            raise commands.CheckFailure()
 
     def cog_unload(self):
         if self._init_task is not None:

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -73,7 +73,16 @@ class Downloader(commands.Cog):
             self._init_task.cancel()
 
     def create_init_task(self):
+        def _done_callback(task: asyncio.Task) -> None:
+            exc = task.exception()
+            if exc is not None:
+                log.error(
+                    "An unexpected error occurred during Downloader's initialization.",
+                    exc_info=exc,
+                )
+
         self._init_task = asyncio.create_task(self.initialize())
+        self._init_task.add_done_callback(_done_callback)
 
     async def initialize(self) -> None:
         await self._repo_manager.initialize()


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This adds done callback which will log any exception (and its traceback) that may occur in initialization task. If error occurs during initialization, all command calls will tell about it and won't run.
// I was wondering for quite a while why initialization task just stopped working after I've tried changing something in Downloader...