### PR TITLE
Stop Outdated field from showing in `[p]info` when up-to-date

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -350,7 +350,7 @@ class Core(commands.Cog, CoreLogic):
         embed.add_field(name="Python", value=python_version)
         embed.add_field(name="discord.py", value=dpy_version)
         embed.add_field(name=_("Red version"), value=red_version)
-        if outdated is (True, None):
+        if outdated in (True, None):
             if outdated is True:
                 outdated_value = _("Yes, {version} is available.").format(
                     version=data["info"]["version"]

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -350,15 +350,14 @@ class Core(commands.Cog, CoreLogic):
         embed.add_field(name="Python", value=python_version)
         embed.add_field(name="discord.py", value=dpy_version)
         embed.add_field(name=_("Red version"), value=red_version)
-        if outdated is True:
-            outdated_value = _("Yes, {version} is available").format(
-                version=data["info"]["version"]
-            )
-        elif outdated is None:
-            outdated_value = _("Checking for updates failed.")
-        else:
-            outdated_value = _("No")
-        embed.add_field(name=_("Outdated"), value=outdated_value)
+        if outdated is any([True, None]):
+            if outdated is True:
+                outdated_value = _("Yes, {version} is available.").format(
+                    version=data["info"]["version"]
+                )
+            else:
+                outdated_value = _("Checking for updates failed.")
+            embed.add_field(name=_("Outdated"), value=outdated_value)
         if custom_info:
             embed.add_field(name=_("About this instance"), value=custom_info, inline=False)
         embed.add_field(name=_("About Red"), value=about, inline=False)

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -350,7 +350,7 @@ class Core(commands.Cog, CoreLogic):
         embed.add_field(name="Python", value=python_version)
         embed.add_field(name="discord.py", value=dpy_version)
         embed.add_field(name=_("Red version"), value=red_version)
-        if outdated is any([True, None]):
+        if outdated is (True, None):
             if outdated is True:
                 outdated_value = _("Yes, {version} is available.").format(
                     version=data["info"]["version"]


### PR DESCRIPTION
# Bugfix request

<!--
THIS TEMPLATE IS CURRENTLY UNUSED DUE TO GITHUB LIMITATIONS!
To be used for pull requests that fix a bug
-->

#### Describe the bug being fixed

Fix outdated from appearing on up to date versions.

#### Anything we need to know about this fix?
