### PR TITLE
Fix config conversion in image cog

### DIFF
--- a/redbot/cogs/image/image.py
+++ b/redbot/cogs/image/image.py
@@ -30,7 +30,7 @@ class Image(commands.Cog):
         imgur_token = await self.settings.imgur_client_id()
         if imgur_token is not None:
             if not await self.bot.get_shared_api_tokens("imgur"):
-                await self.bot.set_shared_api_tokens(client_id=imgur_token)
+                await self.bot.set_shared_api_tokens("imgur", client_id=imgur_token)
             await self.settings.imgur_client_id.clear()
 
     @commands.group(name="imgur")


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes this error during conversion from pre-3.1 releases:
```
[2020-02-27 20:50:52] [ERROR] red: Package loading failed
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/redbot/core/core_commands.py", line 114, in _load
    await bot.load_extension(spec)
  File "/usr/local/lib/python3.8/dist-packages/redbot/core/bot.py", line 870, in load_extension
    await lib.setup(self)
  File "/usr/local/lib/python3.8/dist-packages/redbot/cogs/image/init.py", line 6, in setup
    await cog.initialize()
  File "/usr/local/lib/python3.8/dist-packages/redbot/cogs/image/image.py", line 33, in initialize
    await self.bot.set_shared_api_tokens(client_id=imgur_token)
TypeError: set_shared_api_tokens() missing 1 required positional argument: 'service_name'
```