### PR TITLE
Revert "[CI] Less weekly churn from automated tasks"

### DIFF
--- a/.github/workflows/publish_crowdin.yml
+++ b/.github/workflows/publish_crowdin.yml
@@ -35,9 +35,6 @@ jobs:
     - name: Download translations
       run: |
         make download_translations
-    - name: Remove files from PR which only have a date changed
-      run: |
-        git checkout HEAD -- $(git diff HEAD --numstat | awk 'BEGIN {ORS=" "} $1 == "1" && $2 == "1" && $3 ~ /.po$/ {print $3}')
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v2
       with:


### PR DESCRIPTION
Reverts Cog-Creators/Red-DiscordBot#3548
Crowdin team tuned parser for our project so the .po files should no longer contain `PO-Revision-Date` (see https://github.com/crowdin/crowdin-cli-2/issues/183)
We'll see how that works in practice when the new build comes...