### PR TITLE
[Core] Add `bot.set_prefixes()`

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -454,6 +454,21 @@ class RedBase(
         """
         return await self.get_prefix(NotMessage(guild))
 
+    async def set_prefixes(self, prefixes: List[str], guild: Optional[discord.Guild] = None):
+        """
+        Set server or DM prefixes.
+
+        If not provided a guild (or passed None) it will set the DM prefixes.
+
+        Parameters
+        ----------
+        prefixes : List[str]
+            The prefixes you want to set
+        guild : Optional[discord.Guild]
+            The guild you want to set prefixes for.  Omit (or pass None) to set the DM prefixes
+        """
+        await self._prefix_cache.set_prefixes(guild=guild, prefixes=prefixes)
+
     async def get_embed_color(self, location: discord.abc.Messageable) -> discord.Color:
         """
         Get the embed color for a location. This takes into account all related settings.

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -463,7 +463,7 @@ class RedBase(
         Parameters
         ----------
         prefixes : List[str]
-            The prefixes you want to set
+            The prefixes you want to set. Passing empty list will reset prefixes for the ``guild``
         guild : Optional[discord.Guild]
             The guild you want to set the prefixes for. Omit (or pass None) to set the global prefixes
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -456,9 +456,9 @@ class RedBase(
 
     async def set_prefixes(self, prefixes: List[str], guild: Optional[discord.Guild] = None):
         """
-        Set server or DM prefixes.
+        Set global/server prefixes.
 
-        If not provided a guild (or passed None) it will set the DM prefixes.
+        If ``guild`` is not provided (or None is passed), this will set the global prefixes.
 
         Parameters
         ----------
@@ -466,6 +466,13 @@ class RedBase(
             The prefixes you want to set
         guild : Optional[discord.Guild]
             The guild you want to set prefixes for.  Omit (or pass None) to set the DM prefixes
+
+        Raises
+        ------
+        TypeError
+            If prefixes are not a list of strings
+        ValueError
+            If setting global prefixes and pass an empty prefix list
         """
         await self._prefix_cache.set_prefixes(guild=guild, prefixes=prefixes)
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -465,14 +465,14 @@ class RedBase(
         prefixes : List[str]
             The prefixes you want to set
         guild : Optional[discord.Guild]
-            The guild you want to set prefixes for.  Omit (or pass None) to set the DM prefixes
+            The guild you want to set the prefixes for. Omit (or pass None) to set the global prefixes
 
         Raises
         ------
         TypeError
-            If prefixes are not a list of strings
+            If ``prefixes`` is not a list of strings
         ValueError
-            If setting global prefixes and pass an empty prefix list
+            If empty list is passed to ``prefixes`` when setting global prefixes
         """
         await self._prefix_cache.set_prefixes(guild=guild, prefixes=prefixes)
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -261,7 +261,7 @@ class CoreLogic:
             The current (or new) list of prefixes.
         """
         if prefixes:
-            await self.bot._prefix_cache.set_prefixes(guild=None, prefixes=prefixes)
+            await self.bot.set_prefixes(guild=None, prefixes=prefixes)
             return prefixes
         return await self.bot._prefix_cache.get_prefixes(guild=None)
 
@@ -1284,7 +1284,7 @@ class Core(commands.Cog, CoreLogic):
         if not prefixes:
             await ctx.send_help()
             return
-        await self._prefixes(prefixes)
+        await ctx.bot.set_prefixes(guild=None, prefixes=prefixes)
         await ctx.send(_("Prefix set."))
 
     @_set.command(aliases=["serverprefixes"])
@@ -1293,11 +1293,11 @@ class Core(commands.Cog, CoreLogic):
     async def serverprefix(self, ctx: commands.Context, *prefixes: str):
         """Sets [botname]'s server prefix(es)"""
         if not prefixes:
-            await ctx.bot._prefix_cache.set_prefixes(guild=ctx.guild, prefixes=[])
+            await ctx.bot.set_prefixes(guild=ctx.guild, prefixes=[])
             await ctx.send(_("Guild prefixes have been reset."))
             return
         prefixes = sorted(prefixes, reverse=True)
-        await ctx.bot._prefix_cache.set_prefixes(guild=ctx.guild, prefixes=prefixes)
+        await ctx.bot.set_prefixes(guild=ctx.guild, prefixes=prefixes)
         await ctx.send(_("Prefix set."))
 
     @_set.command()


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Adds a documented way to set the global or server prefixes for the bot, so users do not have to use `_prefix_cache` and have Jack change them and break their cogs... Anyways, also changes `[p]set prefix` and `[p]set serverprefix` to use this new method.

Also, crossing my fingers, it won't cause RecursionError.