### PR TITLE
Improve error message for `OSError` in `[p]repo add`

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -520,7 +520,7 @@ class Downloader(commands.Cog):
             await ctx.send(
                 _(
                     "Something went wrong trying to add that repo."
-                    " Your repo name might have an invalid character."
+                    " See logs for more information."
                 )
             )
         else:

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -506,7 +506,12 @@ class Downloader(commands.Cog):
         except errors.ExistingGitRepo:
             await ctx.send(_("That git repo has already been added under another name."))
         except errors.CloningError as err:
-            await ctx.send(_("Something went wrong during the cloning process."))
+            await ctx.send(
+                _(
+                    "Something went wrong during the cloning process."
+                    " See logs for more information."
+                )
+            )
             log.exception(
                 "Something went wrong whilst cloning %s (to revision: %s)",
                 repo_url,


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
I know why "Your repo name might have an invalid character." was there originally but because of the regex check that we do before this, this exception will most likely never be raised because of invalid character in repo name, but it might be raised in some other cases like missing permissions.