### PR TITLE
Remove usage of `loop` arg in calls to `start_adding_reactions`

### DIFF
--- a/redbot/cogs/audio/audio.py
+++ b/redbot/cogs/audio/audio.py
@@ -2001,7 +2001,7 @@ class Audio(commands.Cog):
             with contextlib.suppress(discord.HTTPException):
                 await eq_message.add_reaction("\N{INFORMATION SOURCE}")
         else:
-            start_adding_reactions(eq_message, reactions, self.bot.loop)
+            start_adding_reactions(eq_message, reactions)
 
         eq_msg_with_reacts = await ctx.fetch_message(eq_message.id)
         player.store("eq_message", eq_msg_with_reacts)
@@ -2605,7 +2605,7 @@ class Audio(commands.Cog):
         if not player.queue:
             expected = ("⏹", "⏯")
         if player.current:
-            task = start_adding_reactions(message, expected[:4], ctx.bot.loop)
+            task = start_adding_reactions(message, expected[:4])
         else:
             task = None
 
@@ -6334,7 +6334,7 @@ class Audio(commands.Cog):
             expected = ("⏹", "⏯")
             emoji = {"stop": "⏹", "pause": "⏯"}
             if player.current:
-                task = start_adding_reactions(message, expected[:4], ctx.bot.loop)
+                task = start_adding_reactions(message, expected[:4])
             else:
                 task = None
 

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1281,7 +1281,7 @@ class Downloader(commands.Cog):
             query: discord.Message = await ctx.send(message)
             if can_react:
                 # noinspection PyAsyncCall
-                start_adding_reactions(query, ReactionPredicate.YES_OR_NO_EMOJIS, ctx.bot.loop)
+                start_adding_reactions(query, ReactionPredicate.YES_OR_NO_EMOJIS)
                 pred = ReactionPredicate.yes_or_no(query, ctx.author)
                 event = "reaction_add"
             else:

--- a/redbot/cogs/permissions/permissions.py
+++ b/redbot/cogs/permissions/permissions.py
@@ -645,7 +645,7 @@ class Permissions(commands.Cog):
         if ctx.guild is None or ctx.guild.me.permissions_in(ctx.channel).add_reactions:
             msg = await ctx.send(_("Are you sure?"))
             # noinspection PyAsyncCall
-            task = start_adding_reactions(msg, ReactionPredicate.YES_OR_NO_EMOJIS, ctx.bot.loop)
+            task = start_adding_reactions(msg, ReactionPredicate.YES_OR_NO_EMOJIS)
             pred = ReactionPredicate.yes_or_no(msg, ctx.author)
             try:
                 await ctx.bot.wait_for("reaction_add", check=pred, timeout=30)

--- a/redbot/core/checks.py
+++ b/redbot/core/checks.py
@@ -56,6 +56,7 @@ def is_mod_or_superior(ctx: "Context") -> Awaitable[bool]:
         "`redbot.core.checks.is_mod_or_superior` is deprecated and will be removed in a future "
         "release, please use `redbot.core.utils.mod.is_mod_or_superior` instead.",
         category=DeprecationWarning,
+        stacklevel=2,
     )
     return _is_mod_or_superior(ctx.bot, ctx.author)
 
@@ -65,6 +66,7 @@ def is_admin_or_superior(ctx: "Context") -> Awaitable[bool]:
         "`redbot.core.checks.is_admin_or_superior` is deprecated and will be removed in a future "
         "release, please use `redbot.core.utils.mod.is_admin_or_superior` instead.",
         category=DeprecationWarning,
+        stacklevel=2,
     )
     return _is_admin_or_superior(ctx.bot, ctx.author)
 
@@ -72,6 +74,8 @@ def is_admin_or_superior(ctx: "Context") -> Awaitable[bool]:
 def check_permissions(ctx: "Context", perms: Dict[str, bool]) -> Awaitable[bool]:
     warnings.warn(
         "`redbot.core.checks.check_permissions` is deprecated and will be removed in a future "
-        "release, please use `redbot.core.utils.mod.check_permissions`."
+        "release, please use `redbot.core.utils.mod.check_permissions`.",
+        DeprecationWarning,
+        stacklevel=2,
     )
     return _check_permissions(ctx, perms)

--- a/redbot/core/utils/__init__.py
+++ b/redbot/core/utils/__init__.py
@@ -183,6 +183,7 @@ def bounded_gather_iter(
             "Explicitly passing the loop will not work in Red 3.4+ and is currently ignored."
             "Call this from the related event loop.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
     loop = asyncio.get_running_loop()
@@ -240,6 +241,7 @@ def bounded_gather(
             "Explicitly passing the loop will not work in Red 3.4+ and is currently ignored."
             "Call this from the related event loop.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
     loop = asyncio.get_running_loop()

--- a/redbot/core/utils/menus.py
+++ b/redbot/core/utils/menus.py
@@ -78,7 +78,7 @@ async def menu(
             message = await ctx.send(current_page)
         # Don't wait for reactions to be added (GH-1797)
         # noinspection PyAsyncCall
-        start_adding_reactions(message, controls.keys(), ctx.bot.loop)
+        start_adding_reactions(message, controls.keys())
     else:
         try:
             if isinstance(current_page, discord.Embed):

--- a/redbot/core/utils/menus.py
+++ b/redbot/core/utils/menus.py
@@ -213,7 +213,11 @@ def start_adding_reactions(
     if loop is None:
         loop = asyncio.get_running_loop()
     else:
-        warnings.warn("Explicitly passing the loop will not work in Red 3.4+", DeprecationWarning)
+        warnings.warn(
+            "Explicitly passing the loop will not work in Red 3.4+",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     return loop.create_task(task())
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This PR does 2 things:
- warnings in Red now use correct stack level so that the warnings are of any use to developers
- usage of `loop` arg in calls to `start_adding_reactions` has been fully removed
