### PR TITLE
Show member's activities in `[p]userinfo` command

### DIFF
--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -87,14 +87,10 @@ class ModInfo(MixinMeta):
 
     def handle_playing(self, user):
         p_acts = [c for c in user.activities if c.type == discord.ActivityType.playing]
-        p_act = p_acts[0] if p_acts else None
-        act = (
-            _("Playing: {name}").format(name=p_act.name if p_act and p_act.name else None)
-            if p_act and hasattr(p_act, "name")
-            else p_act.name
-            if p_act and p_act.name
-            else None
-        )
+        if not p_acts:
+            return
+        p_act = p_acts[0]
+        act = _("Playing: {name}").format(name=p_act.name)
         return act, discord.ActivityType.playing
 
     def handle_streaming(self, user):

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -116,19 +116,18 @@ class ModInfo(MixinMeta):
 
     def handle_listening(self, user):
         l_acts = [c for c in user.activities if c.type == discord.ActivityType.listening]
-        l_act = l_acts[0] if l_acts else None
-        act = (
-            _("Listening: [{title}{sep}{artist}]({url})").format(
-                title=l_act.title,
-                sep=" | " if l_act.artists[0] else "",
+        if not l_acts:
+            return None, discord.ActivityType.listening
+        l_act = l_acts[0]
+        if isinstance(l_act, discord.Spotify):
+            act = _("Listening: [{title}{sep}{artist}]({url})").format(
+                title=discord.utils.escape_markdown(l_act.title),
+                sep=" | " if l_act.artist else "",
                 artist=discord.utils.escape_markdown(l_act.artist) if l_act.artist else "",
                 url=f"https://open.spotify.com/track/{l_act.track_id}",
             )
-            if l_act and hasattr(l_act, "title")
-            else l_act.name
-            if l_act and l_act.name
-            else None
-        )
+        else:
+            act = _("Listening: {title}").format(title=l_act.title)
         return act, discord.ActivityType.listening
 
     def handle_watching(self, user):

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -100,7 +100,6 @@ class ModInfo(MixinMeta):
         s_act = s_acts[0]
         if isinstance(s_act, discord.Streaming):
             act = _("Streaming on {platform}: [{name}{sep}{game}]({url})").format(
-                platform=s_act.platform,
                 name=discord.utils.escape_markdown(s_act.name),
                 sep=" | " if s_act.game else "",
                 game=discord.utils.escape_markdown(s_act.game) if s_act.game else "",

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -132,14 +132,10 @@ class ModInfo(MixinMeta):
 
     def handle_watching(self, user):
         w_acts = [c for c in user.activities if c.type == discord.ActivityType.watching]
-        w_act = w_acts[0] if w_acts else None
-        act = (
-            _("Watching: {name}").format(name=w_act.name if w_act else None)
-            if w_act and hasattr(w_act, "name")
-            else w_act.name
-            if w_act and w_act.name
-            else None
-        )
+        if not w_acts:
+            return None, discord.ActivityType.watching
+        w_act = w_acts[0]
+        act = _("Watching: {name}").format(name=w_act.name)
         return act, discord.ActivityType.watching
 
     def get_status_string(self, user):

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -156,16 +156,7 @@ class ModInfo(MixinMeta):
             status_string, status_type = a
             if status_string is None:
                 continue
-            if status_type == discord.ActivityType.custom:
-                string += "{}\n".format(status_string)
-            elif status_type == discord.ActivityType.playing:
-                string += "{}\n".format(status_string)
-            elif status_type == discord.ActivityType.streaming:
-                string += "{}\n".format(status_string)
-            elif status_type == discord.ActivityType.listening:
-                string += _("{}\n".format(status_string))
-            elif status_type == discord.ActivityType.watching:
-                string += "{}\n".format(status_string)
+            string += f"{status_string}\n"
         return string
 
     @commands.command()

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -191,14 +191,14 @@ class ModInfo(MixinMeta):
         created_on = _("{}\n({} days ago)").format(user_created, since_created)
         joined_on = _("{}\n({} days ago)").format(user_joined, since_joined)
 
-        if user.status.name == "online":
+        if any(a.type is discord.ActivityType.streaming for a in user.activities):
+            statusemoji = "\N{LARGE PURPLE CIRCLE}"
+        elif user.status.name == "online":
             statusemoji = "\N{LARGE GREEN CIRCLE}"
         elif user.status.name == "offline":
             statusemoji = "\N{MEDIUM WHITE CIRCLE}"
         elif user.status.name == "dnd":
             statusemoji = "\N{LARGE RED CIRCLE}"
-        elif user.status.name == "streaming":
-            statusemoji = "\N{LARGE PURPLE CIRCLE}"
         elif user.status.name == "idle":
             statusemoji = "\N{LARGE ORANGE CIRCLE}"
         activity = _("Chilling in {} status").format(user.status)

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -75,6 +75,8 @@ class ModInfo(MixinMeta):
             return None, discord.ActivityType.custom
         a = a[0]
         c_status = None
+        if not a.name and not a.emoji:
+        	return None, discord.ActivityType.custom
         if not a.name:
             c_status = self.bot.get_emoji(a.emoji.id)
         if c_status:

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -32,9 +32,7 @@ class ModInfo(MixinMeta):
     @commands.guild_only()
     @commands.bot_has_permissions(manage_nicknames=True)
     @checks.admin_or_permissions(manage_nicknames=True)
-    async def rename(
-        self, ctx: commands.Context, user: discord.Member, *, nickname: str = ""
-    ):
+    async def rename(self, ctx: commands.Context, user: discord.Member, *, nickname: str = ""):
         """Change a user's nickname.
 
         Leaving the nickname empty will remove it.
@@ -47,10 +45,7 @@ class ModInfo(MixinMeta):
             await ctx.send(_("Nicknames must be between 2 and 32 characters long."))
             return
         if not (
-            (
-                me.guild_permissions.manage_nicknames
-                or me.guild_permissions.administrator
-            )
+            (me.guild_permissions.manage_nicknames or me.guild_permissions.administrator)
             and me.top_role > user.top_role
             and user != ctx.guild.owner
         ):
@@ -62,9 +57,7 @@ class ModInfo(MixinMeta):
             )
         else:
             try:
-                await user.edit(
-                    reason=get_audit_reason(ctx.author, None), nick=nickname
-                )
+                await user.edit(reason=get_audit_reason(ctx.author, None), nick=nickname)
             except discord.Forbidden:
                 # Just in case we missed something in the permissions check above
                 await ctx.send(_("I do not have permission to rename that member."))
@@ -103,9 +96,7 @@ class ModInfo(MixinMeta):
         return act, discord.ActivityType.playing
 
     def handle_streaming(self, user):
-        s_acts = [
-            c for c in user.activities if c.type == discord.ActivityType.streaming
-        ]
+        s_acts = [c for c in user.activities if c.type == discord.ActivityType.streaming]
         s_act = s_acts[0] if s_acts else None
         act = (
             f"[{s_act.name}{' | ' if s_act.game else ''}{s_act.game or ''}]({s_act.url})"
@@ -117,9 +108,7 @@ class ModInfo(MixinMeta):
         return act, discord.ActivityType.streaming
 
     def handle_listening(self, user):
-        l_acts = [
-            c for c in user.activities if c.type == discord.ActivityType.listening
-        ]
+        l_acts = [c for c in user.activities if c.type == discord.ActivityType.listening]
         l_act = l_acts[0] if l_acts else None
         act = (
             f"[{l_act.title}{' | ' if l_act.artists[0] else ''}{l_act.artists[0] or ''}](https://open.spotify.com/track/{l_act.track_id})"
@@ -196,9 +185,7 @@ class ModInfo(MixinMeta):
         user_created = user.created_at.strftime("%d %b %Y %H:%M")
         voice_state = user.voice
         member_number = (
-            sorted(
-                guild.members, key=lambda m: m.joined_at or ctx.message.created_at
-            ).index(user)
+            sorted(guild.members, key=lambda m: m.joined_at or ctx.message.created_at).index(user)
             + 1
         )
 
@@ -222,9 +209,7 @@ class ModInfo(MixinMeta):
                 continuation_string = _(
                     "and {numeric_number} more roles not displayed due to embed limits."
                 )
-                available_length = 1024 - len(
-                    continuation_string
-                )  # do not attempt to tweak, i18n
+                available_length = 1024 - len(continuation_string)  # do not attempt to tweak, i18n
 
                 role_chunks = []
                 remaining_roles = 0
@@ -239,9 +224,7 @@ class ModInfo(MixinMeta):
                     else:
                         remaining_roles += 1
 
-                role_chunks.append(
-                    continuation_string.format(numeric_number=remaining_roles)
-                )
+                role_chunks.append(continuation_string.format(numeric_number=remaining_roles))
 
                 role_str = "".join(role_chunks)
 
@@ -268,9 +251,7 @@ class ModInfo(MixinMeta):
                 value="{0.mention} ID: {0.id}".format(voice_state.channel),
                 inline=False,
             )
-        data.set_footer(
-            text=_("Member #{} | User ID: {}").format(member_number, user.id)
-        )
+        data.set_footer(text=_("Member #{} | User ID: {}").format(member_number, user.id))
 
         name = str(user)
         name = " ~ ".join((name, user.nick)) if user.nick else name
@@ -304,7 +285,4 @@ class ModInfo(MixinMeta):
             msg = filter_various_mentions(msg)
             await ctx.send(msg)
         else:
-            await ctx.send(
-                _("That user doesn't have any recorded name or nickname change.")
-            )
-
+            await ctx.send(_("That user doesn't have any recorded name or nickname change."))

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -123,7 +123,7 @@ class ModInfo(MixinMeta):
                 url=f"https://open.spotify.com/track/{l_act.track_id}",
             )
         else:
-            act = _("Listening: {title}").format(title=l_act.title)
+            act = _("Listening: {title}").format(title=l_act.name)
         return act, discord.ActivityType.listening
 
     def handle_watching(self, user):

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -99,7 +99,7 @@ class ModInfo(MixinMeta):
             return None, discord.ActivityType.streaming
         s_act = s_acts[0]
         if isinstance(s_act, discord.Streaming):
-            act = _("Streaming on {platform}: [{name}{sep}{game}]({url})").format(
+            act = _("Streaming: [{name}{sep}{game}]({url})").format(
                 name=discord.utils.escape_markdown(s_act.name),
                 sep=" | " if s_act.game else "",
                 game=discord.utils.escape_markdown(s_act.game) if s_act.game else "",

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -88,7 +88,7 @@ class ModInfo(MixinMeta):
     def handle_playing(self, user):
         p_acts = [c for c in user.activities if c.type == discord.ActivityType.playing]
         if not p_acts:
-            return
+            return None, discord.ActivityType.playing
         p_act = p_acts[0]
         act = _("Playing: {name}").format(name=p_act.name)
         return act, discord.ActivityType.playing

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -274,7 +274,7 @@ class ModInfo(MixinMeta):
             )
             data.set_thumbnail(url=avatar)
         else:
-            data.set_author(name=name)
+            data.set_author(name="{statusemoji} {name}".format(statusemoji=statusemoji, name=name))
 
         await ctx.send(embed=data)
 

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -92,7 +92,7 @@ class ModInfo(MixinMeta):
             _("Playing: {name}").format(name=p_act.name if p_act and p_act.name else None)
             if p_act and hasattr(p_act, "name")
             else p_act.name
-            if p_act and p_act_name
+            if p_act and p_act.name
             else None
         )
         return act, discord.ActivityType.playing
@@ -139,7 +139,7 @@ class ModInfo(MixinMeta):
             _("Watching: {name}").format(name=w_act.name if w_act else None)
             if w_act and hasattr(w_act, "name")
             else w_act.name
-            if w_act and w_act_name
+            if w_act and w_act.name
             else None
         )
         return act, discord.ActivityType.watching

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -32,7 +32,9 @@ class ModInfo(MixinMeta):
     @commands.guild_only()
     @commands.bot_has_permissions(manage_nicknames=True)
     @checks.admin_or_permissions(manage_nicknames=True)
-    async def rename(self, ctx: commands.Context, user: discord.Member, *, nickname: str = ""):
+    async def rename(
+        self, ctx: commands.Context, user: discord.Member, *, nickname: str = ""
+    ):
         """Change a user's nickname.
 
         Leaving the nickname empty will remove it.
@@ -45,7 +47,10 @@ class ModInfo(MixinMeta):
             await ctx.send(_("Nicknames must be between 2 and 32 characters long."))
             return
         if not (
-            (me.guild_permissions.manage_nicknames or me.guild_permissions.administrator)
+            (
+                me.guild_permissions.manage_nicknames
+                or me.guild_permissions.administrator
+            )
             and me.top_role > user.top_role
             and user != ctx.guild.owner
         ):
@@ -57,7 +62,9 @@ class ModInfo(MixinMeta):
             )
         else:
             try:
-                await user.edit(reason=get_audit_reason(ctx.author, None), nick=nickname)
+                await user.edit(
+                    reason=get_audit_reason(ctx.author, None), nick=nickname
+                )
             except discord.Forbidden:
                 # Just in case we missed something in the permissions check above
                 await ctx.send(_("I do not have permission to rename that member."))
@@ -94,16 +101,35 @@ class ModInfo(MixinMeta):
         p_act = p_acts[0] if p_acts else None
         act = p_act.name if p_act and p_act.name else None
         return act, discord.ActivityType.playing
+
     def handle_streaming(self, user):
-        s_acts = [c for c in user.activities if c.type == discord.ActivityType.streaming]
+        s_acts = [
+            c for c in user.activities if c.type == discord.ActivityType.streaming
+        ]
         s_act = s_acts[0] if s_acts else None
-        act = f"[{s_act.name}{' | ' if s_act.game else ''}{s_act.game or ''}]({s_act.url})" if s_act and s_act.name and hasattr(s_act, "game") else s_act.name if s_act and s_act.name else None
+        act = (
+            f"[{s_act.name}{' | ' if s_act.game else ''}{s_act.game or ''}]({s_act.url})"
+            if s_act and s_act.name and hasattr(s_act, "game")
+            else s_act.name
+            if s_act and s_act.name
+            else None
+        )
         return act, discord.ActivityType.streaming
+
     def handle_listening(self, user):
-        l_acts = [c for c in user.activities if c.type == discord.ActivityType.listening]
+        l_acts = [
+            c for c in user.activities if c.type == discord.ActivityType.listening
+        ]
         l_act = l_acts[0] if l_acts else None
-        act = f"[{l_act.title}{' | ' if l_act.artists[0] else ''}{l_act.artists[0] or ''}](https://open.spotify.com/track/{l_act.track_id})" if l_act and hasattr(l_act, "title") else l_act.name if l_act and l_act.name else None
+        act = (
+            f"[{l_act.title}{' | ' if l_act.artists[0] else ''}{l_act.artists[0] or ''}](https://open.spotify.com/track/{l_act.track_id})"
+            if l_act and hasattr(l_act, "title")
+            else l_act.name
+            if l_act and l_act.name
+            else None
+        )
         return act, discord.ActivityType.listening
+
     def handle_watching(self, user):
         w_acts = [c for c in user.activities if c.type == discord.ActivityType.watching]
         w_act = w_acts[0] if w_acts else None
@@ -112,8 +138,14 @@ class ModInfo(MixinMeta):
 
     def get_status_string(self, user):
         string = ""
-        for a in [self.handle_custom(user), self.handle_playing(user), self.handle_listening(user), self.handle_streaming(user), self.handle_watching(user)]:
-            status_string, status_type= a
+        for a in [
+            self.handle_custom(user),
+            self.handle_playing(user),
+            self.handle_listening(user),
+            self.handle_streaming(user),
+            self.handle_watching(user),
+        ]:
+            status_string, status_type = a
             if status_string is None:
                 continue
             if status_type == discord.ActivityType.custom:
@@ -127,7 +159,7 @@ class ModInfo(MixinMeta):
             elif status_type == discord.ActivityType.watching:
                 string += f"Watching: {status_string}\n"
         return string
-    
+
     @commands.command()
     @commands.guild_only()
     @commands.bot_has_permissions(embed_links=True)
@@ -164,7 +196,9 @@ class ModInfo(MixinMeta):
         user_created = user.created_at.strftime("%d %b %Y %H:%M")
         voice_state = user.voice
         member_number = (
-            sorted(guild.members, key=lambda m: m.joined_at or ctx.message.created_at).index(user)
+            sorted(
+                guild.members, key=lambda m: m.joined_at or ctx.message.created_at
+            ).index(user)
             + 1
         )
 
@@ -188,7 +222,9 @@ class ModInfo(MixinMeta):
                 continuation_string = _(
                     "and {numeric_number} more roles not displayed due to embed limits."
                 )
-                available_length = 1024 - len(continuation_string)  # do not attempt to tweak, i18n
+                available_length = 1024 - len(
+                    continuation_string
+                )  # do not attempt to tweak, i18n
 
                 role_chunks = []
                 remaining_roles = 0
@@ -203,7 +239,9 @@ class ModInfo(MixinMeta):
                     else:
                         remaining_roles += 1
 
-                role_chunks.append(continuation_string.format(numeric_number=remaining_roles))
+                role_chunks.append(
+                    continuation_string.format(numeric_number=remaining_roles)
+                )
 
                 role_str = "".join(role_chunks)
 
@@ -211,7 +249,7 @@ class ModInfo(MixinMeta):
             role_str = None
 
         data = discord.Embed(description=status_string or activity, colour=user.colour)
-            
+
         data.add_field(name=_("Joined Discord on"), value=created_on)
         data.add_field(name=_("Joined this server on"), value=joined_on)
         if role_str is not None:
@@ -230,7 +268,9 @@ class ModInfo(MixinMeta):
                 value="{0.mention} ID: {0.id}".format(voice_state.channel),
                 inline=False,
             )
-        data.set_footer(text=_("Member #{} | User ID: {}").format(member_number, user.id))
+        data.set_footer(
+            text=_("Member #{} | User ID: {}").format(member_number, user.id)
+        )
 
         name = str(user)
         name = " ~ ".join((name, user.nick)) if user.nick else name
@@ -264,4 +304,7 @@ class ModInfo(MixinMeta):
             msg = filter_various_mentions(msg)
             await ctx.send(msg)
         else:
-            await ctx.send(_("That user doesn't have any recorded name or nickname change."))
+            await ctx.send(
+                _("That user doesn't have any recorded name or nickname change.")
+            )
+

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -99,20 +99,19 @@ class ModInfo(MixinMeta):
 
     def handle_streaming(self, user):
         s_acts = [c for c in user.activities if c.type == discord.ActivityType.streaming]
-        s_act = s_acts[0] if s_acts else None
-        act = (
-            _("Streaming on {platform}: [{name}{sep}{game}]({url})").format(
+        if not s_acts:
+            return None, discord.ActivityType.streaming
+        s_act = s_acts[0]
+        if isinstance(s_act, discord.Streaming):
+            act = _("Streaming on {platform}: [{name}{sep}{game}]({url})").format(
                 platform=s_act.platform,
                 name=discord.utils.escape_markdown(s_act.name),
                 sep=" | " if s_act.game else "",
                 game=discord.utils.escape_markdown(s_act.game) if s_act.game else "",
                 url=s_act.url,
             )
-            if s_act and s_act.name and hasattr(s_act, "game")
-            else discord.utils.escape_markdown(s_act.name)
-            if s_act and s_act.name
-            else None
-        )
+        else:
+            act = _("Streaming: {name}").format(name=s_act.name)
         return act, discord.ActivityType.streaming
 
     def handle_listening(self, user):

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -76,7 +76,7 @@ class ModInfo(MixinMeta):
         a = a[0]
         c_status = None
         if not a.name and not a.emoji:
-        	return None, discord.ActivityType.custom
+            return None, discord.ActivityType.custom
         if not a.name:
             c_status = self.bot.get_emoji(a.emoji.id)
         if c_status:


### PR DESCRIPTION
Adds support for statues in the userinfo command including custom status, playing and listening improvements

### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Adds new support for statuses in userinfo, such as spotify listening statues, playing statuses, streaming, and custom statuses with emoji support if the bot can see the emoji in question