### PR TITLE
Fix no message when unregistered reason is used in `[p]warn`

### DIFF
--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -1,5 +1,6 @@
 import contextlib
 from collections import namedtuple
+from copy import copy
 from typing import Union, Optional
 
 import discord

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -350,22 +350,27 @@ class Warnings(commands.Cog):
 
         reason_type = None
         async with self.config.guild(ctx.guild).reasons() as registered_reasons:
-            if reason.lower() not in registered_reasons:
+            if (reason_type := registered_reasons.get(reason.lower())) is None:
                 msg = _("That is not a registered reason!")
                 if custom_allowed:
                     reason_type = {"description": reason, "points": points}
-                elif (
-                    ctx.guild.owner == ctx.author
-                    or ctx.channel.permissions_for(ctx.author).administrator
-                    or await ctx.bot.is_owner(ctx.author)
-                ):
-                    msg += " " + _(
-                        "Do `{prefix}warningset allowcustomreasons true` to enable custom "
-                        "reasons."
-                    ).format(prefix=ctx.clean_prefix)
+                else:
+                    # logic taken from `[p]permissions canrun`
+                    fake_message = copy(ctx.message)
+                    fake_message.content = f"{ctx.prefix}warningset allowcustomreasons"
+                    fake_context = await ctx.bot.get_context(fake_message)
+                    try:
+                        can = await self.allowcustomreasons.can_run(
+                            fake_context, check_all_parents=True, change_permission_state=False
+                        )
+                    except commands.CommandError:
+                        can = False
+                    if can:
+                        msg += " " + _(
+                            "Do `{prefix}warningset allowcustomreasons true` to enable custom "
+                            "reasons."
+                        ).format(prefix=ctx.clean_prefix)
                     return await ctx.send(msg)
-            else:
-                reason_type = registered_reasons[reason.lower()]
         if reason_type is None:
             return
         member_settings = self.config.member(user)


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #3839

This PR also improves the way we check whether command caller can run `[p]warningset allowcustomreasons`