### PR TITLE
Suppress `DeprecationWarning` caused by uvloop

### DIFF
--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -215,9 +215,11 @@ if "--debug" not in _sys.argv:
     _warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=21)
     # DeprecationWarning: rename klass to create_protocol
     #   warnings.warn("rename klass to create_protocol", DeprecationWarning)
-    #
-    # discord.py is using deprecated kwarg name when making websockets connection
-    # https://github.com/Rapptz/discord.py/issues/2574
     _warnings.filterwarnings(
         "ignore", category=DeprecationWarning, module="websockets", lineno=407
+    )
+    # DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
+    #   transport, protocol = await self._create_connection()
+    _warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, module="websockets", lineno=535
     )


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Closes #3686 that is caused by https://github.com/MagicStack/uvloop/pull/327

Individual warnings are still tracked in #3529 