### PR TITLE
Fix ignored channels list in `[p]ignore`

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2544,7 +2544,7 @@ class Core(commands.Cog, CoreLogic):
             if channel.category and channel.category not in category_channels:
                 if await self.bot._ignored_cache.get_ignored_channel(channel.category):
                     category_channels.append(channel.category)
-            if await self.bot._ignored_cache.get_ignored_channel(channel):
+            if await self.bot._ignored_cache.get_ignored_channel(channel, check_category=False):
                 text_channels.append(channel)
 
         cat_str = (

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2544,9 +2544,6 @@ class Core(commands.Cog, CoreLogic):
             if channel.category and channel.category not in category_channels:
                 if await self.bot._ignored_cache.get_ignored_channel(channel.category):
                     category_channels.append(channel.category)
-                continue
-            else:
-                continue
             if await self.bot._ignored_cache.get_ignored_channel(channel):
                 text_channels.append(channel)
 
@@ -2554,7 +2551,7 @@ class Core(commands.Cog, CoreLogic):
             humanize_list([c.name for c in category_channels]) if category_channels else "None"
         )
         chan_str = humanize_list([c.mention for c in text_channels]) if text_channels else "None"
-        msg = _("Currently ignored categories: {categories}\nChannels:{channels}").format(
+        msg = _("Currently ignored categories: {categories}\nChannels: {channels}").format(
             categories=cat_str, channels=chan_str
         )
         return msg

--- a/redbot/core/settings_caches.py
+++ b/redbot/core/settings_caches.py
@@ -59,11 +59,15 @@ class IgnoreManager:
         self._cached_channels: Dict[int, bool] = {}
         self._cached_guilds: Dict[int, bool] = {}
 
-    async def get_ignored_channel(self, channel: discord.TextChannel) -> bool:
+    async def get_ignored_channel(
+        self, channel: discord.TextChannel, check_category: bool = True
+    ) -> bool:
         ret: bool
 
         cid: int = channel.id
-        cat_id: Optional[int] = channel.category.id if channel.category else None
+        cat_id: Optional[int] = (
+            channel.category.id if check_category and channel.category else None
+        )
         if cid in self._cached_channels:
             chan_ret = self._cached_channels[cid]
         else:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Currently ignored channels list is always showing as empty in `[p]ignore`, this fixes it - I decided to only show explicitly ignored channels in ignored channels list so it doesn't include those that are only ignored because of the category they're in. Let me know if that's not how it should be done.

