### PR TITLE
[Mod] Preemptive fix for the next dpy update

### DIFF
--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -551,8 +551,7 @@ class KickBanMixin(MixinMeta):
         # Store this channel for the case channel.
 
         try:
-            await member.move_to(discord.Object(id=None))
-            # Work around till we get D.py 1.1.0, whereby we can directly do None.
+            await member.move_to(None)
         except discord.Forbidden:  # Very unlikely that this will ever occur
             await ctx.send(_("I am unable to kick this member from the voice channel."))
             return


### PR DESCRIPTION
### Type
- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This PR replaces an old workaround used by `[p]voicekick` with the supported method for disconnecting users from voice channels. The existing code will begin to error when [this commit](https://github.com/Rapptz/discord.py/commit/e473f3c775b26a4bb54b18eb6240757306f4f5c1#diff-218d2af2b752b1274096efbf1721c806) is in our dpy.

*This change is untested because windows*