### PR TITLE
Fix `BalanceTooHigh` error in Trivia session

### DIFF
--- a/redbot/cogs/trivia/session.py
+++ b/redbot/cogs/trivia/session.py
@@ -303,7 +303,10 @@ class TriviaSession:
                 amount = int(multiplier * score)
                 if amount > 0:
                     LOG.debug("Paying trivia winner: %d credits --> %s", amount, str(winner))
-                    await bank.deposit_credits(winner, int(multiplier * score))
+                    try:
+                        await bank.deposit_credits(winner, int(multiplier * score))
+                    except bank.BalanceTooHigh as e:
+                        await bank.set_balance(winner, e.max_balance)
                     await self.ctx.send(
                         _(
                             "Congratulations, {user}, you have received {num} {currency}"


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #3584