### PR TITLE
Log failures when requesting Twitch bearer token

### DIFF
--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -145,7 +145,6 @@ class Streams(commands.Cog):
                     log.error(
                         "Twitch API request failed authentication: set Client ID is invalid."
                     )
-                    return
                 elif req.status == 403 and data.get("message") == "invalid client secret":
                     log.error(
                         "Twitch API request failed authentication: set Client Secret is invalid."

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -157,13 +157,11 @@ class Streams(commands.Cog):
                         data["message"],
                     )
                 else:
-                    log.error(
-                        "Twitch OAuth2 API request failed with status code %s", req.status
-                    )
-                
+                    log.error("Twitch OAuth2 API request failed with status code %s", req.status)
+
                 if req.status != 200:
                     return
-                    
+
         self.ttv_bearer_cache = data
         self.ttv_bearer_cache["expires_at"] = datetime.now().timestamp() + data.get("expires_in")
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
I included the most likely causes of errors (invalid client id or secret), and added a generic error message for rest.