### PR TITLE
Make the checks in `[p]alias global add` and `[p]alias add` consistent

### DIFF
--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -134,7 +134,7 @@ class Alias(commands.Cog):
                 _(
                     "You attempted to create a new alias"
                     " with the name {name} but that"
-                    " alias already exists on this server."
+                    " alias already exists."
                 ).format(name=alias_name)
             )
             return
@@ -187,13 +187,13 @@ class Alias(commands.Cog):
             )
             return
 
-        alias = await self._aliases.get_alias(ctx.guild, alias_name)
+        alias = await self._aliases.get_alias(None, alias_name)
         if alias:
             await ctx.send(
                 _(
                     "You attempted to create a new global alias"
                     " with the name {name} but that"
-                    " alias already exists on this server."
+                    " alias already exists."
                 ).format(name=alias_name)
             )
             return
@@ -207,6 +207,13 @@ class Alias(commands.Cog):
                     " name is an invalid alias name. Alias"
                     " names may not contain spaces."
                 ).format(name=alias_name)
+            )
+            return
+
+        given_command_exists = self.bot.get_command(command.split(maxsplit=1)[0]) is not None
+        if not given_command_exists:
+            await ctx.send(
+                _("You attempted to create a new alias for a command that doesn't exist.")
             )
             return
         # endregion


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
- Added missing check for command existence in `[p]alias global add`
- Changed `[p]alias global add` to only check global aliases to know if alias already exists (global alias takes precedence so already existing guild alias shouldn't stop the owner from adding global alias, especially that they can do so from any other guild that doesn't have such guild alias)
- Removed "on this server" from both strings as the already existing alias doesn't necessarily have to be a guild alias