### PR TITLE
Use correct prefixes when sending messages to owners

### DIFF
--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -20,7 +20,6 @@ from .slowmode import Slowmode
 from .settings import ModSettings
 
 _ = T_ = Translator("Mod", __file__)
-log = logging.getLogger("red.mod")
 
 __version__ = "1.1.0"
 
@@ -106,7 +105,6 @@ class Mod(
                     val = -1
                 await self.settings.guild(discord.Object(id=guild_id)).delete_repeats.set(val)
             await self.settings.version.set("1.0.0")  # set version of last update
-
         if await self.settings.version() < "1.1.0":
             msg = _(
                 "Ignored guilds and channels have been moved. "

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -9,6 +9,7 @@ import discord
 from redbot.core import Config, modlog, commands
 from redbot.core.bot import Red
 from redbot.core.i18n import Translator, cog_i18n
+from redbot.core.utils._internal_utils import send_to_owners_with_prefix_replaced
 from .casetypes import CASETYPES
 from .events import Events
 from .kickban import KickBanMixin
@@ -106,27 +107,13 @@ class Mod(
                 await self.settings.guild(discord.Object(id=guild_id)).delete_repeats.set(val)
             await self.settings.version.set("1.0.0")  # set version of last update
 
-        async def notify_owners(content: str) -> None:
-            destinations = await self.bot.get_owner_notification_destinations()
-            for destination in destinations:
-                prefixes = await self.bot.get_valid_prefixes(getattr(destination, "guild", None))
-                prefix = re.sub(rf"<@!?{self.bot.user.id}>", f"@{self.bot.user.name}", prefixes[0])
-                try:
-                    await destination.send(content.format(prefix=prefix))
-                except Exception:
-                    log.exception(
-                        "I could not send an owner notification to (%s)%s",
-                        destination.id,
-                        destination,
-                    )
-
         if await self.settings.version() < "1.1.0":
             msg = _(
                 "Ignored guilds and channels have been moved. "
-                "Please use `{prefix}moveignoredchannels` if "
+                "Please use `[p]moveignoredchannels` if "
                 "you were previously using these functions."
             )
-            self.bot.loop.create_task(notify_owners(msg))
+            self.bot.loop.create_task(send_to_owners_with_prefix_replaced(self.bot, msg))
             await self.settings.version.set(__version__)
 
     @commands.command()

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -124,7 +124,7 @@ class Streams(commands.Cog):
                     "Note: These tokens are sensitive and should only be used in a private channel "
                     "or in DM with the bot."
                 )
-                await send_to_owners_with_prefix_replace(self.bot, message)
+                await send_to_owners_with_prefix_replaced(self.bot, message)
         async with aiohttp.ClientSession() as session:
             async with session.post(
                 "https://id.twitch.tv/oauth2/token",

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -48,7 +48,7 @@ from .utils._internal_utils import send_to_owners_with_prefix_replaced
 CUSTOM_GROUPS = "CUSTOM_GROUPS"
 SHARED_API_TOKENS = "SHARED_API_TOKENS"
 
-log = logging.getLogger("redbot")
+log = logging.getLogger("red")
 
 __all__ = ["RedBase", "Red", "ExitCodes"]
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1193,8 +1193,11 @@ class RedBase(
             try:
                 await location.send(content, **kwargs)
             except Exception as _exc:
-                log.exception(
-                    f"I could not send an owner notification to ({location.id}){location}"
+                log.error(
+                    "I could not send an owner notification to %s (%s)",
+                    location,
+                    location.id,
+                    exc_info=_exc,
                 )
 
         sends = [wrapped_send(d, content, **kwargs) for d in destinations]

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -43,6 +43,7 @@ from .settings_caches import PrefixManager, IgnoreManager, WhitelistBlacklistMan
 
 from .rpc import RPCMixin
 from .utils import common_filters
+from .utils._internal_utils import send_to_owners_with_prefix_replaced
 
 CUSTOM_GROUPS = "CUSTOM_GROUPS"
 SHARED_API_TOKENS = "SHARED_API_TOKENS"
@@ -548,18 +549,6 @@ class RedBase(
 
         last_system_info = await self._config.last_system_info()
 
-        async def notify_owners(content: str) -> None:
-            destinations = await self.get_owner_notification_destinations()
-            for destination in destinations:
-                prefixes = await self.get_valid_prefixes(getattr(destination, "guild", None))
-                prefix = re.sub(rf"<@!?{self.bot.user.id}>", f"@{self.bot.user.name}", prefixes[0])
-                try:
-                    await destination.send(content.format(prefix=prefix))
-                except Exception as _exc:
-                    log.exception(
-                        f"I could not send an owner notification to ({destination.id}){destination}"
-                    )
-
         ver_info = list(sys.version_info[:2])
         python_version_changed = False
         LIB_PATH = cog_data_path(raw_name="Downloader") / "lib"
@@ -569,13 +558,14 @@ class RedBase(
                 shutil.rmtree(str(LIB_PATH))
                 LIB_PATH.mkdir()
                 self.loop.create_task(
-                    notify_owners(
+                    send_to_owners_with_prefix_replaced(
+                        self,
                         "We detected a change in minor Python version"
                         " and cleared packages in lib folder.\n"
                         "The instance was started with no cogs, please load Downloader"
-                        " and use `{prefix}cog reinstallreqs` to regenerate lib folder."
+                        " and use `[p]cog reinstallreqs` to regenerate lib folder."
                         " After that, restart the bot to get"
-                        " all of your previously loaded cogs loaded again."
+                        " all of your previously loaded cogs loaded again.",
                     )
                 )
                 python_version_changed = True
@@ -603,11 +593,12 @@ class RedBase(
 
         if system_changed and not python_version_changed:
             self.loop.create_task(
-                notify_owners(
+                send_to_owners_with_prefix_replaced(
+                    self,
                     "We detected a possible change in machine's operating system"
                     " or architecture. You might need to regenerate your lib folder"
                     " if 3rd-party cogs stop working properly.\n"
-                    "To regenerate lib folder, load Downloader and use `{prefix}cog reinstallreqs`."
+                    "To regenerate lib folder, load Downloader and use `[p]cog reinstallreqs`.",
                 )
             )
 

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -15,10 +15,10 @@ import discord
 from fuzzywuzzy import fuzz, process
 
 from redbot.core import data_manager
-from redbot.core.bot import Red
 from redbot.core.utils.chat_formatting import box
 
 if TYPE_CHECKING:
+    from redbot.core.bot import Red
     from redbot.core.commands import Command, Context
 
 main_log = logging.getLogger("redbot")

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from redbot.core.bot import Red
     from redbot.core.commands import Command, Context
 
-main_log = logging.getLogger("redbot")
+main_log = logging.getLogger("red")
 
 __all__ = ("safe_delete", "fuzzy_command_search", "format_fuzzy_results", "create_backup")
 

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -240,8 +240,11 @@ async def send_to_owners_with_preprocessor(
                 content = await preprocessor(bot, location, content)
             await location.send(content, **kwargs)
         except Exception as _exc:
-            main_log.exception(
-                f"I could not send an owner notification to ({location.id}){location}"
+            main_log.error(
+                "I could not send an owner notification to %s (%s)",
+                location,
+                location.id,
+                exc_info=_exc,
             )
 
     sends = [wrapped_send(bot, d, content, content_preprocessor, **kwargs) for d in destinations]

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -257,7 +257,7 @@ async def send_to_owners_with_prefix_replaced(bot: Red, content: str, **kwargs):
     """
 
     async def preprocessor(bot: Red, destination: discord.abc.Messageable, content: str) -> str:
-        prefixes = await bot.get_valid_prefixes()
+        prefixes = await bot.get_valid_prefixes(getattr(destination, "guild", None))
         prefix = re.sub(rf"<@!?{bot.user.id}>", f"@{bot.user.name}", prefixes[0])
         return content.replace("[p]", prefix)
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This replaces usage of `bot.send_to_owners()` with `bot.get_owner_notification_destinations()` in places where we use a prefix in the message - owner notifications destination can be a channel and if a guild this channel is in overwrites global prefix, then the message contains incorrect prefix.

Because of slight reordering, it also fixes the same issue that PR #3626 fixes. I guess you could call this an alternative approach to that issue.
