### PR TITLE
Add non-generic message when loading a cog with command name that is already registered

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -60,6 +60,14 @@ _ = i18n.Translator("Core", __file__)
 
 TokenConverter = commands.get_dict_converter(delims=[" ", ",", ";"])
 
+# DEP-WARN
+# we're basing this handling on d.py's exception message which might change
+_ALREADY_REGISTERED_PATTERN = re.compile(
+    r"The alias (?P<alias>.+) is already an existing command or alias\."
+    r"|"
+    r"Command (?P<command>.+) is already registered\."
+)
+
 
 class CoreLogic:
     def __init__(self, bot: "Red"):
@@ -121,14 +129,23 @@ class CoreLogic:
             except errors.CogLoadError as e:
                 failed_with_reason_packages.append((name, str(e)))
             except Exception as e:
-                # DEP-WARN
-                # we're basing this handling on d.py's exception message which might change
-                if isinstance(e, discord.ClientException) and (error_message := str(e)).endswith(
-                    (" is already registered.", " is already an existing command or alias.")
+                if isinstance(e, discord.ClientException) and (
+                    (match := _ALREADY_REGISTERED_PATTERN.fullmatch(str(e))) is not None
                 ):
-                    error_message = f"{error_message[:-1]} in one of the loaded cogs."
+                    if (alias_name := match.group("alias")) is not None:
+                        error_message = _(
+                            "Alias {alias_name} is already an existing command"
+                            " or alias in one of the loaded cogs."
+                        ).format(alias_name=inline(alias_name))
+                    else:
+                        command_name = match.group("command")
+                        error_message = _(
+                            "Command {command_name} is already an existing command"
+                            " or alias in one of the loaded cogs."
+                        ).format(command_name=inline(command_name))
                     failed_with_reason_packages.append((name, error_message))
                     continue
+
                 log.exception("Package loading failed", exc_info=e)
 
                 exception_log = "Exception during loading of cog\n"

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -121,6 +121,14 @@ class CoreLogic:
             except errors.CogLoadError as e:
                 failed_with_reason_packages.append((name, str(e)))
             except Exception as e:
+                # DEP-WARN
+                # we're basing this handling on d.py's exception message which might change
+                if isinstance(e, discord.ClientException) and (error_message := str(e)).endswith(
+                    (" is already registered.", " is already an existing command or alias.")
+                ):
+                    error_message = f"{error_message[:-1]} in one of the loaded cogs."
+                    failed_with_reason_packages.append((name, error_message))
+                    continue
                 log.exception("Package loading failed", exc_info=e)
 
                 exception_log = "Exception during loading of cog\n"


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
@Drapersniper this is what's needed to have a friendly message:
![image](https://user-images.githubusercontent.com/6032823/83081649-71e0ba80-a081-11ea-87fe-305482c6e215.png)

~~We might want to go for a regex instead though, as that would allow us to improve this message easily now or in future, instead of being limited by whatever d.py already gives us in exception message.~~
[Update 1](https://github.com/Cog-Creators/Red-DiscordBot/pull/3870#issuecomment-634992977): ~~I already did that, see comment below.~~
[Update 2](https://github.com/Cog-Creators/Red-DiscordBot/pull/3870#issuecomment-646903416): Fuck all these 
hacky ideas, Danny agreed on adding `CommandRegistrationError` that solves all our problems <3

~~In any case, this isn't the most future-proof implementation, but I think it's still worth the enhancement we get nonetheless.~~ see [update 2](https://github.com/Cog-Creators/Red-DiscordBot/pull/3870#issuecomment-646903416)

Blocked by #3845