### PR TITLE
Use `bot.send_help_for` in `[p]alias help` instead of "hacky way"

### DIFF
--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -251,11 +251,7 @@ class Alias(commands.Cog):
         """Try to execute help for the base command of the alias."""
         alias = await self._aliases.get_alias(ctx.guild, alias_name=alias_name)
         if alias:
-            if self.is_command(alias.command):
-                base_cmd = alias.command
-            else:
-                base_cmd = alias.command.rsplit(" ", 1)[0]
-            await self.bot.send_help_for(ctx, base_cmd)
+            await self.bot.send_help_for(ctx, alias.command)
         else:
             await ctx.send(_("No such alias exists."))
 

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -255,10 +255,7 @@ class Alias(commands.Cog):
                 base_cmd = alias.command
             else:
                 base_cmd = alias.command.rsplit(" ", 1)[0]
-
-            new_msg = copy(ctx.message)
-            new_msg.content = f"{ctx.prefix}help {base_cmd}"
-            await self.bot.process_commands(new_msg)
+            await self.bot.send_help_for(ctx, base_cmd)
         else:
             await ctx.send(_("No such alias exists."))
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This uses a better way of sending help for given command than creating a copy of a message with `[p]help {command}` and then calling `bot.process_message` on it. And if anyone else looks at code of alias, this a lot better example how to use bot's APIs instead of somewhat *abusing* them (or at least doing something ugly) :smile:
Also fixes the issues with this command showing "Command `group` has no subcommand named `argument`" when part of the alias contains command arguments.