### PR TITLE
[Core] Unify commands that set bot's activity status

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1073,7 +1073,7 @@ class Core(commands.Cog, CoreLogic):
         else:
             await ctx.send(_("Done."))
 
-    @_set.command(name="game", aliases=["playing"])
+    @_set.command(name="playing", aliases=["game"])
     @checks.bot_in_a_guild()
     @checks.is_owner()
     async def _game(self, ctx: commands.Context, *, game: str = None):
@@ -1158,7 +1158,7 @@ class Core(commands.Cog, CoreLogic):
             await ctx.bot.change_presence(status=status, activity=game)
             await ctx.send(_("Status changed to {}.").format(status))
 
-    @_set.command()
+    @_set.command(name="streaming", aliases=["stream"])
     @checks.bot_in_a_guild()
     @checks.is_owner()
     async def stream(self, ctx: commands.Context, streamer=None, *, stream_title=None):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1073,7 +1073,7 @@ class Core(commands.Cog, CoreLogic):
         else:
             await ctx.send(_("Done."))
 
-    @_set.command(name="game")
+    @_set.command(name="game", aliases=["playing"])
     @checks.bot_in_a_guild()
     @checks.is_owner()
     async def _game(self, ctx: commands.Context, *, game: str = None):


### PR DESCRIPTION
### Type


- [X] Enhancement


### Description of the changes
I aliased ``[p]set game`` with ``[p]set playing`` to resolve #3590 . Not sure if adding an alias or renaming it outright is the way to go. This way users that are used to ``[p]set game`` can keep using it while people who intuitively type ``[p]set playing`` will also get the expected result.