### PR TITLE
Red 3.3.5 - Changelog

### DIFF
--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -1,6 +1,6 @@
 .. 3.3.x Changelogs
 
-Redbot 3.3.4 (Unreleased)
+Redbot 3.3.4 (2020-04-09)
 =========================
 
 | Thanks to all these amazing people that contributed to this release:
@@ -18,21 +18,6 @@ Alias
 *****
 
 - Fixed regression in ``[p]alias add`` that caused it to reject commands containing arguments (:issue:`3734`)
-
-
-Developer changelog
--------------------
-
-
-
-Documentation changes
----------------------
-
-
-
-Miscellaneous
--------------
-
 
 
 Redbot 3.3.4 (2020-04-05)

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -1,5 +1,31 @@
 .. 3.3.x Changelogs
 
+Redbot 3.3.4 (Unreleased)
+=========================
+
+| Thanks to all these amazing people that contributed to this release:
+| 
+
+End-user changelog
+------------------
+
+
+
+Developer changelog
+-------------------
+
+
+
+Documentation changes
+---------------------
+
+
+
+Miscellaneous
+-------------
+
+
+
 Redbot 3.3.4 (2020-04-05)
 =========================
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,11 +4,15 @@ Redbot 3.3.4 (Unreleased)
 =========================
 
 | Thanks to all these amazing people that contributed to this release:
-| 
+| :ghuser:`Kowlin`
 
 End-user changelog
 ------------------
 
+Core Bot
+********
+
+- "Outdated" field no longer shows in ``[p]info`` when Red is up-to-date (:issue:`3730`)
 
 
 Developer changelog

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.4 (Unreleased)
 =========================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`Kowlin`
+| :ghuser:`jack1142`, :ghuser:`Kowlin`
 
 End-user changelog
 ------------------
@@ -13,6 +13,11 @@ Core Bot
 ********
 
 - "Outdated" field no longer shows in ``[p]info`` when Red is up-to-date (:issue:`3730`)
+
+Alias
+*****
+
+- Fixed regression in ``[p]alias add`` that caused it to reject commands containing arguments (:issue:`3734`)
 
 
 Developer changelog


### PR DESCRIPTION
Draft PR for Red 3.3.5 changelog.

This is getting updated as new PRs from the milestone get merged.

Rendered changelog can be seen here: https://red-discordbot--3727.org.readthedocs.build/en/3727/changelog_3_3_0.html#redbot-3-3-5-unreleased