### PR TITLE
Fix misleading error appearing when repo name is already taken

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -505,7 +505,7 @@ class Downloader(commands.Cog):
                 repo = await self._repo_manager.add_repo(name=name, url=repo_url, branch=branch)
         except errors.ExistingGitRepo:
             await ctx.send(
-                _("That repo name you have provided is already in use, use another name.")
+                _("The repo name you provided is already in use. Please choose another name.")
             )
         except errors.CloningError as err:
             await ctx.send(

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -504,7 +504,9 @@ class Downloader(commands.Cog):
                 # noinspection PyTypeChecker
                 repo = await self._repo_manager.add_repo(name=name, url=repo_url, branch=branch)
         except errors.ExistingGitRepo:
-            await ctx.send(_("That git repo has already been added under another name."))
+            await ctx.send(
+                _("That repo name you have provided is already in use, use another name.")
+            )
         except errors.CloningError as err:
             await ctx.send(
                 _(


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #2826