### PR TITLE
[Trivia] Better handling for session errors

### DIFF
--- a/redbot/cogs/trivia/session.py
+++ b/redbot/cogs/trivia/session.py
@@ -111,10 +111,12 @@ class TriviaSession:
             LOG.error("A trivia session has encountered an error.\n", exc_info=exc)
             asyncio.create_task(
                 self.ctx.send(
-                    "An unexpected error occurred in the trivia session.\nCheck your console or logs for details."
+                    _(
+                        "An unexpected error occurred in the trivia session.\nCheck your console or logs for details."
+                    )
                 )
             )
-            asyncio.create_task(self.end_game())
+            self.stop()
 
     async def run(self):
         """Run the trivia session.


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Properly cleans up a trivia session when it encounters an error and alerts the user that an error had occurred.

Fixes #3578