### PR TITLE
Allow to disable escaping in chat formatting utils

### DIFF
--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -78,7 +78,7 @@ def bold(text: str, escape_formatting: bool = True) -> str:
         The marked up text.
 
     """
-    text = escape(text, escape_formatting)
+    text = escape(text, formatting=escape_formatting)
     return "**{}**".format(text)
 
 
@@ -140,7 +140,7 @@ def italics(text: str, escape_formatting: bool = True) -> str:
         The marked up text.
 
     """
-    text = escape(text, escape_formatting)
+    text = escape(text, formatting=escape_formatting)
     return "*{}*".format(text)
 
 
@@ -300,7 +300,7 @@ def strikethrough(text: str, escape_formatting: bool = True) -> str:
         The marked up text.
 
     """
-    text = escape(text, escape_formatting)
+    text = escape(text, formatting=escape_formatting)
     return "~~{}~~".format(text)
 
 
@@ -322,7 +322,7 @@ def underline(text: str, escape_formatting: bool = True) -> str:
         The marked up text.
 
     """
-    text = escape(text, escape_formatting)
+    text = escape(text, formatting=escape_formatting)
     return "__{}__".format(text)
 
 

--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -60,7 +60,7 @@ def question(text: str) -> str:
     return "\N{BLACK QUESTION MARK ORNAMENT} {}".format(text)
 
 
-def bold(text: str) -> str:
+def bold(text: str, formatting: bool = True) -> str:
     """Get the given text in bold.
 
     Note: This escapes text prior to bolding.
@@ -69,6 +69,8 @@ def bold(text: str) -> str:
     ----------
     text : str
         The text to be marked up.
+    formatting : `bool`, optional
+        Set to :code:`False` to don't escape any markdown formatting in the text.
 
     Returns
     -------
@@ -76,7 +78,7 @@ def bold(text: str) -> str:
         The marked up text.
 
     """
-    text = escape(text, formatting=True)
+    text = escape(text, formatting)
     return "**{}**".format(text)
 
 
@@ -120,7 +122,7 @@ def inline(text: str) -> str:
         return "`{}`".format(text)
 
 
-def italics(text: str) -> str:
+def italics(text: str, formatting: bool = True) -> str:
     """Get the given text in italics.
 
     Note: This escapes text prior to italicising
@@ -129,6 +131,8 @@ def italics(text: str) -> str:
     ----------
     text : str
         The text to be marked up.
+    formatting : `bool`, optional
+        Set to :code:`False` to don't escape any markdown formatting in the text.
 
     Returns
     -------
@@ -136,7 +140,7 @@ def italics(text: str) -> str:
         The marked up text.
 
     """
-    text = escape(text, formatting=True)
+    text = escape(text, formatting)
     return "*{}*".format(text)
 
 
@@ -278,7 +282,7 @@ def pagify(
             yield in_text
 
 
-def strikethrough(text: str) -> str:
+def strikethrough(text: str, formatting: bool = True) -> str:
     """Get the given text with a strikethrough.
 
     Note: This escapes text prior to applying a strikethrough
@@ -287,6 +291,8 @@ def strikethrough(text: str) -> str:
     ----------
     text : str
         The text to be marked up.
+    formatting : `bool`, optional
+        Set to :code:`False` to don't escape any markdown formatting in the text.
 
     Returns
     -------
@@ -294,11 +300,11 @@ def strikethrough(text: str) -> str:
         The marked up text.
 
     """
-    text = escape(text, formatting=True)
+    text = escape(text, formatting)
     return "~~{}~~".format(text)
 
 
-def underline(text: str) -> str:
+def underline(text: str, formatting: bool = True) -> str:
     """Get the given text with an underline.
 
     Note: This escapes text prior to underlining
@@ -307,6 +313,8 @@ def underline(text: str) -> str:
     ----------
     text : str
         The text to be marked up.
+    formatting : `bool`, optional
+        Set to :code:`False` to don't escape any markdown formatting in the text.
 
     Returns
     -------
@@ -314,7 +322,7 @@ def underline(text: str) -> str:
         The marked up text.
 
     """
-    text = escape(text, formatting=True)
+    text = escape(text, formatting)
     return "__{}__".format(text)
 
 
@@ -328,7 +336,7 @@ def escape(text: str, *, mass_mentions: bool = False, formatting: bool = False) 
     mass_mentions : `bool`, optional
         Set to :code:`True` to escape mass mentions in the text.
     formatting : `bool`, optional
-        Set to :code:`True` to escpae any markdown formatting in the text.
+        Set to :code:`True` to escape any markdown formatting in the text.
 
     Returns
     -------

--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -63,7 +63,7 @@ def question(text: str) -> str:
 def bold(text: str, escape_formatting: bool = True) -> str:
     """Get the given text in bold.
 
-    Note: This escapes text prior to bolding.
+    Note: By default, this function will escape ``text`` prior to emboldening.
 
     Parameters
     ----------
@@ -285,7 +285,7 @@ def pagify(
 def strikethrough(text: str, escape_formatting: bool = True) -> str:
     """Get the given text with a strikethrough.
 
-    Note: This escapes text prior to applying a strikethrough
+    Note: By default, this function will escape ``text`` prior to applying a strikethrough.
 
     Parameters
     ----------
@@ -307,7 +307,7 @@ def strikethrough(text: str, escape_formatting: bool = True) -> str:
 def underline(text: str, escape_formatting: bool = True) -> str:
     """Get the given text with an underline.
 
-    Note: This escapes text prior to underlining
+    Note: By default, this function will escape ``text`` prior to underlining.
 
     Parameters
     ----------

--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -70,7 +70,7 @@ def bold(text: str, escape_formatting: bool = True) -> str:
     text : str
         The text to be marked up.
     escape_formatting : `bool`, optional
-        Set to :code:`False` to don't escape any markdown formatting in the text.
+        Set to :code:`False` to not escape markdown formatting in the text.
 
     Returns
     -------
@@ -132,7 +132,7 @@ def italics(text: str, escape_formatting: bool = True) -> str:
     text : str
         The text to be marked up.
     escape_formatting : `bool`, optional
-        Set to :code:`False` to don't escape any markdown formatting in the text.
+        Set to :code:`False` to not escape markdown formatting in the text.
 
     Returns
     -------
@@ -292,7 +292,7 @@ def strikethrough(text: str, escape_formatting: bool = True) -> str:
     text : str
         The text to be marked up.
     escape_formatting : `bool`, optional
-        Set to :code:`False` to don't escape any markdown formatting in the text.
+        Set to :code:`False` to not escape markdown formatting in the text.
 
     Returns
     -------
@@ -314,7 +314,7 @@ def underline(text: str, escape_formatting: bool = True) -> str:
     text : str
         The text to be marked up.
     escape_formatting : `bool`, optional
-        Set to :code:`False` to don't escape any markdown formatting in the text.
+        Set to :code:`False` to not escape markdown formatting in the text.
 
     Returns
     -------

--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -125,7 +125,7 @@ def inline(text: str) -> str:
 def italics(text: str, escape_formatting: bool = True) -> str:
     """Get the given text in italics.
 
-    Note: This escapes text prior to italicising
+    Note: By default, this function will escape ``text`` prior to italicising.
 
     Parameters
     ----------

--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -60,7 +60,7 @@ def question(text: str) -> str:
     return "\N{BLACK QUESTION MARK ORNAMENT} {}".format(text)
 
 
-def bold(text: str, formatting: bool = True) -> str:
+def bold(text: str, escape_formatting: bool = True) -> str:
     """Get the given text in bold.
 
     Note: This escapes text prior to bolding.
@@ -69,7 +69,7 @@ def bold(text: str, formatting: bool = True) -> str:
     ----------
     text : str
         The text to be marked up.
-    formatting : `bool`, optional
+    escape_formatting : `bool`, optional
         Set to :code:`False` to don't escape any markdown formatting in the text.
 
     Returns
@@ -78,7 +78,7 @@ def bold(text: str, formatting: bool = True) -> str:
         The marked up text.
 
     """
-    text = escape(text, formatting)
+    text = escape(text, escape_formatting)
     return "**{}**".format(text)
 
 
@@ -122,7 +122,7 @@ def inline(text: str) -> str:
         return "`{}`".format(text)
 
 
-def italics(text: str, formatting: bool = True) -> str:
+def italics(text: str, escape_formatting: bool = True) -> str:
     """Get the given text in italics.
 
     Note: This escapes text prior to italicising
@@ -131,7 +131,7 @@ def italics(text: str, formatting: bool = True) -> str:
     ----------
     text : str
         The text to be marked up.
-    formatting : `bool`, optional
+    escape_formatting : `bool`, optional
         Set to :code:`False` to don't escape any markdown formatting in the text.
 
     Returns
@@ -140,7 +140,7 @@ def italics(text: str, formatting: bool = True) -> str:
         The marked up text.
 
     """
-    text = escape(text, formatting)
+    text = escape(text, escape_formatting)
     return "*{}*".format(text)
 
 
@@ -282,7 +282,7 @@ def pagify(
             yield in_text
 
 
-def strikethrough(text: str, formatting: bool = True) -> str:
+def strikethrough(text: str, escape_formatting: bool = True) -> str:
     """Get the given text with a strikethrough.
 
     Note: This escapes text prior to applying a strikethrough
@@ -291,7 +291,7 @@ def strikethrough(text: str, formatting: bool = True) -> str:
     ----------
     text : str
         The text to be marked up.
-    formatting : `bool`, optional
+    escape_formatting : `bool`, optional
         Set to :code:`False` to don't escape any markdown formatting in the text.
 
     Returns
@@ -300,11 +300,11 @@ def strikethrough(text: str, formatting: bool = True) -> str:
         The marked up text.
 
     """
-    text = escape(text, formatting)
+    text = escape(text, escape_formatting)
     return "~~{}~~".format(text)
 
 
-def underline(text: str, formatting: bool = True) -> str:
+def underline(text: str, escape_formatting: bool = True) -> str:
     """Get the given text with an underline.
 
     Note: This escapes text prior to underlining
@@ -313,7 +313,7 @@ def underline(text: str, formatting: bool = True) -> str:
     ----------
     text : str
         The text to be marked up.
-    formatting : `bool`, optional
+    escape_formatting : `bool`, optional
         Set to :code:`False` to don't escape any markdown formatting in the text.
 
     Returns
@@ -322,7 +322,7 @@ def underline(text: str, formatting: bool = True) -> str:
         The marked up text.
 
     """
-    text = escape(text, formatting)
+    text = escape(text, escape_formatting)
     return "__{}__".format(text)
 
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This removes the default markdown formatting to each functions that are using escape() in chat_formatting, which can be useful sometimes we don't want having markdown escaped.