### PR TITLE
[Core] Use new PyPI urls

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -310,7 +310,7 @@ class Core(commands.Cog, CoreLogic):
         author_repo = "https://github.com/Twentysix26"
         org_repo = "https://github.com/Cog-Creators"
         red_repo = org_repo + "/Red-DiscordBot"
-        red_pypi = "https://pypi.org/pypi/Red-DiscordBot"
+        red_pypi_data = "https://pypi.org/pypi/Red-DiscordBot/json"
         support_server_url = "https://discord.gg/red"
         dpy_repo = "https://github.com/Rapptz/discord.py"
         python_url = "https://www.python.org/"
@@ -327,7 +327,7 @@ class Core(commands.Cog, CoreLogic):
         custom_info = await self.bot._config.custom_info()
 
         async with aiohttp.ClientSession() as session:
-            async with session.get("{}/json".format(red_pypi)) as r:
+            async with session.get(red_pypi_data) as r:
                 data = await r.json()
         outdated = VersionInfo.from_str(data["info"]["version"]) > red_version_info
         about = _(

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -310,7 +310,8 @@ class Core(commands.Cog, CoreLogic):
         author_repo = "https://github.com/Twentysix26"
         org_repo = "https://github.com/Cog-Creators"
         red_repo = org_repo + "/Red-DiscordBot"
-        red_pypi_data = "https://pypi.org/pypi/Red-DiscordBot/json"
+        red_pypi = "https://pypi.org/project/Red-DiscordBot"
+        red_pypi_json = "https://pypi.org/pypi/Red-DiscordBot/json"
         support_server_url = "https://discord.gg/red"
         dpy_repo = "https://github.com/Rapptz/discord.py"
         python_url = "https://www.python.org/"
@@ -327,7 +328,7 @@ class Core(commands.Cog, CoreLogic):
         custom_info = await self.bot._config.custom_info()
 
         async with aiohttp.ClientSession() as session:
-            async with session.get(red_pypi_data) as r:
+            async with session.get(red_pypi_json) as r:
                 data = await r.json()
         outdated = VersionInfo.from_str(data["info"]["version"]) > red_version_info
         about = _(

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -310,7 +310,7 @@ class Core(commands.Cog, CoreLogic):
         author_repo = "https://github.com/Twentysix26"
         org_repo = "https://github.com/Cog-Creators"
         red_repo = org_repo + "/Red-DiscordBot"
-        red_pypi = "https://pypi.python.org/pypi/Red-DiscordBot"
+        red_pypi = "https://pypi.org/pypi/Red-DiscordBot"
         support_server_url = "https://discord.gg/red"
         dpy_repo = "https://github.com/Rapptz/discord.py"
         python_url = "https://www.python.org/"

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -86,7 +86,7 @@ def init_events(bot, cli_flags):
         outdated_red_message = ""
         with contextlib.suppress(aiohttp.ClientError, discord.HTTPException):
             async with aiohttp.ClientSession() as session:
-                async with session.get("https://pypi.python.org/pypi/red-discordbot/json") as r:
+                async with session.get("https://pypi.org/pypi/red-discordbot/json") as r:
                     data = await r.json()
             if VersionInfo.from_str(data["info"]["version"]) > red_version_info:
                 INFO.append(


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
> While `pypi.python.org` is may still be used in links from other PyPA documentation, etc, the default interface for browsing packages is `pypi.org`. The domain pypi.python.org now redirects to pypi.org, and may be disabled sometime in the future.

Source: https://packaging.python.org/guides/migrating-to-pypi-org/