### PR TITLE
Make `[p]announce` send error message only when an actual errors occurs

### DIFF
--- a/redbot/cogs/admin/announcer.py
+++ b/redbot/cogs/admin/announcer.py
@@ -77,5 +77,5 @@ class Announcer:
         )
         if failed:
             msg += humanize_list(tuple(map(inline, failed)))
-        await self.ctx.bot.send_to_owners(msg)
+            await self.ctx.bot.send_to_owners(msg)
         self.active = False

--- a/redbot/cogs/admin/announcer.py
+++ b/redbot/cogs/admin/announcer.py
@@ -70,12 +70,12 @@ class Announcer:
                 failed.append(str(g.id))
             await asyncio.sleep(0.5)
 
-        msg = (
-            _("I could not announce to the following server: ")
-            if len(failed) == 1
-            else _("I could not announce to the following servers: ")
-        )
         if failed:
+            msg = (
+                _("I could not announce to the following server: ")
+                if len(failed) == 1
+                else _("I could not announce to the following servers: ")
+            )
             msg += humanize_list(tuple(map(inline, failed)))
             await self.ctx.bot.send_to_owners(msg)
         self.active = False


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Announce should only send an error message if an actual error occurs. Issue #3513 