### PR TITLE
Add `[p]set regionalformat` command to set regional formatting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -217,6 +217,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "dpy": (f"https://discordpy.readthedocs.io/en/v{dpy_version}/", None),
     "motor": ("https://motor.readthedocs.io/en/stable/", None),
+    "babel": ("http://babel.pocoo.org/en/stable/", None),
 }
 
 # Extlinks

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -89,7 +89,7 @@ class RedBase(
             whitelist=[],
             blacklist=[],
             locale="en-US",
-            region=None,
+            regional_format=None,
             embeds=True,
             color=15158332,
             fuzzy=False,
@@ -538,8 +538,8 @@ class RedBase(
 
         i18n_locale = await self._config.locale()
         i18n.set_locale(i18n_locale)
-        i18n_region = await self._config.region()
-        i18n.set_region(i18n_region)
+        i18n_regional_format = await self._config.regional_format()
+        i18n.set_regional_format(i18n_regional_format)
 
         self.add_cog(Core(self))
         self.add_cog(CogManagerUI())

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -89,6 +89,7 @@ class RedBase(
             whitelist=[],
             blacklist=[],
             locale="en-US",
+            region=None,
             embeds=True,
             color=15158332,
             fuzzy=False,
@@ -537,6 +538,8 @@ class RedBase(
 
         i18n_locale = await self._config.locale()
         i18n.set_locale(i18n_locale)
+        i18n_region = await self._config.region()
+        i18n.set_region(i18n_region)
 
         self.add_cog(Core(self))
         self.add_cog(CogManagerUI())

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -897,18 +897,21 @@ class Core(commands.Cog, CoreLogic):
 
             prefixes = await ctx.bot._prefix_cache.get_prefixes(ctx.guild)
             locale = await ctx.bot._config.locale()
+            region = await ctx.bot._config.region() or _("Same as bot's locale")
 
             prefix_string = " ".join(prefixes)
             settings = _(
                 "{bot_name} Settings:\n\n"
                 "Prefixes: {prefixes}\n"
                 "{guild_settings}"
-                "Locale: {locale}"
+                "Locale: {locale}\n"
+                "Region: {region}"
             ).format(
                 bot_name=ctx.bot.user.name,
                 prefixes=prefix_string,
                 guild_settings=guild_settings,
                 locale=locale,
+                region=region,
             )
             for page in pagify(settings):
                 await ctx.send(box(page))
@@ -1302,6 +1305,42 @@ class Core(commands.Cog, CoreLogic):
         i18n.set_locale(standardized_locale_name)
         await ctx.bot._config.locale.set(standardized_locale_name)
         await ctx.send(_("Locale has been set."))
+
+    @_set.command()
+    @checks.is_owner()
+    async def region(self, ctx: commands.Context, language_code: str = None):
+        """
+        Changes bot's regional formatting. This is used for formatting date, time and numbers.
+
+        `<language_code>` can be any language code with country code included,
+        e.g. `en-US`, `de-DE`, `fr-FR`, `pl-PL`, etc.
+
+        Leave `<language_code>` empty to base regional formatting on bot's locale.
+        """
+        if language_code is None:
+            i18n.set_region(None)
+            await ctx.bot._config.region.set(None)
+            await ctx.send(_("Regional formatting will now be based on bot's locale."))
+            return
+
+        try:
+            locale = BabelLocale.parse(language_code, sep="-")
+        except (ValueError, UnknownLocaleError):
+            await ctx.send(_("Invalid language code. Use format: `en-US`"))
+            return
+        if locale.territory is None:
+            await ctx.send(
+                _("Invalid format - language code has to include country code, e.g. `en-US`")
+            )
+            return
+        standardized_locale_name = f"{locale.language}-{locale.territory}"
+        i18n.set_region(standardized_locale_name)
+        await ctx.bot._config.region.set(standardized_locale_name)
+        await ctx.send(
+            _("Regional formatting will now be based on `{language_code}` locale.").format(
+                language_code=standardized_locale_name
+            )
+        )
 
     @_set.command()
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -897,7 +897,7 @@ class Core(commands.Cog, CoreLogic):
 
             prefixes = await ctx.bot._prefix_cache.get_prefixes(ctx.guild)
             locale = await ctx.bot._config.locale()
-            region = await ctx.bot._config.region() or _("Same as bot's locale")
+            regional_format = await ctx.bot._config.regional_format() or _("Same as bot's locale")
 
             prefix_string = " ".join(prefixes)
             settings = _(
@@ -905,13 +905,13 @@ class Core(commands.Cog, CoreLogic):
                 "Prefixes: {prefixes}\n"
                 "{guild_settings}"
                 "Locale: {locale}\n"
-                "Region: {region}"
+                "Regional format: {regional_format}"
             ).format(
                 bot_name=ctx.bot.user.name,
                 prefixes=prefix_string,
                 guild_settings=guild_settings,
                 locale=locale,
-                region=region,
+                regional_format=regional_format,
             )
             for page in pagify(settings):
                 await ctx.send(box(page))
@@ -1306,11 +1306,11 @@ class Core(commands.Cog, CoreLogic):
         await ctx.bot._config.locale.set(standardized_locale_name)
         await ctx.send(_("Locale has been set."))
 
-    @_set.command()
+    @_set.command(aliases=["region"])
     @checks.is_owner()
-    async def region(self, ctx: commands.Context, language_code: str = None):
+    async def regionalformat(self, ctx: commands.Context, language_code: str = None):
         """
-        Changes bot's regional formatting. This is used for formatting date, time and numbers.
+        Changes bot's regional format. This is used for formatting date, time and numbers.
 
         `<language_code>` can be any language code with country code included,
         e.g. `en-US`, `de-DE`, `fr-FR`, `pl-PL`, etc.
@@ -1318,8 +1318,8 @@ class Core(commands.Cog, CoreLogic):
         Leave `<language_code>` empty to base regional formatting on bot's locale.
         """
         if language_code is None:
-            i18n.set_region(None)
-            await ctx.bot._config.region.set(None)
+            i18n.set_regional_format(None)
+            await ctx.bot._config.regional_format.set(None)
             await ctx.send(_("Regional formatting will now be based on bot's locale."))
             return
 
@@ -1334,8 +1334,8 @@ class Core(commands.Cog, CoreLogic):
             )
             return
         standardized_locale_name = f"{locale.language}-{locale.territory}"
-        i18n.set_region(standardized_locale_name)
-        await ctx.bot._config.region.set(standardized_locale_name)
+        i18n.set_regional_format(standardized_locale_name)
+        await ctx.bot._config.regional_format.set(standardized_locale_name)
         await ctx.send(
             _("Regional formatting will now be based on `{language_code}` locale.").format(
                 language_code=standardized_locale_name

--- a/redbot/core/i18n.py
+++ b/redbot/core/i18n.py
@@ -18,6 +18,7 @@ __all__ = [
 ]
 
 _current_locale = "en-US"
+_current_region = None
 
 WAITING_FOR_MSGID = 1
 IN_MSGID = 2
@@ -30,17 +31,28 @@ MSGSTR = 'msgstr "'
 _translators = []
 
 
-def get_locale():
+def get_locale() -> str:
     return _current_locale
 
 
-def set_locale(locale):
+def set_locale(locale: str) -> None:
     global _current_locale
     _current_locale = locale
     reload_locales()
 
 
-def reload_locales():
+def get_region() -> str:
+    if _current_region is None:
+        return _current_locale
+    return _current_region
+
+
+def set_region(region: Optional[str]) -> None:
+    global _current_region
+    _current_region = region
+
+
+def reload_locales() -> None:
     for translator in _translators:
         translator.load_translations()
 
@@ -192,7 +204,7 @@ def _get_babel_locale(red_locale: str) -> babel.core.Locale:
 
 
 def get_babel_locale(locale: Optional[str] = None) -> babel.core.Locale:
-    """Function to convert a locale to a ``babel.core.Locale``.
+    """Function to convert a locale to a `babel.core.Locale`.
 
     Parameters
     ----------
@@ -207,6 +219,26 @@ def get_babel_locale(locale: Optional[str] = None) -> babel.core.Locale:
     if locale is None:
         locale = get_locale()
     return _get_babel_locale(locale)
+
+
+def get_babel_region(region: Optional[str] = None) -> babel.core.Locale:
+    """Function to convert a region to a `babel.core.Locale`.
+
+    If ``region`` parameter is passed, this behaves the same as `get_babel_locale`.
+
+    Parameters
+    ----------
+    region : Optional[str]
+        The region to convert, if not specified it defaults to the bot's region.
+
+    Returns
+    -------
+    babel.core.Locale
+        The babel locale object.
+    """
+    if region is None:
+        region = get_region()
+    return _get_babel_locale(region)
 
 
 # This import to be down here to avoid circular import issues.

--- a/redbot/core/i18n.py
+++ b/redbot/core/i18n.py
@@ -18,7 +18,7 @@ __all__ = [
 ]
 
 _current_locale = "en-US"
-_current_region = None
+_current_regional_format = None
 
 WAITING_FOR_MSGID = 1
 IN_MSGID = 2
@@ -41,15 +41,15 @@ def set_locale(locale: str) -> None:
     reload_locales()
 
 
-def get_region() -> str:
-    if _current_region is None:
+def get_regional_format() -> str:
+    if _current_regional_format is None:
         return _current_locale
-    return _current_region
+    return _current_regional_format
 
 
-def set_region(region: Optional[str]) -> None:
-    global _current_region
-    _current_region = region
+def set_regional_format(regional_format: Optional[str]) -> None:
+    global _current_regional_format
+    _current_regional_format = regional_format
 
 
 def reload_locales() -> None:
@@ -221,24 +221,24 @@ def get_babel_locale(locale: Optional[str] = None) -> babel.core.Locale:
     return _get_babel_locale(locale)
 
 
-def get_babel_region(region: Optional[str] = None) -> babel.core.Locale:
-    """Function to convert a region to a `babel.core.Locale`.
+def get_babel_regional_format(regional_format: Optional[str] = None) -> babel.core.Locale:
+    """Function to convert a regional format to a `babel.core.Locale`.
 
-    If ``region`` parameter is passed, this behaves the same as `get_babel_locale`.
+    If ``regional_format`` parameter is passed, this behaves the same as `get_babel_locale`.
 
     Parameters
     ----------
-    region : Optional[str]
-        The region to convert, if not specified it defaults to the bot's region.
+    regional_format : Optional[str]
+        The regional format to convert, if not specified it defaults to the bot's regional format.
 
     Returns
     -------
     babel.core.Locale
         The babel locale object.
     """
-    if region is None:
-        region = get_region()
-    return _get_babel_locale(region)
+    if regional_format is None:
+        regional_format = get_regional_format()
+    return _get_babel_locale(regional_format)
 
 
 # This import to be down here to avoid circular import issues.

--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -7,7 +7,7 @@ from io import BytesIO
 import discord
 from babel.numbers import format_decimal
 
-from redbot.core.i18n import Translator, get_babel_locale
+from redbot.core.i18n import Translator, get_babel_region
 
 _ = Translator("UtilsChatFormatting", __file__)
 
@@ -473,14 +473,14 @@ def humanize_number(val: Union[int, float], override_locale=None) -> str:
     val : Union[int, float]
         The int/float to be formatted.
     override_locale: Optional[str]
-        A value to override the bots locale.
+        A value to override the bots region.
 
     Returns
     -------
     str
         locale aware formatted number.
     """
-    return format_decimal(val, locale=get_babel_locale(override_locale))
+    return format_decimal(val, locale=get_babel_region(override_locale))
 
 
 def text_to_file(

--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -7,7 +7,7 @@ from io import BytesIO
 import discord
 from babel.numbers import format_decimal
 
-from redbot.core.i18n import Translator, get_babel_region
+from redbot.core.i18n import Translator, get_babel_regional_format
 
 _ = Translator("UtilsChatFormatting", __file__)
 
@@ -473,14 +473,14 @@ def humanize_number(val: Union[int, float], override_locale=None) -> str:
     val : Union[int, float]
         The int/float to be formatted.
     override_locale: Optional[str]
-        A value to override the bots region.
+        A value to override bot's regional format.
 
     Returns
     -------
     str
         locale aware formatted number.
     """
-    return format_decimal(val, locale=get_babel_region(override_locale))
+    return format_decimal(val, locale=get_babel_regional_format(override_locale))
 
 
 def text_to_file(


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes
Depends on #3676, fixes #3588
This adds a `[p]set regionalformat` command that will allow users to set regional formatting for their bot that is different from bot's locale.

As always, I'm open to better names.