### PR TITLE
[Docs] Trigger update on `sudo add-apt-repository ...`

### DIFF
--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -231,14 +231,14 @@ We recommend adding the ``git-core`` ppa to install Git 2.11 or greater:
 .. code-block:: none
 
     sudo apt update
-    sudo apt install software-properties-common
-    sudo add-apt-repository ppa:git-core/ppa
+    sudo apt -y install software-properties-common
+    sudo add-apt-repository -yu ppa:git-core/ppa
 
 We recommend adding the ``deadsnakes`` ppa to install Python 3.8.1 or greater:
 
 .. code-block:: none
 
-    sudo add-apt-repository ppa:deadsnakes/ppa
+    sudo add-apt-repository -yu ppa:deadsnakes/ppa
 
 Now install the pre-requirements with apt:
 
@@ -262,8 +262,8 @@ We recommend adding the ``git-core`` ppa to install Git 2.11 or greater:
 .. code-block:: none
 
     sudo apt update
-    sudo apt install software-properties-common
-    sudo add-apt-repository ppa:git-core/ppa
+    sudo apt -y install software-properties-common
+    sudo add-apt-repository -yu ppa:git-core/ppa
 
 Now, to install non-native version of python on non-LTS versions of Ubuntu, we recommend
 installing pyenv. To do this, first run the following commands:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Added `-u` flag to `add-apt-repository` command to automatically update given repository.
Unneeded in Ubuntu 18.04+ but the option is left there for legacy syntax so it's safe to do Ubuntu 18.04+ too.