### PR TITLE
Add `-e` flag to `journalctl` command in systemd guide so that it takes the user to the end of logs automatically.

### DIFF
--- a/changelog.d/3483.docs.rst
+++ b/changelog.d/3483.docs.rst
@@ -1,0 +1,1 @@
+Add `-e` flag to `journalctl` command in systemd guide so that it takes the user to the end of logs automatically.

--- a/docs/autostart_systemd.rst
+++ b/docs/autostart_systemd.rst
@@ -71,4 +71,4 @@ type the following command in the terminal, still by adding the instance name af
 
 To view Red’s log, you can acccess through journalctl:
 
-:code:`sudo journalctl -u red@instancename`
+:code:`sudo journalctl -eu red@instancename`


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Added `-e` flag that will make journalctl tell the pager to go to the end of logs so that users can immediately see the most recent logs.