### PR TITLE
Don't run command checks on each message starting with a prefix

### DIFF
--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -566,13 +566,14 @@ class RedHelpFormatter:
         """
         Sends an error, fuzzy help, or stays quiet based on settings
         """
-        coms = {
-            c
-            async for c in self.help_filter_func(
+        fuzzy_commands = await fuzzy_command_search(
+            ctx,
+            help_for,
+            commands=self.help_filter_func(
                 ctx, ctx.bot.walk_commands(), help_settings=help_settings
-            )
-        }
-        fuzzy_commands = await fuzzy_command_search(ctx, help_for, commands=coms, min_score=75)
+            ),
+            min_score=75,
+        )
         use_embeds = await ctx.embed_requested()
         if fuzzy_commands:
             ret = await format_fuzzy_results(ctx, fuzzy_commands, embed=use_embeds)

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -196,12 +196,9 @@ def init_events(bot, cli_flags):
             help_settings = await HelpSettings.from_context(ctx)
             fuzzy_commands = await fuzzy_command_search(
                 ctx,
-                commands={
-                    c
-                    async for c in RedHelpFormatter.help_filter_func(
-                        ctx, bot.walk_commands(), help_settings=help_settings
-                    )
-                },
+                commands=RedHelpFormatter.help_filter_func(
+                    ctx, bot.walk_commands(), help_settings=help_settings
+                ),
             )
             if not fuzzy_commands:
                 pass


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This PR changes the `fuzzy_command_search` util to accept iterators instead of sets so that the bot doesn't waste time on filtering out commands if fuzzy search isn't enabled.

This PR has NOT been tested.