### PR TITLE
[CI] Less weekly churn from automated tasks

### DIFF
--- a/.github/workflows/publish_crowdin.yml
+++ b/.github/workflows/publish_crowdin.yml
@@ -35,6 +35,9 @@ jobs:
     - name: Download translations
       run: |
         make download_translations
+    - name: Remove files from PR which only have a date changed
+      run: |
+        git checkout HEAD -- $(git diff V3/develop --numstat | awk 'BEGIN {ORS=" "} $1 == "1" && $2 == "1" {print $3}')
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v2
       with:

--- a/.github/workflows/publish_crowdin.yml
+++ b/.github/workflows/publish_crowdin.yml
@@ -37,7 +37,7 @@ jobs:
         make download_translations
     - name: Remove files from PR which only have a date changed
       run: |
-        git checkout HEAD -- $(git diff V3/develop --numstat | awk 'BEGIN {ORS=" "} $1 == "1" && $2 == "1" {print $3}')
+        git checkout HEAD -- $(git diff HEAD --numstat | awk 'BEGIN {ORS=" "} $1 == "1" && $2 == "1" && $3 ~ /.po$/ {print $3}')
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v2
       with:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

Since Crowdin *always* updates the date of a .po file, even if nothing has changed, this removes any +1 -1 changes from the automated weekly Crowdin PR