### PR TITLE
Skip publish actions for forks

### DIFF
--- a/.github/workflows/publish_crowdin.yml
+++ b/.github/workflows/publish_crowdin.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   deploy:
+    if: github.repository == 'Cog-Creators/Red-DiscordBot'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   deploy:
+    if: github.repository == 'Cog-Creators/Red-DiscordBot'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This will make publish actions not run on forks - while they just fail on forks, failed workflow runs may send unnecessary notifications to fork owners.