### PR TITLE
Use `choco upgrade`, not `choco install`

### DIFF
--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -26,9 +26,9 @@ Then run each of the following commands:
 
     Set-ExecutionPolicy Bypass -Scope Process -Force
     iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-    choco install git --params "/GitOnlyOnPath /WindowsTerminal" -y
-    choco install visualstudio2019-workload-vctools -y
-    choco install python3 -y
+    choco upgrade git --params "/GitOnlyOnPath /WindowsTerminal" -y
+    choco upgrade visualstudio2019-workload-vctools -y
+    choco upgrade python3 -y --version 3.8.2
 
 For Audio support, you should also run the following command before exiting:
 

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -34,7 +34,7 @@ For Audio support, you should also run the following command before exiting:
 
 .. code-block:: none
 
-    choco install adoptopenjdk11jre -y
+    choco upgrade adoptopenjdk11jre -y
 
 
 From here, exit the prompt then continue onto `creating-venv-windows`.

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -28,7 +28,7 @@ Then run each of the following commands:
     iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
     choco upgrade git --params "/GitOnlyOnPath /WindowsTerminal" -y
     choco upgrade visualstudio2019-workload-vctools -y
-    choco upgrade python3 -y --version 3.8.2
+    choco upgrade python3 -y
 
 For Audio support, you should also run the following command before exiting:
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
`choco upgrade` installs package if it's not installed and using that over `choco install` will ensure that packages are up-to-date (especially Python package)