### PR TITLE
Stop showing instance names in `redbot-setup` help's syntax

### DIFF
--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -313,7 +313,7 @@ def cli(ctx, debug):
 
 
 @cli.command()
-@click.argument("instance", type=click.Choice(instance_list))
+@click.argument("instance", type=click.Choice(instance_list), metavar="<INSTANCE_NAME>")
 @click.option(
     "--no-prompt",
     "interactive",
@@ -378,7 +378,7 @@ def delete(
 
 
 @cli.command()
-@click.argument("instance", type=click.Choice(instance_list))
+@click.argument("instance", type=click.Choice(instance_list), metavar="<INSTANCE_NAME>")
 @click.argument("backend", type=click.Choice(["json", "postgres"]))
 def convert(instance, backend):
     """Convert data backend of an instance."""
@@ -406,7 +406,7 @@ def convert(instance, backend):
 
 
 @cli.command()
-@click.argument("instance", type=click.Choice(instance_list))
+@click.argument("instance", type=click.Choice(instance_list), metavar="<INSTANCE_NAME>")
 @click.argument(
     "destination_folder",
     type=click.Path(


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
If you provide wrong name, it will still list you all available ones.