### PR TITLE
Don't allow to warn other bots

### DIFF
--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -323,6 +323,9 @@ class Warnings(commands.Cog):
         if user == ctx.author:
             await ctx.send(_("You cannot warn yourself."))
             return
+        if user.bot:
+            await ctx.send(_("You cannot warn other bots"))
+            return
         custom_allowed = await self.config.guild(ctx.guild).allow_custom_reasons()
         guild_settings = self.config.guild(ctx.guild)
         reason_type = None

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -324,7 +324,7 @@ class Warnings(commands.Cog):
             await ctx.send(_("You cannot warn yourself."))
             return
         if user.bot:
-            await ctx.send(_("You cannot warn other bots"))
+            await ctx.send(_("You cannot warn other bots."))
             return
         custom_allowed = await self.config.guild(ctx.guild).allow_custom_reasons()
         guild_settings = self.config.guild(ctx.guild)


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Prevents warning of other bots

Fixes #3854