### PR TITLE
Fix behavior of `is_owner` for team applications and put all owner IDs in one attribute

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -77,7 +77,6 @@ class RedBase(
         self._shutdown_mode = ExitCodes.CRITICAL
         self._cli_flags = cli_flags
         self._config = Config.get_core_conf(force_registration=False)
-        self._co_owners = cli_flags.co_owner
         self.rpc_enabled = cli_flags.rpc
         self.rpc_port = cli_flags.rpc_port
         self._last_exception = None
@@ -151,8 +150,16 @@ class RedBase(
         if "command_prefix" not in kwargs:
             kwargs["command_prefix"] = prefix_manager
 
-        if cli_flags.owner and "owner_id" not in kwargs:
-            kwargs["owner_id"] = cli_flags.owner
+        if "owner_id" in kwargs:
+            raise RuntimeError("Red doesn't accept owner_id kwarg, use owner_ids instead.")
+
+        self._owner_id_overwrite = cli_flags.owner
+
+        if "owner_ids" in kwargs:
+            kwargs["owner_ids"] = set(kwargs["owner_ids"])
+        else:
+            kwargs["owner_ids"] = set()
+        kwargs["owner_ids"].update(cli_flags.co_owner)
 
         if "command_not_found" not in kwargs:
             kwargs["command_not_found"] = "Command {} not found.\n{}"
@@ -535,8 +542,10 @@ class RedBase(
         init_global_checks(self)
         init_events(self, cli_flags)
 
-        if self.owner_id is None:
-            self.owner_id = await self._config.owner()
+        if self._owner_id_overwrite is None:
+            self._owner_id_overwrite = await self._config.owner()
+        if self._owner_id_overwrite is not None:
+            self.owner_ids.add(self._owner_id_overwrite)
 
         i18n_locale = await self._config.locale()
         i18n.set_locale(i18n_locale)
@@ -703,40 +712,20 @@ class RedBase(
         -------
         bool
         """
-        # user is co-owner, no need to check anything else (oh man, that's so simple!)
-        if user.id in self._co_owners:
+        if user.id in self.owner_ids:
             return True
 
-        # for poor souls who will have to look at this in future...
-        #
-        # Before app owners are fetched:
-        # - `owner_id` can be `None` or it can contain ID set through Config or `--owner` flag
-        # - `owner_ids` is an empty set
-        #
-        # After app owners are fetched:
-        # - `owner_id` can only be `None` if we're dealing with team app,
-        # *however* it might also contain user ID that was set through Config or `--owner` flag
-        # - `owner_ids` will only be filled if it's a team application
-        # and `--team-members-are-owners` flag is used
-        #
-        # Because the owner can be set through Config or `--owner` flag
-        # and it's then put into `owner_id`, unlike d.py, we have to
-        # consider both `owner_id` and `owner_ids` owners
-
         ret = False
-
-        if self.owner_id:
-            ret = self.owner_id == user.id
-        if self.owner_ids:
-            ret = ret or user.id in self.owner_ids
-        elif not self._app_owners_fetched:
+        if not self._app_owners_fetched:
             app = await self.application_info()
             if app.team:
                 if self._use_team_features:
-                    self.owner_ids = ids = {m.id for m in app.team.members}
+                    ids = {m.id for m in app.team.members}
+                    self.owner_ids.update(ids)
                     ret = user.id in ids
-            elif not self.owner_id:
-                self.owner_id = owner_id = app.owner.id
+            elif self._owner_id_overwrite is None:
+                owner_id = app.owner.id
+                self.owner_ids.add(owner_id)
                 ret = user.id == owner_id
             self._app_owners_fetched = True
 
@@ -1179,8 +1168,7 @@ class RedBase(
         await self.wait_until_red_ready()
         destinations = []
         opt_outs = await self._config.owner_opt_out_list()
-        team_ids = () if not self._use_team_features else self.owner_ids
-        for user_id in set((self.owner_id, *self._co_owners, *team_ids)):
+        for user_id in self.owner_ids:
             if user_id not in opt_outs:
                 user = self.get_user(user_id)
                 if user and not user.bot:  # user.bot is possible with flags and teams

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -709,10 +709,10 @@ class RedBase(
         ret = False
 
         if self.owner_id:
-            return self.owner_id == user.id
-        elif self.owner_ids:
-            return user.id in self.owner_ids
-        elif not self._app_owners_fetched:
+            ret = self.owner_id == user.id
+        if self.owner_ids:
+            ret = ret or user.id in self.owner_ids
+        elif not (self._app_owners_fetched and self.owner_id):
             app = await self.application_info()
             if app.team:
                 if self._use_team_features:

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -133,6 +133,10 @@ def init_events(bot, cli_flags):
         if invite_url:
             print("\nInvite URL: {}\n".format(invite_url))
 
+        if not bot.owner_ids:
+            # we could possibly exit here in future
+            log.warning("Bot doesn't have any owner set!")
+
         bot._color = discord.Colour(await bot._config.color())
         bot._red_ready.set()
         if outdated_red_message:

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -57,10 +57,9 @@ def init_events(bot, cli_flags):
 
         if app_info.team:
             if bot._use_team_features:
-                bot.owner_ids = {m.id for m in app_info.team.members}
-        else:
-            if bot.owner_id is None:
-                bot.owner_id = app_info.owner.id
+                bot.owner_ids.update(m.id for m in app_info.team.members)
+        elif bot._owner_id_overwrite is None:
+            bot.owner_ids.add(app_info.owner.id)
         bot._app_owners_fetched = True
 
         try:

--- a/redbot/pytest/core.py
+++ b/redbot/pytest/core.py
@@ -171,7 +171,7 @@ def red(config_fr):
 
     Config.get_core_conf = lambda *args, **kwargs: config_fr
 
-    red = Red(cli_flags=cli_flags, description=description, dm_help=None, owner_id=None)
+    red = Red(cli_flags=cli_flags, description=description, dm_help=None, owner_ids=set())
 
     yield red
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
All owner IDs (application owners, co-owners, owner passed by `--owner` flag or set through Config) are now put into one set under `bot.owner_ids` attribute.

Behaviour of bot owners in Red after this PR should be as follows:
a) If bot's application belongs to a team, owners are:
>    1. everyone passed to `--co-owner` flag
>    2. user passed to `--owner` flag or if it's not passed, user that was set through Config (i.e. `redbot --edit` or the no longer existing `[p]set owner`) or **if neither exist**, this part is skipped
>    3. **IF** `--team-members-are-owners` flag is passed, members of application's team are also the owners

b) If bot's application belongs to a user, owners are:
>    1. everyone passed to `--co-owner` flag
>    2. user passed to `--owner` flag or if it's not passed, user that was set through Config (i.e. `redbot --edit` or the no longer existing `[p]set owner`) or **if neither exist**, owner of bot's application is used

Before this PR, `--team-members-are-owners` flag didn't work if `--owner` flag was passed or if there was a user set in Config already.


Two things that I'm not sure about:
1. Should owner saved in Config (not talking about the one explicitly set through `--owner` flag as that one should definitely be included) be included when `--team-members-are-owners` flag is used? Currently it is, but I should be able to easily change it.
**(Mr. Reviewer, I want a response for ↑ one)**
2. Is there any good reason why co-owners were never exposed in public attribute before? IMO, they should be, but maybe I'm missing something.

// I also added a warning if bot is started with no owner set, we might try to exit from there in future but for now I'm leaving this as just a warning.