### PR TITLE
[A Config Alternative]

### DIFF
--- a/redbot/core/rapid_storage.py
+++ b/redbot/core/rapid_storage.py
@@ -1,0 +1,55 @@
+from rapid_dev_storage import SQLiteBackend, Storage, StoredValue, StorageGroup, NoValue
+import discord
+
+from .data_manager import cog_data_path
+
+__all__ = ["RapidStorage", "StorageGroup", "StoredValue", "NoValue"]
+
+
+class RapidStorage(Storage):
+
+    @classmethod
+    async def get_cog_storage(cls, cog_name: str, unique_identifier: int):
+
+        path = cog_data_path(raw_name=cog_name) / "rapid_storage.db"
+        backend = await SQLiteBackend.create_backend_instance(path, cog_name, unique_identifier)
+        return cls(backend)
+
+    @property
+    def botwide(self) -> StorageGroup:
+        return self.get_group("RED_BOTWIDE")
+
+    @property
+    def guild_group(self) -> StorageGroup:
+        return self.get_group("RED_GUILD")
+
+    @property
+    def user_group(self) -> StorageGroup:
+        return self.get_group("RED_USER")
+
+    @property
+    def member_group(self) -> StorageGroup:
+        return self.get_group("RED_MEMBER")
+
+    @property
+    def role_group(self) -> StorageGroup:
+        return self.get_group("RED_ROLE")
+
+    @property
+    def channel_group(self) -> StorageGroup:
+        return self.get_group("RED_ANY_CHANNEL")
+
+    def member(self, member: discord.Member) -> StoredValue:
+        return self.get_group("RED_MEMBER")[f"{member.guild.id}", f"{member.id}"]
+
+    def user(self, user: discord.User) -> StoredValue:
+        return self.get_group("RED_USER")[f"{user.id}"]
+
+    def channel(self, channel) -> StoredValue:
+        return self.get_group("RED_ANY_CHANNEL")[f"{channel.id}"]
+
+    def guild(self, guild: discord.Guild) -> StoredValue:
+        return self.get_group("RED_GUILD")[f"{guild.id}"]
+
+    def role(self, role: discord.Role) -> StoredValue:
+        return self.get_group("RED_ROLE")[f"{role.id}"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ install_requires =
     python-Levenshtein-wheels==0.13.1
     pytz==2019.3
     PyYAML==5.3.1
+    rapid-dev-storage==1.0.0
     Red-Lavalink==0.5.0
     schema==0.7.1
     tqdm==4.45.0


### PR DESCRIPTION
 ### Type

- [ ] Bugfix
- [ ] Enhancement
- [X] New feature

### Description of the changes

- This provides the bare necessities of storing data in Red. It
  doesn't do anything fancy.
- it utilizes an extremely small standalone library I've personally
  written as a means of storing non-relational
  data quickly.
- This is directly related to ideas originally expressed in #3112
- This is a draft form of the technical side of things, I won't put in
  the time on documenting this if the ideas are no longer wanted. If the
  slimmer alternative is still wanted, I'll get to documenting, but I
  wanted to be able to show the direction I was willing to provide
  before putting in more on this to ensure it was still something people
  more active in the project were still interested in

### Limitations and considerations

1. The provided wrapper here in red isn't technically necessary, and cog devs could easily use the library without its inclusion in Red. However, there is a lot of code which would be repeated due to how red handles cog imports, and that shared libs have been deprecated.

2. This allows for less arbitrary identifiers. I consider this a necessary concession to get the most out of it while still not requiring cog devs be committing to a full DB schema

3. Nested access isn't handled for cog devs. What they put in is what they get back. This makes it less magical, but it improves performance significantly.

4. Stored values must be msgpack serializable with this wrapper. This actually allows storing things config can't store, such as dicts utilizing tuple keys. (This can be changed, the serialization can be swapped out)

5. There are no docs yet. I'll be fixing this on the library side first, then if this is still something which this project is interested in, I'll update this PR with additional documentation.

6. This isn't a replacement for config. It's another tool with different considerations. It's slimmer, should perform faster for most use cases, but it also does less for the user automatically.
