### PR TITLE
[Core] Add a cli flag for setting a max size of message cache

### DIFF
--- a/changelog.d/3474.feature.rst
+++ b/changelog.d/3474.feature.rst
@@ -1,0 +1,1 @@
+Add a cli flag for setting a max size of message cache

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -150,10 +150,8 @@ class RedBase(
             kwargs["command_not_found"] = "Command {} not found.\n{}"
 
         message_cache_size = cli_flags.message_cache_size
-        if message_cache_size == "None":
+        if cli_flags.no_message_cache:
             message_cache_size = None
-        else:
-            message_cache_size = int(message_cache_size)
         kwargs["max_messages"] = message_cache_size
         self._max_messages = message_cache_size
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -149,8 +149,13 @@ class RedBase(
         if "command_not_found" not in kwargs:
             kwargs["command_not_found"] = "Command {} not found.\n{}"
 
-        kwargs["max_messages"] = cli_flags.message_cache_size
-        self._max_messages = cli_flags.message_cache_size
+        message_cache_size = cli_flags.message_cache_size
+        if message_cache_size == "None":
+            message_cache_size = None
+        else:
+            message_cache_size = int(message_cache_size)
+        kwargs["max_messages"] = message_cache_size
+        self._max_messages = message_cache_size
 
         self._uptime = None
         self._checked_time_accuracy = None

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -277,6 +277,10 @@ class RedBase(
     def colour(self) -> NoReturn:
         raise AttributeError("Please fetch the embed colour with `get_embed_colour`")
 
+    @property
+    def max_messages(self) -> Optional[int]:
+        return self._max_messages
+
     async def allowed_by_whitelist_blacklist(
         self,
         who: Optional[Union[discord.Member, discord.User]] = None,

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -149,6 +149,9 @@ class RedBase(
         if "command_not_found" not in kwargs:
             kwargs["command_not_found"] = "Command {} not found.\n{}"
 
+        kwargs["max_messages"] = cli_flags.message_cache_size
+        self._max_messages = cli_flags.message_cache_size
+
         self._uptime = None
         self._checked_time_accuracy = None
         self._color = discord.Embed.Empty  # This is needed or color ends up 0x000000

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -80,9 +80,13 @@ def positive_int(arg: str) -> int:
     except ValueError:
         raise argparse.ArgumentTypeError("Message cache size has to be a number.")
     if x < 1000:
-        raise argparse.ArgumentTypeError("Message cache size has to be greater than or equal to 1000.")
+        raise argparse.ArgumentTypeError(
+            "Message cache size has to be greater than or equal to 1000."
+        )
     if x > sys.maxsize:
-        raise argparse.ArgumentTypeError(f"Message cache size has to be lower than or equal to {sys.maxsize}.")
+        raise argparse.ArgumentTypeError(
+            f"Message cache size has to be lower than or equal to {sys.maxsize}."
+        )
     return x
 
 

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -80,9 +80,9 @@ def positive_int(arg: str) -> int:
     except ValueError:
         raise argparse.ArgumentTypeError("Message cache size has to be a number.")
     if x < 1000:
-        raise argparse.ArgumentTypeError("Message cache size has to be greater than 1000.")
+        raise argparse.ArgumentTypeError("Message cache size has to be greater than or equal to 1000.")
     if x > sys.maxsize:
-        raise argparse.ArgumentTypeError(f"Message cache size has to be lower than {sys.maxsize}.")
+        raise argparse.ArgumentTypeError(f"Message cache size has to be greater than or equal to {sys.maxsize}.")
     return x
 
 

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -219,6 +219,9 @@ def parse_cli_flags(args):
         dest="message_cache_size",
         help="Set the maximum number of messages to store in the internal message cache.",
     )
+    parser.add_argument(
+        "--no-message-cache", action="store_true", help="Disable the internal message cache.",
+    )
 
     args = parser.parse_args(args)
 

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -81,6 +81,8 @@ def positive_int(arg: str) -> int:
         raise argparse.ArgumentTypeError("Message cache size has to be a number.")
     if x <= 0:
         raise argparse.ArgumentTypeError("Message cache size has to be greater than 0.")
+    if x > sys.maxsize:
+        raise argparse.ArgumentTypeError(f"Message cache size has to be lower than {sys.maxsize}.")
     return x
 
 

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -82,7 +82,7 @@ def positive_int(arg: str) -> int:
     if x < 1000:
         raise argparse.ArgumentTypeError("Message cache size has to be greater than or equal to 1000.")
     if x > sys.maxsize:
-        raise argparse.ArgumentTypeError(f"Message cache size has to be greater than or equal to {sys.maxsize}.")
+        raise argparse.ArgumentTypeError(f"Message cache size has to be lower than or equal to {sys.maxsize}.")
     return x
 
 

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -212,6 +212,13 @@ def parse_cli_flags(args):
             "all of the data on the host machine."
         ),
     )
+    parser.add_argument(
+        "--message-cache-size",
+        type=int,
+        default=1000,
+        dest="message_cache_size",
+        help="Set the maximum number of messages to store in the internal message cache.",
+    )
 
     args = parser.parse_args(args)
 

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -214,7 +214,7 @@ def parse_cli_flags(args):
     )
     parser.add_argument(
         "--message-cache-size",
-        type=str,
+        type=int,
         default=1000,
         help="Set the maximum number of messages to store in the internal message cache.",
     )

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -74,6 +74,16 @@ async def interactive_config(red, token_set, prefix_set, *, print_header=True):
     return token
 
 
+def positive_int(arg: str) -> int:
+    try:
+        x = int(arg)
+    except ValueError:
+        raise argparse.ArgumentTypeError("Message cache size has to be a number.")
+    if x <= 0:
+        raise argparse.ArgumentTypeError("Message cache size has to be greater than 0.")
+    return x
+
+
 def parse_cli_flags(args):
     parser = argparse.ArgumentParser(
         description="Red - Discord Bot", usage="redbot <instance_name> [arguments]"
@@ -214,7 +224,7 @@ def parse_cli_flags(args):
     )
     parser.add_argument(
         "--message-cache-size",
-        type=int,
+        type=positive_int,
         default=1000,
         help="Set the maximum number of messages to store in the internal message cache.",
     )

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -79,8 +79,8 @@ def positive_int(arg: str) -> int:
         x = int(arg)
     except ValueError:
         raise argparse.ArgumentTypeError("Message cache size has to be a number.")
-    if x <= 0:
-        raise argparse.ArgumentTypeError("Message cache size has to be greater than 0.")
+    if x < 1000:
+        raise argparse.ArgumentTypeError("Message cache size has to be greater than 1000.")
     if x > sys.maxsize:
         raise argparse.ArgumentTypeError(f"Message cache size has to be lower than {sys.maxsize}.")
     return x

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -214,7 +214,7 @@ def parse_cli_flags(args):
     )
     parser.add_argument(
         "--message-cache-size",
-        type=int,
+        type=str,
         default=1000,
         dest="message_cache_size",
         help="Set the maximum number of messages to store in the internal message cache.",

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -216,7 +216,6 @@ def parse_cli_flags(args):
         "--message-cache-size",
         type=str,
         default=1000,
-        dest="message_cache_size",
         help="Set the maximum number of messages to store in the internal message cache.",
     )
     parser.add_argument(


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes
This adds a cli flag for being able to set a max size for the message cache.
Resolves #3473. 