### PR TITLE
Allow to edit prefixes through `redbot --edit`

### DIFF
--- a/changelog.d/3481.feature.rst
+++ b/changelog.d/3481.feature.rst
@@ -1,0 +1,1 @@
+Allow to edit prefix from command line using ``redbot --edit``.

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -107,6 +107,7 @@ async def edit_instance(red, cli_flags):
     no_prompt = cli_flags.no_prompt
     token = cli_flags.token
     owner = cli_flags.owner
+    prefix = cli_flags.prefix
     old_name = cli_flags.instance_name
     new_name = cli_flags.edit_instance_name
     data_path = cli_flags.edit_data_path
@@ -119,14 +120,20 @@ async def edit_instance(red, cli_flags):
     if new_name is None and confirm_overwrite:
         print("--overwrite-existing-instance can't be used without --edit-instance-name argument")
         sys.exit(1)
-    if no_prompt and all(to_change is None for to_change in (token, owner, new_name, data_path)):
+    if (
+        no_prompt
+        and all(to_change is None for to_change in (token, owner, new_name, data_path))
+        and not prefix
+    ):
         print(
-            "No arguments to edit were provided. Available arguments (check help for more "
-            "information): --edit-instance-name, --edit-data-path, --copy-data, --owner, --token"
+            "No arguments to edit were provided."
+            " Available arguments (check help for more information):"
+            " --edit-instance-name, --edit-data-path, --copy-data, --owner, --token, --prefix"
         )
         sys.exit(1)
 
     await _edit_token(red, token, no_prompt)
+    await _edit_prefix(red, prefix, no_prompt)
     await _edit_owner(red, owner, no_prompt)
 
     data = deepcopy(data_manager.basic_config)
@@ -149,6 +156,15 @@ async def _edit_token(red, token, no_prompt):
         await red._config.token.set(token)
     elif not no_prompt and confirm("Would you like to change instance's token?", default=False):
         await interactive_config(red, False, True, print_header=False)
+        print("Token updated.\n")
+
+
+async def _edit_prefix(red, prefix, no_prompt):
+    if prefix:
+        await red._config.token.set(prefix)
+    elif not no_prompt and confirm("Would you like to change instance's prefixes?", default=False):
+        # TODO: Allow to setup multiple prefixes, similarly to what was in launcher before 3.2
+        await interactive_config(red, True, False, print_header=False)
         print("Token updated.\n")
 
 

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -172,6 +172,7 @@ async def _edit_prefix(red, prefix, no_prompt):
             if not prefixes:
                 print("You need to pass at least one prefix!")
                 continue
+            prefixes = sorted(prefixes, reverse=True)
             await red._config.prefix.set(prefixes)
             print("Prefixes updated.\n")
             break

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -161,7 +161,8 @@ async def _edit_token(red, token, no_prompt):
 
 async def _edit_prefix(red, prefix, no_prompt):
     if prefix:
-        await red._config.prefix.set(prefix)
+        prefixes = sorted(prefix, reverse=True)
+        await red._config.prefix.set(prefixes)
     elif not no_prompt and confirm("Would you like to change instance's prefixes?", default=False):
         print(
             "Enter the prefixes, separated by a space (please note "

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -163,9 +163,17 @@ async def _edit_prefix(red, prefix, no_prompt):
     if prefix:
         await red._config.token.set(prefix)
     elif not no_prompt and confirm("Would you like to change instance's prefixes?", default=False):
-        # TODO: Allow to setup multiple prefixes, similarly to what was in launcher before 3.2
-        await interactive_config(red, True, False, print_header=False)
-        print("Token updated.\n")
+        print(
+            "Enter the prefixes, separated by a space (please note "
+            "that prefixes containing a space will need to be added with [p]set prefix)"
+        )
+        while True:
+            prefixes = input("> ").strip().split()
+            if not prefixes:
+                print("You need to pass at least one prefix!")
+                continue
+        await red._config.prefix.set(prefixes)
+        print("Prefixes updated.\n")
 
 
 async def _edit_owner(red, owner, no_prompt):

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -161,7 +161,7 @@ async def _edit_token(red, token, no_prompt):
 
 async def _edit_prefix(red, prefix, no_prompt):
     if prefix:
-        await red._config.token.set(prefix)
+        await red._config.prefix.set(prefix)
     elif not no_prompt and confirm("Would you like to change instance's prefixes?", default=False):
         print(
             "Enter the prefixes, separated by a space (please note "

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -172,8 +172,9 @@ async def _edit_prefix(red, prefix, no_prompt):
             if not prefixes:
                 print("You need to pass at least one prefix!")
                 continue
-        await red._config.prefix.set(prefixes)
-        print("Prefixes updated.\n")
+            await red._config.prefix.set(prefixes)
+            print("Prefixes updated.\n")
+            break
 
 
 async def _edit_owner(red, owner, no_prompt):

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -90,7 +90,7 @@ def parse_cli_flags(args):
         action="store_true",
         help="Edit the instance. This can be done without console interaction "
         "by passing --no-prompt and arguments that you want to change (available arguments: "
-        "--edit-instance-name, --edit-data-path, --copy-data, --owner, --token).",
+        "--edit-instance-name, --edit-data-path, --copy-data, --owner, --token, --prefix).",
     )
     parser.add_argument(
         "--edit-instance-name",


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes
Allows users to edit prefixes through `redbot --edit`. There's a limitation in interactive use - user can only set prefixes that don't contain spaces. This limitation doesn't exist when using `-p/--prefix` flag(s).

Resolves #3481 