### PR TITLE
Red 3.3.9 - Changelog

### DIFF
--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.9 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`Dav-Git`, :ghuser:`Drapersniper`, :ghuser:`Flame442`, :ghuser:`NeuroAssassin`
+| :ghuser:`Dav-Git`, :ghuser:`Drapersniper`, :ghuser:`Flame442`, :ghuser:`NeuroAssassin`, :ghuser:`Predeactor`
 
 End-user changelog
 ------------------
@@ -33,7 +33,7 @@ Documentation changes
 Miscellaneous
 -------------
 
-- **Audio** - Typo fix (:issue:`3889`)
+- **Audio** - Typo fix (:issue:`3889`, :issue:`3900`)
 - **Mod** - Preemptive fix for d.py 1.4 (:issue:`3891`)
 
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -1,7 +1,7 @@
 .. 3.3.x Changelogs
 
-Redbot 3.3.9 or 3.4.0 (Unreleased)
-==================================
+Redbot 3.3.9 (2020-06-12)
+=========================
 
 | Thanks to all these amazing people that contributed to this release:
 | :ghuser:`aikaterna`, :ghuser:`Dav-Git`, :ghuser:`Drapersniper`, :ghuser:`Flame442`, :ghuser:`mikeshardmind`, :ghuser:`NeuroAssassin`, :ghuser:`Predeactor`, :ghuser:`Vexed01`

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.9 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`aikaterna`, :ghuser:`Dav-Git`, :ghuser:`Drapersniper`, :ghuser:`Flame442`, :ghuser:`NeuroAssassin`, :ghuser:`Predeactor`, :ghuser:`Vexed01`
+| :ghuser:`aikaterna`, :ghuser:`Dav-Git`, :ghuser:`Drapersniper`, :ghuser:`Flame442`, :ghuser:`mikeshardmind`, :ghuser:`NeuroAssassin`, :ghuser:`Predeactor`, :ghuser:`Vexed01`
 
 End-user changelog
 ------------------
@@ -26,6 +26,23 @@ Filter
 ******
 
 - Fixed behavior of detecting quotes in commands for adding/removing filtered words (:issue:`3925`)
+
+Permissions
+***********
+
+- **Both global and server rules** can no longer prevent guild owners from accessing commands for changing server rules. Bot owners can still use ``[p]command disable`` if they wish to completely disable any command in Permissions cog (:issue:`3955`, :issue:`3107`)
+
+  Full list of affected commands:
+
+  - ``[p]permissions acl getserver``
+  - ``[p]permissions acl setserver``
+  - ``[p]permissions acl updateserver``
+  - ``[p]permissions addserverrule``
+  - ``[p]permissions removeserverrule``
+  - ``[p]permissions setdefaultserverrule``
+  - ``[p]permissions clearserverrules``
+  - ``[p]permissions canrun``
+  - ``[p]permissions explain``
 
 Warnings
 ********

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.9 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`Dav-Git`, :ghuser:`Drapersniper`, :ghuser:`Flame442`, :ghuser:`NeuroAssassin`, :ghuser:`Predeactor`, :ghuser:`Vexed01`
+| :ghuser:`aikaterna`, :ghuser:`Dav-Git`, :ghuser:`Drapersniper`, :ghuser:`Flame442`, :ghuser:`NeuroAssassin`, :ghuser:`Predeactor`, :ghuser:`Vexed01`
 
 End-user changelog
 ------------------
@@ -13,6 +13,11 @@ Core Bot
 ********
 
 - ``[p]info`` command can now be used when bot doesn't have Embed Links permission (:issue:`3907`, :issue:`3102`)
+
+Audio
+*****
+
+- Audio now properly ignores streams when max length is enabled (:issue:`3878`, :issue:`3877`)
 
 Warnings
 ********

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -18,6 +18,7 @@ Audio
 *****
 
 - Audio now properly ignores streams when max length is enabled (:issue:`3878`, :issue:`3877`)
+- Commands that should work in DMs no longer error (:issue:`3880`)
 
 Warnings
 ********

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -34,6 +34,7 @@ Miscellaneous
 -------------
 
 - **Audio** - Typo fix (:issue:`3889`, :issue:`3900`)
+- **Audio** - Fixed ``[p]audioset autoplay`` being available in DMs (:issue:`3899`)
 - **Mod** - Preemptive fix for d.py 1.4 (:issue:`3891`)
 
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.9 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| 
+| :ghuser:`Drapersniper`
 
 End-user changelog
 ------------------
@@ -24,6 +24,7 @@ Documentation changes
 Miscellaneous
 -------------
 
+- **Audio** - Typo fix (:issue:`3889`)
 
 
 Redbot 3.3.8 (2020-05-29)

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -5,6 +5,11 @@ Redbot 3.3.9 or 3.4.0 (Unreleased)
 
 | Thanks to all these amazing people that contributed to this release:
 | :ghuser:`aikaterna`, :ghuser:`Dav-Git`, :ghuser:`Drapersniper`, :ghuser:`Flame442`, :ghuser:`mikeshardmind`, :ghuser:`NeuroAssassin`, :ghuser:`Predeactor`, :ghuser:`Vexed01`
+|
+| **Read before updating**:
+| 1. Bot owners can no longer restrict access to some commands in Permissions cog using global permissions rules. Look at `Permissions changelog <important-339-2>` for full details.
+| 2. There's been a change in behavior of warning messages. Look at `Warnings changelog <important-339-1>` for full details.
+
 
 End-user changelog
 ------------------
@@ -27,6 +32,8 @@ Filter
 
 - Fixed behavior of detecting quotes in commands for adding/removing filtered words (:issue:`3925`)
 
+.. _important-339-2:
+
 Permissions
 ***********
 
@@ -43,6 +50,8 @@ Permissions
   - ``[p]permissions clearserverrules``
   - ``[p]permissions canrun``
   - ``[p]permissions explain``
+
+.. _important-339-1:
 
 Warnings
 ********

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -34,6 +34,7 @@ Miscellaneous
 -------------
 
 - Added missing help message for Downloader, Reports and Streams cogs (:issue:`3892`)
+- **Alias** - ``[p]alias global`` group, ``[p]alias help``, and ``[p]alias show`` commands can now be used in DMs (:issue:`3941`, :issue:`3940`)
 - **Audio** - Typo fix (:issue:`3889`, :issue:`3900`)
 - **Audio** - Fixed ``[p]audioset autoplay`` being available in DMs (:issue:`3899`)
 - **Mod** - Preemptive fix for d.py 1.4 (:issue:`3891`)

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -51,6 +51,7 @@ Miscellaneous
 -------------
 
 - Added missing help message for Downloader, Reports and Streams cogs (:issue:`3892`)
+- **Core Bot** - cooldown in ``[p]contact`` no longer applies when it's used without any arguments (:issue:`3942`)
 - **Alias** - ``[p]alias global`` group, ``[p]alias help``, and ``[p]alias show`` commands can now be used in DMs (:issue:`3941`, :issue:`3940`)
 - **Audio** - Typo fix (:issue:`3889`, :issue:`3900`)
 - **Audio** - Fixed ``[p]audioset autoplay`` being available in DMs (:issue:`3899`)

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -33,6 +33,7 @@ Documentation changes
 Miscellaneous
 -------------
 
+- Added missing help message for Downloader, Reports and Streams cogs (:issue:`3892`)
 - **Audio** - Typo fix (:issue:`3889`, :issue:`3900`)
 - **Audio** - Fixed ``[p]audioset autoplay`` being available in DMs (:issue:`3899`)
 - **Mod** - Preemptive fix for d.py 1.4 (:issue:`3891`)

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,11 +4,16 @@ Redbot 3.3.9 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`Drapersniper`, :ghuser:`Flame442`, :ghuser:`NeuroAssassin`
+| :ghuser:`Dav-Git`, :ghuser:`Drapersniper`, :ghuser:`Flame442`, :ghuser:`NeuroAssassin`
 
 End-user changelog
 ------------------
 
+Warnings
+********
+
+- Warnings sent to users don't show the moderator who warned the user by default now. Newly added ``[p]warningset showmoderators`` command can be used to switch this behaviour (:issue:`3781`)
+- Warn channel functionality has been fixed (:issue:`3781`)
 
 
 Developer changelog

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -53,6 +53,7 @@ Miscellaneous
 
 - Added missing help message for Downloader, Reports and Streams cogs (:issue:`3892`)
 - **Core Bot** - cooldown in ``[p]contact`` no longer applies when it's used without any arguments (:issue:`3942`)
+- **Core Bot** - improved instructions on obtaining user ID in help of ``[p]dm`` command (:issue:`3946`)
 - **Alias** - ``[p]alias global`` group, ``[p]alias help``, and ``[p]alias show`` commands can now be used in DMs (:issue:`3941`, :issue:`3940`)
 - **Audio** - Typo fix (:issue:`3889`, :issue:`3900`)
 - **Audio** - Fixed ``[p]audioset autoplay`` being available in DMs (:issue:`3899`)

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.9 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`Drapersniper`
+| :ghuser:`Drapersniper`, :ghuser:`NeuroAssassin`
 
 End-user changelog
 ------------------
@@ -14,6 +14,10 @@ End-user changelog
 Developer changelog
 -------------------
 
+Core Bot
+********
+
+- Added `bot.set_prefixes() <RedBase.set_prefixes()>` method that allows developers to set global/server prefixes (:issue:`3890`)
 
 
 Documentation changes

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.9 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`Dav-Git`, :ghuser:`Drapersniper`, :ghuser:`Flame442`, :ghuser:`NeuroAssassin`, :ghuser:`Predeactor`
+| :ghuser:`Dav-Git`, :ghuser:`Drapersniper`, :ghuser:`Flame442`, :ghuser:`NeuroAssassin`, :ghuser:`Predeactor`, :ghuser:`Vexed01`
 
 End-user changelog
 ------------------
@@ -28,7 +28,7 @@ Core Bot
 Documentation changes
 ---------------------
 
-
+- Added Oracle Cloud to free hosting section in :ref:`host-list` (:issue:`3916`)
 
 Miscellaneous
 -------------

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -20,6 +20,11 @@ Audio
 - Audio now properly ignores streams when max length is enabled (:issue:`3878`, :issue:`3877`)
 - Commands that should work in DMs no longer error (:issue:`3880`)
 
+Filter
+******
+
+- Fixed behavior of detecting quotes in commands for adding/removing filtered words (:issue:`3925`)
+
 Warnings
 ********
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -14,6 +14,7 @@ Core Bot
 
 - ``[p]info`` command can now be used when bot doesn't have Embed Links permission (:issue:`3907`, :issue:`3102`)
 - Fixed ungraceful error that happened in ``[p]set custominfo`` when provided text was too long (:issue:`3923`)
+- Red's start up message now shows storage type (:issue:`3935`)
 
 Audio
 *****

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -13,6 +13,7 @@ Core Bot
 ********
 
 - ``[p]info`` command can now be used when bot doesn't have Embed Links permission (:issue:`3907`, :issue:`3102`)
+- Fixed ungraceful error that happened in ``[p]set custominfo`` when provided text was too long (:issue:`3923`)
 
 Audio
 *****

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -57,6 +57,7 @@ Miscellaneous
 - **Alias** - ``[p]alias global`` group, ``[p]alias help``, and ``[p]alias show`` commands can now be used in DMs (:issue:`3941`, :issue:`3940`)
 - **Audio** - Typo fix (:issue:`3889`, :issue:`3900`)
 - **Audio** - Fixed ``[p]audioset autoplay`` being available in DMs (:issue:`3899`)
+- **Bank** - ``[p]bankset`` now displays bank's scope (:issue:`3954`)
 - **Mod** - Preemptive fix for d.py 1.4 (:issue:`3891`)
 
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -9,6 +9,11 @@ Redbot 3.3.9 or 3.4.0 (Unreleased)
 End-user changelog
 ------------------
 
+Core Bot
+********
+
+- ``[p]info`` command can now be used when bot doesn't have Embed Links permission (:issue:`3907`, :issue:`3102`)
+
 Warnings
 ********
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -1,5 +1,31 @@
 .. 3.3.x Changelogs
 
+Redbot 3.3.9 or 3.4.0 (Unreleased)
+==================================
+
+| Thanks to all these amazing people that contributed to this release:
+| 
+
+End-user changelog
+------------------
+
+
+
+Developer changelog
+-------------------
+
+
+
+Documentation changes
+---------------------
+
+
+
+Miscellaneous
+-------------
+
+
+
 Redbot 3.3.8 (2020-05-29)
 ==================================
 

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -4,7 +4,7 @@ Redbot 3.3.9 or 3.4.0 (Unreleased)
 ==================================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`Drapersniper`, :ghuser:`NeuroAssassin`
+| :ghuser:`Drapersniper`, :ghuser:`Flame442`, :ghuser:`NeuroAssassin`
 
 End-user changelog
 ------------------
@@ -29,6 +29,7 @@ Miscellaneous
 -------------
 
 - **Audio** - Typo fix (:issue:`3889`)
+- **Mod** - Preemptive fix for d.py 1.4 (:issue:`3891`)
 
 
 Redbot 3.3.8 (2020-05-29)

--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -14,6 +14,13 @@ Redbot 3.3.9 or 3.4.0 (Unreleased)
 End-user changelog
 ------------------
 
+Security
+********
+
+**NOTE**: If you can't update immediately, we recommend disabling the affected command until you can.
+
+- **Mod** - ``[p]tempban`` now properly respects Discord's hierarchy rules (:issue:`3957`)
+
 Core Bot
 ********
 


### PR DESCRIPTION
Draft PR for Red 3.3.9 changelog.

This is getting updated as new PRs from the milestone get merged.

Rendered changelog can be seen here: https://red-discordbot--3876.org.readthedocs.build/en/3876/changelog_3_3_0.html#redbot-3-3-9-2020-06-12