### PR TITLE
Fix few deprecation warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -230,5 +230,5 @@ extlinks = {"dpy_docs": (f"https://discordpy.readthedocs.io/en/v{dpy_version}/%s
 doctest_test_doctest_blocks = ""
 
 # Autodoc options
-autodoc_default_flags = ["show-inheritance"]
+autodoc_default_options = {"show-inheritance": True}
 autodoc_typehints = "none"

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -1,5 +1,5 @@
 import asyncio
-import collections
+import collections.abc
 import logging
 import pickle
 import weakref
@@ -510,7 +510,7 @@ class Group(Value):
         return self(acquire_lock=acquire_lock)
 
     def nested_update(
-        self, current: collections.Mapping, defaults: Dict[str, Any] = ...
+        self, current: collections.abc.Mapping, defaults: Dict[str, Any] = ...
     ) -> Dict[str, Any]:
         """Robust updater for nested dictionaries
 
@@ -521,7 +521,7 @@ class Group(Value):
             defaults = self.defaults
 
         for key, value in current.items():
-            if isinstance(value, collections.Mapping):
+            if isinstance(value, collections.abc.Mapping):
                 result = self.nested_update(value, defaults.get(key, {}))
                 defaults[key] = result
             else:

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -22,7 +22,7 @@ from .utils.chat_formatting import inline, bordered, format_perms_list, humanize
 log = logging.getLogger("red")
 init()
 
-INTRO = """
+INTRO = r"""
 ______         _           ______ _                       _  ______       _
 | ___ \       | |          |  _  (_)                     | | | ___ \     | |
 | |_/ /___  __| |  ______  | | | |_ ___  ___ ___  _ __ __| | | |_/ / ___ | |_


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Minimizes some console noise we now have because of enabling deprecation warnings in our logging.

Specifically, it fixes these deprecation warnings:
1. Using ABCs from `collections` instead of `collections.abc`:
```py
redbot/core/config.py:513: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working

  self, current: collections.Mapping, defaults: Dict[str, Any] = ..
```
2. Invalid escape sequence:
```py
redbot/core/events.py:25: DeprecationWarning: invalid escape sequence \

  INTRO = """
```
3. Deprecation of `autodoc_default_flags` in Sphinx (this one is only about docs build, it's not part of bot's output):
```py
RemovedInSphinx30Warning: autodoc_default_flags is now deprecated. Please use autodoc_default_options instead.
```