### PR TITLE
[Audio] Redefine max length with livestream exception

### DIFF
--- a/redbot/cogs/audio/apis/interface.py
+++ b/redbot/cogs/audio/apis/interface.py
@@ -566,7 +566,7 @@ class AudioAPIInterface:
                     if len(player.queue) >= 10000:
                         continue
                     if guild_data["maxlength"] > 0:
-                        if self.cog.is_track_too_long(single_track, guild_data["maxlength"]):
+                        if self.cog.is_track_length_allowed(single_track, guild_data["maxlength"]):
                             enqueued_tracks += 1
                             player.add(ctx.author, single_track)
                             self.bot.dispatch(

--- a/redbot/cogs/audio/core/abc.py
+++ b/redbot/cogs/audio/core/abc.py
@@ -165,7 +165,7 @@ class MixinMeta(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def is_track_too_long(self, track: lavalink.Track, maxlength: int) -> bool:
+    def is_track_length_allowed(self, track: lavalink.Track, maxlength: int) -> bool:
         raise NotImplementedError()
 
     @abstractmethod

--- a/redbot/cogs/audio/core/abc.py
+++ b/redbot/cogs/audio/core/abc.py
@@ -165,7 +165,7 @@ class MixinMeta(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def is_track_too_long(self, track: Union[lavalink.Track, int], maxlength: int) -> bool:
+    def is_track_too_long(self, track: lavalink.Track, maxlength: int) -> bool:
         raise NotImplementedError()
 
     @abstractmethod

--- a/redbot/cogs/audio/core/commands/player.py
+++ b/redbot/cogs/audio/core/commands/player.py
@@ -274,7 +274,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 description=_("This track is not allowed in this server."),
             )
         elif guild_data["maxlength"] > 0:
-            if self.is_track_too_long(single_track, guild_data["maxlength"]):
+            if self.is_track_length_allowed(single_track, guild_data["maxlength"]):
                 single_track.requester = ctx.author
                 player.queue.insert(0, single_track)
                 player.maybe_shuffle()
@@ -763,7 +763,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                             log.debug(f"Query is not allowed in {ctx.guild} ({ctx.guild.id})")
                         continue
                     elif guild_data["maxlength"] > 0:
-                        if self.is_track_too_long(track, guild_data["maxlength"]):
+                        if self.is_track_length_allowed(track, guild_data["maxlength"]):
                             track_len += 1
                             player.add(ctx.author, track)
                             self.bot.dispatch(

--- a/redbot/cogs/audio/core/commands/playlists.py
+++ b/redbot/cogs/audio/core/commands/playlists.py
@@ -1489,7 +1489,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                         pass
                     if not local_path.exists() and not local_path.is_file():
                         continue
-                if maxlength > 0 and not self.is_track_too_long(track.length, maxlength):
+                if maxlength > 0 and not self.is_track_length_allowed(track, maxlength):
                     continue
 
                 player.add(author_obj, track)

--- a/redbot/cogs/audio/core/utilities/formatting.py
+++ b/redbot/cogs/audio/core/utilities/formatting.py
@@ -165,7 +165,7 @@ class FormattingUtilities(MixinMeta, metaclass=CompositeMetaClass):
             )
         elif guild_data["maxlength"] > 0:
 
-            if self.is_track_too_long(search_choice.length, guild_data["maxlength"]):
+            if self.is_track_length_allowed(search_choice, guild_data["maxlength"]):
                 player.add(ctx.author, search_choice)
                 player.maybe_shuffle()
                 self.bot.dispatch(

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -435,7 +435,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                         log.debug(f"Query is not allowed in {ctx.guild} ({ctx.guild.id})")
                     continue
                 elif guild_data["maxlength"] > 0:
-                    if self.is_track_too_long(track, guild_data["maxlength"]):
+                    if self.is_track_length_allowed(track, guild_data["maxlength"]):
                         track_len += 1
                         player.add(ctx.author, track)
                         self.bot.dispatch(
@@ -514,7 +514,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                         ctx, title=_("This track is not allowed in this server.")
                     )
                 elif guild_data["maxlength"] > 0:
-                    if self.is_track_too_long(single_track, guild_data["maxlength"]):
+                    if self.is_track_length_allowed(single_track, guild_data["maxlength"]):
                         player.add(ctx.author, single_track)
                         player.maybe_shuffle()
                         self.bot.dispatch(
@@ -661,15 +661,11 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
         else:
             return False
 
-    def is_track_too_long(self, track: Union[lavalink.Track, int], maxlength: int) -> bool:
-        try:
-            length = round(track.length / 1000)
-        except AttributeError:
-            length = round(track / 1000)
-
-        if length > 900000000000000:  # livestreams return 9223372036854775807ms
+    def is_track_length_allowed(self, track: lavalink.Track, maxlength: int) -> bool:
+        if track.is_stream:
             return True
-        elif length >= maxlength:
+        length = track.length / 1000
+        if length > maxlength:
             return False
         else:
             return True

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -667,6 +667,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
         except AttributeError:
             length = round(track / 1000)
 
-        if maxlength < length <= 92233720368547758070:  # livestreams return 9223372036854775807ms
+        if length > 900000000000000:  # livestreams return 9223372036854775807ms
+            return True
+        elif length >= maxlength:
             return False
-        return True
+        else:
+            return True

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -667,5 +667,4 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
         length = track.length / 1000
         if length > maxlength:
             return False
-        else:
-            return True
+        return True


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Resolves #3877