### PR TITLE
[Warnings] Stop using `inspect.getsource` to check for `is_owner` check

### DIFF
--- a/changelog.d/warnings/3515.misc.rst
+++ b/changelog.d/warnings/3515.misc.rst
@@ -1,0 +1,1 @@
+Don't use `inspect.getsource` to check for ``is_owner`` check.

--- a/redbot/cogs/warnings/helpers.py
+++ b/redbot/cogs/warnings/helpers.py
@@ -54,7 +54,9 @@ async def create_and_invoke_context(
     try:
         await realctx.bot.invoke(fctx)
     except (commands.CheckFailure, commands.CommandOnCooldown):
-        await fctx.reinvoke()
+        # reinvoke bypasses checks and we don't want to run bot owner only commands here
+        if fctx.command.requires.privilege_level < PrivilegeLevel.BOT_OWNER:
+            await fctx.reinvoke()
 
 
 def get_command_from_input(bot, userinput: str):

--- a/redbot/cogs/warnings/helpers.py
+++ b/redbot/cogs/warnings/helpers.py
@@ -1,9 +1,9 @@
 from copy import copy
 import asyncio
-import inspect
 import discord
 
 from redbot.core import Config, checks, commands
+from redbot.core.commands.requires import PrivilegeLevel
 from redbot.core.i18n import Translator
 from redbot.core.utils.predicates import MessagePredicate
 
@@ -69,9 +69,7 @@ def get_command_from_input(bot, userinput: str):
     if com is None:
         return None, _("I could not find a command from that input!")
 
-    check_str = inspect.getsource(checks.is_owner)
-    if any(inspect.getsource(x) in check_str for x in com.checks):
-        # command the user specified has the is_owner check
+    if com.requires.privilege_level >= PrivilegeLevel.BOT_OWNER:
         return (
             None,
             _("That command requires bot owner. I can't allow you to use that for an action"),


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Resolves #3515 