### PR TITLE
Send error in `[p]alias add` when target command doesn't exist

### DIFF
--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -279,6 +279,13 @@ class Alias(commands.Cog):
                 ).format(name=alias_name)
             )
             return
+
+        given_command_exists = self.bot.get_command(command) is not None
+        if not given_command_exists:
+            await ctx.send(
+                _("You attempted to create a new alias for a command that doesn't exist.")
+            )
+            return
         # endregion
 
         # At this point we know we need to make a new alias


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Fixes #3545, this sends an error when target command doesn't exist same as commands in Permissions cog do when target command/cog for the rules doesn't exist.