### PR TITLE
Check permissions before trying to clear reactions in `menu()`

### DIFF
--- a/redbot/core/utils/menus.py
+++ b/redbot/core/utils/menus.py
@@ -96,10 +96,18 @@ async def menu(
         )
     except asyncio.TimeoutError:
         try:
-            await message.clear_reactions()
-        except discord.Forbidden:  # cannot remove all reactions
+            if message.channel.permissions_for(ctx.me).manage_messages:
+                await message.clear_reactions()
+            else:
+                raise RuntimeError
+        except (discord.Forbidden, RuntimeError):  # cannot remove all reactions
             for key in controls.keys():
-                await message.remove_reaction(key, ctx.bot.user)
+                try:
+                    await message.remove_reaction(key, ctx.bot.user)
+                except discord.Forbidden:
+                    return
+                except discord.HTTPException:
+                    pass
         except discord.NotFound:
             return
     else:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #3145