### PR TITLE
[Driver] Ensure JSON driver has a singular lock per cog name

### DIFF
--- a/redbot/core/drivers/json.py
+++ b/redbot/core/drivers/json.py
@@ -70,7 +70,6 @@ class JsonDriver(BaseDriver):
             self.data_path = data_manager.core_data_path()
         else:
             self.data_path = data_manager.cog_data_path(raw_name=cog_name)
-        self._lock = asyncio.Lock()
         self.data_path.mkdir(parents=True, exist_ok=True)
         self.data_path = self.data_path / self.file_name
         self._load_data()

--- a/redbot/core/drivers/json.py
+++ b/redbot/core/drivers/json.py
@@ -79,7 +79,8 @@ class JsonDriver(BaseDriver):
 
     @_lock.setter
     def _lock(self, value):
-        _locks[self.cog_name] = value
+        if not _locks.get(self.cog_name):
+            _locks[self.cog_name] = value
 
     @property
     def data(self):

--- a/redbot/core/drivers/json.py
+++ b/redbot/core/drivers/json.py
@@ -69,6 +69,7 @@ class JsonDriver(BaseDriver):
             self.data_path = data_manager.core_data_path()
         else:
             self.data_path = data_manager.cog_data_path(raw_name=cog_name)
+        self._lock = asyncio.Lock()
         self.data_path.mkdir(parents=True, exist_ok=True)
         self.data_path = self.data_path / self.file_name
         self._load_data()

--- a/redbot/core/drivers/json.py
+++ b/redbot/core/drivers/json.py
@@ -4,6 +4,7 @@ import logging
 import os
 import pickle
 import weakref
+from collections import defaultdict
 from pathlib import Path
 from typing import Any, AsyncIterator, Dict, Optional, Tuple
 from uuid import uuid4
@@ -17,7 +18,7 @@ __all__ = ["JsonDriver"]
 _shared_datastore = {}
 _driver_counts = {}
 _finalizers = []
-_locks = {}
+_locks = defaultdict(asyncio.Lock)
 
 log = logging.getLogger("redbot.json_driver")
 
@@ -76,12 +77,7 @@ class JsonDriver(BaseDriver):
 
     @property
     def _lock(self):
-        return _locks.get(self.cog_name)
-
-    @_lock.setter
-    def _lock(self, value):
-        if not _locks.get(self.cog_name):
-            _locks[self.cog_name] = value
+        return _locks[self.cog_name]
 
     @property
     def data(self):

--- a/redbot/core/drivers/json.py
+++ b/redbot/core/drivers/json.py
@@ -49,6 +49,7 @@ class JsonDriver(BaseDriver):
 
         The path in which to store the file indicated by :py:attr:`file_name`.
     """
+
     saving_task = None
 
     def __init__(

--- a/redbot/core/drivers/json.py
+++ b/redbot/core/drivers/json.py
@@ -17,6 +17,7 @@ __all__ = ["JsonDriver"]
 _shared_datastore = {}
 _driver_counts = {}
 _finalizers = []
+_locks = {}
 
 log = logging.getLogger("redbot.json_driver")
 
@@ -30,6 +31,8 @@ def finalize_driver(cog_name):
     if _driver_counts[cog_name] == 0:
         if cog_name in _shared_datastore:
             del _shared_datastore[cog_name]
+        if cog_name in _locks:
+            del _locks[cog_name]
 
     for f in _finalizers:
         if not f.alive:
@@ -71,11 +74,18 @@ class JsonDriver(BaseDriver):
         self.data_path.mkdir(parents=True, exist_ok=True)
         self.data_path = self.data_path / self.file_name
         self.data_changed = False
+        self._lock = asyncio.Lock()
         loop = asyncio.get_event_loop()
         self.saving_task = loop.create_task(self._save_task())
-
-        self._lock = asyncio.Lock()
         self._load_data()
+
+    @property
+    def _lock(self):
+        return _locks.get(self.cog_name)
+
+    @_lock.setter
+    def _lock(self, value):
+        _locks[self.cog_name] = value
 
     @property
     def data(self):
@@ -227,8 +237,9 @@ class JsonDriver(BaseDriver):
         try:
             while True:
                 if self.data_changed:
-                    await self._actually_save()
-                    self.data_changed = False
+                    with self._lock:
+                        await self._actually_save()
+                        self.data_changed = False
                 await asyncio.sleep(1)
         except asyncio.CancelledError:
             _save_json(self.data_path, self.data)


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
JSON driver is supposed to have 1 lock per `self.cog_name` howver currently this is not true, if 2 loaded cogs have the same name but different identifier 2 different locks will be used which could end up writting to file in a incorrect order.