### PR TITLE
(again) Handle the ints for user objects in Modlog appropriately

### DIFF
--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -311,7 +311,7 @@ class Case:
             until = end_fmt
             duration = dur_fmt
 
-        if self.amended_by:
+        if self.amended_by is None:
             amended_by = None
         elif isinstance(self.amended_by, int):
             amended_by = f"[Unknown or Deleted User] ({self.amended_by})"

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -309,7 +309,9 @@ class Case:
         if self.moderator is None:
             moderator = _("Unknown")
         elif isinstance(self.moderator, int):
-            moderator = f"[Unknown or Deleted User] ({self.moderator})"
+            # can't use _() inside f-string expressions, see bpo-36310 and red#3818
+            translated = _("Unknown or Deleted User")
+            moderator = f"[{translated}] ({self.moderator})"
         else:
             moderator = escape_spoilers(f"{self.moderator} ({self.moderator.id})")
         until = None
@@ -326,7 +328,9 @@ class Case:
         if self.amended_by is None:
             amended_by = None
         elif isinstance(self.amended_by, int):
-            amended_by = f"[Unknown or Deleted User] ({self.amended_by})"
+            # can't use _() inside f-string expressions, see bpo-36310 and red#3818
+            translated = _("Unknown or Deleted User")
+            amended_by = f"[{translated}] ({self.amended_by})"
         else:
             amended_by = escape_spoilers(f"{self.amended_by} ({self.amended_by.id})")
 
@@ -338,7 +342,9 @@ class Case:
 
         if isinstance(self.user, int):
             if self.last_known_username is None:
-                user = f"[Unknown or Deleted User] ({self.user})"
+                # can't use _() inside f-string expressions, see bpo-36310 and red#3818
+                translated = _("Unknown or Deleted User")
+                user = f"[{translated}] ({self.user})"
             else:
                 user = f"{self.last_known_username} ({self.user})"
             avatar_url = None

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -266,6 +266,11 @@ class Case:
                 await self.message.edit(embed=case_content)
             else:
                 await self.message.edit(content=case_content)
+        except discord.Forbidden:
+            log.info(
+                "Modlog failed to edit the Discord message for"
+                " the case #%s from guild with ID due to missing permissions."
+            )
         except Exception:  # `finally` with `return` suppresses unexpected exceptions
             log.exception(
                 "Modlog failed to edit the Discord message for"
@@ -825,6 +830,11 @@ async def create_case(
         await case.edit({"message": msg})
     except RuntimeError:  # modlog channel isn't set
         pass
+    except discord.Forbidden:
+        log.info(
+            "Modlog failed to edit the Discord message for"
+            " the case #%s from guild with ID due to missing permissions."
+        )
     except Exception:  # `finally` with `return` suppresses unexpected exceptions
         log.exception(
             "Modlog failed to send the Discord message for"

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -266,6 +266,13 @@ class Case:
                 await self.message.edit(embed=case_content)
             else:
                 await self.message.edit(content=case_content)
+        except Exception:  # `finally` with `return` suppresses unexpected exceptions
+            log.exception(
+                "Modlog failed to edit the Discord message for"
+                " the case #%s from guild with ID %s due to unexpected error.",
+                self.case_number,
+                self.guild.id,
+            )
         finally:
             return None
 
@@ -816,8 +823,15 @@ async def create_case(
         else:
             msg = await mod_channel.send(case_content)
         await case.edit({"message": msg})
-    except (RuntimeError, discord.HTTPException):
+    except RuntimeError:  # modlog channel isn't set
         pass
+    except Exception:  # `finally` with `return` suppresses unexpected exceptions
+        log.exception(
+            "Modlog failed to send the Discord message for"
+            " the case #%s from guild with ID %s due to unexpected error.",
+            case.case_number,
+            case.guild.id,
+        )
     finally:
         return case
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This should fix #3778 and not cause a regression this time...
The problem with original PR has been fixed with [this commit](https://github.com/Cog-Creators/Red-DiscordBot/pull/3805/commits/702f7f4881945e95ca0695f912f67994b4819ce4).

I also added logging for unexpected exceptions that were suppressed by `finally` with `return` before to avoid missing such errors in future.