### PR TITLE
[Docs] Add warning on `latest` version of docs.

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,5 +1,14 @@
 {% extends '!layout.html' %}
 {% block document %}
+{% if version_slug == 'latest' %}
+<div class="admonition warning">
+    <p class="first admonition-title">Warning</p>
+    <p class="last">
+        This document is for Red's development version, which can be significantly different from previous releases.
+        If you're a regular user, you should read the <a href="{{ versions['stable'] }}">Red documentation for the current stable release</a>.
+    </p>
+</div>
+{% endif %}
 {{ super() }}
 <a href="https://github.com/Cog-Creators/Red-DiscordBot">
     <img style="position: absolute; top: 0; right: 0; border: 0;"


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This took me longer than it should... If only I knew this file exists: https://github.com/readthedocs/readthedocs.org/blob/master/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl

About PR, I ended up extending our `_templates/layout.html` file but I guess there's also an option of appending to prolog in conf.py:
```py
if os.environ.get("READTHEDOCS_VERSION", "") == "latest":
    lang = os.environ.get("READTHEDOCS_LANGUAGE", "en")
    rst_prolog += f"""
.. warning::

    This document is for Red's development version,
    which can be significantly different from previous releases.
    If you're a regular user, you should read the
    `Red documentation for the current stable release <https://docs.discord.red/{lang}/stable>`_.
    """
```