### PR TITLE
Red 3.3.8 - Changelog (Bonus changelog for 3.3.7 included)

### DIFF
--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.8 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`Bakersbakebread`, :ghuser:`DariusStClair`, :ghuser:`Flame442`, :ghuser:`jack1142`, :ghuser:`mikeshardmind`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`Predeactor`, :ghuser:`qaisjp`, :ghuser:`Tobotimus`
+| :ghuser:`aikaterna`, :ghuser:`Bakersbakebread`, :ghuser:`DariusStClair`, :ghuser:`Drapersniper`, :ghuser:`Flame442`, :ghuser:`jack1142`, :ghuser:`mikeshardmind`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`Predeactor`, :ghuser:`qaisjp`, :ghuser:`Tobotimus`
 
 End-user changelog
 ------------------
@@ -24,6 +24,26 @@ Alias
 *****
 
 - Added pagination to ``[p]alias list`` and ``[p]alias global list`` to avoid errors for users with a lot of aliases (:issue:`3844`, :issue:`3834`)
+
+Audio
+*****
+
+- Added new option (settable with ``[p]audioset lyrics``) that makes Audio cog prefer (prioritize) tracks with lyrics (:issue:`3519`)
+- Added global daily (historical) queues (:issue:`3518`)
+- Added ``[p]audioset countrycode`` that allows to set the country code for spotify searches (:issue:`3528`)
+- Fixed ``[p]local search`` (:issue:`3528`, :issue:`3501`)
+- Local folders with special characters should work properly now (:issue:`3528`, :issue:`3467`)
+- Audio no longer fails to take the last spot in the voice channel with user limit (:issue:`3528`)
+- ``[p]local play`` no longer enqueues tracks from nested folders (:issue:`3528`)
+- Fixed ``[p]playlist dedupe`` not removing tracks (:issue:`3518`)
+- ``[p]disconnect`` now allows to disconnect if both DJ mode and voteskip aren't enabled (:issue:`3502`, :issue:`3485`)
+- Many UX improvements and fixes, including, among other things:
+
+  - Creating playlists without explicitly passing ``-scope`` no longer causes errors (:issue:`3500`)
+  - ``[p]playlist list`` now shows all accessible playlists if ``--scope`` flag isn't used (:issue:`3518`)
+  - ``[p]remove`` now also accepts a track URL in addition to queue index (:issue:`3201`)
+  - ``[p]playlist upload`` now accepts a playlist file uploaded in the message with a command (:issue:`3251`)
+  - Commands now send friendly error messages for common errors like lost Lavalink connection or bot not connected to voice channel (:issue:`3503`, :issue:`3528`, :issue:`3353`, :issue:`3712`)
 
 CustomCommands
 **************

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -1,5 +1,31 @@
 .. 3.3.x Changelogs
 
+Redbot 3.3.8 or 3.4.0 (Unreleased)
+==================================
+
+| Thanks to all these amazing people that contributed to this release:
+| 
+
+End-user changelog
+------------------
+
+
+
+Developer changelog
+-------------------
+
+
+
+Documentation changes
+---------------------
+
+
+
+Miscellaneous
+-------------
+
+
+
 Redbot 3.3.7 (2020-04-28)
 =========================
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -26,6 +26,7 @@ Alias
 *****
 
 - Added pagination to ``[p]alias list`` and ``[p]alias global list`` to avoid errors for users with a lot of aliases (:issue:`3844`, :issue:`3834`)
+- ``[p]alias help`` should now work more reliably (:issue:`3864`)
 
 Audio
 *****

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.8 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`DariusStClair`, :ghuser:`Flame442`, :ghuser:`jack1142`, :ghuser:`mikeshardmind`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`Predeactor`, :ghuser:`qaisjp`, :ghuser:`Tobotimus`
+| :ghuser:`Bakersbakebread`, :ghuser:`DariusStClair`, :ghuser:`Flame442`, :ghuser:`jack1142`, :ghuser:`mikeshardmind`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`Predeactor`, :ghuser:`qaisjp`, :ghuser:`Tobotimus`
 
 End-user changelog
 ------------------
@@ -38,6 +38,11 @@ Permissions
 ***********
 
 - Commands for settings ACL using yaml files now properly works on PostgreSQL data backend (:issue:`3829`, :issue:`3796`)
+
+Warnings
+********
+
+- Warnings cog no longer allows to warn bot users (:issue:`3855`, :issue:`3854`)
 
 
 Developer changelog

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -29,6 +29,8 @@ Alias
 Audio
 *****
 
+- Twitch playback is functional once again (:issue:`3873`)
+- Recent errors with YouTube playback should be resolved (:issue:`3873`)
 - Added new option (settable with ``[p]audioset lyrics``) that makes Audio cog prefer (prioritize) tracks with lyrics (:issue:`3519`)
 - Added global daily (historical) queues (:issue:`3518`)
 - Added ``[p]audioset countrycode`` that allows to set the country code for spotify searches (:issue:`3528`)

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -13,6 +13,7 @@ Core Bot
 ********
 
 - Important fixes to how PostgreSQL data backend saves data in bulks (:issue:`3829`)
+- Fixed ``[p]localwhitelist`` and ``[p]localblacklist`` commands (:issue:`3857`)
 
 Admin
 *****

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.8 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`Flame442`, :ghuser:`jack1142`, :ghuser:`mikeshardmind`, :ghuser:`qaisjp`
+| :ghuser:`Flame442`, :ghuser:`jack1142`, :ghuser:`mikeshardmind`, :ghuser:`NeuroAssassin`, :ghuser:`qaisjp`
 
 End-user changelog
 ------------------
@@ -13,6 +13,11 @@ Admin
 *****
 
 - Fixed server lock (:issue:`3815`, :issue:`3814`)
+
+CustomCommands
+**************
+
+- ``[p]customcom create`` no longer allows spaces in custom command names (:issue:`3816`)
 
 
 Developer changelog

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -1,5 +1,11 @@
 .. 3.3.x Changelogs
 
+Redbot 3.3.7 (2020-04-28)
+=========================
+
+This is a hotfix release fixing issue with generating messages for new cases in Modlog.
+
+
 Redbot 3.3.6 (2020-04-27)
 =========================
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.8 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`aikaterna`, :ghuser:`Bakersbakebread`, :ghuser:`DariusStClair`, :ghuser:`Drapersniper`, :ghuser:`Flame442`, :ghuser:`jack1142`, :ghuser:`mikeshardmind`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`Predeactor`, :ghuser:`qaisjp`, :ghuser:`Tobotimus`
+| :ghuser:`aikaterna`, :ghuser:`Bakersbakebread`, :ghuser:`DariusStClair`, :ghuser:`Dav-Git`, :ghuser:`Drapersniper`, :ghuser:`Flame442`, :ghuser:`jack1142`, :ghuser:`mikeshardmind`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`Predeactor`, :ghuser:`qaisjp`, :ghuser:`Tobotimus`
 
 End-user changelog
 ------------------
@@ -91,7 +91,7 @@ Documentation changes
 
 - Added information about provisional status of RPC (:issue:`3862`)
 - Revised install instructions (:issue:`3847`)
-- Improved navigation in `document about updating Red <update_red>` (:issue:`3856`)
+- Improved navigation in `document about updating Red <update_red>` (:issue:`3856`, :issue:`3849`)
 
 
 Miscellaneous

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -88,6 +88,7 @@ Documentation changes
 
 - Added information about provisional status of RPC (:issue:`3862`)
 - Revised install instructions (:issue:`3847`)
+- Improved navigation in `document about updating Red <update_red>` (:issue:`3856`)
 
 
 Miscellaneous

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -15,6 +15,7 @@ Core Bot
 - Important fixes to how PostgreSQL data backend saves data in bulks (:issue:`3829`)
 - Fixed ``[p]localwhitelist`` and ``[p]localblacklist`` commands (:issue:`3857`)
 - Red now includes information on how to update when sending information about being out of date (:issue:`3744`)
+- Using backslashes in bot's username/nickname no longer causes issues (:issue:`3826`, :issue:`3825`)
 
 Admin
 *****

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -60,6 +60,11 @@ Mod
 
 - ``[p]userinfo`` now shows default avatar when no avatar is set (:issue:`3819`)
 
+Modlog
+******
+
+- Fixed (again) ``AttributeError`` for cases whose moderator doesn't share the server with the bot (:issue:`3805`, :issue:`3784`, :issue:`3778`)
+
 Permissions
 ***********
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -95,6 +95,7 @@ Miscellaneous
 -------------
 
 - Few clarifications and typo fixes in few command help docstrings (:issue:`3817`, :issue:`3823`, :issue:`3837`, :issue:`3851`, :issue:`3861`)
+- **Downloader** - Downloader no longer removes the repo when it fails to load it (:issue:`3867`)
 
 
 Redbot 3.3.7 (2020-04-28)

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.8 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`Flame442`, :ghuser:`jack1142`, :ghuser:`mikeshardmind`, :ghuser:`NeuroAssassin`, :ghuser:`qaisjp`
+| :ghuser:`Flame442`, :ghuser:`jack1142`, :ghuser:`mikeshardmind`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`qaisjp`
 
 End-user changelog
 ------------------
@@ -18,6 +18,11 @@ CustomCommands
 **************
 
 - ``[p]customcom create`` no longer allows spaces in custom command names (:issue:`3816`)
+
+Mod
+***
+
+- ``[p]userinfo`` now shows default avatar when no avatar is set (:issue:`3819`)
 
 
 Developer changelog

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -81,6 +81,7 @@ Core Bot
 ********
 
 - Red now inherits from `discord.ext.commands.AutoShardedBot` for better compatibility with code expecting d.py bot (:issue:`3822`)
+- Libraries using ``pkg_resources`` (like ``humanize`` or ``google-api-python-client``) that were installed through Downloader should now work properly (:issue:`3843`)
 
 
 Documentation changes

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.8 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`jack1142`, :ghuser:`mikeshardmind`
+| :ghuser:`Flame442`, :ghuser:`jack1142`, :ghuser:`mikeshardmind`, :ghuser:`qaisjp`
 
 End-user changelog
 ------------------
@@ -32,6 +32,7 @@ Documentation changes
 Miscellaneous
 -------------
 
+- Few clarifications and typo fixes in few command help docstrings (:issue:`3817`, :issue:`3823`, :issue:`3837`)
 
 
 Redbot 3.3.7 (2020-04-28)

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -69,6 +69,11 @@ Warnings
 Developer changelog
 -------------------
 
+| **Important:**
+| If you're using RPC, please see the full annoucement about current state of RPC in main Red server
+  `by clicking here <https://discord.com/channels/133049272517001216/411381123101491200/714560168465137694>`_.
+
+
 Core Bot
 ********
 
@@ -78,6 +83,7 @@ Core Bot
 Documentation changes
 ---------------------
 
+- Added information about provisional status of RPC (:issue:`3862`)
 
 
 Miscellaneous

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -1,6 +1,6 @@
 .. 3.3.x Changelogs
 
-Redbot 3.3.8 or 3.4.0 (Unreleased)
+Redbot 3.3.8 (2020-05-29)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.8 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`Flame442`, :ghuser:`jack1142`, :ghuser:`mikeshardmind`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`qaisjp`, :ghuser:`Tobotimus`
+| :ghuser:`DariusStClair`, :ghuser:`Flame442`, :ghuser:`jack1142`, :ghuser:`mikeshardmind`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`qaisjp`, :ghuser:`Tobotimus`
 
 End-user changelog
 ------------------
@@ -18,6 +18,11 @@ Admin
 *****
 
 - Fixed server lock (:issue:`3815`, :issue:`3814`)
+
+Alias
+*****
+
+- Added pagination to ``[p]alias list`` and ``[p]alias global list`` to avoid errors for users with a lot of aliases (:issue:`3844`, :issue:`3834`)
 
 CustomCommands
 **************

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.8 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`DariusStClair`, :ghuser:`Flame442`, :ghuser:`jack1142`, :ghuser:`mikeshardmind`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`qaisjp`, :ghuser:`Tobotimus`
+| :ghuser:`DariusStClair`, :ghuser:`Flame442`, :ghuser:`jack1142`, :ghuser:`mikeshardmind`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`Predeactor`, :ghuser:`qaisjp`, :ghuser:`Tobotimus`
 
 End-user changelog
 ------------------
@@ -57,7 +57,7 @@ Documentation changes
 Miscellaneous
 -------------
 
-- Few clarifications and typo fixes in few command help docstrings (:issue:`3817`, :issue:`3823`, :issue:`3837`)
+- Few clarifications and typo fixes in few command help docstrings (:issue:`3817`, :issue:`3823`, :issue:`3837`, :issue:`3851`)
 
 
 Redbot 3.3.7 (2020-04-28)

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -87,6 +87,7 @@ Documentation changes
 ---------------------
 
 - Added information about provisional status of RPC (:issue:`3862`)
+- Revised install instructions (:issue:`3847`)
 
 
 Miscellaneous

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,11 +4,15 @@ Redbot 3.3.8 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| 
+| :ghuser:`jack1142`
 
 End-user changelog
 ------------------
 
+Admin
+*****
+
+- Fixed server lock (:issue:`3815`, :issue:`3814`)
 
 
 Developer changelog

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -84,6 +84,9 @@ Core Bot
 
 - Red now inherits from `discord.ext.commands.AutoShardedBot` for better compatibility with code expecting d.py bot (:issue:`3822`)
 - Libraries using ``pkg_resources`` (like ``humanize`` or ``google-api-python-client``) that were installed through Downloader should now work properly (:issue:`3843`)
+- All bot owner IDs can now be found under ``bot.owner_ids`` attribute (:issue:`3793`)
+
+  -  Note: If you want to use this on bot startup (e.g. in cog's initialisation), you need to await ``bot.wait_until_red_ready()`` first
 
 
 Documentation changes

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,10 +4,15 @@ Redbot 3.3.8 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`Flame442`, :ghuser:`jack1142`, :ghuser:`mikeshardmind`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`qaisjp`
+| :ghuser:`Flame442`, :ghuser:`jack1142`, :ghuser:`mikeshardmind`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`qaisjp`, :ghuser:`Tobotimus`
 
 End-user changelog
 ------------------
+
+Core Bot
+********
+
+- Important fixes to how PostgreSQL data backend saves data in bulks (:issue:`3829`)
 
 Admin
 *****
@@ -23,6 +28,11 @@ Mod
 ***
 
 - ``[p]userinfo`` now shows default avatar when no avatar is set (:issue:`3819`)
+
+Permissions
+***********
+
+- Commands for settings ACL using yaml files now properly works on PostgreSQL data backend (:issue:`3829`, :issue:`3796`)
 
 
 Developer changelog

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -83,7 +83,7 @@ Documentation changes
 Miscellaneous
 -------------
 
-- Few clarifications and typo fixes in few command help docstrings (:issue:`3817`, :issue:`3823`, :issue:`3837`, :issue:`3851`)
+- Few clarifications and typo fixes in few command help docstrings (:issue:`3817`, :issue:`3823`, :issue:`3837`, :issue:`3851`, :issue:`3861`)
 
 
 Redbot 3.3.7 (2020-04-28)

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.8 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`jack1142`
+| :ghuser:`jack1142`, :ghuser:`mikeshardmind`
 
 End-user changelog
 ------------------
@@ -18,6 +18,10 @@ Admin
 Developer changelog
 -------------------
 
+Core Bot
+********
+
+- Red now inherits from `discord.ext.commands.AutoShardedBot` for better compatibility with code expecting d.py bot (:issue:`3822`)
 
 
 Documentation changes

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -14,6 +14,7 @@ Core Bot
 
 - Important fixes to how PostgreSQL data backend saves data in bulks (:issue:`3829`)
 - Fixed ``[p]localwhitelist`` and ``[p]localblacklist`` commands (:issue:`3857`)
+- Red now includes information on how to update when sending information about being out of date (:issue:`3744`)
 
 Admin
 *****


### PR DESCRIPTION
Draft PR for Red 3.3.8 or 3.4.0 changelog + one-liner for Red 3.3.7.

This is getting updated as new PRs from the milestone get merged.

Rendered changelog can be seen here: https://red-discordbot--3800.org.readthedocs.build/en/3800/changelog_3_3_0.html#redbot-3-3-8-2020-05-29