### PR TITLE
Properly check for command's existence in `[p]alias add`

### DIFF
--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -280,7 +280,7 @@ class Alias(commands.Cog):
             )
             return
 
-        given_command_exists = self.bot.get_command(command) is not None
+        given_command_exists = self.bot.get_command(command.split(maxsplit=1)[0]) is not None
         if not given_command_exists:
             await ctx.send(
                 _("You attempted to create a new alias for a command that doesn't exist.")


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
We should only use first word of the passed `command` argument when we're trying to get the command.
This fixes cases when "command" passed to `command` contains args, e.g:
`alias add 18+ selfrole add 18+`