### PR TITLE
[commands module] functools.partial support

### DIFF
--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -317,7 +317,7 @@ class Command(CogCommandMixin, DPYCommand):
             self.module = function.__module__
             globals_ = function.__globals__
 
-        signature = inspect.signature(function, follow_wrapped=False)
+        signature = inspect.signature(function)
         self.params = signature.parameters.copy()
 
         # PEP-563 allows postponing evaluation of annotations with a __future__

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -12,9 +12,6 @@ import weakref
 from typing import (
     Awaitable,
     Callable,
-    Coroutine,
-    TypeVar,
-    Type,
     Dict,
     List,
     Optional,
@@ -22,7 +19,6 @@ from typing import (
     Union,
     MutableMapping,
     TYPE_CHECKING,
-    cast,
 )
 
 import discord
@@ -39,7 +35,6 @@ from discord.ext.commands import (
     Greedy,
 )
 
-from . import converter as converters
 from .errors import ConversionFailure
 from .requires import PermState, PrivilegeLevel, Requires, PermStateAllowedStates
 from ..i18n import Translator
@@ -308,9 +303,9 @@ class Command(CogCommandMixin, DPYCommand):
     def callback(self, function):
         """
         Below should be mostly the same as discord.py
-        
+
         Currently, we modify behavior for
-        
+
           - functools.partial support
           - typing.Optional behavior change as an option
         """


### PR DESCRIPTION
### Type

- [X] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

As the annotations are derived from the source function, using the source module and globals here is fine for functool partials.