### PR TITLE
Revise install instructions (+ install Java 11 everywhere, and update pyenv to use Python 3.8.3)

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -270,7 +270,7 @@ If you want to do it, follow these steps.
 2. **Install Linux**
 
   Most of the VPS providers have tools for installing Linux automatically. If
-  you're a beginner, we recommend **Ubuntu 18**.
+  you're a beginner, we recommend **Ubuntu 20.04 LTS**.
 
   For Raspberry Pi users, just install `Raspbian
   <https://www.raspberrypi.org/downloads/raspbian/>`_ on a micro-SD card.

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -56,6 +56,12 @@ Continue by `creating-venv-linux`.
 CentOS and RHEL 7
 ~~~~~~~~~~~~~~~~~
 
+.. code-block:: none
+
+    yum -y groupinstall development
+    sudo yum -y install zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel \
+      openssl-devel xz xz-devel libffi-devel findutils java-11-openjdk-headless
+
 We recommend adding the IUS repository to install Git 2.11 or greater:
 
 .. code-block:: none
@@ -63,12 +69,6 @@ We recommend adding the IUS repository to install Git 2.11 or greater:
     yum -y install https://repo.ius.io/ius-release-el7.rpm
     yum install -y yum-plugin-replace
     yum replace -y git --replace-with git2u
-
-.. code-block:: none
-
-    yum -y groupinstall development
-    sudo yum -y install zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel \
-      openssl-devel xz xz-devel libffi-devel findutils java-11-openjdk-headless
 
 Complete the rest of the installation by `installing Python 3.8 with pyenv <install-python-pyenv>`.
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -204,9 +204,10 @@ First, add the Opt-Python community repository:
 .. code-block:: none
 
     source /etc/os-release
-    sudo zypper -n --gpg-auto-import-keys ar -f \
+    sudo zypper -n ar -f \
       https://download.opensuse.org/repositories/home:/Rotkraut:/Opt-Python/openSUSE_Leap_${VERSION_ID}/ \
       Opt-Python
+    sudo zypper -n --gpg-auto-import-keys ref
 
 Now install the pre-requirements with zypper:
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -71,8 +71,7 @@ In order to install Git 2.11 or greater, we recommend adding the IUS repository:
 .. code-block:: none
 
     sudo yum -y install https://repo.ius.io/ius-release-el7.rpm
-    sudo yum -y install yum-plugin-replace
-    sudo yum -y replace git --replace-with git224
+    sudo yum -y swap git git224
 
 Complete the rest of the installation by `installing Python 3.8 with pyenv <install-python-pyenv>`.
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -58,7 +58,7 @@ CentOS and RHEL 7
 
 .. code-block:: none
 
-    yum -y groupinstall development
+    sudo yum -y groupinstall development
     sudo yum -y install zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel \
       openssl-devel xz xz-devel libffi-devel findutils java-11-openjdk-headless
 
@@ -66,9 +66,9 @@ In order to install Git 2.11 or greater, we recommend adding the IUS repository:
 
 .. code-block:: none
 
-    yum -y install https://repo.ius.io/ius-release-el7.rpm
-    yum -y install yum-plugin-replace
-    yum -y replace git --replace-with git2u
+    sudo yum -y install https://repo.ius.io/ius-release-el7.rpm
+    sudo yum -y install yum-plugin-replace
+    sudo yum -y replace git --replace-with git2u
 
 Complete the rest of the installation by `installing Python 3.8 with pyenv <install-python-pyenv>`.
 
@@ -83,10 +83,10 @@ CentOS and RHEL 8
 
 .. code-block:: none
 
-    yum -y install epel-release
-    yum -y update
-    yum -y groupinstall development
-    yum -y install git zlib-devel bzip2 bzip2-devel readline-devel sqlite \
+    sudo yum -y install epel-release
+    sudo yum -y update
+    sudo yum -y groupinstall development
+    sudo yum -y install git zlib-devel bzip2 bzip2-devel readline-devel sqlite \
       sqlite-devel openssl-devel xz xz-devel libffi-devel findutils java-11-openjdk-headless
 
 Complete the rest of the installation by `installing Python 3.8 with pyenv <install-python-pyenv>`.

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -146,7 +146,7 @@ them with dnf:
 
 .. code-block:: none
 
-    sudo dnf -y install python38 git java-latest-openjdk-headless @development-tools
+    sudo dnf -y install python38 git java-11-openjdk-headless @development-tools
 
 Continue by `creating-venv-linux`.
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -230,7 +230,7 @@ with zypper:
 
 .. code-block:: none
 
-    sudo zypper install python3-base python3-pip git-core java-12-openjdk-headless
+    sudo zypper install python3-base python3-pip git-core java-11-openjdk-headless
     sudo zypper install -t pattern devel_basis
 
 Continue by `creating-venv-linux`.

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -197,14 +197,14 @@ First, add the Opt-Python community repository:
 .. code-block:: none
 
     source /etc/os-release
-    sudo zypper ar -f https://download.opensuse.org/repositories/home:/Rotkraut:/Opt-Python/openSUSE_Leap_${VERSION_ID}/ Opt-Python
+    sudo zypper -n ar -f https://download.opensuse.org/repositories/home:/Rotkraut:/Opt-Python/openSUSE_Leap_${VERSION_ID}/ Opt-Python
 
 Now install the pre-requirements with zypper:
 
 .. code-block:: none
 
-    sudo zypper install opt-python38 opt-python38-setuptools git-core java-11-openjdk-headless
-    sudo zypper install -t pattern devel_basis
+    sudo zypper -n install opt-python38 opt-python38-setuptools git-core java-11-openjdk-headless
+    sudo zypper -n install -t pattern devel_basis
 
 Since Python is now installed to ``/opt/python``, we should add it to PATH. You can add a file in
 ``/etc/profile.d/`` to do this:
@@ -230,8 +230,8 @@ with zypper:
 
 .. code-block:: none
 
-    sudo zypper install python3-base python3-pip git-core java-11-openjdk-headless
-    sudo zypper install -t pattern devel_basis
+    sudo zypper -n install python3-base python3-pip git-core java-11-openjdk-headless
+    sudo zypper -n install -t pattern devel_basis
 
 Continue by `creating-venv-linux`.
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -71,7 +71,7 @@ In order to install Git 2.11 or greater, we recommend adding the IUS repository:
 
     sudo yum -y install https://repo.ius.io/ius-release-el7.rpm
     sudo yum -y install yum-plugin-replace
-    sudo yum -y replace git --replace-with git2u
+    sudo yum -y replace git --replace-with git222
 
 Complete the rest of the installation by `installing Python 3.8 with pyenv <install-python-pyenv>`.
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -237,19 +237,31 @@ Continue by `creating-venv-linux`.
 
 ----
 
-.. _install-ubuntu:
+.. _install-ubuntu-1604:
 
 ~~~~~~~~~~~~~~~~
-Ubuntu 20.04 LTS
+Ubuntu 16.04 LTS
 ~~~~~~~~~~~~~~~~
 
-We recommend adding the ``git-core`` ppa to install Git 2.11 or greater:
+We recommend adding the ``openjdk-r`` ppa to install Java 11:
 
 .. code-block:: none
 
     sudo apt update
     sudo apt -y install software-properties-common
-    sudo add-apt-repository -y ppa:git-core/ppa
+    sudo add-apt-repository -yu ppa:openjdk-r/ppa
+
+We recommend adding the ``git-core`` ppa to install Git 2.11 or greater:
+
+.. code-block:: none
+
+    sudo add-apt-repository -yu ppa:git-core/ppa
+
+We recommend adding the ``deadsnakes`` ppa to install Python 3.8.1 or greater:
+
+.. code-block:: none
+
+    sudo add-apt-repository -yu ppa:deadsnakes/ppa
 
 Now install the pre-requirements with apt:
 
@@ -293,31 +305,19 @@ Continue by `creating-venv-linux`.
 
 ----
 
-.. _install-ubuntu-1604:
+.. _install-ubuntu:
 
 ~~~~~~~~~~~~~~~~
-Ubuntu 16.04 LTS
+Ubuntu 20.04 LTS
 ~~~~~~~~~~~~~~~~
-
-We recommend adding the ``openjdk-r`` ppa to install Java 11:
-
-.. code-block:: none
-
-    sudo apt update
-    sudo apt -y install software-properties-common
-    sudo add-apt-repository -yu ppa:openjdk-r/ppa
 
 We recommend adding the ``git-core`` ppa to install Git 2.11 or greater:
 
 .. code-block:: none
 
-    sudo add-apt-repository -yu ppa:git-core/ppa
-
-We recommend adding the ``deadsnakes`` ppa to install Python 3.8.1 or greater:
-
-.. code-block:: none
-
-    sudo add-apt-repository -yu ppa:deadsnakes/ppa
+    sudo apt update
+    sudo apt -y install software-properties-common
+    sudo add-apt-repository -y ppa:git-core/ppa
 
 Now install the pre-requirements with apt:
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -72,7 +72,7 @@ In order to install Git 2.11 or greater, we recommend adding the IUS repository:
 
     sudo yum -y install https://repo.ius.io/ius-release-el7.rpm
     sudo yum -y install yum-plugin-replace
-    sudo yum -y replace git --replace-with git222
+    sudo yum -y replace git --replace-with git224
 
 Complete the rest of the installation by `installing Python 3.8 with pyenv <install-python-pyenv>`.
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -49,26 +49,33 @@ Continue by `creating-venv-linux`.
 
 ----
 
-.. _install-centos:
-.. _install-rhel:
+.. _install-centos7:
+.. _install-rhel7:
 
 ~~~~~~~~~~~~~~~~~
 CentOS and RHEL 7
 ~~~~~~~~~~~~~~~~~
 
+We recommend adding the IUS repository to install Git 2.11 or greater:
+
+.. code-block:: none
+
+    yum -y install https://repo.ius.io/ius-release-el7.rpm
+    yum install -y yum-plugin-replace
+    yum replace -y git --replace-with git2u
+
 .. code-block:: none
 
     yum -y groupinstall development
-    yum -y install https://centos7.iuscommunity.org/ius-release.rpm
     sudo yum -y install zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel \
-      openssl-devel xz xz-devel libffi-devel findutils git2u java-11-openjdk-headless
+      openssl-devel xz xz-devel libffi-devel findutils java-11-openjdk-headless
 
 Complete the rest of the installation by `installing Python 3.8 with pyenv <install-python-pyenv>`.
 
 ----
 
-.. _install-centos8:
-.. _install-rhel8:
+.. _install-centos:
+.. _install-rhel:
 
 ~~~~~~~~~~~~~~~~~
 CentOS and RHEL 8
@@ -80,8 +87,8 @@ CentOS and RHEL 8
     yum update -y
     yum -y groupinstall development
     yum -y install git zlib-devel bzip2 bzip2-devel readline-devel sqlite \
-     sqlite-devel openssl-devel xz xz-devel libffi-devel findutils java-11-openjdk-headless
-     
+      sqlite-devel openssl-devel xz xz-devel libffi-devel findutils java-11-openjdk-headless
+
 Complete the rest of the installation by `installing Python 3.8 with pyenv <install-python-pyenv>`.
 
 ----

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -204,7 +204,9 @@ First, add the Opt-Python community repository:
 .. code-block:: none
 
     source /etc/os-release
-    sudo zypper -n ar -f https://download.opensuse.org/repositories/home:/Rotkraut:/Opt-Python/openSUSE_Leap_${VERSION_ID}/ Opt-Python
+    sudo zypper -n --gpg-auto-import-keys ar -f \
+      https://download.opensuse.org/repositories/home:/Rotkraut:/Opt-Python/openSUSE_Leap_${VERSION_ID}/ \
+      Opt-Python
 
 Now install the pre-requirements with zypper:
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -239,9 +239,9 @@ Continue by `creating-venv-linux`.
 
 .. _install-ubuntu:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Ubuntu LTS versions (20.04, 18.04, and 16.04)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Ubuntu LTS versions (20.04, 18.04)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 We recommend adding the ``git-core`` ppa to install Git 2.11 or greater:
 
@@ -263,6 +263,42 @@ Now install the pre-requirements with apt:
 
     sudo apt -y install python3.8 python3.8-dev python3.8-venv python3-pip git default-jre-headless \
       build-essential
+
+Continue by `creating-venv-linux`.
+
+----
+
+.. _install-ubuntu-1604:
+
+~~~~~~~~~~~~~~~~
+Ubuntu 16.04 LTS
+~~~~~~~~~~~~~~~~
+
+We recommend adding the ``openjdk-r`` ppa to install Java 11:
+
+.. code-block:: none
+
+    sudo apt update
+    sudo apt -y install software-properties-common
+    sudo add-apt-repository -yu ppa:openjdk-r/ppa
+
+We recommend adding the ``git-core`` ppa to install Git 2.11 or greater:
+
+.. code-block:: none
+
+    sudo add-apt-repository -yu ppa:git-core/ppa
+
+We recommend adding the ``deadsnakes`` ppa to install Python 3.8.1 or greater:
+
+.. code-block:: none
+
+    sudo add-apt-repository -yu ppa:deadsnakes/ppa
+
+Now install the pre-requirements with apt:
+
+.. code-block:: none
+
+    sudo apt -y install python3.8 python3.8-dev python3.8-venv python3-pip git build-essential
 
 Continue by `creating-venv-linux`.
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -249,7 +249,7 @@ We recommend adding the ``git-core`` ppa to install Git 2.11 or greater:
 
     sudo apt update
     sudo apt -y install software-properties-common
-    sudo add-apt-repository -yu ppa:git-core/ppa
+    sudo add-apt-repository -y ppa:git-core/ppa
 
 Now install the pre-requirements with apt:
 
@@ -274,13 +274,13 @@ We recommend adding the ``git-core`` ppa to install Git 2.11 or greater:
 
     sudo apt update
     sudo apt -y install software-properties-common
-    sudo add-apt-repository -yu ppa:git-core/ppa
+    sudo add-apt-repository -y ppa:git-core/ppa
 
 We recommend adding the ``deadsnakes`` ppa to install Python 3.8.1 or greater:
 
 .. code-block:: none
 
-    sudo add-apt-repository -yu ppa:deadsnakes/ppa
+    sudo add-apt-repository -y ppa:deadsnakes/ppa
 
 Now install the pre-requirements with apt:
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -393,7 +393,7 @@ Then run the following command:
 
 .. code-block:: none
 
-    CONFIGURE_OPTS=--enable-optimizations pyenv install 3.8.2 -v
+    CONFIGURE_OPTS=--enable-optimizations pyenv install 3.8.3 -v
 
 This may take a long time to complete, depending on your hardware. For some machines (such as
 Raspberry Pis and micro-tier VPSes), it may take over an hour; in this case, you may wish to remove
@@ -405,7 +405,7 @@ After that is finished, run:
 
 .. code-block:: none
 
-    pyenv global 3.8.2
+    pyenv global 3.8.3
 
 Pyenv is now installed and your system should be configured to run Python 3.8.
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -60,7 +60,7 @@ CentOS and RHEL 7
 
     sudo yum -y groupinstall development
     sudo yum -y install zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel \
-      openssl-devel xz xz-devel libffi-devel findutils java-11-openjdk-headless
+      openssl-devel xz xz-devel tk-devel libffi-devel findutils java-11-openjdk-headless
 
 In order to install Git 2.11 or greater, we recommend adding the IUS repository:
 
@@ -86,8 +86,8 @@ CentOS and RHEL 8
     sudo yum -y install epel-release
     sudo yum -y update
     sudo yum -y groupinstall development
-    sudo yum -y install git zlib-devel bzip2 bzip2-devel readline-devel sqlite \
-      sqlite-devel openssl-devel xz xz-devel libffi-devel findutils java-11-openjdk-headless
+    sudo yum -y install git zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel \
+      openssl-devel xz xz-devel tk-devel libffi-devel findutils java-11-openjdk-headless
 
 Complete the rest of the installation by `installing Python 3.8 with pyenv <install-python-pyenv>`.
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -43,7 +43,7 @@ Arch Linux
 
 .. code-block:: none
 
-    sudo pacman -Syu python python-pip git jre-openjdk-headless base-devel
+    sudo pacman -Syu python python-pip git jre11-openjdk-headless base-devel
 
 Continue by `creating-venv-linux`.
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -61,6 +61,9 @@ CentOS and RHEL 7
     sudo yum -y groupinstall development
     sudo yum -y install zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel \
       openssl-devel xz xz-devel tk-devel libffi-devel findutils java-11-openjdk-headless
+    sudo yum -y install centos-release-scl
+    sudo yum -y install devtoolset-8-gcc devtoolset-8-gcc-c++
+    echo "source scl_source enable devtoolset-8" >> ~/.bashrc
 
 In order to install Git 2.11 or greater, we recommend adding the IUS repository:
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -61,7 +61,7 @@ CentOS and RHEL 7
     yum -y groupinstall development
     yum -y install https://centos7.iuscommunity.org/ius-release.rpm
     sudo yum -y install zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel \
-      openssl-devel xz xz-devel libffi-devel findutils git2u java-11-openjdk
+      openssl-devel xz xz-devel libffi-devel findutils git2u java-11-openjdk-headless
 
 Complete the rest of the installation by `installing Python 3.8 with pyenv <install-python-pyenv>`.
 
@@ -80,7 +80,7 @@ CentOS and RHEL 8
     yum update -y
     yum -y groupinstall development
     yum -y install git zlib-devel bzip2 bzip2-devel readline-devel sqlite \
-     sqlite-devel openssl-devel xz xz-devel libffi-devel findutils java-11-openjdk
+     sqlite-devel openssl-devel xz xz-devel libffi-devel findutils java-11-openjdk-headless
      
 Complete the rest of the installation by `installing Python 3.8 with pyenv <install-python-pyenv>`.
 
@@ -105,8 +105,8 @@ Debian Stretch. This guide will tell you how. First, run the following commands:
     sudo echo "deb http://deb.debian.org/debian stretch-backports main" >> /etc/apt/sources.list.d/red-sources.list
     sudo apt update
     sudo apt -y install make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev \
-      libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev \
-      libxmlsec1-dev libffi-dev liblzma-dev libgdbm-dev uuid-dev python3-openssl git openjdk-11-jre
+      libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
+      libffi-dev liblzma-dev libgdbm-dev uuid-dev python3-openssl git openjdk-11-jre-headless
     CXX=/usr/bin/g++
 
 Complete the rest of the installation by `installing Python 3.8 with pyenv <install-python-pyenv>`.
@@ -127,8 +127,8 @@ Debian/Raspbian Buster. This guide will tell you how. First, run the following c
 
     sudo apt update
     sudo apt -y install make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev \
-      libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev \
-      libxmlsec1-dev libffi-dev liblzma-dev libgdbm-dev uuid-dev python3-openssl git openjdk-11-jre
+      libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
+      libffi-dev liblzma-dev libgdbm-dev uuid-dev python3-openssl git openjdk-11-jre-headless
     CXX=/usr/bin/g++
 
 Complete the rest of the installation by `installing Python 3.8 with pyenv <install-python-pyenv>`.
@@ -351,7 +351,7 @@ installing pyenv. To do this, first run the following commands:
 
     sudo apt -y install make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev \
       libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev \
-      libxmlsec1-dev libffi-dev liblzma-dev libgdbm-dev uuid-dev python3-openssl git openjdk-11-jre
+      libxmlsec1-dev libffi-dev liblzma-dev libgdbm-dev uuid-dev python3-openssl git openjdk-11-jre-headless
     CXX=/usr/bin/g++
 
 And then complete the rest of the installation by `installing Python 3.8 with pyenv <install-python-pyenv>`.

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -67,8 +67,8 @@ In order to install Git 2.11 or greater, we recommend adding the IUS repository:
 .. code-block:: none
 
     yum -y install https://repo.ius.io/ius-release-el7.rpm
-    yum install -y yum-plugin-replace
-    yum replace -y git --replace-with git2u
+    yum -y install yum-plugin-replace
+    yum -y replace git --replace-with git2u
 
 Complete the rest of the installation by `installing Python 3.8 with pyenv <install-python-pyenv>`.
 
@@ -84,7 +84,7 @@ CentOS and RHEL 8
 .. code-block:: none
 
     yum -y install epel-release
-    yum update -y
+    yum -y update
     yum -y groupinstall development
     yum -y install git zlib-devel bzip2 bzip2-devel readline-devel sqlite \
       sqlite-devel openssl-devel xz xz-devel libffi-devel findutils java-11-openjdk-headless

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -239,9 +239,34 @@ Continue by `creating-venv-linux`.
 
 .. _install-ubuntu:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Ubuntu LTS versions (20.04, 18.04)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
+Ubuntu 20.04 LTS
+~~~~~~~~~~~~~~~~
+
+We recommend adding the ``git-core`` ppa to install Git 2.11 or greater:
+
+.. code-block:: none
+
+    sudo apt update
+    sudo apt -y install software-properties-common
+    sudo add-apt-repository -yu ppa:git-core/ppa
+
+Now install the pre-requirements with apt:
+
+.. code-block:: none
+
+    sudo apt -y install python3.8 python3.8-dev python3.8-venv python3-pip git default-jre-headless \
+      build-essential
+
+Continue by `creating-venv-linux`.
+
+----
+
+.. _install-ubuntu-1804:
+
+~~~~~~~~~~~~~~~~
+Ubuntu 18.04 LTS
+~~~~~~~~~~~~~~~~
 
 We recommend adding the ``git-core`` ppa to install Git 2.11 or greater:
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -255,7 +255,7 @@ Now install the pre-requirements with apt:
 
 .. code-block:: none
 
-    sudo apt -y install python3.8 python3.8-dev python3.8-venv python3-pip git default-jre-headless \
+    sudo apt -y install python3.8 python3.8-dev python3.8-venv python3-pip git openjdk-11-jre-headless \
       build-essential
 
 Continue by `creating-venv-linux`.
@@ -286,7 +286,7 @@ Now install the pre-requirements with apt:
 
 .. code-block:: none
 
-    sudo apt -y install python3.8 python3.8-dev python3.8-venv python3-pip git default-jre-headless \
+    sudo apt -y install python3.8 python3.8-dev python3.8-venv python3-pip git openjdk-11-jre-headless \
       build-essential
 
 Continue by `creating-venv-linux`.
@@ -323,7 +323,8 @@ Now install the pre-requirements with apt:
 
 .. code-block:: none
 
-    sudo apt -y install python3.8 python3.8-dev python3.8-venv python3-pip git build-essential
+    sudo apt -y install python3.8 python3.8-dev python3.8-venv python3-pip git openjdk-11-jre-headless \
+      build-essential
 
 Continue by `creating-venv-linux`.
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -62,7 +62,7 @@ CentOS and RHEL 7
     sudo yum -y install zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel \
       openssl-devel xz xz-devel libffi-devel findutils java-11-openjdk-headless
 
-We recommend adding the IUS repository to install Git 2.11 or greater:
+In order to install Git 2.11 or greater, we recommend adding the IUS repository:
 
 .. code-block:: none
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -377,8 +377,8 @@ virtual environment.
 
     command -v pyenv && pyenv update || curl https://pyenv.run | bash
 
-After this command, you may see a warning about 'pyenv' not being in the load path. Follow the
-instructions given to fix that, then close and reopen your shell.
+**After this command, you may see a warning about 'pyenv' not being in the load path. Follow the
+instructions given to fix that, then close and reopen your shell.**
 
 Then run the following command:
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -64,6 +64,7 @@ CentOS and RHEL 7
     sudo yum -y install centos-release-scl
     sudo yum -y install devtoolset-8-gcc devtoolset-8-gcc-c++
     echo "source scl_source enable devtoolset-8" >> ~/.bashrc
+    source ~/.bashrc
 
 In order to install Git 2.11 or greater, we recommend adding the IUS repository:
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

Java 11 Checklist:
- [x] Windows (no changes)
- [x] Arch Linux (install command updated)
- [x] CentOS and RHEL 7 (no changes)
- [x] CentOS and RHEL 8 (no changes)
- [x] Debian Stretch (no changes)
- [x] Debian and Raspbian Buster (no changes)
- [x] Fedora Linux 30+ (install command updated)
- [x] MacOS (no changes)
- [x] openSUSE Leap (no changes)
- [x] openSUSE Tumbleweed (install command updated)
- [x] Ubuntu 20.04 (no changes)
- [x] Ubuntu 18.04 (no changes)
- [x] Ubuntu 16.04 (install command updated)

Other changes:
- Stop telling people to add `deadsnakes` ppa in instructions for Ubuntu 20.04 (now split) - `deadsnakes` doesn't provide Python 3.8 as it's a main system python in Ubuntu 20.04
- Recommend Ubuntu 20.04 over 18 in getting started guide
- Use headless jre everywhere
- Remove unneeded `-u` for Ubuntu 20.04 and 18.04
- Use `openjdk-11-jre-headless` instead of `default-jre-headless` on all ubuntus (installs same thing but is more explicit)
- Add non-interactive flags to `zypper` calls
- Fix CentOS 7 instructions (use `yum swap` to install Git 2.11+, use `git224` instead of archived `git2u`, use gcc 8 to compile Python with pyenv)
- Make pyenv instructions use Python 3.8.3
- Use new IUS repo url for CentOS 7 (old one is a redirect)
- Emphasise info about pyenv's warning

Test of install instructions:
https://github.com/jack1142/Red-DiscordBot/actions/runs/107526897