### PR TITLE
[Audio] Fix DM Crash

### DIFF
--- a/redbot/cogs/audio/core/events/dpy.py
+++ b/redbot/cogs/audio/core/events/dpy.py
@@ -44,17 +44,19 @@ class DpyEvents(MixinMeta, metaclass=CompositeMetaClass):
         #     notify_channel = player.fetch("channel")
         #     if not notify_channel:
         #         player.store("channel", ctx.channel.id)
+        self._daily_global_playlist_cache.setdefault(
+            self.bot.user.id, await self.config.daily_playlists()
+        )
+        if self.local_folder_current_path is None:
+            self.local_folder_current_path = Path(await self.config.localpath())
+        if not ctx.guild:
+            return
         dj_enabled = self._dj_status_cache.setdefault(
             ctx.guild.id, await self.config.guild(ctx.guild).dj_enabled()
         )
         self._daily_playlist_cache.setdefault(
             ctx.guild.id, await self.config.guild(ctx.guild).daily_playlists()
         )
-        self._daily_global_playlist_cache.setdefault(
-            self.bot.user.id, await self.config.daily_playlists()
-        )
-        if self.local_folder_current_path is None:
-            self.local_folder_current_path = Path(await self.config.localpath())
         if dj_enabled:
             dj_role = self._dj_role_cache.setdefault(
                 ctx.guild.id, await self.config.guild(ctx.guild).dj_role()


### PR DESCRIPTION
Signed-off-by: Drapersniper <27962761+drapersniper@users.noreply.github.com>

### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
fixes the following
```
Traceback (most recent call last):
  File "C:\Users\cuzto\redenv\lib\site-packages\discord\client.py", line 312, in _run_event
    await coro(*args, **kwargs)
  File "C:\Users\cuzto\redenv\lib\site-packages\redbot\core\events.py", line 300, in on_message
    await bot.process_commands(message)
  File "C:\Users\cuzto\redenv\lib\site-packages\redbot\core\bot.py", line 876, in process_commands
    await self.invoke(ctx)
  File "C:\Users\cuzto\redenv\lib\site-packages\discord\ext\commands\bot.py", line 892, in invoke
    await ctx.command.invoke(ctx)
  File "C:\Users\cuzto\redenv\lib\site-packages\redbot\core\commands\commands.py", line 799, in invoke
    await super().invoke(ctx)
  File "C:\Users\cuzto\redenv\lib\site-packages\discord\ext\commands\core.py", line 1217, in invoke
    await self.prepare(ctx)
  File "C:\Users\cuzto\redenv\lib\site-packages\redbot\core\commands\commands.py", line 474, in prepare
    await self.call_before_hooks(ctx)
  File "C:\Users\cuzto\redenv\lib\site-packages\discord\ext\commands\core.py", line 707, in call_before_hooks
    await hook(ctx)
  File "C:\Users\cuzto\redenv\lib\site-packages\redbot\cogs\audio\core\events\dpy.py", line 48, in cog_before_invoke
    ctx.guild.id, await self.config.guild(ctx.guild).dj_enabled()
AttributeError: 'NoneType' object has no attribute 'id'
```