### PR TITLE
Red 3.3.4 - Changelog

### DIFF
--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -1,5 +1,31 @@
 .. 3.3.x Changelogs
 
+Redbot 3.3.4 (Unreleased)
+=========================
+
+| Thanks to all these amazing people that contributed to this release:
+| 
+
+End-user changelog
+------------------
+
+
+
+Developer changelog
+-------------------
+
+
+
+Documentation changes
+---------------------
+
+
+
+Miscellaneous
+-------------
+
+
+
 Redbot 3.3.3 (2020-03-28)
 =========================
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -22,7 +22,7 @@ Developer changelog
 Documentation changes
 ---------------------
 
-
+- Versions of pre-requirements are now included in Windows install guide (:issue:`3708`)
 
 Miscellaneous
 -------------

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.4 (Unreleased)
 =========================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`jack1142`
+| :ghuser:`jack1142`, :ghuser:`kennnyshiwa`
 
 End-user changelog
 ------------------
@@ -17,7 +17,11 @@ Alias
 Developer changelog
 -------------------
 
+Utility Functions
+*****************
 
+- `redbot.core.utils.common_filters.filter_invites` now filters ``discord.io/discord.li`` invites links (:issue:`3717`)
+- Fixed false-positives in `redbot.core.utils.common_filters.filter_invites` (:issue:`3717`)
 
 Documentation changes
 ---------------------

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -1,6 +1,6 @@
 .. 3.3.x Changelogs
 
-Redbot 3.3.4 (Unreleased)
+Redbot 3.3.4 (2020-04-05)
 =========================
 
 | Thanks to all these amazing people that contributed to this release:
@@ -37,10 +37,6 @@ Documentation changes
 ---------------------
 
 - Versions of pre-requirements are now included in Windows install guide (:issue:`3708`)
-
-Miscellaneous
--------------
-
 
 
 Redbot 3.3.3 (2020-03-28)

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -17,6 +17,11 @@ Alias
 Developer changelog
 -------------------
 
+Core Bot
+********
+
+- Bump dependencies, including update to discord.py 1.3.3 (:issue:`3723`)
+
 Utility Functions
 *****************
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,12 +4,15 @@ Redbot 3.3.4 (Unreleased)
 =========================
 
 | Thanks to all these amazing people that contributed to this release:
-| 
+| :ghuser:`jack1142`
 
 End-user changelog
 ------------------
 
+Alias
+*****
 
+- ``[p]alias add`` now sends an error when command user tries to alias doesn't exist (:issue:`3710`, :issue:`3545`)
 
 Developer changelog
 -------------------

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -9,6 +9,11 @@ Redbot 3.3.4 (Unreleased)
 End-user changelog
 ------------------
 
+Core Bot
+********
+
+- Fixed checks related to bank's global state that were used in commands in Bank, Economy and Trivia cogs (:issue:`3707`)
+
 Alias
 *****
 


### PR DESCRIPTION
Draft PR for Red 3.3.4 changelog.

This is getting updated as new PRs from the milestone get merged.

Rendered changelog can be seen here: https://red-discordbot--3706.org.readthedocs.build/en/3706/changelog_3_3_0.html#redbot-3-3-4-unreleased