### PR TITLE
Fix type hints for var-positional parameters in whitelist/blacklist commands

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1746,9 +1746,7 @@ class Core(commands.Cog, CoreLogic):
             await ctx.send(box(page))
 
     @whitelist.command(name="remove")
-    async def whitelist_remove(
-        self, ctx: commands.Context, *users: Union[discord.Member, int]
-    ):
+    async def whitelist_remove(self, ctx: commands.Context, *users: Union[discord.Member, int]):
         """
         Removes user from whitelist.
         """
@@ -1811,9 +1809,7 @@ class Core(commands.Cog, CoreLogic):
             await ctx.send(box(page))
 
     @blacklist.command(name="remove")
-    async def blacklist_remove(
-        self, ctx: commands.Context, *users: Union[discord.Member, int]
-    ):
+    async def blacklist_remove(self, ctx: commands.Context, *users: Union[discord.Member, int]):
         """
         Removes user from blacklist.
         """
@@ -1842,9 +1838,7 @@ class Core(commands.Cog, CoreLogic):
 
     @localwhitelist.command(name="add")
     async def localwhitelist_add(
-        self,
-        ctx: commands.Context,
-        *users_or_roles: Union[discord.Member, discord.Role, int],
+        self, ctx: commands.Context, *users_or_roles: Union[discord.Member, discord.Role, int]
     ):
         """
         Adds a user or role to the whitelist.
@@ -1875,9 +1869,7 @@ class Core(commands.Cog, CoreLogic):
 
     @localwhitelist.command(name="remove")
     async def localwhitelist_remove(
-        self,
-        ctx: commands.Context,
-        *users_or_roles: Union[discord.Member, discord.Role, int],
+        self, ctx: commands.Context, *users_or_roles: Union[discord.Member, discord.Role, int]
     ):
         """
         Removes user or role from whitelist.
@@ -1909,9 +1901,7 @@ class Core(commands.Cog, CoreLogic):
 
     @localblacklist.command(name="add")
     async def localblacklist_add(
-        self,
-        ctx: commands.Context,
-        *users_or_roles: Union[discord.Member, discord.Role, int],
+        self, ctx: commands.Context, *users_or_roles: Union[discord.Member, discord.Role, int]
     ):
         """
         Adds a user or role to the blacklist.

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1718,7 +1718,7 @@ class Core(commands.Cog, CoreLogic):
         pass
 
     @whitelist.command(name="add")
-    async def whitelist_add(self, ctx: commands.Context, *users: List[Union[discord.Member, int]]):
+    async def whitelist_add(self, ctx: commands.Context, *users: Union[discord.Member, int]):
         """
         Adds a user to the whitelist.
         """
@@ -1747,7 +1747,7 @@ class Core(commands.Cog, CoreLogic):
 
     @whitelist.command(name="remove")
     async def whitelist_remove(
-        self, ctx: commands.Context, *users: List[Union[discord.Member, int]]
+        self, ctx: commands.Context, *users: Union[discord.Member, int]
     ):
         """
         Removes user from whitelist.
@@ -1774,7 +1774,7 @@ class Core(commands.Cog, CoreLogic):
         pass
 
     @blacklist.command(name="add")
-    async def blacklist_add(self, ctx: commands.Context, *users: List[Union[discord.Member, int]]):
+    async def blacklist_add(self, ctx: commands.Context, *users: Union[discord.Member, int]):
         """
         Adds a user to the blacklist.
         """
@@ -1812,7 +1812,7 @@ class Core(commands.Cog, CoreLogic):
 
     @blacklist.command(name="remove")
     async def blacklist_remove(
-        self, ctx: commands.Context, *users: List[Union[discord.Member, int]]
+        self, ctx: commands.Context, *users: Union[discord.Member, int]
     ):
         """
         Removes user from blacklist.
@@ -1844,7 +1844,7 @@ class Core(commands.Cog, CoreLogic):
     async def localwhitelist_add(
         self,
         ctx: commands.Context,
-        *users_or_roles: List[Union[discord.Member, discord.Role, int]],
+        *users_or_roles: Union[discord.Member, discord.Role, int],
     ):
         """
         Adds a user or role to the whitelist.
@@ -1877,7 +1877,7 @@ class Core(commands.Cog, CoreLogic):
     async def localwhitelist_remove(
         self,
         ctx: commands.Context,
-        *users_or_roles: List[Union[discord.Member, discord.Role, int]],
+        *users_or_roles: Union[discord.Member, discord.Role, int],
     ):
         """
         Removes user or role from whitelist.
@@ -1911,7 +1911,7 @@ class Core(commands.Cog, CoreLogic):
     async def localblacklist_add(
         self,
         ctx: commands.Context,
-        *users_or_roles: List[Union[discord.Member, discord.Role, int]],
+        *users_or_roles: Union[discord.Member, discord.Role, int],
     ):
         """
         Adds a user or role to the blacklist.


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #3576 