### PR TITLE
Show default avatars in `[p]userinfo` when no avatar is set

### DIFF
--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -266,14 +266,9 @@ class ModInfo(MixinMeta):
         name = " ~ ".join((name, user.nick)) if user.nick else name
         name = filter_invites(name)
 
-        if user.avatar:
-            avatar = user.avatar_url_as(static_format="png")
-            data.set_author(
-                name="{statusemoji} {name}".format(statusemoji=statusemoji, name=name), url=avatar
-            )
-            data.set_thumbnail(url=avatar)
-        else:
-            data.set_author(name="{statusemoji} {name}".format(statusemoji=statusemoji, name=name))
+        avatar = user.avatar_url_as(static_format="png")
+        data.set_author(name=f"{statusemoji} {name}", url=avatar)
+        data.set_thumbnail(url=avatar)
 
         await ctx.send(embed=data)
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Since default avatars are exposed on d.py, we now can use them on `[p]userinfo`.