### PR TITLE
[Cleanup] Add `[p]cleanup spam` command

### DIFF
--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -549,7 +549,7 @@ class Cleanup(commands.Cog):
         """Deletes duplicate messages in the channel from the last X messages. Default 50."""
         msgs = []
         spam = []
-        async for msg in ctx.channel.history(limit=number + 1):
+        async for msg in ctx.channel.history(limit=number, before=ctx.message):
             c = "{0.author.id}-{0.content}".format(msg)
             if c in msgs:
                 spam.append(msg)

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -546,10 +546,10 @@ class Cleanup(commands.Cog):
     @commands.guild_only()
     @commands.bot_has_permissions(manage_messages=True)
     async def cleanup_spam(self, ctx: commands.Context, number: int = 50):
-        """Deletes duplicate messages in the channel from the last X messages, but keeps the original. Default 50."""
+        """Deletes duplicate messages in the channel from the last X messages, but keeps only one. Default 50."""
         msgs = []
         spam = []
-        async for msg in ctx.channel.history(limit=number, before=ctx.message, oldest_first=True):
+        async for msg in ctx.channel.history(limit=number, before=ctx.message):
             if msg.attachments:
                 continue
             c = (msg.author.id, msg.content, [e.to_dict() for e in msg.embeds])
@@ -563,10 +563,13 @@ class Cleanup(commands.Cog):
             if not cont:
                 return
 
+        reason = "{}({}) deleted {} spam messages in channel {}.".format(
+            ctx.author.name,
+            ctx.author.id,
+            humanize_number(len(spam), override_locale="en_US"),
+            ctx.channel.name,
+        )
+        log.info(reason)
+
         spam.append(ctx.message)
         await mass_purge(spam, ctx.channel)
-        log.info(
-            "{0.author} deleted {1} spam messages in channel {0.channel}.".format(
-                ctx, len(spam) - 1
-            )
-        )

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -553,12 +553,14 @@ class Cleanup(commands.Cog):
 
         def check(m):
             if m.attachments:
-                False
+                return False
             c = (m.author.id, m.content, [e.to_dict() for e in m.embeds])
             if c in msgs:
                 spam.append(m)
+                return True
             else:
                 msgs.append(c)
+                return False
 
         to_delete = await self.get_messages_for_deletion(
             channel=ctx.channel, limit=number, check=check, before=ctx.message,

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -547,7 +547,10 @@ class Cleanup(commands.Cog):
     @commands.guild_only()
     @commands.bot_has_permissions(manage_messages=True)
     async def cleanup_spam(self, ctx: commands.Context, number: int = 50):
-        """Deletes duplicate messages in the channel from the last X messages, but keeps only one. Default 50."""
+        """Deletes duplicate messages in the channel from the last X messages and keeps only one copy.
+        
+        Defaults to 50.
+        """
         msgs = []
         spam = []
 

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -545,11 +545,11 @@ class Cleanup(commands.Cog):
     @cleanup.command(name="spam")
     @commands.guild_only()
     @commands.bot_has_permissions(manage_messages=True)
-    async def cleanup_spam(self, ctx: commands.Context):
-        """Deletes duplicate messages in the channel from the last 50 messages."""
+    async def cleanup_spam(self, ctx: commands.Context, number: int = 50):
+        """Deletes duplicate messages in the channel from the last X messages. Default 50."""
         msgs = []
         spam = []
-        async for msg in ctx.channel.history(limit=50):
+        async for msg in ctx.channel.history(limit=number + 1):
             c = "{0.author.id}-{0.content}".format(msg)
             if c in msgs:
                 spam.append(msg)
@@ -559,5 +559,7 @@ class Cleanup(commands.Cog):
 
         await mass_purge(spam, ctx.channel)
         log.info(
-            "{0.author} deleted {1} spam messages in channel {0.channel}.".format(ctx, len(spam))
+            "{0.author} deleted {1} spam messages in channel {0.channel}.".format(
+                ctx, len(spam) - 1
+            )
         )

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -559,6 +559,11 @@ class Cleanup(commands.Cog):
                 msgs.append(c)
         spam.append(ctx.message)
 
+        if len(spam) - 1 > 100:
+            cont = await self.check_100_plus(ctx, len(spam) - 1)
+            if not cont:
+                return
+
         await mass_purge(spam, ctx.channel)
         log.info(
             "{0.author} deleted {1} spam messages in channel {0.channel}.".format(

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -573,10 +573,10 @@ class Cleanup(commands.Cog):
             "%s (%s) deleted %s spam messages in channel %s (%s).",
             ctx.author,
             ctx.author.id,
-            len(spam),
+            len(to_delete),
             ctx.channel,
             ctx.channel.id,
         )
 
-        spam.append(ctx.message)
-        await mass_purge(spam, ctx.channel)
+        to_delete.append(ctx.message)
+        await mass_purge(to_delete, ctx.channel)

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -563,13 +563,14 @@ class Cleanup(commands.Cog):
             if not cont:
                 return
 
-        reason = "{}({}) deleted {} spam messages in channel {}.".format(
-            ctx.author.name,
+        log.info(
+            "%s (%s) deleted %s spam messages in channel %s (%s).",
+            ctx.author,
             ctx.author.id,
-            humanize_number(len(spam), override_locale="en_US"),
-            ctx.channel.name,
+            len(spam),
+            ctx.channel,
+            ctx.channel.id,
         )
-        log.info(reason)
 
         spam.append(ctx.message)
         await mass_purge(spam, ctx.channel)

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -546,10 +546,10 @@ class Cleanup(commands.Cog):
     @commands.guild_only()
     @commands.bot_has_permissions(manage_messages=True)
     async def cleanup_spam(self, ctx: commands.Context, number: int = 50):
-        """Deletes duplicate messages in the channel from the last X messages. Default 50."""
+        """Deletes duplicate messages in the channel from the last X messages, but keeps the original. Default 50."""
         msgs = []
         spam = []
-        async for msg in ctx.channel.history(limit=number, before=ctx.message):
+        async for msg in ctx.channel.history(limit=number, before=ctx.message, oldest_first=True):
             if msg.attachments:
                 continue
             c = (msg.author.id, msg.content, [e.to_dict() for e in msg.embeds])

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -557,13 +557,13 @@ class Cleanup(commands.Cog):
                 spam.append(msg)
             else:
                 msgs.append(c)
-        spam.append(ctx.message)
 
-        if len(spam) - 1 > 100:
-            cont = await self.check_100_plus(ctx, len(spam) - 1)
+        if len(spam) > 100:
+            cont = await self.check_100_plus(ctx, len(spam))
             if not cont:
                 return
 
+        spam.append(ctx.message)
         await mass_purge(spam, ctx.channel)
         log.info(
             "{0.author} deleted {1} spam messages in channel {0.channel}.".format(

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -550,7 +550,7 @@ class Cleanup(commands.Cog):
         msgs = []
         spam = []
         async for msg in ctx.channel.history(limit=50):
-            c = '{0.author.id}-{0.content}'.format(msg)
+            c = "{0.author.id}-{0.content}".format(msg)
             if c in msgs:
                 spam.append(msg)
             else:
@@ -558,4 +558,6 @@ class Cleanup(commands.Cog):
         spam.append(ctx.message)
 
         await mass_purge(spam, ctx.channel)
-        log.info('{0.author} deleted {1} spam messages in channel {0.channel}.'.format(ctx, len(spam)))
+        log.info(
+            "{0.author} deleted {1} spam messages in channel {0.channel}.".format(ctx, len(spam))
+        )

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -541,3 +541,21 @@ class Cleanup(commands.Cog):
             await mass_purge(to_delete, channel)
         else:
             await slow_deletion(to_delete)
+
+    @cleanup.command(name="spam")
+    @commands.guild_only()
+    @commands.bot_has_permissions(manage_messages=True)
+    async def cleanup_spam(self, ctx: commands.Context):
+        """Deletes duplicate messages in the channel from the last 50 messages."""
+        msgs = []
+        spam = []
+        async for msg in ctx.channel.history(limit=50):
+            c = '{0.author.id}-{0.content}'.format(msg)
+            if c in msgs:
+                spam.append(msg)
+            else:
+                msgs.append(c)
+        spam.append(ctx.message)
+
+        await mass_purge(spam, ctx.channel)
+        log.info('{0.author} deleted {1} spam messages in channel {0.channel}.'.format(ctx, len(spam)))

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -550,7 +550,9 @@ class Cleanup(commands.Cog):
         msgs = []
         spam = []
         async for msg in ctx.channel.history(limit=number, before=ctx.message):
-            c = "{0.author.id}-{0.content}".format(msg)
+            if msg.attachments:
+                continue
+            c = (msg.author.id, msg.content, [e.to_dict() for e in msg.embeds])
             if c in msgs:
                 spam.append(msg)
             else:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes

An addition to the cleanup cog. Checks the last 50 messages from the current channel, stores the message along with a reference to the author, and compares them. Deletes the duplicate/spam messages, but keeps a single copy.

![image](https://user-images.githubusercontent.com/15640986/77448198-b748e900-6dad-11ea-9e3f-7b1d62ea5636.png)

![image](https://user-images.githubusercontent.com/15640986/77448220-bca63380-6dad-11ea-89c9-9f1fdc35dd93.png)

