### PR TITLE
Update deprecation warnings

### DIFF
--- a/docs/framework_commands.rst
+++ b/docs/framework_commands.rst
@@ -34,3 +34,5 @@ extend functionalities used throughout the bot, as outlined below.
     :members:
     :exclude-members: convert
     :no-undoc-members:
+
+    .. autoclass:: APIToken

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -29,7 +29,7 @@ _ = Translator("Downloader", __file__)
 
 DEPRECATION_NOTICE = _(
     "\n**WARNING:** The following repos are using shared libraries"
-    " which are marked for removal in Red 3.4: {repo_list}.\n"
+    " which are marked for removal in future: {repo_list}.\n"
     " You should inform maintainers of these repos about this message."
 )
 
@@ -233,7 +233,6 @@ class Downloader(commands.Cog):
                     installed[module._json_repo_name].pop(module.name)
 
     async def _shared_lib_load_check(self, cog_name: str) -> Optional[Repo]:
-        # remove in Red 3.4
         is_installed, cog = await self.is_installed(cog_name)
         # it's not gonna be None when `is_installed` is True
         # if we'll use typing_extensions in future, `Literal` can solve this

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -29,7 +29,7 @@ _ = Translator("Downloader", __file__)
 
 DEPRECATION_NOTICE = _(
     "\n**WARNING:** The following repos are using shared libraries"
-    " which are marked for removal in future: {repo_list}.\n"
+    " which are marked for removal in the future: {repo_list}.\n"
     " You should inform maintainers of these repos about this message."
 )
 

--- a/redbot/core/_sharedlibdeprecation.py
+++ b/redbot/core/_sharedlibdeprecation.py
@@ -22,7 +22,7 @@ class SharedLibImportWarner(MetaPathFinder):
             return None
         msg = (
             "One of cogs uses shared libraries which are"
-            " deprecated and scheduled for removal in Red 3.4.\n"
+            " deprecated and scheduled for removal in future.\n"
             "You should inform author of the cog about this message."
         )
         warnings.warn(msg, SharedLibDeprecationWarning, stacklevel=2)

--- a/redbot/core/_sharedlibdeprecation.py
+++ b/redbot/core/_sharedlibdeprecation.py
@@ -22,7 +22,7 @@ class SharedLibImportWarner(MetaPathFinder):
             return None
         msg = (
             "One of cogs uses shared libraries which are"
-            " deprecated and scheduled for removal in future.\n"
+            " deprecated and scheduled for removal in the future.\n"
             "You should inform author of the cog about this message."
         )
         warnings.warn(msg, SharedLibDeprecationWarning, stacklevel=2)

--- a/redbot/core/commands/__init__.py
+++ b/redbot/core/commands/__init__.py
@@ -28,7 +28,7 @@ from .converter import (
     NoParseOptional as NoParseOptional,
     UserInputOptional as UserInputOptional,
     Literal as Literal,
-    __getattr__,  # this contains deprecation of APIToken
+    __getattr__ as _converter__getattr__,  # this contains deprecation of APIToken
 )
 from .errors import (
     ConversionFailure as ConversionFailure,
@@ -143,6 +143,13 @@ from discord.ext.commands import (
     MaxConcurrencyReached as MaxConcurrencyReached,
     bot_has_guild_permissions as bot_has_guild_permissions,
 )
+
+
+def __getattr__(name):
+    try:
+        return _converter__getattr__(name)
+    except AttributeError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
 
 
 def __dir__():

--- a/redbot/core/commands/__init__.py
+++ b/redbot/core/commands/__init__.py
@@ -147,7 +147,7 @@ from discord.ext.commands import (
 
 def __getattr__(name):
     try:
-        return _converter__getattr__(name)
+        return _converter__getattr__(name, stacklevel=3)
     except AttributeError:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
 

--- a/redbot/core/commands/__init__.py
+++ b/redbot/core/commands/__init__.py
@@ -143,3 +143,7 @@ from discord.ext.commands import (
     MaxConcurrencyReached as MaxConcurrencyReached,
     bot_has_guild_permissions as bot_has_guild_permissions,
 )
+
+
+def __dir__():
+    return [*globals().keys(), "APIToken"]

--- a/redbot/core/commands/__init__.py
+++ b/redbot/core/commands/__init__.py
@@ -19,7 +19,6 @@ from .commands import (
 )
 from .context import Context as Context, GuildContext as GuildContext, DMContext as DMContext
 from .converter import (
-    APIToken as APIToken,
     DictConverter as DictConverter,
     GuildConverter as GuildConverter,
     TimedeltaConverter as TimedeltaConverter,
@@ -29,6 +28,7 @@ from .converter import (
     NoParseOptional as NoParseOptional,
     UserInputOptional as UserInputOptional,
     Literal as Literal,
+    __getattr__,  # this contains deprecation of APIToken
 )
 from .errors import (
     ConversionFailure as ConversionFailure,

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -189,14 +189,14 @@ class _APIToken(discord.ext.commands.Converter):
 _APIToken.__name__ = "APIToken"
 
 
-def __getattr__(name: str) -> Any:
+def __getattr__(name: str, *, stacklevel: int = 2) -> Any:
     # honestly, this is awesome (PEP-562)
     if name == "APIToken":
         warnings.warn(
             "`APIToken` is deprecated since Red 3.3.0 and will be removed"
             " in the first minor release after 2020-08-05. Use `DictConverter` instead.",
             DeprecationWarning,
-            stacklevel=2,
+            stacklevel=stacklevel,
         )
         return globals()["_APIToken"]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -202,6 +202,10 @@ def __getattr__(name: str) -> Any:
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+def __dir__() -> List[str]:
+    return [*globals().keys(), "APIToken"]
+
+
 # Below this line are a lot of lies for mypy about things that *end up* correct when
 # These are used for command conversion purposes. Please refer to the portion
 # which is *not* for type checking for the actual implementation

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -168,7 +168,7 @@ class APIToken(discord.ext.commands.Converter):
     Note: Core usage of this has been replaced with `DictConverter` use instead.
 
     .. warning::
-        This will be removed in version 3.4.
+        This will be removed in first minor release after [PUT A DATE HERE].
     """
 
     async def convert(self, ctx: "Context", argument) -> dict:

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -169,7 +169,7 @@ class _APIToken(discord.ext.commands.Converter):
     Note: Core usage of this has been replaced with `DictConverter` use instead.
 
     .. warning::
-        This will be removed in first minor release after 2020-08-05.
+        This will be removed in the first minor release after 2020-08-05.
     """
 
     async def convert(self, ctx: "Context", argument) -> dict:
@@ -194,7 +194,7 @@ def __getattr__(name: str) -> Any:
     if name == "APIToken":
         warnings.warn(
             "`APIToken` is deprecated since Red 3.3.0 and will be removed"
-            " in first minor release after 2020-08-05. Use `DictConverter` instead.",
+            " in the first minor release after 2020-08-05. Use `DictConverter` instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -5,9 +5,10 @@ This module contains useful functions and classes for command argument conversio
 
 Some of the converters within are included provisionaly and are marked as such.
 """
+import functools
 import os
 import re
-import functools
+import warnings
 from datetime import timedelta
 from typing import (
     TYPE_CHECKING,
@@ -20,6 +21,7 @@ from typing import (
     Type,
     TypeVar,
     Literal as Literal,
+    Any,
 )
 
 import discord
@@ -33,7 +35,6 @@ if TYPE_CHECKING:
     from .context import Context
 
 __all__ = [
-    "APIToken",
     "DictConverter",
     "GuildConverter",
     "UserInputOptional",
@@ -154,7 +155,7 @@ class GuildConverter(discord.Guild):
         return ret
 
 
-class APIToken(discord.ext.commands.Converter):
+class _APIToken(discord.ext.commands.Converter):
     """Converts to a `dict` object.
 
     This will parse the input argument separating the key value pairs into a 
@@ -183,6 +184,22 @@ class APIToken(discord.ext.commands.Converter):
         if not result:
             raise BadArgument(_("The provided tokens are not in a valid format."))
         return result
+
+
+_APIToken.__name__ = "APIToken"
+
+
+def __getattr__(name: str) -> Any:
+    # honestly, this is awesome (PEP-562)
+    if name == "APIToken":
+        warnings.warn(
+            "`APIToken` is deprecated since Red 3.3.0 and will be removed"
+            " in first minor release after 2020-08-05. Use `DictConverter` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()["_APIToken"]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 # Below this line are a lot of lies for mypy about things that *end up* correct when

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -169,7 +169,7 @@ class _APIToken(discord.ext.commands.Converter):
     Note: Core usage of this has been replaced with `DictConverter` use instead.
 
     .. warning::
-        This will be removed in first minor release after [PUT A DATE HERE].
+        This will be removed in first minor release after 2020-08-05.
     """
 
     async def convert(self, ctx: "Context", argument) -> dict:

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -718,13 +718,13 @@ class Core(commands.Cog, CoreLogic):
             if len(repos_with_shared_libs) == 1:
                 formed = _(
                     "**WARNING**: The following repo is using shared libs"
-                    " which are marked for removal in Red 3.4: {repo}.\n"
+                    " which are marked for removal in future: {repo}.\n"
                     "You should inform maintainer of the repo about this message."
                 ).format(repo=inline(repos_with_shared_libs.pop()))
             else:
                 formed = _(
                     "**WARNING**: The following repos are using shared libs"
-                    " which are marked for removal in Red 3.4: {repos}.\n"
+                    " which are marked for removal in future: {repos}.\n"
                     "You should inform maintainers of these repos about this message."
                 ).format(repos=humanize_list([inline(repo) for repo in repos_with_shared_libs]))
             output.append(formed)
@@ -836,13 +836,13 @@ class Core(commands.Cog, CoreLogic):
             if len(repos_with_shared_libs) == 1:
                 formed = _(
                     "**WARNING**: The following repo is using shared libs"
-                    " which are marked for removal in Red 3.4: {repo}.\n"
+                    " which are marked for removal in future: {repo}.\n"
                     "You should inform maintainers of these repos about this message."
                 ).format(repo=inline(repos_with_shared_libs.pop()))
             else:
                 formed = _(
                     "**WARNING**: The following repos are using shared libs"
-                    " which are marked for removal in Red 3.4: {repos}.\n"
+                    " which are marked for removal in future: {repos}.\n"
                     "You should inform maintainers of these repos about this message."
                 ).format(repos=humanize_list([inline(repo) for repo in repos_with_shared_libs]))
             output.append(formed)

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -718,13 +718,13 @@ class Core(commands.Cog, CoreLogic):
             if len(repos_with_shared_libs) == 1:
                 formed = _(
                     "**WARNING**: The following repo is using shared libs"
-                    " which are marked for removal in future: {repo}.\n"
+                    " which are marked for removal in the future: {repo}.\n"
                     "You should inform maintainer of the repo about this message."
                 ).format(repo=inline(repos_with_shared_libs.pop()))
             else:
                 formed = _(
                     "**WARNING**: The following repos are using shared libs"
-                    " which are marked for removal in future: {repos}.\n"
+                    " which are marked for removal in the future: {repos}.\n"
                     "You should inform maintainers of these repos about this message."
                 ).format(repos=humanize_list([inline(repo) for repo in repos_with_shared_libs]))
             output.append(formed)
@@ -836,13 +836,13 @@ class Core(commands.Cog, CoreLogic):
             if len(repos_with_shared_libs) == 1:
                 formed = _(
                     "**WARNING**: The following repo is using shared libs"
-                    " which are marked for removal in future: {repo}.\n"
+                    " which are marked for removal in the future: {repo}.\n"
                     "You should inform maintainers of these repos about this message."
                 ).format(repo=inline(repos_with_shared_libs.pop()))
             else:
                 formed = _(
                     "**WARNING**: The following repos are using shared libs"
-                    " which are marked for removal in future: {repos}.\n"
+                    " which are marked for removal in the future: {repos}.\n"
                     "You should inform maintainers of these repos about this message."
                 ).format(repos=humanize_list([inline(repo) for repo in repos_with_shared_libs]))
             output.append(formed)

--- a/redbot/core/utils/__init__.py
+++ b/redbot/core/utils/__init__.py
@@ -182,8 +182,8 @@ def bounded_gather_iter(
     """
     if loop is not None:
         warnings.warn(
-            "Explicitly passing the loop will not work in Red 3.4+ and is currently ignored."
-            "Call this from the related event loop.",
+            "`loop` kwarg will be removed in first minor release after [PUT A DATE HERE]"
+            " and is currently ignored. Call this from the related event loop.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -240,8 +240,8 @@ def bounded_gather(
     """
     if loop is not None:
         warnings.warn(
-            "Explicitly passing the loop will not work in Red 3.4+ and is currently ignored."
-            "Call this from the related event loop.",
+            "`loop` kwarg will be removed in first minor release after [PUT A DATE HERE]"
+            " and is currently ignored. Call this from the related event loop.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/redbot/core/utils/__init__.py
+++ b/redbot/core/utils/__init__.py
@@ -182,8 +182,8 @@ def bounded_gather_iter(
     """
     if loop is not None:
         warnings.warn(
-            "`loop` kwarg will be removed in the first minor release after 2020-08-05"
-            " and is currently ignored. Call this from the related event loop.",
+            "`loop` kwarg is deprecated since Red 3.3.1. It is currently being ignored"
+            " and will be removed in the first minor release after 2020-08-05.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -240,8 +240,8 @@ def bounded_gather(
     """
     if loop is not None:
         warnings.warn(
-            "`loop` kwarg will be removed in the first minor release after 2020-08-05"
-            " and is currently ignored. Call this from the related event loop.",
+            "`loop` kwarg is deprecated since Red 3.3.1. It is currently being ignored"
+            " and will be removed in the first minor release after 2020-08-05.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/redbot/core/utils/__init__.py
+++ b/redbot/core/utils/__init__.py
@@ -182,7 +182,7 @@ def bounded_gather_iter(
     """
     if loop is not None:
         warnings.warn(
-            "`loop` kwarg will be removed in first minor release after [PUT A DATE HERE]"
+            "`loop` kwarg will be removed in first minor release after 2020-08-05"
             " and is currently ignored. Call this from the related event loop.",
             DeprecationWarning,
             stacklevel=2,
@@ -240,7 +240,7 @@ def bounded_gather(
     """
     if loop is not None:
         warnings.warn(
-            "`loop` kwarg will be removed in first minor release after [PUT A DATE HERE]"
+            "`loop` kwarg will be removed in first minor release after 2020-08-05"
             " and is currently ignored. Call this from the related event loop.",
             DeprecationWarning,
             stacklevel=2,

--- a/redbot/core/utils/__init__.py
+++ b/redbot/core/utils/__init__.py
@@ -182,7 +182,7 @@ def bounded_gather_iter(
     """
     if loop is not None:
         warnings.warn(
-            "`loop` kwarg will be removed in first minor release after 2020-08-05"
+            "`loop` kwarg will be removed in the first minor release after 2020-08-05"
             " and is currently ignored. Call this from the related event loop.",
             DeprecationWarning,
             stacklevel=2,
@@ -240,7 +240,7 @@ def bounded_gather(
     """
     if loop is not None:
         warnings.warn(
-            "`loop` kwarg will be removed in first minor release after 2020-08-05"
+            "`loop` kwarg will be removed in the first minor release after 2020-08-05"
             " and is currently ignored. Call this from the related event loop.",
             DeprecationWarning,
             stacklevel=2,

--- a/redbot/core/utils/menus.py
+++ b/redbot/core/utils/menus.py
@@ -214,7 +214,7 @@ def start_adding_reactions(
         loop = asyncio.get_running_loop()
     else:
         warnings.warn(
-            "`loop` kwarg will be removed in first minor release after 2020-08-05"
+            "`loop` kwarg will be removed in the first minor release after 2020-08-05"
             " and is currently ignored. Call this from the related event loop.",
             DeprecationWarning,
             stacklevel=2,

--- a/redbot/core/utils/menus.py
+++ b/redbot/core/utils/menus.py
@@ -214,8 +214,8 @@ def start_adding_reactions(
         loop = asyncio.get_running_loop()
     else:
         warnings.warn(
-            "`loop` kwarg will be removed in the first minor release after 2020-08-05"
-            " and is currently ignored. Call this from the related event loop.",
+            "`loop` kwarg is deprecated since Red 3.3.1. It is currently being ignored"
+            " and will be removed in the first minor release after 2020-08-05.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/redbot/core/utils/menus.py
+++ b/redbot/core/utils/menus.py
@@ -214,7 +214,7 @@ def start_adding_reactions(
         loop = asyncio.get_running_loop()
     else:
         warnings.warn(
-            "`loop` kwarg will be removed in first minor release after [PUT A DATE HERE]"
+            "`loop` kwarg will be removed in first minor release after 2020-08-05"
             " and is currently ignored. Call this from the related event loop.",
             DeprecationWarning,
             stacklevel=2,

--- a/redbot/core/utils/menus.py
+++ b/redbot/core/utils/menus.py
@@ -214,7 +214,8 @@ def start_adding_reactions(
         loop = asyncio.get_running_loop()
     else:
         warnings.warn(
-            "Explicitly passing the loop will not work in Red 3.4+",
+            "`loop` kwarg will be removed in first minor release after [PUT A DATE HERE]"
+            " and is currently ignored. Call this from the related event loop.",
             DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
### Description of the changes

Updates deprecations to be based on earliest date when it can be removed instead of specific minor version number. Removal will still occur in minor versions.
For Downloader's shared libraries, the warning is changed to indefinite "in future" as it is currently unknown when shared libraries will be removed.

This PR also adds a proper DeprecationWarning when APIToken class is imported/used.
