### PR TITLE
Handle users leaving the server while we're applying mutes

### DIFF
--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -383,8 +383,8 @@ class MuteMixin(MixinMeta):
 
         unmute_success = []
         for channel in guild.channels:
-            success, message = await self.unmute_user(guild, channel, author, user, audit_reason)
-            unmute_success.append((success, message))
+            success, issue = await self.unmute_user(guild, channel, author, user, audit_reason)
+            unmute_success.append((success, issue))
             await asyncio.sleep(0.1)
 
             if success is False:  # Check the latest entry

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -22,8 +22,7 @@ mute_unmute_issues = {
         "permission and the user I'm muting must be "
         "lower than myself in the role hierarchy."
     ),
-    "left_guild": _("The user has left the server while were applying an overwrite."),
-    "unknown_channel": _("The channel I tried to mute the user in isn't found."),
+    "left_guild": _("The user has left the server while we're applying an overwrite."),
 }
 _ = T_
 
@@ -253,36 +252,27 @@ class MuteMixin(MixinMeta):
         author = ctx.message.author
         guild = ctx.guild
         audit_reason = get_audit_reason(author, reason)
-        guild_success = True
 
         mute_success = []
         for channel in guild.channels:
             success, issue = await self.mute_user(guild, channel, author, user, audit_reason)
             mute_success.append((success, issue))
             await asyncio.sleep(0.1)
-
-            if success is False:  # Check the latest entry
-                guild_success = False
-                break
-
-        if guild_success:
-            try:
-                await modlog.create_case(
-                    self.bot,
-                    guild,
-                    ctx.message.created_at,
-                    "smute",
-                    user,
-                    author,
-                    reason,
-                    until=None,
-                    channel=None,
-                )
-            except RuntimeError as e:
-                await ctx.send(e)
-            await ctx.send(_("User has been muted in this server."))
-        else:
-            await ctx.channel.send(issue)
+        try:
+            await modlog.create_case(
+                self.bot,
+                guild,
+                ctx.message.created_at,
+                "smute",
+                user,
+                author,
+                reason,
+                until=None,
+                channel=None,
+            )
+        except RuntimeError as e:
+            await ctx.send(e)
+        await ctx.send(_("User has been muted in this server."))
 
     @commands.group()
     @commands.guild_only()
@@ -379,50 +369,26 @@ class MuteMixin(MixinMeta):
         guild = ctx.guild
         author = ctx.author
         audit_reason = get_audit_reason(author, reason)
-        guild_success = True
 
         unmute_success = []
         for channel in guild.channels:
             success, message = await self.unmute_user(guild, channel, author, user, audit_reason)
             unmute_success.append((success, message))
             await asyncio.sleep(0.1)
-
-            if success is False:  # Check the latest entry
-                guild_success = False
-                break
-
-        if guild_success:
-            try:
-                await modlog.create_case(
-                    self.bot,
-                    guild,
-                    ctx.message.created_at,
-                    "sunmute",
-                    user,
-                    author,
-                    reason,
-                    until=None,
-                )
-            except RuntimeError as e:
-                await ctx.send(e)
-            await ctx.send(_("User has been unmuted in this server."))
-        else:
-            await ctx.channel.send(issue)
-
-    # Reference to L#13 for errors
-    # Kill muting on the following errors:
-    # Kill the mutes with returning False
-    # is_admin
-    # hierarchy_problem
-    # left_guild
-    # permissions_issue
-    #
-    # Keep alive on the following errors:
-    # Keep the muting going with None
-    # unknown_channel
-    # already_muted
-    #
-    # Else return True
+        try:
+            await modlog.create_case(
+                self.bot,
+                guild,
+                ctx.message.created_at,
+                "sunmute",
+                user,
+                author,
+                reason,
+                until=None,
+            )
+        except RuntimeError as e:
+            await ctx.send(e)
+        await ctx.send(_("User has been unmuted in this server."))
 
     async def mute_user(
         self,
@@ -446,7 +412,7 @@ class MuteMixin(MixinMeta):
             new_overs.update(send_messages=False, add_reactions=False)
 
         if all(getattr(permissions, p) is False for p in new_overs.keys()):
-            return None, _(mute_unmute_issues["already_muted"])
+            return False, _(mute_unmute_issues["already_muted"])
 
         elif not await is_allowed_by_hierarchy(self.bot, self.settings, guild, author, user):
             return False, _(mute_unmute_issues["hierarchy_problem"])
@@ -457,11 +423,8 @@ class MuteMixin(MixinMeta):
             await channel.set_permissions(user, overwrite=overwrites, reason=reason)
         except discord.Forbidden:
             return False, _(mute_unmute_issues["permissions_issue"])
-        except discord.NotFound as e:
-            if e.code == 10003:
-                return None, _(mute_unmute_issues["unknown_channel"])
-            elif e.code == 10009:
-                return False, _(mute_unmute_issues["left_guild"])
+        except discord.NotFound:
+            return False, _(mute_unmute_issues["left_guild"])
         else:
             await self.settings.member(user).set_raw(
                 "perms_cache", str(channel.id), value=old_overs
@@ -500,11 +463,8 @@ class MuteMixin(MixinMeta):
                 await channel.set_permissions(user, overwrite=overwrites, reason=reason)
         except discord.Forbidden:
             return False, _(mute_unmute_issues["permissions_issue"])
-        except discord.NotFound as e:
-            if e.code == 10003:
-                return None, _(mute_unmute_issues["unknown_channel"])
-            elif e.code == 10009:
-                return False, _(mute_unmute_issues["left_guild"])
+        except discord.NotFound:
+            return False, _(mute_unmute_issues["left_guild"])
         else:
             await self.settings.member(user).clear_raw("perms_cache", str(channel.id))
             return True, None

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -383,8 +383,8 @@ class MuteMixin(MixinMeta):
 
         unmute_success = []
         for channel in guild.channels:
-            success, issue = await self.unmute_user(guild, channel, author, user, audit_reason)
-            unmute_success.append((success, issue))
+            success, message = await self.unmute_user(guild, channel, author, user, audit_reason)
+            unmute_success.append((success, message))
             await asyncio.sleep(0.1)
 
             if success is False:  # Check the latest entry

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -23,6 +23,7 @@ mute_unmute_issues = {
         "lower than myself in the role hierarchy."
     ),
     "left_guild": _("The user has left the server while we're applying an overwrite."),
+    "unknown_channel": _("The channel I tried to mute the user in isn't found."),
 }
 _ = T_
 
@@ -423,8 +424,11 @@ class MuteMixin(MixinMeta):
             await channel.set_permissions(user, overwrite=overwrites, reason=reason)
         except discord.Forbidden:
             return False, _(mute_unmute_issues["permissions_issue"])
-        except discord.NotFound:
-            return False, _(mute_unmute_issues["left_guild"])
+        except discord.NotFound as e:
+            if e.code == 10003:
+                return False, _(mute_unmute_issues["unknown_channel"])
+            elif e.code == 10009:
+                return False, _(mute_unmute_issues["left_guild"])
         else:
             await self.settings.member(user).set_raw(
                 "perms_cache", str(channel.id), value=old_overs
@@ -463,8 +467,11 @@ class MuteMixin(MixinMeta):
                 await channel.set_permissions(user, overwrite=overwrites, reason=reason)
         except discord.Forbidden:
             return False, _(mute_unmute_issues["permissions_issue"])
-        except discord.NotFound:
-            return False, _(mute_unmute_issues["left_guild"])
+        except discord.NotFound as e:
+            if e.code == 10003:
+                return False, _(mute_unmute_issues["unknown_channel"])
+            elif e.code == 10009:
+                return False, _(mute_unmute_issues["left_guild"])
         else:
             await self.settings.member(user).clear_raw("perms_cache", str(channel.id))
             return True, None

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -22,6 +22,7 @@ mute_unmute_issues = {
         "permission and the user I'm muting must be "
         "lower than myself in the role hierarchy."
     ),
+    "left_guild": _("The user has left the server while we're applying a overwrite.")
 }
 _ = T_
 
@@ -422,6 +423,8 @@ class MuteMixin(MixinMeta):
             await channel.set_permissions(user, overwrite=overwrites, reason=reason)
         except discord.Forbidden:
             return False, _(mute_unmute_issues["permissions_issue"])
+        except discord.NotFound:
+            return False, _(mute_unmute_issues["left_guild"])
         else:
             await self.settings.member(user).set_raw(
                 "perms_cache", str(channel.id), value=old_overs
@@ -460,6 +463,8 @@ class MuteMixin(MixinMeta):
                 await channel.set_permissions(user, overwrite=overwrites, reason=reason)
         except discord.Forbidden:
             return False, _(mute_unmute_issues["permissions_issue"])
+        except discord.NotFound:
+            return False, _(mute_unmute_issues["left_guild"])
         else:
             await self.settings.member(user).clear_raw("perms_cache", str(channel.id))
             return True, None

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -22,7 +22,7 @@ mute_unmute_issues = {
         "permission and the user I'm muting must be "
         "lower than myself in the role hierarchy."
     ),
-    "left_guild": _("The user has left the server while were applying an overwrite."),
+    "left_guild": _("The user has left the server while applying an overwrite."),
     "unknown_channel": _("The channel I tried to mute the user in isn't found."),
 }
 _ = T_

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -22,7 +22,7 @@ mute_unmute_issues = {
         "permission and the user I'm muting must be "
         "lower than myself in the role hierarchy."
     ),
-    "left_guild": _("The user has left the server while we're applying a overwrite.")
+    "left_guild": _("The user has left the server while we're applying a overwrite."),
 }
 _ = T_
 

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -22,7 +22,7 @@ mute_unmute_issues = {
         "permission and the user I'm muting must be "
         "lower than myself in the role hierarchy."
     ),
-    "left_guild": _("The user has left the server while we're applying a overwrite."),
+    "left_guild": _("The user has left the server while we're applying an overwrite."),
 }
 _ = T_
 

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -22,7 +22,7 @@ mute_unmute_issues = {
         "permission and the user I'm muting must be "
         "lower than myself in the role hierarchy."
     ),
-    "left_guild": _("The user has left the server while we're applying an overwrite."),
+    "left_guild": _("The user has left the server while were applying an overwrite."),
     "unknown_channel": _("The channel I tried to mute the user in isn't found."),
 }
 _ = T_


### PR DESCRIPTION

### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Thanks @Sharkytheking. This PR fixes an issue when a member leaves the guild when a mute is being applied.

```
Traceback (most recent call last):
  File "/red-v32/lib/python3.8/site-packages/discord/ext/commands/core.py", line 79, in wrapped
    ret = await coro(*args, **kwargs)
  File "/red-v32/lib/python3.8/site-packages/redbot/cogs/mod/mutes.py", line 257, in guild_mute
    success, issue = await self.mute_user(guild, channel, author, user, audit_reason)
  File "/red-v32/lib/python3.8/site-packages/redbot/cogs/mod/mutes.py", line 422, in mute_user
    await channel.set_permissions(user, overwrite=overwrites, reason=reason)
  File "/red-v32/lib/python3.8/site-packages/discord/abc.py", line 602, in set_permissions
    await http.edit_channel_permissions(self.id, target.id, allow.value, deny.value, perm_type, reason=reason)
  File "/red-v32/lib/python3.8/site-packages/discord/http.py", line 220, in request
    raise NotFound(r, data)
discord.errors.NotFound: 404 NOT FOUND (error code: 10009): Unknown Overwrite

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/red-v32/lib/python3.8/site-packages/discord/ext/commands/bot.py", line 863, in invoke
    await ctx.command.invoke(ctx)
  File "/red-v32/lib/python3.8/site-packages/redbot/core/commands/commands.py", line 631, in invoke
    await super().invoke(ctx)
  File "/red-v32/lib/python3.8/site-packages/discord/ext/commands/core.py", line 1158, in invoke
    await ctx.invoked_subcommand.invoke(ctx)
  File "/red-v32/lib/python3.8/site-packages/discord/ext/commands/core.py", line 728, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/red-v32/lib/python3.8/site-packages/discord/ext/commands/core.py", line 88, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: NotFound: 404 NOT FOUND (error code: 10009): Unknown Overwrite
```