### PR TITLE
Indicate instructions for different venv types in systemd guide better

### DIFF
--- a/docs/autostart_systemd.rst
+++ b/docs/autostart_systemd.rst
@@ -21,7 +21,7 @@ Next, your python :code:`path` can be fetched with the following commands:
 .. code-block:: bash
 
     # If redbot is installed in a venv
-    source redenv/bin/activate
+    source ~/redenv/bin/activate
     which python
 
     # If redbot is installed in a pyenv virtualenv

--- a/docs/autostart_systemd.rst
+++ b/docs/autostart_systemd.rst
@@ -20,12 +20,12 @@ Next, your python :code:`path` can be fetched with the following commands:
 
 .. code-block:: bash
 
-    # If redbot is installed in a virtualenv
+    # If redbot is installed in a venv
     source redenv/bin/activate
     which python
 
-    # If you are using pyenv
-    pyenv shell <name>
+    # If redbot is installed in a pyenv virtualenv
+    pyenv shell <virtualenv_name>
     pyenv which python
 
 Then create the new service file:


### PR DESCRIPTION
### Type

- [x] Docs

### Description of the changes
Instructions are based only on venv type so let's make it clearer which set should be used for which type.
Also adds `~/` to venv path to make it consistent with our venv guide.