### PR TITLE
Red 3.3.6 - Changelog

### DIFF
--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.6 (Unreleased)
 =========================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`MiniJennJenn`
+| :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`MiniJennJenn`, :ghuser:`yamikaitou`
 
 End-user changelog
 ------------------
@@ -34,6 +34,7 @@ Documentation changes
 Miscellaneous
 -------------
 
+- **Trivia** - Corrected spelling of Compact Disc in ``games`` list (:issue:`3759`, :issue:`3758`)
 
 
 Redbot 3.3.5 (2020-04-09)

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -76,6 +76,7 @@ Documentation changes
 Miscellaneous
 -------------
 
+- **Core Commands** - ``[p]debuginfo`` now shows used storage type (:issue:`3794`)
 - **Trivia** - Corrected spelling of Compact Disc in ``games`` list (:issue:`3759`, :issue:`3758`)
 
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,10 +4,17 @@ Redbot 3.3.6 (Unreleased)
 =========================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`MiniJennJenn`, :ghuser:`yamikaitou`
+| :ghuser:`Drapersniper`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`MiniJennJenn`, :ghuser:`yamikaitou`
 
 End-user changelog
 ------------------
+
+Core Bot
+********
+
+- Various optimizations
+
+  - Reduced calls to data backend when loading bot's commands (:issue:`3764`)
 
 Core Commands
 *************

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -22,6 +22,7 @@ Core Commands
 *************
 
 - ``[p]set avatar`` now supports setting avatar using attachment (:issue:`3747`)
+- Added ``[p]set avatar remove`` subcommand for removing bot's avatar (:issue:`3757`)
 - Fixed list of ignored channels that is shown in ``[p]ignore``/``[p]unignore`` (:issue:`3746`)
 
 Trivia Lists

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.6 (Unreleased)
 =========================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`jack1142`
+| :ghuser:`jack1142`, :ghuser:`MiniJennJenn`
 
 End-user changelog
 ------------------
@@ -13,6 +13,11 @@ Core Commands
 *************
 
 - Fixed list of ignored channels that is shown in ``[p]ignore``/``[p]unignore`` (:issue:`3746`)
+
+Trivia Lists
+************
+
+- Updated ``leagueoflegends`` list with new changes to League of Legends (`b8ac70e <https://github.com/Cog-Creators/Red-DiscordBot/commit/b8ac70e59aa1328f246784f14f992d6ffe00d778>`_)
 
 
 Developer changelog

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -15,6 +15,7 @@ Core Bot
 - Various optimizations
 
   - Reduced calls to data backend when loading bot's commands (:issue:`3764`)
+  - Reduced calls to data backend when showing help for cogs/commands (:issue:`3766`)
 
 Core Commands
 *************

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -30,6 +30,11 @@ Streams
 
 - Fixed incorrect stream URLs for Twitch channels that have localised display name (:issue:`3773`, :issue:`3772`)
 
+Trivia
+******
+
+- Fixed the error in ``[p]trivia stop`` that happened when there was no ongoing trivia session in the channel (:issue:`3774`)
+
 Trivia Lists
 ************
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.6 (Unreleased)
 =========================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`Drapersniper`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`MiniJennJenn`, :ghuser:`yamikaitou`
+| :ghuser:`Drapersniper`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`MiniJennJenn`, :ghuser:`PredaaA`, :ghuser:`yamikaitou`
 
 End-user changelog
 ------------------
@@ -56,6 +56,7 @@ Utility Functions
 *****************
 
 - Added `redbot.core.utils.AsyncIter` utility class which allows you to wrap regular iterable into async iterator yielding items and sleeping for ``delay`` seconds every ``steps`` items (:issue:`3767`, :issue:`3776`)
+- `bold()`, `italics()`, `strikethrough()`, and `underline()` now accept ``escape_formatting`` argument that can be used to disable escaping of markdown formatting in passed text (:issue:`3742`)
 
 
 Documentation changes

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -1,6 +1,6 @@
 .. 3.3.x Changelogs
 
-Redbot 3.3.6 (Unreleased)
+Redbot 3.3.6 (2020-04-27)
 =========================
 
 | Thanks to all these amazing people that contributed to this release:

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -19,6 +19,7 @@ Core Bot
   - Reduced calls to data backend when showing help for cogs/commands (:issue:`3766`)
   - Improved performance for bots with big amount of guilds (:issue:`3767`)
   - Mod cog no longer fetches guild's bans every 60 seconds when handling unbanning for tempbans (:issue:`3783`)
+  - Reduced the bot load for messages starting with a prefix when fuzzy search is disabled (:issue:`3718`)
 
 Core Commands
 *************

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.6 (Unreleased)
 =========================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`jack1142`, :ghuser:`MiniJennJenn`
+| :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`MiniJennJenn`
 
 End-user changelog
 ------------------
@@ -12,6 +12,7 @@ End-user changelog
 Core Commands
 *************
 
+- ``[p]set avatar`` now supports setting avatar using attachment (:issue:`3747`)
 - Fixed list of ignored channels that is shown in ``[p]ignore``/``[p]unignore`` (:issue:`3746`)
 
 Trivia Lists

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -12,6 +12,7 @@ End-user changelog
 Core Bot
 ********
 
+- Converting from and to Postgres driver with ``redbot-setup convert`` have been fixed (:issue:`3714`, :issue:`3115`)
 - Fixed big delays in commands that happened when the bot was owner-less (or if it only used co-owners feature) and command caller wasn't the owner (:issue:`3782`)
 - Various optimizations
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -76,6 +76,7 @@ Documentation changes
 Miscellaneous
 -------------
 
+- **Config** - JSON driver will now properly have only one lock per cog name (:issue:`3780`)
 - **Core Commands** - ``[p]debuginfo`` now shows used storage type (:issue:`3794`)
 - **Trivia** - Corrected spelling of Compact Disc in ``games`` list (:issue:`3759`, :issue:`3758`)
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.6 (Unreleased)
 =========================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`Drapersniper`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`MiniJennJenn`, :ghuser:`PredaaA`, :ghuser:`yamikaitou`
+| :ghuser:`aikaterna`, :ghuser:`Drapersniper`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`MiniJennJenn`, :ghuser:`PredaaA`, :ghuser:`yamikaitou`
 
 End-user changelog
 ------------------
@@ -27,6 +27,12 @@ Core Commands
 - ``[p]set avatar`` now supports setting avatar using attachment (:issue:`3747`)
 - Added ``[p]set avatar remove`` subcommand for removing bot's avatar (:issue:`3757`)
 - Fixed list of ignored channels that is shown in ``[p]ignore``/``[p]unignore`` (:issue:`3746`)
+
+Audio
+*****
+
+- Age-restricted tracks, live streams, and mix playlists from YouTube should work in Audio again (:issue:`3791`)
+- Soundcloud's sets and playlists with more than 50 tracks should work in Audio again (:issue:`3791`)
 
 Modlog
 ******

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -16,6 +16,7 @@ Core Bot
 
   - Reduced calls to data backend when loading bot's commands (:issue:`3764`)
   - Reduced calls to data backend when showing help for cogs/commands (:issue:`3766`)
+  - Improved performance for bots with big amount of guilds (:issue:`3767`)
 
 Core Commands
 *************
@@ -32,6 +33,10 @@ Trivia Lists
 Developer changelog
 -------------------
 
+Utility Functions
+*****************
+
+- Added `redbot.core.utils.AsyncIter` utility class which allows you to wrap regular iterable into async iterator yielding items and sleeping for ``delay`` seconds every ``steps`` items (:issue:`3767`)
 
 
 Documentation changes

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.6 (Unreleased)
 =========================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`aikaterna`, :ghuser:`Drapersniper`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`MiniJennJenn`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`yamikaitou`
+| :ghuser:`aikaterna`, :ghuser:`Drapersniper`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`MiniJennJenn`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`TrustyJAID`, :ghuser:`yamikaitou`
 
 End-user changelog
 ------------------
@@ -21,6 +21,7 @@ Core Bot
   - Improved performance for bots with big amount of guilds (:issue:`3767`)
   - Mod cog no longer fetches guild's bans every 60 seconds when handling unbanning for tempbans (:issue:`3783`)
   - Reduced the bot load for messages starting with a prefix when fuzzy search is disabled (:issue:`3718`)
+  - Aliases in Alias cog are now cached for better performance (:issue:`3788`)
 
 Core Commands
 *************

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.6 (Unreleased)
 =========================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`aikaterna`, :ghuser:`Drapersniper`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`MiniJennJenn`, :ghuser:`PredaaA`, :ghuser:`yamikaitou`
+| :ghuser:`aikaterna`, :ghuser:`Drapersniper`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`MiniJennJenn`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`yamikaitou`
 
 End-user changelog
 ------------------
@@ -33,6 +33,11 @@ Audio
 
 - Age-restricted tracks, live streams, and mix playlists from YouTube should work in Audio again (:issue:`3791`)
 - Soundcloud's sets and playlists with more than 50 tracks should work in Audio again (:issue:`3791`)
+
+CustomCommands
+**************
+
+- Added ``[p]cc raw`` command that gives you the raw response of a custom command for ease of copy pasting (:issue:`3795`)
 
 Modlog
 ******

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -70,6 +70,7 @@ Documentation changes
 
 - ``pyenv`` instructions will now update ``pyenv`` if it's already installed (:issue:`3740`)
 - Updated Python version in ``pyenv`` instructions (:issue:`3740`)
+- Updated install docs to include Ubuntu 20.04 (:issue:`3792`)
 
 
 Miscellaneous

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -18,6 +18,7 @@ Core Bot
   - Reduced calls to data backend when loading bot's commands (:issue:`3764`)
   - Reduced calls to data backend when showing help for cogs/commands (:issue:`3766`)
   - Improved performance for bots with big amount of guilds (:issue:`3767`)
+  - Stop fetching guild bans when handling unbanning for tempbans (:issue:`3783`)
 
 Core Commands
 *************

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -68,6 +68,7 @@ Utility Functions
 Documentation changes
 ---------------------
 
+- Added `document about updating Red <update_red>` (:issue:`3790`)
 - ``pyenv`` instructions will now update ``pyenv`` if it's already installed (:issue:`3740`)
 - Updated Python version in ``pyenv`` instructions (:issue:`3740`)
 - Updated install docs to include Ubuntu 20.04 (:issue:`3792`)

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,11 +4,15 @@ Redbot 3.3.6 (Unreleased)
 =========================
 
 | Thanks to all these amazing people that contributed to this release:
-| 
+| :ghuser:`jack1142`
 
 End-user changelog
 ------------------
 
+Core Commands
+*************
+
+- Fixed list of ignored channels that is shown in ``[p]ignore``/``[p]unignore`` (:issue:`3746`)
 
 
 Developer changelog

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -25,6 +25,11 @@ Core Commands
 - Added ``[p]set avatar remove`` subcommand for removing bot's avatar (:issue:`3757`)
 - Fixed list of ignored channels that is shown in ``[p]ignore``/``[p]unignore`` (:issue:`3746`)
 
+Modlog
+******
+
+- Fixed ``AttributeError`` for cases whose moderator doesn't share the server with the bot (:issue:`3784`, :issue:`3778`)
+
 Streams
 *******
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -1,5 +1,31 @@
 .. 3.3.x Changelogs
 
+Redbot 3.3.6 (Unreleased)
+=========================
+
+| Thanks to all these amazing people that contributed to this release:
+| 
+
+End-user changelog
+------------------
+
+
+
+Developer changelog
+-------------------
+
+
+
+Documentation changes
+---------------------
+
+
+
+Miscellaneous
+-------------
+
+
+
 Redbot 3.3.5 (2020-04-09)
 =========================
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -36,7 +36,7 @@ Developer changelog
 Utility Functions
 *****************
 
-- Added `redbot.core.utils.AsyncIter` utility class which allows you to wrap regular iterable into async iterator yielding items and sleeping for ``delay`` seconds every ``steps`` items (:issue:`3767`)
+- Added `redbot.core.utils.AsyncIter` utility class which allows you to wrap regular iterable into async iterator yielding items and sleeping for ``delay`` seconds every ``steps`` items (:issue:`3767`, :issue:`3776`)
 
 
 Documentation changes

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -18,7 +18,7 @@ Core Bot
   - Reduced calls to data backend when loading bot's commands (:issue:`3764`)
   - Reduced calls to data backend when showing help for cogs/commands (:issue:`3766`)
   - Improved performance for bots with big amount of guilds (:issue:`3767`)
-  - Stop fetching guild bans when handling unbanning for tempbans (:issue:`3783`)
+  - Mod cog no longer fetches guild's bans every 60 seconds when handling unbanning for tempbans (:issue:`3783`)
 
 Core Commands
 *************

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -25,6 +25,11 @@ Core Commands
 - Added ``[p]set avatar remove`` subcommand for removing bot's avatar (:issue:`3757`)
 - Fixed list of ignored channels that is shown in ``[p]ignore``/``[p]unignore`` (:issue:`3746`)
 
+Streams
+*******
+
+- Fixed incorrect stream URLs for Twitch channels that have localised display name (:issue:`3773`, :issue:`3772`)
+
 Trivia Lists
 ************
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -48,6 +48,8 @@ Utility Functions
 Documentation changes
 ---------------------
 
+- ``pyenv`` instructions will now update ``pyenv`` if it's already installed (:issue:`3740`)
+- Updated Python version in ``pyenv`` instructions (:issue:`3740`)
 
 
 Miscellaneous

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -12,6 +12,7 @@ End-user changelog
 Core Bot
 ********
 
+- Fixed big delays in commands that happened when the bot was owner-less (or if it only used co-owners feature) and command caller wasn't the owner (:issue:`3782`)
 - Various optimizations
 
   - Reduced calls to data backend when loading bot's commands (:issue:`3764`)


### PR DESCRIPTION
Draft PR for Red 3.3.6 changelog.

This is getting updated as new PRs from the milestone get merged.

Rendered changelog can be seen here: https://red-discordbot--3738.org.readthedocs.build/en/3738/changelog_3_3_0.html#redbot-3-3-6-2020-04-27