### PR TITLE
Bring back "new mention behavior, new filter behavior (#3553)"

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -974,6 +974,7 @@ class RedBase(
     async def send_filtered(
         destination: discord.abc.Messageable,
         filter_mass_mentions=True,
+        filter_roles=True,
         filter_invite_links=True,
         filter_all_links=False,
         **kwargs,
@@ -1000,6 +1001,10 @@ class RedBase(
         content = kwargs.pop("content", None)
 
         if content:
+            if filter_roles and isinstance(destination, discord.TextChannel):
+                content = common_filters.sanitize_role_mentions(
+                    content, destination.guild.roles
+                )
             if filter_mass_mentions:
                 content = common_filters.filter_mass_mentions(content)
             if filter_invite_links:

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1002,9 +1002,7 @@ class RedBase(
 
         if content:
             if filter_roles and isinstance(destination, discord.TextChannel):
-                content = common_filters.sanitize_role_mentions(
-                    content, destination.guild.roles
-                )
+                content = common_filters.sanitize_role_mentions(content, destination.guild.roles)
             if filter_mass_mentions:
                 content = common_filters.filter_mass_mentions(content)
             if filter_invite_links:

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -77,6 +77,7 @@ class Context(DPYContext):
             the sanitized `str`.
         sanitize_roles : bool
             Whether or not role mentions should be sanitized for you.
+            Defaults to ``True``
         **kwargs
             See `discord.ext.commands.Context.send`.
 

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -75,6 +75,8 @@ class Context(DPYContext):
             :func:`~redbot.core.utils.common_filters.filter_mass_mentions`.
             This must take a single `str` as an argument, and return
             the sanitized `str`.
+        sanitize_roles : bool
+            Whether or not role mentions should be sanitized for you.
         **kwargs
             See `discord.ext.commands.Context.send`.
 
@@ -86,6 +88,10 @@ class Context(DPYContext):
         """
 
         _filter = kwargs.pop("filter", common_filters.filter_mass_mentions)
+        sanitize_roles = kwargs.pop("sanitize_roles", True)
+
+        if sanitize_roles and content and self.guild:
+            content = common_filters.sanitize_role_mentions(str(content), self.guild.roles)
 
         if _filter and content:
             content = _filter(str(content))

--- a/redbot/core/utils/common_filters.py
+++ b/redbot/core/utils/common_filters.py
@@ -180,6 +180,23 @@ def escape_spoilers_and_mass_mentions(content: str) -> str:
 
 
 def sanitize_role_mentions(content: str, roles: List[discord.Role]) -> str:
+    """
+    Swaps out role mentions for @RoleName
+
+    This should always be used prior to filtering everyone mentions
+
+    Parameters
+    ----------
+    content: str
+        The string to make substitutions to
+    roles: List[discord.Role]
+        The roles to make substitutions for
+
+    Returns
+    -------
+    str
+        The resulting string
+    """
     transformations = {re.escape(fr"<@&{role.id}>"): f"@{role.name}" for role in roles}
 
     def repl(obj):

--- a/redbot/core/utils/common_filters.py
+++ b/redbot/core/utils/common_filters.py
@@ -1,4 +1,7 @@
 import re
+from typing import List
+
+import discord
 
 __all__ = [
     "URL_RE",
@@ -11,6 +14,7 @@ __all__ = [
     "normalize_smartquotes",
     "escape_spoilers",
     "escape_spoilers_and_mass_mentions",
+    "sanitize_role_mentions",
 ]
 
 # regexes
@@ -173,3 +177,15 @@ def escape_spoilers_and_mass_mentions(content: str) -> str:
         The escaped string.
     """
     return escape_spoilers(filter_mass_mentions(content))
+
+
+def sanitize_role_mentions(content: str, roles: List[discord.Role]) -> str:
+    transformations = {re.escape(fr"<@&{role.id}>"): f"@{role.name}" for role in roles}
+
+    def repl(obj):
+        return transformations.get(re.escape(obj.group(0)), "")
+
+    pattern = re.compile("|".join(transformations.keys()))
+    result = pattern.sub(repl, content)
+
+    return result

--- a/redbot/core/utils/common_filters.py
+++ b/redbot/core/utils/common_filters.py
@@ -1,5 +1,5 @@
 import re
-from typing import List
+from typing import Iterable
 
 import discord
 
@@ -179,7 +179,7 @@ def escape_spoilers_and_mass_mentions(content: str) -> str:
     return escape_spoilers(filter_mass_mentions(content))
 
 
-def sanitize_role_mentions(content: str, roles: List[discord.Role]) -> str:
+def sanitize_role_mentions(content: str, roles: Iterable[discord.Role]) -> str:
     """
     Swaps out role mentions for @RoleName
 
@@ -189,7 +189,7 @@ def sanitize_role_mentions(content: str, roles: List[discord.Role]) -> str:
     ----------
     content: str
         The string to make substitutions to
-    roles: List[discord.Role]
+    roles: Iterable[discord.Role]
         The roles to make substitutions for
 
     Returns


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Brings back changes from #3553 (reverted by #3619). This needs a discussion (before 3.4.0 release) about whether we want to make this change before Discord's upstream changes (trying to avoid us needing another breakage because of other changes that Discord is planning, supposedly before new role mention behavior will be live).
