### PR TITLE
Deprecation warning - alternative

### DIFF
--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -199,22 +199,23 @@ _warnings.filterwarnings("ignore", module=r"fuzzywuzzy.*")
 # Show DeprecationWarning
 _warnings.filterwarnings("default", category=DeprecationWarning)
 
-# DEP-WARN
-# Individual warnings - tracked in https://github.com/Cog-Creators/Red-DiscordBot/issues/3529
-# DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
-_warnings.filterwarnings("ignore", category=DeprecationWarning, module="importlib", lineno=219)
-# DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
-#   def noop(*args, **kwargs):  # type: ignore
-_warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=107)
-# DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
-#   hosts = await asyncio.shield(self._resolve_host(..
-_warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=964)
-# DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
-#   self._event = asyncio.Event(loop=loop)
-_warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=21)
-# DeprecationWarning: rename klass to create_protocol
-#   warnings.warn("rename klass to create_protocol", DeprecationWarning)
-#
-# discord.py is using deprecated kwarg name when making websockets connection
-# https://github.com/Rapptz/discord.py/issues/2574
-_warnings.filterwarnings("ignore", category=DeprecationWarning, module="websockets", lineno=407)
+if "--debug" not in _sys.argv:
+    # DEP-WARN
+    # Individual warnings - tracked in https://github.com/Cog-Creators/Red-DiscordBot/issues/3529
+    # DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
+    _warnings.filterwarnings("ignore", category=DeprecationWarning, module="importlib", lineno=219)
+    # DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
+    #   def noop(*args, **kwargs):  # type: ignore
+    _warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=107)
+    # DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
+    #   hosts = await asyncio.shield(self._resolve_host(..
+    _warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=964)
+    # DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
+    #   self._event = asyncio.Event(loop=loop)
+    _warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=21)
+    # DeprecationWarning: rename klass to create_protocol
+    #   warnings.warn("rename klass to create_protocol", DeprecationWarning)
+    #
+    # discord.py is using deprecated kwarg name when making websockets connection
+    # https://github.com/Rapptz/discord.py/issues/2574
+    _warnings.filterwarnings("ignore", category=DeprecationWarning, module="websockets", lineno=407)

--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -218,4 +218,6 @@ if "--debug" not in _sys.argv:
     #
     # discord.py is using deprecated kwarg name when making websockets connection
     # https://github.com/Rapptz/discord.py/issues/2574
-    _warnings.filterwarnings("ignore", category=DeprecationWarning, module="websockets", lineno=407)
+    _warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, module="websockets", lineno=407
+    )

--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -221,6 +221,4 @@ _warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp"
 #
 # discord.py is using deprecated kwarg name when making websockets connection
 # https://github.com/Rapptz/discord.py/issues/2574
-_warnings.filterwarnings(
-    "ignore", category=DeprecationWarning, module="websockets", lineno=407
-)
+_warnings.filterwarnings("ignore", category=DeprecationWarning, module="websockets", lineno=407)

--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -196,5 +196,25 @@ version_info = VersionInfo.from_str(__version__)
 
 # Filter fuzzywuzzy slow sequence matcher warning
 _warnings.filterwarnings("ignore", module=r"fuzzywuzzy.*")
+# Show DeprecationWarning in debug mode
 # Show DeprecationWarning
-_warnings.filterwarnings("default", category=DeprecationWarning)
+if "--debug" in _sys.argv:
+    _warnings.filterwarnings("default", category=DeprecationWarning)
+else:
+    _warnings.filterwarnings("default", category=DeprecationWarning)
+    # DEP-WARN
+    # DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
+    #   def noop(*args, **kwargs):  # type: ignore
+    _warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=107)
+    # DEP-WARN
+    # DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
+    #   hosts = await asyncio.shield(self._resolve_host(..
+    _warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=964)
+    # DEP-WARN
+    # DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
+    #   self._event = asyncio.Event(loop=loop)
+    _warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=21)
+    # DEP-WARN
+    # DeprecationWarning: rename klass to create_protocol
+    #   warnings.warn("rename klass to create_protocol", DeprecationWarning)
+    _warnings.filterwarnings("ignore", category=DeprecationWarning, module="websockets", lineno=407)

--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -196,11 +196,9 @@ version_info = VersionInfo.from_str(__version__)
 
 # Filter fuzzywuzzy slow sequence matcher warning
 _warnings.filterwarnings("ignore", module=r"fuzzywuzzy.*")
-# Show DeprecationWarning in debug mode
 # Show DeprecationWarning
-if "--debug" in _sys.argv:
-    _warnings.filterwarnings("default", category=DeprecationWarning)
-else:
+_warnings.filterwarnings("default", category=DeprecationWarning)
+if "--debug" not in _sys.argv:
     _warnings.filterwarnings("default", category=DeprecationWarning)
     # DEP-WARN
     # DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead

--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -198,23 +198,29 @@ version_info = VersionInfo.from_str(__version__)
 _warnings.filterwarnings("ignore", module=r"fuzzywuzzy.*")
 # Show DeprecationWarning
 _warnings.filterwarnings("default", category=DeprecationWarning)
-if "--debug" not in _sys.argv:
-    _warnings.filterwarnings("default", category=DeprecationWarning)
-    # DEP-WARN
-    # DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
-    #   def noop(*args, **kwargs):  # type: ignore
-    _warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=107)
-    # DEP-WARN
-    # DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
-    #   hosts = await asyncio.shield(self._resolve_host(..
-    _warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=964)
-    # DEP-WARN
-    # DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
-    #   self._event = asyncio.Event(loop=loop)
-    _warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=21)
-    # DEP-WARN
-    # DeprecationWarning: rename klass to create_protocol
-    #   warnings.warn("rename klass to create_protocol", DeprecationWarning)
-    _warnings.filterwarnings(
-        "ignore", category=DeprecationWarning, module="websockets", lineno=407
-    )
+
+# Individual warnings - tracked in https://github.com/Cog-Creators/Red-DiscordBot/issues/3529
+# DEP-WARN
+# DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
+_warnings.filterwarnings("ignore", category=DeprecationWarning, module="importlib", lineno=219)
+# DEP-WARN
+# DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
+#   def noop(*args, **kwargs):  # type: ignore
+_warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=107)
+# DEP-WARN
+# DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
+#   hosts = await asyncio.shield(self._resolve_host(..
+_warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=964)
+# DEP-WARN
+# DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
+#   self._event = asyncio.Event(loop=loop)
+_warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=21)
+# DEP-WARN
+# DeprecationWarning: rename klass to create_protocol
+#   warnings.warn("rename klass to create_protocol", DeprecationWarning)
+#
+# discord.py is using deprecated kwarg name when making websockets connection
+# https://github.com/Rapptz/discord.py/issues/2574
+_warnings.filterwarnings(
+    "ignore", category=DeprecationWarning, module="websockets", lineno=407
+)

--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -217,4 +217,6 @@ else:
     # DEP-WARN
     # DeprecationWarning: rename klass to create_protocol
     #   warnings.warn("rename klass to create_protocol", DeprecationWarning)
-    _warnings.filterwarnings("ignore", category=DeprecationWarning, module="websockets", lineno=407)
+    _warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, module="websockets", lineno=407
+    )

--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -199,23 +199,19 @@ _warnings.filterwarnings("ignore", module=r"fuzzywuzzy.*")
 # Show DeprecationWarning
 _warnings.filterwarnings("default", category=DeprecationWarning)
 
-# Individual warnings - tracked in https://github.com/Cog-Creators/Red-DiscordBot/issues/3529
 # DEP-WARN
+# Individual warnings - tracked in https://github.com/Cog-Creators/Red-DiscordBot/issues/3529
 # DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
 _warnings.filterwarnings("ignore", category=DeprecationWarning, module="importlib", lineno=219)
-# DEP-WARN
 # DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
 #   def noop(*args, **kwargs):  # type: ignore
 _warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=107)
-# DEP-WARN
 # DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
 #   hosts = await asyncio.shield(self._resolve_host(..
 _warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=964)
-# DEP-WARN
 # DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
 #   self._event = asyncio.Event(loop=loop)
 _warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=21)
-# DEP-WARN
 # DeprecationWarning: rename klass to create_protocol
 #   warnings.warn("rename klass to create_protocol", DeprecationWarning)
 #


### PR DESCRIPTION
Alternative to #3613

Hides the known ones for non-debug and shows all for debug. 

I did line number variant but could also do regex but I think line number may be better in this case incase there is two errors with same error but different linenumber. This could also be checked easily if it's fixed by debug. 