### PR TITLE
Add changelog label to merged PRs

### DIFF
--- a/.github/workflows/add_changelog_label.yaml
+++ b/.github/workflows/add_changelog_label.yaml
@@ -1,0 +1,26 @@
+name: Add changelog label to merged PR
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  build:
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply label
+        uses: actions/github-script@0.4.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const is_changelog_label = (label) => label.name.startsWith('Changelog Entry: ');
+            if (context.payload.pull_request.labels.some(is_changelog_label)) {
+                console.log('Issue already has Changelog Entry label, skipping...');
+                return;
+            }
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['Changelog Entry: Pending']
+            });


### PR DESCRIPTION
### Description of the changes
For better organization of PRs that have to be added to changelog draft, this PR adds GitHub action which will label merged PRs with "Changelog Entry: Pending" label.
The idea is to have 3 labels which will record the progress on changelog entries (labels have already been created):
![chrome_2020-03-16_16-52-07](https://user-images.githubusercontent.com/6032823/76778297-de019100-67a9-11ea-9cbc-8a818f110465.png)

#3661 should probably be merged prior to this