### PR TITLE
[Core] Update licenseinfo command to conform with non-American English.

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2412,7 +2412,7 @@ class Core(commands.Cog, CoreLogic):
 
 # Removing this command from forks is a violation of the GPLv3 under which it is licensed.
 # Otherwise interfering with the ability for this command to be accessible is also a violation.
-@commands.command(cls=commands.commands._AlwaysAvailableCommand, name="licenseinfo", i18n=_)
+@commands.command(cls=commands.commands._AlwaysAvailableCommand, name="licenceinfo", aliases=["licenseinfo"], i18n=_)
 async def license_info_command(ctx):
     """
     Get info about Red's licenses

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2414,8 +2414,8 @@ class Core(commands.Cog, CoreLogic):
 # Otherwise interfering with the ability for this command to be accessible is also a violation.
 @commands.command(
     cls=commands.commands._AlwaysAvailableCommand,
-    name="licenceinfo",
-    aliases=["licenseinfo"],
+    name="licenseinfo",
+    aliases=["licenceinfo"],
     i18n=_,
 )
 async def license_info_command(ctx):
@@ -2424,7 +2424,7 @@ async def license_info_command(ctx):
     """
 
     message = (
-        "This bot is an instance of Red-DiscordBot (hereafter refered to as Red)\n"
+        "This bot is an instance of Red-DiscordBot (hereafter referred to as Red)\n"
         "Red is a free and open source application made available to the public and "
         "licensed under the GNU GPLv3. The full text of this license is available to you at "
         "<https://github.com/Cog-Creators/Red-DiscordBot/blob/V3/develop/LICENSE>"

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2412,7 +2412,12 @@ class Core(commands.Cog, CoreLogic):
 
 # Removing this command from forks is a violation of the GPLv3 under which it is licensed.
 # Otherwise interfering with the ability for this command to be accessible is also a violation.
-@commands.command(cls=commands.commands._AlwaysAvailableCommand, name="licenceinfo", aliases=["licenseinfo"], i18n=_)
+@commands.command(
+    cls=commands.commands._AlwaysAvailableCommand,
+    name="licenceinfo",
+    aliases=["licenseinfo"],
+    i18n=_,
+)
 async def license_info_command(ctx):
     """
     Get info about Red's licenses


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

Update the licence command to confirm with non-American English and keep it inline with the `colour`/`color` command
