### PR TITLE
[Docs] Fix link in warning on `latest` version of docs

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -5,7 +5,7 @@
     <p class="first admonition-title">Warning</p>
     <p class="last">
         This document is for Red's development version, which can be significantly different from previous releases.
-        If you're a regular user, you should read the <a href="{{ versions['stable'] }}">Red documentation for the current stable release</a>.
+        If you're a regular user, you should read the <a href="{{ dict(versions)['stable'] }}">Red documentation for the current stable release</a>.
     </p>
 </div>
 {% endif %}


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
