### PR TITLE
[Dev] Allow top-level await in code statements

### DIFF
--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -36,8 +36,8 @@ class Dev(commands.Cog):
         self._last_result = None
         self.sessions = set()
 
-    @classmethod
-    def async_compile(cls, source, filename, mode):
+    @staticmethod
+    def async_compile(source, filename, mode):
         return compile(source, filename, mode, flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT, optimize=0)
 
     @staticmethod

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -58,7 +58,9 @@ class Dev(commands.Cog):
         """
         if e.text is None:
             return box("{0.__class__.__name__}: {0}".format(e), lang="py")
-        return box("{0.text}\n{1:>{0.offset}}\n{2}: {0}".format(e, "^", type(e).__name__), lang="py")
+        return box(
+            "{0.text}\n{1:>{0.offset}}\n{2}: {0}".format(e, "^", type(e).__name__), lang="py"
+        )
 
     @staticmethod
     def get_pages(msg: str):

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -216,6 +216,7 @@ class Dev(commands.Cog):
             "author": ctx.author,
             "asyncio": asyncio,
             "_": None,
+            "__builtins__": __builtins__
         }
 
         if ctx.channel.id in self.sessions:

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -1,5 +1,6 @@
 import ast
 import asyncio
+import aiohttp
 import inspect
 import io
 import textwrap
@@ -103,6 +104,8 @@ class Dev(commands.Cog):
             "author": ctx.author,
             "guild": ctx.guild,
             "message": ctx.message,
+            "asyncio": asyncio,
+            "aiohttp": aiohttp,
             "discord": discord,
             "commands": commands,
             "_": self._last_result,
@@ -157,6 +160,8 @@ class Dev(commands.Cog):
             "author": ctx.author,
             "guild": ctx.guild,
             "message": ctx.message,
+            "asyncio": asyncio,
+            "aiohttp": aiohttp,
             "discord": discord,
             "commands": commands,
             "_": self._last_result,

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -216,7 +216,7 @@ class Dev(commands.Cog):
             "author": ctx.author,
             "asyncio": asyncio,
             "_": None,
-            "__builtins__": __builtins__
+            "__builtins__": __builtins__,
         }
 
         if ctx.channel.id in self.sessions:

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -180,7 +180,8 @@ class Dev(commands.Cog):
         to_compile = "async def func():\n%s" % textwrap.indent(body, "  ")
 
         try:
-            exec(to_compile, env)
+            compiled = self.async_compile(to_compile, "<string>", "exec")
+            exec(compiled, env)
         except SyntaxError as e:
             return await ctx.send(self.get_syntax_error(e))
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Allows for top-level await, async for, etc. code in debug and repl using the 3.8+ `ast.PyCF_ALLOW_TOP_LEVEL_AWAIT` flag.

The resulting object may be awaited on twice for backwards compatibility.