### PR TITLE
Add lib folder to `pkg_resources`'s working set

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import pip
+import pkg_resources
 import platform
 import shutil
 import signal
@@ -346,6 +347,14 @@ async def run_bot(red: Red, cli_flags: Namespace) -> None:
     LIB_PATH.mkdir(parents=True, exist_ok=True)
     if str(LIB_PATH) not in sys.path:
         sys.path.append(str(LIB_PATH))
+
+        # "It's important to note that the global `working_set` object is initialized from
+        # `sys.path` when `pkg_resources` is first imported, but is only updated if you do
+        # all future `sys.path` manipulation via `pkg_resources` APIs. If you manually modify
+        # `sys.path`, you must invoke the appropriate methods on the `working_set` instance
+        # to keep it in sync."
+        # Source: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#workingset-objects
+        pkg_resources.working_set.add_entry(str(LIB_PATH))
     sys.meta_path.insert(0, SharedLibImportWarner())
 
     if cli_flags.token:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
`pkg_resources` doesn't do anything about other things modifying `sys.path` so we have to add lib folder to working set's entries ourselves: 

> It’s important to note that the global `working_set` object is initialized from `sys.path` when `pkg_resources` is first imported, but is only updated if you do all future `sys.path` manipulation via `pkg_resources` APIs. If you manually modify `sys.path`, you must invoke the appropriate methods on the `working_set` instance to keep it in sync. Unfortunately, Python does not provide any way to detect arbitrary changes to a list object like `sys.path`, so `pkg_resources` cannot automatically update the `working_set` based on changes to `sys.path`.

Source: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#workingset-objects

For anyone wanting to test it, `google-api-python-client` and `humanize` are two packages that won't work without this if installed through `[p]pipinstall` but there's definitely more out there.