### PR TITLE
Add black config to pyproject.toml

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,7 +79,7 @@ If you're not on Windows, you should also have GNU make installed, and you can o
 **Note:** If you're comfortable with setting up virtual environments yourself and would rather do it manually, just run `pip install -Ur tools/dev-requirements.txt` after setting it up.
 
 ### 4.2 Testing
-We've recently started using [tox](https://github.com/tox-dev/tox) to run all of our tests. It's extremely simple to use, and if you followed the previous section correctly, it is already installed to your virtual environment.
+We're using [tox](https://github.com/tox-dev/tox) to run all of our tests. It's extremely simple to use, and if you followed the previous section correctly, it is already installed to your virtual environment.
 
 Currently, tox does the following, creating its own virtual environments for each stage:
 - Runs all of our unit tests with [pytest](https://github.com/pytest-dev/pytest) on python 3.8 (test environment `py38`)
@@ -95,7 +95,7 @@ Your PR will not be merged until all of these tests pass.
 ### 4.3 Style
 Our style checker of choice, [black](https://github.com/ambv/black), actually happens to be an auto-formatter. The checking functionality simply detects whether or not it would try to reformat something in your code, should you run the formatter on it. For this reason, we recommend using this tool as a formatter, regardless of any disagreements you might have with the style it enforces.
 
-Use the command `black --help` to see how to use this tool. The full style guide is explained in detail on [black's GitHub repository](https://github.com/ambv/black). **There is one exception to this**, however, which is that we set the line length to 99, instead of black's default 88. When using `black` on the command line, simply use it like so: `black -l 99 -N <src>`.
+Use the command `black --help` to see how to use this tool. The full style guide is explained in detail on [black's GitHub repository](https://github.com/ambv/black). **There is one exception to this**, however, which is that we set the line length to 99, instead of black's default 88. This is already set in `pyproject.toml` configuration file in the repo so you can simply format code with Black like so: `black <src>`.
 
 ### 4.4 Make
 You may have noticed we have a `Makefile` and a `make.bat` in the top-level directory. For now, you can do a few things with them:

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ PYTHON ?= python3.8
 
 # Python Code Style
 reformat:
-	$(PYTHON) -m black -l 99 --target-version py38 `git ls-files "*.py"`
+	$(PYTHON) -m black `git ls-files "*.py"`
 stylecheck:
-	$(PYTHON) -m black --check -l 99 --target-version py38 `git ls-files "*.py"`
+	$(PYTHON) -m black --check `git ls-files "*.py"`
 
 # Translations
 gettext:

--- a/make.bat
+++ b/make.bat
@@ -14,11 +14,11 @@ for /F "tokens=* USEBACKQ" %%A in (`git ls-files "*.py"`) do (
 goto %1
 
 :reformat
-black -l 99 --target-version py38 !PYFILES!
+black !PYFILES!
 exit /B %ERRORLEVEL%
 
 :stylecheck
-black -l 99 --check --target-version py38 !PYFILES!
+black --check !PYFILES!
 exit /B %ERRORLEVEL%
 
 :newenv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,22 @@
+[tool.black]
+    line-length = 99
+    target-version = ['py38']
+    include = '\.py$'
+    exclude = '''
+    /(
+          \.eggs
+        | \.git
+        | \.hg
+        | \.mypy_cache
+        | \.tox
+        | \.venv
+        | _build
+        | buck-out
+        | build
+        | dist
+    )/
+    '''
+
 [tool.towncrier]
     package = "redbot"
     filename = "CHANGELOG.rst"


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
A simple change that makes it possible to just run `black .` in repo's folder without bothering with wrong settings. It resembles the flags used in our `Makefile/make.bat`.
Also added the excludes that are used by default in black so that we can simply add new ones if needed in future.
We could technically also modify make files so that we just rely on config in `pyproject.toml` but I left it as is for now.