### PR TITLE
Fix an issue when there is no game set on the twitch stream

### DIFF
--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -310,7 +310,8 @@ class TwitchStream(Stream):
         embed.set_thumbnail(url=logo)
         if data["thumbnail_url"]:
             embed.set_image(url=rnd(data["thumbnail_url"].format(width=320, height=180)))
-        embed.set_footer(text=_("Playing: ") + data["game_name"])
+        if data["game_name"]:
+            embed.set_footer(text=_("Playing: ") + data["game_name"])
         return embed
 
     def __repr__(self):


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Traceback that should be fixed by this:
```
Exception in command 'twitchstream'
Traceback (most recent call last):
  File "/home/ubuntu/red-venv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 83, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/ubuntu/red-venv/lib/python3.8/site-packages/redbot/cogs/streams/streams.py", line 157, in twitchstream
    await self.check_online(ctx, stream)
  File "/home/ubuntu/red-venv/lib/python3.8/site-packages/redbot/cogs/streams/streams.py", line 197, in check_online
    info = await stream.is_online()
  File "/home/ubuntu/red-venv/lib/python3.8/site-packages/redbot/cogs/streams/streamtypes.py", line 265, in is_online
    return self.make_embed(data), is_rerun
  File "/home/ubuntu/red-venv/lib/python3.8/site-packages/redbot/cogs/streams/streamtypes.py", line 313, in make_embed
    embed.set_footer(text=_("Playing: ") + data["game_name"])
TypeError: can only concatenate str (not "NoneType") to str
```