### PR TITLE
Add `.tog()` and `.inc()` to config value methods

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -286,17 +286,17 @@ class Value:
         """
         if not isinstance(value, (int, float)):
             raise ValueError("The value is not a Integer or Float")
-
-        if not hasattr(self.driver, "inc"):
-            current = await self._get(default=...)
-            if not isinstance(current, (int, float)):
+        async with self.get_lock():
+            if not hasattr(self.driver, "inc"):
+                current = await self._get(default=...)
+                if not isinstance(current, (int, float)):
+                    raise ValueError("The stored value is not a Integer or Float")
+                await self.set(current + value)
+                return current + value
+            try:
+                return await self.driver.inc(self.identifier_data, value=value, default=self.default)
+            except StoredTypeError:
                 raise ValueError("The stored value is not a Integer or Float")
-            await self.set(current + value)
-            return current + value
-        try:
-            return await self.driver.inc(self.identifier_data, value=value, default=self.default)
-        except StoredTypeError:
-            raise ValueError("The stored value is not a Integer or Float")
 
     async def tog(self, value: Optional[bool] = None) -> bool:
         """Toggle the value of the data elements pointed to by `identifiers`.
@@ -325,23 +325,23 @@ class Value:
         """
         if value is not None and not isinstance(value, (bool)):
             raise ValueError("The value is not a Boolean or Null")
-
-        if not hasattr(self.driver, "toggle"):
-            current = await self._get(default=...)
-            if current is not None and not isinstance(current, (bool)):
-                raise ValueError("The stored value is not a boolean")
-            if value is None:
-                new_value = not current
-            else:
-                new_value = value
-            await self.set(new_value)
-            return new_value
-        try:
-            return await self.driver.toggle(
-                self.identifier_data, value=value, default=self.default
-            )
-        except StoredTypeError:
-            raise ValueError("The stored value is not a Integer or Float")
+        async with self.get_lock():
+            if not hasattr(self.driver, "toggle"):
+                current = await self._get(default=...)
+                if current is not None and not isinstance(current, (bool)):
+                    raise ValueError("The stored value is not a boolean")
+                if value is None:
+                    new_value = not current
+                else:
+                    new_value = value
+                await self.set(new_value)
+                return new_value
+            try:
+                return await self.driver.toggle(
+                    self.identifier_data, value=value, default=self.default
+                )
+            except StoredTypeError:
+                raise ValueError("The stored value is not a Integer or Float")
 
 
 class Group(Value):

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -341,7 +341,7 @@ class Value:
                     self.identifier_data, value=value, default=self.default
                 )
             except StoredTypeError:
-                raise ValueError("The stored value is not a Integer or Float")
+                raise ValueError("The stored value is not a boolean")
 
 
 class Group(Value):

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -19,6 +19,7 @@ from typing import (
 import discord
 
 from .drivers import IdentifierData, get_driver, ConfigCategory, BaseDriver
+from .errors import StoredTypeError
 
 __all__ = ["Config", "get_latest_confs", "migrate"]
 
@@ -261,6 +262,86 @@ class Value:
         Clears the value from record for the data element pointed to by `identifiers`.
         """
         await self.driver.clear(self.identifier_data)
+
+    async def inc(self, value: Union[int, float] = 1) -> Union[int, float]:
+        """Increments the value of the data elements pointed to by `identifiers`.
+        .. note::
+
+            This is only an atomic operation on supported drivers
+            On unsupported drivers this will perform a `.get()` followed by a `.set()
+
+        Example
+        -------
+        ::
+            # Increment global value "foo" by 2
+            await conf.foo.inc(2)
+        Parameters
+        ----------
+        value
+            The value to increment by (Defaults to 1).
+        Returns
+        -------
+        Union[int, float]
+            The new stored value.
+        """
+        if not isinstance(value, (int, float)):
+            raise ValueError("The value is not a Integer or Float")
+
+        if not hasattr(self.driver, "inc"):
+            current = await self._get(default=...)
+            if not isinstance(current, (int, float)):
+                raise ValueError("The stored value is not a Integer or Float")
+            await self.set(current + value)
+            return current + value
+        try:
+            return await self.driver.inc(self.identifier_data, value=value, default=self.default)
+        except StoredTypeError:
+            raise ValueError("The stored value is not a Integer or Float")
+
+    async def tog(self, value: Optional[bool] = None) -> bool:
+        """Toggle the value of the data elements pointed to by `identifiers`.
+        .. note::
+
+            This is only an atomic operation on supported drivers
+            On unsupported drivers this will perform a `.get()` followed by a `.set()
+
+        Example
+        -------
+        ::
+            # Toggle global value "foo" to the opposite of the currently set value.
+            await conf.foo.toggle()
+            # Set the global value "foo" True
+            await conf.foo.toggle(True)
+
+        Parameters
+        ----------
+        Optional[bool]
+            The value to set the toggle to.
+            Defaults to None, which reverses the current toggle state.
+        Returns
+        -------
+        bool
+            The new stored value.
+        """
+        if value is not None and not isinstance(value, (bool)):
+            raise ValueError("The value is not a Boolean or Null")
+
+        if not hasattr(self.driver, "toggle"):
+            current = await self._get(default=...)
+            if current is not None and not isinstance(current, (bool)):
+                raise ValueError("The stored value is not a boolean")
+            if value is None:
+                new_value = not current
+            else:
+                new_value = value
+            await self.set(new_value)
+            return new_value
+        try:
+            return await self.driver.toggle(
+                self.identifier_data, value=value, default=self.default
+            )
+        except StoredTypeError:
+            raise ValueError("The stored value is not a Integer or Float")
 
 
 class Group(Value):


### PR DESCRIPTION
Signed-off-by: Drapersniper <27962761+drapersniper@users.noreply.github.com>

### Type

- [ ] Bugfix
- [x] Enhancement
- [x] New feature

### Description of the changes

1. Add `Config.Value.tog()` support for all drivers
```py
await conf.foo.set(False)
# Toggle global value "foo" to the opposite boolean of the currently set value.
new_value = await conf.foo.tog() # Return True
new_value = await conf.foo.tog() # Return False

await conf.foo.set(True)
# Set the global value "foo" True
new_value = await conf.foo.tog(True) # Return True
new_value = await conf.foo.tog(False) # Return False
```

2. Add `Config.Value.inc()` support for all drivers
```py
await conf.foo.set(10)
# Increment global value "foo" by 2
new_value = await conf.foo.inc(2) # Returns 12

await conf.foo.set(10)
# Decreates global value "foo" by 2
new_value = await conf.foo.inc(-2) # Return 8
```
