### PR TITLE
Add `redbot-setup restore` cli command for restoring instance from backup

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -117,26 +117,29 @@ class Downloader(commands.Cog):
 
     async def initialize(self) -> None:
         await self._repo_manager.initialize()
-        await self._maybe_update_config()
+        await self._maybe_update_config(self.config)
         self._ready.set()
 
-    async def _maybe_update_config(self) -> None:
-        schema_version = await self.config.schema_version()
+    @classmethod
+    async def _maybe_update_config(cls, config: Config) -> None:
+        # this method might also be called from RepoManager._restore_from_backup()
+        schema_version = await config.schema_version()
 
         if schema_version == 0:
-            await self._schema_0_to_1()
+            await cls._schema_0_to_1(config)
             schema_version += 1
-            await self.config.schema_version.set(schema_version)
+            await config.schema_version.set(schema_version)
 
-    async def _schema_0_to_1(self):
+    @classmethod
+    async def _schema_0_to_1(cls, config: Config) -> None:
         """
         This contains migration to allow saving state
         of both installed cogs and shared libraries.
         """
-        old_conf = await self.config.get_raw("installed", default=[])
+        old_conf = await config.get_raw("installed", default=[])
         if not old_conf:
             return
-        async with self.config.installed_cogs() as new_cog_conf:
+        async with config.installed_cogs() as new_cog_conf:
             for cog_json in old_conf:
                 repo_name = cog_json["repo_name"]
                 module_name = cog_json["cog_name"]
@@ -148,7 +151,7 @@ class Downloader(commands.Cog):
                     "commit": "",
                     "pinned": False,
                 }
-        await self.config.clear_raw("installed")
+        await config.clear_raw("installed")
         # no reliable way to get installed libraries (i.a. missing repo name)
         # but it only helps `[p]cog update` run faster so it's not an issue
 

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -52,6 +52,7 @@ class Downloader(commands.Cog):
         super().__init__()
         self.bot = bot
 
+        # any changes to Config here need to also be applied to RepoManager._restore_from_backup()
         self.config = Config.get_conf(self, identifier=998240343, force_registration=True)
 
         self.config.register_global(schema_version=0, installed_cogs={}, installed_libraries={})

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import json
 import keyword
 import os
 import pkgutil
@@ -1258,9 +1259,30 @@ class RepoManager:
                     branch = tree_url_match["branch"]
         return url, branch
 
-    def _restore_from_backup(self):
+    async def _restore_from_backup(self):
         """Restore cogs using `repos.json` in cog's data path.
 
         Used by `redbot-setup restore` cli command.
         """
-        repos = data_manager.cog_data_path(self) / "repos.json"
+        with open(data_manager.cog_data_path(self) / "repos.json") as fp:
+            raw_repos = json.load(fp)
+        for repo_data in raw_repos:
+            repo_url = repo_data["url"]
+            repo_name = repo_data["name"]
+            repo_branch = repo_data["branch"]
+            try:
+                await self.add_repo(repo_url, repo_name, repo_branch)
+            except errors.CloningError as err:
+                log.exception(
+                    "Something went wrong whilst cloning %s (to branch: %s)",
+                    repo_url,
+                    repo_branch,
+                    exc_info=err,
+                )
+            except OSError:
+                log.exception(
+                    "Something went wrong trying to add repo %s under name %s",
+                    repo_url,
+                    repo_name,
+                )
+        from .downloader import Downloader

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -30,7 +30,7 @@ from typing import (
 
 import discord
 from redbot.core import data_manager, commands, Config
-from redbot.core.utils._internal_utils import safe_delete
+from redbot.core.utils._internal_utils import detailed_progress, safe_delete
 from redbot.core.i18n import Translator
 
 from . import errors
@@ -1267,28 +1267,27 @@ class RepoManager:
         with open(data_manager.cog_data_path(self) / "repos.json") as fp:
             raw_repos = json.load(fp)
 
-        from tqdm import tqdm
-
-        progress_bar = tqdm(raw_repos, desc="Downloading repos", unit="repo", dynamic_ncols=True)
-
-        for repo_data in progress_bar:
-            repo_url = repo_data["url"]
-            repo_name = repo_data["name"]
-            repo_branch = repo_data["branch"]
-            try:
-                await self.add_repo(repo_url, repo_name, repo_branch)
-            except errors.CloningError:
-                log.exception(
-                    "Something went wrong whilst cloning %s (to branch: %s)",
-                    repo_url,
-                    repo_branch,
-                )
-            except OSError:
-                log.exception(
-                    "Something went wrong trying to add repo %s under name %s",
-                    repo_url,
-                    repo_name,
-                )
+        with detailed_progress(unit="repos") as progress:
+            task_id = progress.add_task("Adding repos", total=len(raw_repos))
+            for idx, repo_data in enumerate(raw_repos):
+                repo_url = repo_data["url"]
+                repo_name = repo_data["name"]
+                repo_branch = repo_data["branch"]
+                progress.update(task_id, completed=idx, description=f"Adding {repo_name!r} repo")
+                try:
+                    await self.add_repo(repo_url, repo_name, repo_branch)
+                except errors.CloningError:
+                    log.exception(
+                        "Something went wrong whilst cloning %s (to branch: %s)",
+                        repo_url,
+                        repo_branch,
+                    )
+                except OSError:
+                    log.exception(
+                        "Something went wrong trying to add repo %s under name %s",
+                        repo_url,
+                        repo_name,
+                    )
 
         from .downloader import Downloader
 

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -1284,3 +1284,5 @@ class RepoManager:
                     repo_url,
                     repo_name,
                 )
+        # TODO: run Downloader's config migration
+        # and clear commit data to trigger update for all cogs

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -1266,7 +1266,12 @@ class RepoManager:
         """
         with open(data_manager.cog_data_path(self) / "repos.json") as fp:
             raw_repos = json.load(fp)
-        for repo_data in raw_repos:
+
+        from tqdm import tqdm
+
+        progress_bar = tqdm(raw_repos, desc="Downloading repos", unit="repo", dynamic_ncols=True)
+
+        for repo_data in progress_bar:
             repo_url = repo_data["url"]
             repo_name = repo_data["name"]
             repo_branch = repo_data["branch"]

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -1288,7 +1288,7 @@ class RepoManager:
         from .downloader import Downloader
 
         # this solution is far from perfect, but a better one requires a rewrite
-        conf = Config.get_conf(identifier=998240343, cog_name="Downloader")
+        conf = Config.get_conf(None, identifier=998240343, cog_name="Downloader")
         self.conf.register_global(schema_version=0, installed_cogs={}, installed_libraries={})
         await Downloader._maybe_update_config(conf)
         # clear out saved commit so that `[p]cog update` triggers install for all cogs
@@ -1296,4 +1296,5 @@ class RepoManager:
             for repo_data in installed_cogs.values():
                 for cog_data in repo_data.values():
                     cog_data["commit"] = ""
+                    cog_data["pinned"] = False
         await self.conf.installed_libraries.set({})

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -1257,3 +1257,10 @@ class RepoManager:
                 if branch is None:
                     branch = tree_url_match["branch"]
         return url, branch
+
+    def _restore_from_backup(self):
+        """Restore cogs using `repos.json` in cog's data path.
+
+        Used by `redbot-setup restore` cli command.
+        """
+        repos = data_manager.cog_data_path(self) / "repos.json"

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -1284,5 +1284,16 @@ class RepoManager:
                     repo_url,
                     repo_name,
                 )
-        # TODO: run Downloader's config migration
-        # and clear commit data to trigger update for all cogs
+
+        from .downloader import Downloader
+
+        # this solution is far from perfect, but a better one requires a rewrite
+        conf = Config.get_conf(identifier=998240343, cog_name="Downloader")
+        self.conf.register_global(schema_version=0, installed_cogs={}, installed_libraries={})
+        await Downloader._maybe_update_config(conf)
+        # clear out saved commit so that `[p]cog update` triggers install for all cogs
+        async with self.conf.installed_cogs() as installed_cogs:
+            for repo_data in installed_cogs.values():
+                for cog_data in repo_data.values():
+                    cog_data["commit"] = ""
+        await self.conf.installed_libraries.set({})

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -1259,7 +1259,7 @@ class RepoManager:
                     branch = tree_url_match["branch"]
         return url, branch
 
-    async def _restore_from_backup(self):
+    async def _restore_from_backup(self) -> None:
         """Restore cogs using `repos.json` in cog's data path.
 
         Used by `redbot-setup restore` cli command.
@@ -1272,12 +1272,11 @@ class RepoManager:
             repo_branch = repo_data["branch"]
             try:
                 await self.add_repo(repo_url, repo_name, repo_branch)
-            except errors.CloningError as err:
+            except errors.CloningError:
                 log.exception(
                     "Something went wrong whilst cloning %s (to branch: %s)",
                     repo_url,
                     repo_branch,
-                    exc_info=err,
                 )
             except OSError:
                 log.exception(
@@ -1285,4 +1284,3 @@ class RepoManager:
                     repo_url,
                     repo_name,
                 )
-        from .downloader import Downloader

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -11,7 +11,9 @@ import shutil
 import tarfile
 import warnings
 from datetime import datetime
+from io import BytesIO
 from pathlib import Path
+from tarfile import TarInfo
 from typing import (
     AsyncIterable,
     AsyncIterator,
@@ -217,6 +219,9 @@ async def format_fuzzy_results(
 
 
 async def create_backup(dest: Path = Path.home()) -> Optional[Path]:
+    # version of backup
+    BACKUP_VERSION = 2
+
     data_path = Path(data_manager.core_data_path().parent)
     if not data_path.exists():
         return None
@@ -227,14 +232,19 @@ async def create_backup(dest: Path = Path.home()) -> Optional[Path]:
 
     to_backup = []
     # we need trailing separator to not exclude files and folders that only start with these names
-    # e.g. RepoManager\repos.json
     exclusions = [
         "__pycache__",
+        # Lavalink will be downloaded on Audio load
         "Lavalink.jar",
+        # cogs and repos installed through Downloader can be reinstalled using restore command
         os.path.join("Downloader", "lib", ""),
         os.path.join("CogManager", "cogs", ""),
         os.path.join("RepoManager", "repos", ""),
         os.path.join("Audio", "logs", ""),
+        # these files are created during backup so we exclude them from data path backup
+        os.path.join("RepoManager", "repos.json"),
+        "instance.json",
+        "backup.version",
     ]
 
     # Avoiding circular imports
@@ -245,12 +255,7 @@ async def create_backup(dest: Path = Path.home()) -> Optional[Path]:
     repo_output = []
     for repo in repo_mgr.repos:
         repo_output.append({"url": repo.url, "name": repo.name, "branch": repo.branch})
-    repos_file = data_path / "cogs" / "RepoManager" / "repos.json"
-    with repos_file.open("w") as fs:
-        json.dump(repo_output, fs, indent=4)
-    instance_file = data_path / "instance.json"
-    with instance_file.open("w") as fs:
-        json.dump({data_manager.instance_name(): data_manager.basic_config}, fs, indent=4)
+
     for f in data_path.glob("**/*"):
         if not any(ex in str(f) for ex in exclusions) and f.is_file():
             to_backup.append(f)
@@ -258,6 +263,19 @@ async def create_backup(dest: Path = Path.home()) -> Optional[Path]:
     with tarfile.open(str(backup_fpath), "w:gz") as tar:
         for f in to_backup:
             tar.add(str(f), arcname=str(f.relative_to(data_path)), recursive=False)
+
+        # add repos backup
+        repos_data = json.dumps(repo_output, indent=4)
+        tar.addfile(TarInfo("cogs/RepoManager/repos.json"), BytesIO(repos_data.encode("utf-8")))
+
+        # add instance's original data
+        instance_data = json.dumps(
+            {data_manager.instance_name(): data_manager.basic_config}, indent=4
+        )
+        tar.addfile(TarInfo("instance.json"), BytesIO(instance_data.encode("utf-8")))
+
+        # add info about backup version
+        tar.addfile(TarInfo("backup.version"), BytesIO(f"{BACKUP_VERSION}".encode("utf-8")))
     return backup_fpath
 
 

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -9,6 +9,7 @@ import os
 import re
 import shutil
 import tarfile
+import time
 import warnings
 from datetime import datetime
 from io import BytesIO
@@ -218,6 +219,19 @@ async def format_fuzzy_results(
         return "Perhaps you wanted one of these? " + box("\n".join(lines), lang="vhdl")
 
 
+def _tar_addfile_from_string(tar: tarfile.TarFile, name: str, string: str) -> None:
+    encoded = string.encode("utf-8")
+    fp = BytesIO(encoded)
+
+    # TarInfo needs `mtime` and `size`
+    # https://stackoverflow.com/q/53306000
+    tar_info = tarfile.TarInfo(name)
+    tar_info.mtime = time.time()
+    tar_info.size = len(encoded)
+
+    tar.addfile(tar_info, fp)
+
+
 async def create_backup(dest: Path = Path.home()) -> Optional[Path]:
     # version of backup
     BACKUP_VERSION = 2
@@ -266,16 +280,16 @@ async def create_backup(dest: Path = Path.home()) -> Optional[Path]:
 
         # add repos backup
         repos_data = json.dumps(repo_output, indent=4)
-        tar.addfile(TarInfo("cogs/RepoManager/repos.json"), BytesIO(repos_data.encode("utf-8")))
+        _tar_addfile_from_string(tar, "cogs/RepoManager/repos.json", repos_data)
 
         # add instance's original data
         instance_data = json.dumps(
             {data_manager.instance_name(): data_manager.basic_config}, indent=4
         )
-        tar.addfile(TarInfo("instance.json"), BytesIO(instance_data.encode("utf-8")))
+        _tar_addfile_from_string(tar, "instance.json", instance_data)
 
         # add info about backup version
-        tar.addfile(TarInfo("backup.version"), BytesIO(f"{BACKUP_VERSION}".encode("utf-8")))
+        _tar_addfile_from_string(tar, "backup.version", str(BACKUP_VERSION))
     return backup_fpath
 
 

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -39,6 +39,7 @@ import rapidfuzz
 from rich.progress import ProgressColumn
 from rich.progress_bar import ProgressBar
 from red_commons.logging import VERBOSE, TRACE
+from tqdm import tqdm
 
 from redbot import VersionInfo
 from redbot.core import data_manager
@@ -275,7 +276,8 @@ async def create_backup(dest: Path = Path.home()) -> Optional[Path]:
             to_backup.append(f)
 
     with tarfile.open(str(backup_fpath), "w:gz") as tar:
-        for f in to_backup:
+        progress_bar = tqdm(to_backup, desc="Compressing data", unit=" files", dynamic_ncols=True)
+        for f in progress_bar:
             tar.add(str(f), arcname=str(f.relative_to(data_path)), recursive=False)
 
         # add repos backup

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -36,10 +36,9 @@ import aiohttp
 import discord
 from packaging.requirements import Requirement
 import rapidfuzz
-from rich.progress import ProgressColumn
-from rich.progress_bar import ProgressBar
+import rich.progress
+from rich.text import Text
 from red_commons.logging import VERBOSE, TRACE
-from tqdm import tqdm
 
 from redbot import VersionInfo
 from redbot.core import data_manager
@@ -62,6 +61,8 @@ __all__ = (
     "fetch_latest_red_version_info",
     "deprecated_removed",
     "RichIndefiniteBarColumn",
+    "RichSpeedColumn",
+    "detailed_progress",
     "cli_level_to_log_level",
 )
 
@@ -276,9 +277,10 @@ async def create_backup(dest: Path = Path.home()) -> Optional[Path]:
             to_backup.append(f)
 
     with tarfile.open(str(backup_fpath), "w:gz") as tar:
-        progress_bar = tqdm(to_backup, desc="Compressing data", unit=" files", dynamic_ncols=True)
-        for f in progress_bar:
-            tar.add(str(f), arcname=str(f.relative_to(data_path)), recursive=False)
+        with detailed_progress(unit="files") as progress:
+            progress_tracker = progress.track(to_backup, description="Compressing data")
+            for f in progress_tracker:
+                tar.add(str(f), arcname=str(f.relative_to(data_path)), recursive=False)
 
         # add repos backup
         repos_data = json.dumps(repo_output, indent=4)
@@ -403,15 +405,41 @@ def deprecated_removed(
     )
 
 
-class RichIndefiniteBarColumn(ProgressColumn):
-    def render(self, task):
-        return ProgressBar(
+class RichIndefiniteBarColumn(rich.progress.ProgressColumn):
+    def render(self, task: rich.progress.Task) -> rich.progress.ProgressBar:
+        return rich.progress.ProgressBar(
             pulse=task.completed < task.total,
             animation_time=task.get_time(),
             width=40,
             total=task.total,
             completed=task.completed,
         )
+
+
+class RichSpeedColumn(rich.progress.ProgressColumn):
+    def __init__(self, *, unit: str) -> None:
+        self.unit = unit
+        super().__init__()
+
+    def render(self, task: rich.progress.Task) -> Text:
+        speed = task.finished_speed or task.speed
+        if speed is None:
+            return Text("?", style="progress.data.speed")
+        return Text(f"{int(speed)} {self.unit}/s", style="progress.data.speed")
+
+
+def detailed_progress(*, unit: str) -> rich.progress.Progress:
+    return rich.progress.Progress(
+        rich.progress.SpinnerColumn(),
+        rich.progress.TextColumn("[progress.description]{task.description}"),
+        rich.progress.BarColumn(bar_width=None),
+        RichSpeedColumn(unit=unit),
+        rich.progress.TaskProgressColumn(),
+        rich.progress.TextColumn("eta"),
+        rich.progress.TimeRemainingColumn(),
+        rich.progress.TextColumn("elapsed"),
+        rich.progress.TimeElapsedColumn(),
+    )
 
 
 def cli_level_to_log_level(level: int) -> int:

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -226,13 +226,15 @@ async def create_backup(dest: Path = Path.home()) -> Optional[Path]:
     backup_fpath = dest / f"redv3_{data_manager.instance_name()}_{timestr}.tar.gz"
 
     to_backup = []
+    # we need trailing separator to not exclude files and folders that only start with these names
+    # e.g. RepoManager\repos.json
     exclusions = [
         "__pycache__",
         "Lavalink.jar",
-        os.path.join("Downloader", "lib"),
-        os.path.join("CogManager", "cogs"),
-        os.path.join("RepoManager", "repos"),
-        os.path.join("Audio", "logs"),
+        os.path.join("Downloader", "lib", ""),
+        os.path.join("CogManager", "cogs", ""),
+        os.path.join("RepoManager", "repos", ""),
+        os.path.join("Audio", "logs", ""),
     ]
 
     # Avoiding circular imports

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -1,15 +1,19 @@
+from __future__ import annotations
+
 from redbot import _early_init
 
 # this needs to be called as early as possible
 _early_init()
 
 import asyncio
+import functools
 import json
 import logging
 import sys
 import re
 import tarfile
 from copy import deepcopy
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, IO, Optional, Tuple, Union
 
@@ -381,177 +385,207 @@ def open_file_from_tar(tar: tarfile.TarFile, arcname: str) -> Optional[IO[bytes]
     return fp
 
 
-def get_instance_from_backup(tar: tarfile.TarFile) -> Tuple[str, dict]:
-    if (fp := open_file_from_tar(tar, "instance.json")) is None:
-        print("This isn't a valid backup file!")
-        sys.exit(1)
-    with fp:
-        return json.load(fp).popitem()
+@dataclass
+class RestoreInfo:
+    tar: tarfile.TarFile
+    backup_version: int
+    name: str
+    data_path: Path
+    storage_type: BackendType
+    storage_details: dict
 
+    @classmethod
+    def from_tar(cls, tar: tarfile.TarFile) -> RestoreInfo:
+        instance_name, raw_data = cls.get_instance_from_backup(tar)
+        backup_version = cls.get_backup_version(tar)
 
-def get_backup_version(tar: tarfile.TarFile) -> int:
-    if (fp := open_file_from_tar(tar, "backup.version")) is None:
-        print(
-            "This backup was created using old version (v1) of backup system"
-            " and can't be restored using this command."
+        return cls(
+            tar=tar,
+            backup_version=backup_version,
+            name=instance_name,
+            data_path=Path(raw_data["DATA_PATH"]),
+            storage_type=BackendType(raw_data["STORAGE_TYPE"]),
+            storage_details=raw_data["STORAGE_DETAILS"],
         )
-        sys.exit(1)
-    with fp:
-        backup_version = int(fp.read())
-    if backup_version > 2:
-        print("This backup was created using newer version of Red. Update Red to restore it.")
-        sys.exit(1)
-    return backup_version
 
+    @staticmethod
+    def get_instance_from_backup(tar: tarfile.TarFile) -> Tuple[str, dict]:
+        if (fp := open_file_from_tar(tar, "instance.json")) is None:
+            print("This isn't a valid backup file!")
+            sys.exit(1)
+        with fp:
+            return json.load(fp).popitem()
 
-def print_instance_data(
-    instance_name: str, data_path: Path, storage_type: BackendType, storage_details: dict,
-) -> None:
-    print("\nWhen the instance was backuped, it was using these settings:")
-    print("  Original instance name:", instance_name)
-    print("  Original data path:", data_path)
-    storage_backends = {
-        BackendType.JSON: "JSON",
-        BackendType.POSTGRES: "PostgreSQL",
-        BackendType.MONGOV1: "MongoDB (unavailable)",
-        BackendType.MONGO: "MongoDB (unavailable)",
-    }
-    print("  Original storage backend:", storage_backends[storage_type])
-    if storage_type is BackendType.POSTGRES:
-        print("  Original storage details:")
-        for key in ("host", "port", "database", "user"):
-            print(f"    - DB {key}:", storage_details[key])
-        print("    - DB password: ***")
+    @staticmethod
+    def get_backup_version(tar: tarfile.TarFile) -> int:
+        if (fp := open_file_from_tar(tar, "backup.version")) is None:
+            print(
+                "This backup was created using old version (v1) of backup system"
+                " and can't be restored using this command."
+            )
+            sys.exit(1)
+        with fp:
+            backup_version = int(fp.read())
+        if backup_version > 2:
+            print("This backup was created using newer version of Red. Update Red to restore it.")
+            sys.exit(1)
+        return backup_version
 
+    @property
+    def name_used(self):
+        return self.name in instance_list
 
-async def restore_data(
-    tar: tarfile.TarFile,
-    instance_name: str,
-    data_path: Path,
-    storage_type: BackendType,
-    storage_details: dict,
-) -> bool:
-    all_tar_members = tar.getmembers()
-    ignored_members: Tuple[str, ...] = ("backup.version", "instance.json")
-    downloader_backup_files = (
-        "cogs/RepoManager/repos.json",
-        "cogs/RepoManager/settings.json",
-        "cogs/Downloader/settings.json",
-    )
-    restore_downloader = all(
-        backup_file in all_tar_members for backup_file in downloader_backup_files
-    ) and click.confirm(
-        "Do you want to restore 3rd-party repos and cogs installed through Downloader?\n"
-        "Full offline restore process for this hasn't been made yet, so after it's done"
-        " you will have to load Downloader and run `[p]cog update` command "
-        " to reinstall all cogs you had installed before.",
-        default=True,
-    )
-    if not restore_downloader:
-        ignored_members += downloader_backup_files
+    @property
+    def data_path_not_empty(self):
+        return self.data_path.exists() and next(self.data_path.glob("*"), None) is not None
 
-    tar_members = [member for member in tar.getmembers() if member.name not in ignored_members]
-    # tar.errorlevel == 0 so errors are printed to stderr
-    # TODO: progress bar?
-    tar.extractall(path=data_path, members=tar_members)
+    @property
+    def backend_unavailable(self):
+        return self.storage_type in (BackendType.MONGOV1, BackendType.MONGO)
 
-    default_dirs = deepcopy(data_manager.basic_config_default)
-    default_dirs["DATA_PATH"] = data_path
-    # data in backup file is using json
-    default_dirs["STORAGE_TYPE"] = BackendType.JSON.value
-    default_dirs["STORAGE_DETAILS"] = {}
-    save_config(instance_name, default_dirs)
-
-    data_manager.load_basic_configuration(instance_name)
-
-    if storage_type is not BackendType.JSON:
-        await do_migration(BackendType.JSON, storage_type, storage_details)
-        default_dirs["STORAGE_TYPE"] = storage_type.value
-        default_dirs["STORAGE_DETAILS"] = storage_details
-        save_config(instance_name, default_dirs)
-
-    return restore_downloader
-
-
-async def restore_backup(tar: tarfile.TarFile) -> None:
-    # TODO: split this into smaller parts
-    # TODO: related to above, operate on instance data dict to make it simpler
-    instance_name, instance_data = get_instance_from_backup(tar)
-    backup_version = get_backup_version(tar)
-
-    data_path = Path(instance_data["DATA_PATH"])
-    storage_type = BackendType(instance_data["STORAGE_TYPE"])
-    storage_details = instance_data["STORAGE_DETAILS"]
-    print_instance_data(instance_name, data_path, storage_type, storage_details)
-
-    name_used = instance_name in instance_list
-    data_path_not_empty = data_path.exists() and next(data_path.glob("*"), None) is not None
-    backend_unavailable = storage_type in (BackendType.MONGOV1, BackendType.MONGO)
-    if click.confirm("\nWould you like to change anything?"):
-        if not name_used and click.confirm("Do you want to use different instance name?"):
-            instance_name = get_name("")
-        if not data_path_not_empty and click.confirm("Do you want to use different data path?"):
-            while True:
-                data_path = Path(
-                    get_data_dir(instance_name=instance_name, data_path=None, interactive=True)
-                )
-                data_path_not_empty = (
-                    data_path.exists() and next(data_path.glob("*"), None) is not None
-                )
-                if not data_path_not_empty:
-                    break
-                print("Given path can't be used as it's not empty.")
-        if not backend_unavailable and click.confirm(
-            "Do you want to use different storage backend or change storage details?"
-        ):
-            storage_type = get_storage_type(None, interactive=True)
-            driver_cls = get_driver_class(storage_type)
-            storage_details = driver_cls.get_config_details()
-    if name_used:
-        print(
-            "Original instance name can't be used as other instance is already using it."
-            " You have to choose a different name."
+    @functools.cached_property
+    def restore_downloader(self):
+        return "cogs/RepoManager/repos.json" in self.all_tar_members and click.confirm(
+            "Do you want to restore 3rd-party repos and cogs installed through Downloader?\n"
+            "Full offline restore process for this hasn't been made yet, so after it's done"
+            " you will have to load Downloader and run `[p]cog update` command "
+            " to reinstall all cogs you had installed before.",
+            default=True,
         )
-        instance_name = get_name("")
-    if data_path_not_empty:
-        print(
-            "Original data path can't be used as it's not empty."
-            " You have to choose a different path."
-        )
+
+    @functools.cached_property
+    def all_tar_members(self):
+        return self.tar.getmembers()
+
+    @functools.cached_property
+    def tar_members_to_extract(self):
+        ignored_members: Tuple[str, ...] = ("backup.version", "instance.json")
+        if not self.restore_downloader:
+            ignored_members += (
+                "cogs/RepoManager/repos.json",
+                "cogs/RepoManager/settings.json",
+                "cogs/Downloader/settings.json",
+            )
+        return [member for member in self.all_tar_members if member.name not in ignored_members]
+
+    def print_instance_data(self) -> None:
+        print("\nWhen the instance was backuped, it was using these settings:")
+        print("  Original instance name:", self.name)
+        print("  Original data path:", self.data_path)
+        storage_backends = {
+            BackendType.JSON: "JSON",
+            BackendType.POSTGRES: "PostgreSQL",
+            BackendType.MONGOV1: "MongoDB (unavailable)",
+            BackendType.MONGO: "MongoDB (unavailable)",
+        }
+        print("  Original storage backend:", storage_backends[self.storage_type])
+        if self.storage_type is BackendType.POSTGRES:
+            print("  Original storage details:")
+            for key in ("host", "port", "database", "user"):
+                print(f"    - DB {key}:", self.storage_details[key])
+            print("    - DB password: ***")
+
+    def _ask_for_name(self):
+        self.name = get_name("")
+
+    def _ask_for_data_path(self):
         while True:
-            data_path = Path(
-                get_data_dir(instance_name=instance_name, data_path=None, interactive=True)
+            self.data_path = Path(
+                get_data_dir(instance_name=self.name, data_path=None, interactive=True)
             )
-            data_path_not_empty = (
-                data_path.exists() and next(data_path.glob("*"), None) is not None
-            )
-            if not data_path_not_empty:
-                break
+            if not self.data_path_not_empty:
+                return
             print("Given path can't be used as it's not empty.")
-    if backend_unavailable:
-        print(
-            "Original storage backend is no longer available in Red."
-            " You have to choose a different backend."
-        )
-        storage_type = get_storage_type(None, interactive=True)
-        driver_cls = get_driver_class(storage_type)
-        storage_details = driver_cls.get_config_details()
 
-    restore_downloader = restore_data(tar, instance_name, data_path, storage_type, storage_details)
+    def _ask_for_storage(self):
+        self.storage_type = get_storage_type(None, interactive=True)
+        driver_cls = get_driver_class(self.storage_type)
+        self.storage_details = driver_cls.get_config_details()
 
-    if restore_downloader:
-        repo_mgr = RepoManager()
-        # this line shouldn't be needed since there are no repos:
-        # await repo_mgr.initialize()
-        await repo_mgr._restore_from_backup()
-    print("Restore process has been completed.")
-    if restore_downloader:
-        print(
-            "Remember to run these commands after you start Red"
-            " to complete restoring of 3rd-party cogs:\n"
-            "[p]load downloader\n"
-            "[p]cog update"
-        )
+    def _ask_for_optional_changes(self) -> None:
+        if click.confirm("\nWould you like to change anything?"):
+            if not self.name_used and click.confirm("Do you want to use different instance name?"):
+                self._ask_for_name()
+            if not self.data_path_not_empty and click.confirm(
+                "Do you want to use different data path?"
+            ):
+                self._ask_for_data_path()
+            if not self.backend_unavailable and click.confirm(
+                "Do you want to use different storage backend or change storage details?"
+            ):
+                self._ask_for_storage()
+
+    def _ask_for_required_changes(self) -> None:
+        if self.name_used:
+            print(
+                "Original instance name can't be used as other instance is already using it."
+                " You have to choose a different name."
+            )
+            self._ask_for_name()
+        if self.data_path_not_empty:
+            print(
+                "Original data path can't be used as it's not empty."
+                " You have to choose a different path."
+            )
+            self._ask_for_data_path()
+        if self.backend_unavailable:
+            print(
+                "Original storage backend is no longer available in Red."
+                " You have to choose a different backend."
+            )
+            self._ask_for_storage()
+
+    def ask_for_changes(self) -> None:
+        self._ask_for_optional_changes()
+        self._ask_for_required_changes()
+
+    def extractall(self) -> None:
+        # tar.errorlevel == 0 so errors are printed to stderr
+        # TODO: progress bar?
+        self.tar.extractall(path=self.data_path, members=self.tar_members_to_extract)
+
+    def get_basic_config(self, use_json: bool = False) -> dict:
+        default_dirs = deepcopy(data_manager.basic_config_default)
+        default_dirs["DATA_PATH"] = self.data_path
+        if use_json:
+            default_dirs["STORAGE_TYPE"] = BackendType.JSON.value
+            default_dirs["STORAGE_DETAILS"] = {}
+        else:
+            default_dirs["STORAGE_TYPE"] = self.storage_type.value
+            default_dirs["STORAGE_DETAILS"] = self.storage_details
+        return default_dirs
+
+    async def restore_data(self) -> None:
+        self.extractall()
+
+        # data in backup file is using json
+        save_config(self.name, self.get_basic_config(use_json=True))
+        data_manager.load_basic_configuration(self.name)
+
+        if self.storage_type is not BackendType.JSON:
+            await do_migration(BackendType.JSON, self.storage_type, self.storage_details)
+            save_config(self.name, self.get_basic_config())
+            data_manager.load_basic_configuration(self.name)
+
+        if self.restore_downloader:
+            repo_mgr = RepoManager()
+            # this line shouldn't be needed since there are no repos:
+            # await repo_mgr.initialize()
+            await repo_mgr._restore_from_backup()
+
+    async def run(self):
+        self.print_instance_data()
+        self.ask_for_changes()
+        await self.restore_data()
+
+        print("Restore process has been completed.")
+        if self.restore_downloader:
+            print(
+                "Remember to run these commands after you start Red"
+                " to complete restoring of 3rd-party cogs:\n"
+                "[p]load downloader\n"
+                "[p]cog update"
+            )
 
 
 async def restore_instance():
@@ -579,7 +613,8 @@ async def restore_instance():
         )
         return
     with tar:
-        await restore_backup(tar)
+        restore_info = RestoreInfo.from_tar(tar)
+        await restore_info.run()
 
 
 @click.group(invoke_without_command=True)

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -11,7 +11,7 @@ import re
 import tarfile
 from copy import deepcopy
 from pathlib import Path
-from typing import Dict, Any, Optional, Union
+from typing import Dict, Any, Optional, Tuple, Union
 
 import click
 
@@ -267,12 +267,15 @@ def get_target_backend(backend: str) -> BackendType:
 
 
 async def do_migration(
-    current_backend: BackendType, target_backend: BackendType
+    current_backend: BackendType,
+    target_backend: BackendType,
+    new_storage_details: Optional[dict] = None,
 ) -> Dict[str, Any]:
     cur_driver_cls = get_driver_class_include_old(current_backend)
     new_driver_cls = get_driver_class(target_backend)
     cur_storage_details = data_manager.storage_details()
-    new_storage_details = new_driver_cls.get_config_details()
+    if new_storage_details is None:
+        new_storage_details = new_driver_cls.get_config_details()
 
     await cur_driver_cls.initialize(**cur_storage_details)
     await new_driver_cls.initialize(**new_storage_details)
@@ -454,8 +457,25 @@ async def restore_backup(tar: tarfile.TarFile) -> None:
         driver_cls = get_driver_class(storage_type)
         storage_details = driver_cls.get_config_details()
 
-    tar_members = [member for member in tar.getmembers() if member.name != "instance.json"]
+    all_tar_members = tar.getmembers()
+    ignored_members: Tuple[str, ...] = ("instance.json",)
+    downloader_backup_files = (
+        "cogs/RepoManager/repos.json",
+        "cogs/RepoManager/settings.json",
+        "cogs/Downloader/settings.json",
+    )
+    restore_downloader = all(
+        backup_file in all_tar_members for backup_file in downloader_backup_files
+    ) and click.confirm(
+        "Do you want to restore 3rd-party repos and cogs installed through Downloader?",
+        default=True,
+    )
+    if not restore_downloader:
+        ignored_members += downloader_backup_files
+
+    tar_members = [member for member in tar.getmembers() if member.name not in ignored_members]
     # tar.errorlevel == 0 so errors are printed to stderr
+    # TODO: progress bar?
     tar.extractall(path=data_path, members=tar_members)
 
     default_dirs = deepcopy(data_manager.basic_config_default)
@@ -465,9 +485,21 @@ async def restore_backup(tar: tarfile.TarFile) -> None:
     default_dirs["STORAGE_DETAILS"] = {}
     save_config(instance_name, default_dirs)
 
-    # TODO: handle storage backend migration here...
+    data_manager.load_basic_configuration(instance_name)
 
-    # TODO: ask for repo manager stuff here...
+    if storage_type is not BackendType.JSON:
+        await do_migration(BackendType.JSON, storage_type, storage_details)
+
+    if restore_downloader:
+        from redbot.cogs.downloader.repo_manager import RepoManager
+
+        repo_mgr = RepoManager()
+        # this line shouldn't be needed since there are no repos:
+        # await repo_mgr.initialize()
+        try:
+            repo_mgr._restore_from_backup()
+        except ...:
+            ...
 
 
 async def restore_instance():

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -8,6 +8,7 @@ import json
 import logging
 import sys
 import re
+import tarfile
 from copy import deepcopy
 from pathlib import Path
 from typing import Dict, Any, Optional, Union
@@ -368,6 +369,111 @@ async def remove_instance_interaction() -> None:
     await remove_instance(selected, interactive=True)
 
 
+async def restore_backup(tar: tarfile.TarFile) -> None:
+    # TODO: split this into smaller parts
+    try:
+        fp = tar.extractfile("instance.json")
+    except (KeyError, tarfile.StreamError):
+        print("This isn't a valid backup file!")
+        return
+    if fp is None:
+        print("This isn't a valid backup file!")
+        return
+    with fp:
+        instance_name, instance_data = json.load(fp).popitem()
+
+    print("\nWhen the instance was backuped, it was using these settings:")
+    print("  Original instance name:", instance_name)
+    data_path = Path(instance_data["DATA_PATH"])
+    print("  Original data path:", data_path)
+    storage_backends = {
+        BackendType.JSON: "JSON",
+        BackendType.POSTGRES: "PostgreSQL",
+        BackendType.MONGOV1: "MongoDB (unavailable)",
+        BackendType.MONGO: "MongoDB (unavailable)",
+    }
+    storage_type = BackendType(instance_data["STORAGE_TYPE"])
+    print("  Original storage backend:", storage_backends[storage_type])
+    if storage_type is BackendType.POSTGRES:
+        storage_details = instance_data["STORAGE_DETAILS"]
+        print("  Original storage details:")
+        for key in ("host", "port", "database", "user"):
+            print(f"    - DB {key}:", storage_details[key])
+        print("    - DB password: ***")
+
+    name_used = instance_name in instance_list
+    data_path_not_empty = data_path.exists() and next(data_path.glob("*"), None) is not None
+    backend_unavailable = storage_type in (BackendType.MONGOV1, BackendType.MONGO)
+    if click.confirm("\nWould you like to change anything?"):
+        if not name_used and click.confirm("Do you want to use different instance name?"):
+            instance_name = get_name("")
+            # TODO: gotta check if it's not taken
+        if not data_path_not_empty and click.confirm("Do you want to use different data path?"):
+            data_path = Path(
+                get_data_dir(instance_name=instance_name, data_path=None, interactive=True)
+            )
+        if not backend_unavailable and click.confirm(
+            "Do you want to use different storage backend?"
+        ):
+            storage_type = get_storage_type(None, interactive=True)
+    if name_used:
+        print(
+            "Original instance name can't be used as other instance is already using it."
+            " You have to choose a different name."
+        )
+        instance_name = get_name("")
+        # TODO: gotta check if it's not taken
+    if data_path_not_empty:
+        print(
+            "Original data path can't be used as it's not empty."
+            " You have to choose a different path."
+        )
+        data_path = Path(get_data_dir(instance_name=instance_name, data_path=None, interactive=True))
+    if backend_unavailable:
+        print(
+            "Original storage backend is no longer available in Red."
+            " You have to choose a different backend."
+        )
+        storage_type = get_storage_type(None, interactive=True)
+        # TODO: gotta get the storage details
+
+    # TODO: handle more stuff from above here...
+
+    tar_members = [member for member in tar.getmembers() if member.name != "instance.json"]
+    # tar.errorlevel == 0 so errors are printed to stderr
+    tar.extractall(path=data_path, members=tar_members)
+
+    # TODO: ask for repo manager stuff here...
+
+
+async def restore_instance():
+    print("Hello! This command will guide you through restore process.\n")
+    backup_path_input = ""
+    while not backup_path_input:
+        print("Please enter the path to instance's backup:")
+        backup_path_input = input("> ")
+        backup_path = Path(backup_path_input)
+        try:
+            backup_path = backup_path.resolve()
+        except OSError:
+            print("This doesn't look like a valid path.")
+            backup_path_input = ""
+        else:
+            if not backup_path.is_file():
+                print("This path doesn't exist or it's not a file.")
+                backup_path_input = ""
+
+    try:
+        tar = tarfile.open(backup_path)
+    except tarfile.ReadError:
+        print(
+            "We couldn't open the given backup file. Make sure that you're passing correct file."
+        )
+        return
+    with tar:
+        await restore_backup(tar)
+
+
 @click.group(invoke_without_command=True)
 @click.option(
     "--debug",
@@ -561,6 +667,12 @@ def convert(instance: str, backend: str) -> None:
 def backup(instance: str, destination_folder: Path) -> None:
     """Backup instance's data."""
     asyncio.run(create_backup(instance, destination_folder))
+
+
+@cli.command()
+def restore() -> None:
+    """Restore instance."""
+    asyncio.run(restore_instance())
 
 
 def run_cli():

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -15,6 +15,7 @@ from typing import Dict, Any, Optional, Tuple, Union
 
 import click
 
+from redbot.cogs.downloader.repo_manager import RepoManager
 from redbot.core._cli import confirm
 from redbot.core.utils._internal_utils import (
     safe_delete,
@@ -374,6 +375,7 @@ async def remove_instance_interaction() -> None:
 
 async def restore_backup(tar: tarfile.TarFile) -> None:
     # TODO: split this into smaller parts
+    # TODO: sys.exit() instead of return?
     try:
         fp = tar.extractfile("instance.json")
     except (KeyError, tarfile.StreamError):
@@ -384,6 +386,25 @@ async def restore_backup(tar: tarfile.TarFile) -> None:
         return
     with fp:
         instance_name, instance_data = json.load(fp).popitem()
+    try:
+        fp = tar.extractfile("backup.version")
+    except (KeyError, tarfile.StreamError):
+        print(
+            "This backup was created using old version (v1) of backup system"
+            " and can't be restored using this command."
+        )
+        return
+    if fp is None:
+        print(
+            "This backup was created using old version (v1) of backup system"
+            " and can't be restored using this command."
+        )
+        return
+    with fp:
+        backup_version = int(fp.read())
+    if backup_version > 2:
+        print("This backup was created using newer version of Red. Update Red to restore it.")
+        return
 
     print("\nWhen the instance was backuped, it was using these settings:")
     print("  Original instance name:", instance_name)
@@ -458,7 +479,7 @@ async def restore_backup(tar: tarfile.TarFile) -> None:
         storage_details = driver_cls.get_config_details()
 
     all_tar_members = tar.getmembers()
-    ignored_members: Tuple[str, ...] = ("instance.json",)
+    ignored_members: Tuple[str, ...] = ("backup.version", "instance.json")
     downloader_backup_files = (
         "cogs/RepoManager/repos.json",
         "cogs/RepoManager/settings.json",
@@ -467,7 +488,8 @@ async def restore_backup(tar: tarfile.TarFile) -> None:
     restore_downloader = all(
         backup_file in all_tar_members for backup_file in downloader_backup_files
     ) and click.confirm(
-        "Do you want to restore 3rd-party repos and cogs installed through Downloader?",
+        "Do you want to restore 3rd-party repos"
+        " and cogs installed through Downloader (Git required)?",
         default=True,
     )
     if not restore_downloader:
@@ -491,13 +513,11 @@ async def restore_backup(tar: tarfile.TarFile) -> None:
         await do_migration(BackendType.JSON, storage_type, storage_details)
 
     if restore_downloader:
-        from redbot.cogs.downloader.repo_manager import RepoManager
-
         repo_mgr = RepoManager()
         # this line shouldn't be needed since there are no repos:
         # await repo_mgr.initialize()
         try:
-            repo_mgr._restore_from_backup()
+            await repo_mgr._restore_from_backup()
         except ...:
             ...
 

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -394,8 +394,8 @@ async def restore_backup(tar: tarfile.TarFile) -> None:
     }
     storage_type = BackendType(instance_data["STORAGE_TYPE"])
     print("  Original storage backend:", storage_backends[storage_type])
+    storage_details = instance_data["STORAGE_DETAILS"]
     if storage_type is BackendType.POSTGRES:
-        storage_details = instance_data["STORAGE_DETAILS"]
         print("  Original storage details:")
         for key in ("host", "port", "database", "user"):
             print(f"    - DB {key}:", storage_details[key])
@@ -407,41 +407,65 @@ async def restore_backup(tar: tarfile.TarFile) -> None:
     if click.confirm("\nWould you like to change anything?"):
         if not name_used and click.confirm("Do you want to use different instance name?"):
             instance_name = get_name("")
-            # TODO: gotta check if it's not taken
         if not data_path_not_empty and click.confirm("Do you want to use different data path?"):
-            data_path = Path(
-                get_data_dir(instance_name=instance_name, data_path=None, interactive=True)
-            )
+            while True:
+                data_path = Path(
+                    get_data_dir(instance_name=instance_name, data_path=None, interactive=True)
+                )
+                data_path_not_empty = (
+                    data_path.exists() and next(data_path.glob("*"), None) is not None
+                )
+                if not data_path_not_empty:
+                    break
+                print("Given path can't be used as it's not empty.")
         if not backend_unavailable and click.confirm(
-            "Do you want to use different storage backend?"
+            "Do you want to use different storage backend or change storage details?"
         ):
             storage_type = get_storage_type(None, interactive=True)
+            driver_cls = get_driver_class(storage_type)
+            storage_details = driver_cls.get_config_details()
     if name_used:
         print(
             "Original instance name can't be used as other instance is already using it."
             " You have to choose a different name."
         )
         instance_name = get_name("")
-        # TODO: gotta check if it's not taken
     if data_path_not_empty:
         print(
             "Original data path can't be used as it's not empty."
             " You have to choose a different path."
         )
-        data_path = Path(get_data_dir(instance_name=instance_name, data_path=None, interactive=True))
+        while True:
+            data_path = Path(
+                get_data_dir(instance_name=instance_name, data_path=None, interactive=True)
+            )
+            data_path_not_empty = (
+                data_path.exists() and next(data_path.glob("*"), None) is not None
+            )
+            if not data_path_not_empty:
+                break
+            print("Given path can't be used as it's not empty.")
     if backend_unavailable:
         print(
             "Original storage backend is no longer available in Red."
             " You have to choose a different backend."
         )
         storage_type = get_storage_type(None, interactive=True)
-        # TODO: gotta get the storage details
-
-    # TODO: handle more stuff from above here...
+        driver_cls = get_driver_class(storage_type)
+        storage_details = driver_cls.get_config_details()
 
     tar_members = [member for member in tar.getmembers() if member.name != "instance.json"]
     # tar.errorlevel == 0 so errors are printed to stderr
     tar.extractall(path=data_path, members=tar_members)
+
+    default_dirs = deepcopy(data_manager.basic_config_default)
+    default_dirs["DATA_PATH"] = data_path
+    # data in backup file is using json
+    default_dirs["STORAGE_TYPE"] = BackendType.JSON
+    default_dirs["STORAGE_DETAILS"] = {}
+    save_config(instance_name, default_dirs)
+
+    # TODO: handle storage backend migration here...
 
     # TODO: ask for repo manager stuff here...
 

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, IO, List, Optional, Set, Tuple, Union
 
 import click
+from tqdm import tqdm
 
 from redbot.cogs.downloader.repo_manager import RepoManager
 from redbot.core._cli import confirm
@@ -519,7 +520,7 @@ class RestoreInfo:
                 "WARNING: Original instance name is already used by a different instance."
                 " Continuing will overwrite the existing instance config."
             )
-            if click.confirm("Do you want to use different instance name?"):
+            if click.confirm("Do you want to use different instance name?", default=True):
                 self._ask_for_name()
         if self.data_path_not_empty:
             print(
@@ -552,9 +553,11 @@ class RestoreInfo:
         self.storage_details = driver_cls.get_config_details()
 
     def extractall(self) -> None:
+        progress_bar = tqdm(
+            self.tar_members_to_extract, desc="Extracting data", unit=" files", dynamic_ncols=True
+        )
         # tar.errorlevel == 0 so errors are printed to stderr
-        # TODO: progress bar?
-        self.tar.extractall(path=self.data_path, members=self.tar_members_to_extract)
+        self.tar.extractall(path=self.data_path, members=progress_bar)
 
     def get_basic_config(self, use_json: bool = False) -> dict:
         default_dirs = deepcopy(data_manager.basic_config_default)

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -427,11 +427,8 @@ class RestoreInfo:
     @staticmethod
     def get_backup_version(tar: tarfile.TarFile) -> int:
         if (fp := open_file_from_tar(tar, "backup.version")) is None:
-            print(
-                "This backup was created using old version (v1) of backup system"
-                " and can't be restored using this command."
-            )
-            sys.exit(1)
+            # backup version 1 doesn't have the version file
+            return 1
         with fp:
             backup_version = int(fp.read())
         if backup_version > 2:
@@ -592,6 +589,13 @@ class RestoreInfo:
                 await repo_mgr._restore_from_backup()
             finally:
                 await driver_cls.teardown()
+        elif self.backup_version == 1:
+            print(
+                "INFO: Downloader's data isn't included in the backup file"
+                " - this backup was created with Red 3.5.24 or older."
+            )
+        else:
+            print("WARNING: Downloader's data isn't included in the backup file.")
 
     async def run(self) -> None:
         self.print_instance_data()

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -11,7 +11,7 @@ import re
 import tarfile
 from copy import deepcopy
 from pathlib import Path
-from typing import Dict, Any, Optional, Tuple, Union
+from typing import Any, Dict, IO, Optional, Tuple, Union
 
 import click
 
@@ -373,42 +373,42 @@ async def remove_instance_interaction() -> None:
     await remove_instance(selected, interactive=True)
 
 
-async def restore_backup(tar: tarfile.TarFile) -> None:
-    # TODO: split this into smaller parts
-    # TODO: sys.exit() instead of return?
+def open_file_from_tar(tar: tarfile.TarFile, arcname: str) -> Optional[IO[bytes]]:
     try:
-        fp = tar.extractfile("instance.json")
+        fp = tar.extractfile(arcname)
     except (KeyError, tarfile.StreamError):
+        return None
+    return fp
+
+
+def get_instance_from_backup(tar: tarfile.TarFile) -> Tuple[str, dict]:
+    if (fp := open_file_from_tar(tar, "instance.json")) is None:
         print("This isn't a valid backup file!")
-        return
-    if fp is None:
-        print("This isn't a valid backup file!")
-        return
+        sys.exit(1)
     with fp:
-        instance_name, instance_data = json.load(fp).popitem()
-    try:
-        fp = tar.extractfile("backup.version")
-    except (KeyError, tarfile.StreamError):
+        return json.load(fp).popitem()
+
+
+def get_backup_version(tar: tarfile.TarFile) -> int:
+    if (fp := open_file_from_tar(tar, "backup.version")) is None:
         print(
             "This backup was created using old version (v1) of backup system"
             " and can't be restored using this command."
         )
-        return
-    if fp is None:
-        print(
-            "This backup was created using old version (v1) of backup system"
-            " and can't be restored using this command."
-        )
-        return
+        sys.exit(1)
     with fp:
         backup_version = int(fp.read())
     if backup_version > 2:
         print("This backup was created using newer version of Red. Update Red to restore it.")
-        return
+        sys.exit(1)
+    return backup_version
 
+
+def print_instance_data(
+    instance_name: str, data_path: Path, storage_type: BackendType, storage_details: dict,
+) -> None:
     print("\nWhen the instance was backuped, it was using these settings:")
     print("  Original instance name:", instance_name)
-    data_path = Path(instance_data["DATA_PATH"])
     print("  Original data path:", data_path)
     storage_backends = {
         BackendType.JSON: "JSON",
@@ -416,14 +416,73 @@ async def restore_backup(tar: tarfile.TarFile) -> None:
         BackendType.MONGOV1: "MongoDB (unavailable)",
         BackendType.MONGO: "MongoDB (unavailable)",
     }
-    storage_type = BackendType(instance_data["STORAGE_TYPE"])
     print("  Original storage backend:", storage_backends[storage_type])
-    storage_details = instance_data["STORAGE_DETAILS"]
     if storage_type is BackendType.POSTGRES:
         print("  Original storage details:")
         for key in ("host", "port", "database", "user"):
             print(f"    - DB {key}:", storage_details[key])
         print("    - DB password: ***")
+
+
+async def restore_data(
+    tar: tarfile.TarFile,
+    instance_name: str,
+    data_path: Path,
+    storage_type: BackendType,
+    storage_details: dict,
+) -> bool:
+    all_tar_members = tar.getmembers()
+    ignored_members: Tuple[str, ...] = ("backup.version", "instance.json")
+    downloader_backup_files = (
+        "cogs/RepoManager/repos.json",
+        "cogs/RepoManager/settings.json",
+        "cogs/Downloader/settings.json",
+    )
+    restore_downloader = all(
+        backup_file in all_tar_members for backup_file in downloader_backup_files
+    ) and click.confirm(
+        "Do you want to restore 3rd-party repos and cogs installed through Downloader?\n"
+        "Full offline restore process for this hasn't been made yet, so after it's done"
+        " you will have to load Downloader and run `[p]cog update` command "
+        " to reinstall all cogs you had installed before.",
+        default=True,
+    )
+    if not restore_downloader:
+        ignored_members += downloader_backup_files
+
+    tar_members = [member for member in tar.getmembers() if member.name not in ignored_members]
+    # tar.errorlevel == 0 so errors are printed to stderr
+    # TODO: progress bar?
+    tar.extractall(path=data_path, members=tar_members)
+
+    default_dirs = deepcopy(data_manager.basic_config_default)
+    default_dirs["DATA_PATH"] = data_path
+    # data in backup file is using json
+    default_dirs["STORAGE_TYPE"] = BackendType.JSON.value
+    default_dirs["STORAGE_DETAILS"] = {}
+    save_config(instance_name, default_dirs)
+
+    data_manager.load_basic_configuration(instance_name)
+
+    if storage_type is not BackendType.JSON:
+        await do_migration(BackendType.JSON, storage_type, storage_details)
+        default_dirs["STORAGE_TYPE"] = storage_type.value
+        default_dirs["STORAGE_DETAILS"] = storage_details
+        save_config(instance_name, default_dirs)
+
+    return restore_downloader
+
+
+async def restore_backup(tar: tarfile.TarFile) -> None:
+    # TODO: split this into smaller parts
+    # TODO: related to above, operate on instance data dict to make it simpler
+    instance_name, instance_data = get_instance_from_backup(tar)
+    backup_version = get_backup_version(tar)
+
+    data_path = Path(instance_data["DATA_PATH"])
+    storage_type = BackendType(instance_data["STORAGE_TYPE"])
+    storage_details = instance_data["STORAGE_DETAILS"]
+    print_instance_data(instance_name, data_path, storage_type, storage_details)
 
     name_used = instance_name in instance_list
     data_path_not_empty = data_path.exists() and next(data_path.glob("*"), None) is not None
@@ -478,48 +537,21 @@ async def restore_backup(tar: tarfile.TarFile) -> None:
         driver_cls = get_driver_class(storage_type)
         storage_details = driver_cls.get_config_details()
 
-    all_tar_members = tar.getmembers()
-    ignored_members: Tuple[str, ...] = ("backup.version", "instance.json")
-    downloader_backup_files = (
-        "cogs/RepoManager/repos.json",
-        "cogs/RepoManager/settings.json",
-        "cogs/Downloader/settings.json",
-    )
-    restore_downloader = all(
-        backup_file in all_tar_members for backup_file in downloader_backup_files
-    ) and click.confirm(
-        "Do you want to restore 3rd-party repos"
-        " and cogs installed through Downloader (Git required)?",
-        default=True,
-    )
-    if not restore_downloader:
-        ignored_members += downloader_backup_files
-
-    tar_members = [member for member in tar.getmembers() if member.name not in ignored_members]
-    # tar.errorlevel == 0 so errors are printed to stderr
-    # TODO: progress bar?
-    tar.extractall(path=data_path, members=tar_members)
-
-    default_dirs = deepcopy(data_manager.basic_config_default)
-    default_dirs["DATA_PATH"] = data_path
-    # data in backup file is using json
-    default_dirs["STORAGE_TYPE"] = BackendType.JSON
-    default_dirs["STORAGE_DETAILS"] = {}
-    save_config(instance_name, default_dirs)
-
-    data_manager.load_basic_configuration(instance_name)
-
-    if storage_type is not BackendType.JSON:
-        await do_migration(BackendType.JSON, storage_type, storage_details)
+    restore_downloader = restore_data(tar, instance_name, data_path, storage_type, storage_details)
 
     if restore_downloader:
         repo_mgr = RepoManager()
         # this line shouldn't be needed since there are no repos:
         # await repo_mgr.initialize()
-        try:
-            await repo_mgr._restore_from_backup()
-        except ...:
-            ...
+        await repo_mgr._restore_from_backup()
+    print("Restore process has been completed.")
+    if restore_downloader:
+        print(
+            "Remember to run these commands after you start Red"
+            " to complete restoring of 3rd-party cogs:\n"
+            "[p]load downloader\n"
+            "[p]cog update"
+        )
 
 
 async def restore_instance():

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -516,10 +516,11 @@ class RestoreInfo:
     def _ask_for_required_changes(self) -> None:
         if self.name_used:
             print(
-                "Original instance name can't be used as other instance is already using it."
-                " You have to choose a different name."
+                "WARNING: Original instance name is already used by a different instance."
+                " Continuing will overwrite the existing instance config."
             )
-            self._ask_for_name()
+            if click.confirm("Do you want to use different instance name?"):
+                self._ask_for_name()
         if self.data_path_not_empty:
             print(
                 "Original data path can't be used as it's not empty."

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -13,9 +13,8 @@ import sys
 import re
 import tarfile
 from copy import deepcopy
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, IO, Optional, Tuple, Union
+from typing import Any, Dict, IO, List, Optional, Set, Tuple, Union
 
 import click
 
@@ -385,14 +384,22 @@ def open_file_from_tar(tar: tarfile.TarFile, arcname: str) -> Optional[IO[bytes]
     return fp
 
 
-@dataclass
 class RestoreInfo:
-    tar: tarfile.TarFile
-    backup_version: int
-    name: str
-    data_path: Path
-    storage_type: BackendType
-    storage_details: dict
+    def __init__(
+        self,
+        tar: tarfile.TarFile,
+        backup_version: int,
+        name: str,
+        data_path: Path,
+        storage_type: BackendType,
+        storage_details: dict,
+    ):
+        self.tar = tar
+        self.backup_version = backup_version
+        self.name = name
+        self.data_path = data_path
+        self.storage_type = storage_type
+        self.storage_details = storage_details
 
     @classmethod
     def from_tar(cls, tar: tarfile.TarFile) -> RestoreInfo:
@@ -432,20 +439,20 @@ class RestoreInfo:
         return backup_version
 
     @property
-    def name_used(self):
+    def name_used(self) -> bool:
         return self.name in instance_list
 
     @property
-    def data_path_not_empty(self):
+    def data_path_not_empty(self) -> bool:
         return self.data_path.exists() and next(self.data_path.glob("*"), None) is not None
 
     @property
-    def backend_unavailable(self):
+    def backend_unavailable(self) -> bool:
         return self.storage_type in (BackendType.MONGOV1, BackendType.MONGO)
 
     @functools.cached_property
-    def restore_downloader(self):
-        return "cogs/RepoManager/repos.json" in self.all_tar_members and click.confirm(
+    def restore_downloader(self) -> bool:
+        return "cogs/RepoManager/repos.json" in self.all_tar_member_names and click.confirm(
             "Do you want to restore 3rd-party repos and cogs installed through Downloader?\n"
             "Full offline restore process for this hasn't been made yet, so after it's done"
             " you will have to load Downloader and run `[p]cog update` command "
@@ -454,18 +461,22 @@ class RestoreInfo:
         )
 
     @functools.cached_property
-    def all_tar_members(self):
+    def all_tar_members(self) -> List[tarfile.TarInfo]:
         return self.tar.getmembers()
 
     @functools.cached_property
-    def tar_members_to_extract(self):
-        ignored_members: Tuple[str, ...] = ("backup.version", "instance.json")
+    def all_tar_member_names(self) -> List[str]:
+        return [tarinfo.name for tarinfo in self.all_tar_members]
+
+    @functools.cached_property
+    def tar_members_to_extract(self) -> List[tarfile.TarInfo]:
+        ignored_members: Set[str] = {"backup.version", "instance.json"}
         if not self.restore_downloader:
-            ignored_members += (
+            ignored_members |= {
                 "cogs/RepoManager/repos.json",
                 "cogs/RepoManager/settings.json",
                 "cogs/Downloader/settings.json",
-            )
+            }
         return [member for member in self.all_tar_members if member.name not in ignored_members]
 
     def print_instance_data(self) -> None:
@@ -485,22 +496,9 @@ class RestoreInfo:
                 print(f"    - DB {key}:", self.storage_details[key])
             print("    - DB password: ***")
 
-    def _ask_for_name(self):
-        self.name = get_name("")
-
-    def _ask_for_data_path(self):
-        while True:
-            self.data_path = Path(
-                get_data_dir(instance_name=self.name, data_path=None, interactive=True)
-            )
-            if not self.data_path_not_empty:
-                return
-            print("Given path can't be used as it's not empty.")
-
-    def _ask_for_storage(self):
-        self.storage_type = get_storage_type(None, interactive=True)
-        driver_cls = get_driver_class(self.storage_type)
-        self.storage_details = driver_cls.get_config_details()
+    def ask_for_changes(self) -> None:
+        self._ask_for_optional_changes()
+        self._ask_for_required_changes()
 
     def _ask_for_optional_changes(self) -> None:
         if click.confirm("\nWould you like to change anything?"):
@@ -535,9 +533,22 @@ class RestoreInfo:
             )
             self._ask_for_storage()
 
-    def ask_for_changes(self) -> None:
-        self._ask_for_optional_changes()
-        self._ask_for_required_changes()
+    def _ask_for_name(self) -> None:
+        self.name = get_name("")
+
+    def _ask_for_data_path(self) -> None:
+        while True:
+            self.data_path = Path(
+                get_data_dir(instance_name=self.name, data_path=None, interactive=True)
+            )
+            if not self.data_path_not_empty:
+                return
+            print("Given path can't be used as it's not empty.")
+
+    def _ask_for_storage(self) -> None:
+        self.storage_type = get_storage_type(None, interactive=True)
+        driver_cls = get_driver_class(self.storage_type)
+        self.storage_details = driver_cls.get_config_details()
 
     def extractall(self) -> None:
         # tar.errorlevel == 0 so errors are printed to stderr
@@ -546,7 +557,7 @@ class RestoreInfo:
 
     def get_basic_config(self, use_json: bool = False) -> dict:
         default_dirs = deepcopy(data_manager.basic_config_default)
-        default_dirs["DATA_PATH"] = self.data_path
+        default_dirs["DATA_PATH"] = str(self.data_path)
         if use_json:
             default_dirs["STORAGE_TYPE"] = BackendType.JSON.value
             default_dirs["STORAGE_DETAILS"] = {}
@@ -568,12 +579,17 @@ class RestoreInfo:
             data_manager.load_basic_configuration(self.name)
 
         if self.restore_downloader:
-            repo_mgr = RepoManager()
-            # this line shouldn't be needed since there are no repos:
-            # await repo_mgr.initialize()
-            await repo_mgr._restore_from_backup()
+            driver_cls = get_driver_class(self.storage_type)
+            await driver_cls.initialize(**self.storage_details)
+            try:
+                repo_mgr = RepoManager()
+                # this line shouldn't be needed since there are no repos:
+                # await repo_mgr.initialize()
+                await repo_mgr._restore_from_backup()
+            finally:
+                await driver_cls.teardown()
 
-    async def run(self):
+    async def run(self) -> None:
         self.print_instance_data()
         self.ask_for_changes()
         await self.restore_data()

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import Any, Dict, IO, List, Optional, Set, Tuple, Union
 
 import click
-from tqdm import tqdm
 
 from redbot.cogs.downloader.repo_manager import RepoManager
 from redbot.core._cli import confirm
@@ -25,6 +24,7 @@ from redbot.core.utils._internal_utils import (
     safe_delete,
     create_backup as red_create_backup,
     cli_level_to_log_level,
+    detailed_progress,
 )
 from redbot.core import config, data_manager
 from redbot.core._config import migrate
@@ -466,8 +466,7 @@ class RestoreInfo:
     def all_tar_member_names(self) -> List[str]:
         return [tarinfo.name for tarinfo in self.all_tar_members]
 
-    @functools.cached_property
-    def tar_members_to_extract(self) -> List[tarfile.TarInfo]:
+    def get_tar_members_to_extract(self) -> List[tarfile.TarInfo]:
         ignored_members: Set[str] = {"backup.version", "instance.json"}
         if not self.restore_downloader:
             ignored_members |= {
@@ -550,11 +549,11 @@ class RestoreInfo:
         self.storage_details = driver_cls.get_config_details()
 
     def extractall(self) -> None:
-        progress_bar = tqdm(
-            self.tar_members_to_extract, desc="Extracting data", unit=" files", dynamic_ncols=True
-        )
-        # tar.errorlevel == 0 so errors are printed to stderr
-        self.tar.extractall(path=self.data_path, members=progress_bar)
+        to_extract = self.get_tar_members_to_extract()
+        with detailed_progress(unit="files") as progress:
+            progress_tracker = progress.track(to_extract, description="Extracting data")
+            # tar.errorlevel == 0 so errors are printed to stderr
+            self.tar.extractall(path=self.data_path, members=progress_tracker)
 
     def get_basic_config(self, use_json: bool = False) -> dict:
         default_dirs = deepcopy(data_manager.basic_config_default)


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes
Fixes #2947, depends on #6696

I added progress bars to indicate to the user that the command does something but they're surely not the most accurate progress bars - progress bar for (un)packing archives are based on file amount, not on file size and progress bar for downloading repos is based on repo amount. I'm open to improving it but I think it still serves its purpose even if it's not very linear.

Backup can now have a version of its own in case we need to change something about its format later.

#### Note:
Restoring cogs is still far from perfect as it requires running `[p]cog update` after the offline restoring process so that the previously installed cogs get reinstalled (it's totally possible to reinstall cogs offline but it would require rewriting more than I currently have time for).

Update: There's now work done on improving this as well:
https://github.com/Jackenmen/Red-DiscordBot/pull/47