### PR TITLE
Add missing class docstrings in Downloader, Reports and Streams

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -36,6 +36,16 @@ DEPRECATION_NOTICE = _(
 
 @cog_i18n(_)
 class Downloader(commands.Cog):
+    """Install community cogs from Cog Creators.
+
+    Community cogs, also called third party cogs, are not included
+    in the default Red install. Cogs come in repositories. Repos are
+    groups of cogs by one creator you can install.
+
+    You always need to add a repository using the `[p]repo` command
+    before you can install cogs from the repo.
+    """
+
     def __init__(self, bot: Red):
         super().__init__()
         self.bot = bot

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -45,8 +45,6 @@ class Downloader(commands.Cog):
     group of cogs by one creator you can install. You always need
     to add the creater's repository using the `[p]repo` command
     before you can install cogs from the creator.
-
-    A list of approved repos can be found on the [Cog Board](https://cogboard.red/t/approved-repositories/210).
     """
 
     def __init__(self, bot: Red):

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -36,14 +36,15 @@ DEPRECATION_NOTICE = _(
 
 @cog_i18n(_)
 class Downloader(commands.Cog):
-    """Install community cogs from Cog Creators.
+    """Install community cogs made by Cog Creators.
 
     Community cogs, also called third party cogs, are not included
-    in the default Red install. Cogs come in repositories. Repos are
-    groups of cogs by one creator you can install.
-
-    You always need to add a repository using the `[p]repo` command
-    before you can install cogs from the repo.
+    in the default Red install.
+    
+    Community cogs always come in repositories. Repos are a
+    group of cogs by one creator you can install. You always need
+    to add the creater's repository using the `[p]repo` command
+    before you can install cogs from the creator.
     """
 
     def __init__(self, bot: Red):

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -45,6 +45,8 @@ class Downloader(commands.Cog):
     group of cogs by one creator you can install. You always need
     to add the creater's repository using the `[p]repo` command
     before you can install cogs from the creator.
+
+    A list of approved repos can be found on the [Cog Board](https://cogboard.red/t/approved-repositories/210).
     """
 
     def __init__(self, bot: Red):

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -41,10 +41,10 @@ class Downloader(commands.Cog):
     Community cogs, also called third party cogs, are not included
     in the default Red install.
     
-    Community cogs always come in repositories. Repos are a
-    group of cogs by one creator you can install. You always need
-    to add the creater's repository using the `[p]repo` command
-    before you can install cogs from the creator.
+    Community cogs come in repositories. Repos are a group of cogs
+    you can install. You always need to add the creator's repository
+    using the `[p]repo` command before you can install one or more
+    cogs from the creator.
     """
 
     def __init__(self, bot: Red):

--- a/redbot/cogs/reports/reports.py
+++ b/redbot/cogs/reports/reports.py
@@ -23,7 +23,13 @@ log = logging.getLogger("red.reports")
 
 @cog_i18n(_)
 class Reports(commands.Cog):
+    """Create user reports that server staff can respond to.
 
+    Users can open reports using `[p]report`. These are then
+    sent to a channel in the server, where staff members can
+    respond.
+    """
+    
     default_guild_settings = {"output_channel": None, "active": False, "next_ticket": 1}
 
     default_report = {"report": {}}

--- a/redbot/cogs/reports/reports.py
+++ b/redbot/cogs/reports/reports.py
@@ -29,7 +29,7 @@ class Reports(commands.Cog):
     sent to a channel in the server, where staff members can
     respond.
     """
-    
+
     default_guild_settings = {"output_channel": None, "active": False, "next_ticket": 1}
 
     default_report = {"report": {}}

--- a/redbot/cogs/reports/reports.py
+++ b/redbot/cogs/reports/reports.py
@@ -25,9 +25,9 @@ log = logging.getLogger("red.reports")
 class Reports(commands.Cog):
     """Create user reports that server staff can respond to.
 
-    Users can open reports using `[p]report`. These are then
-    sent to a channel in the server, where staff members can
-    respond.
+    Users can open reports using `[p]report`. These are then sent
+    to a channel in the server for staff, and the report creator
+    gets a DM. Both can be used to communicate. 
     """
 
     default_guild_settings = {"output_channel": None, "active": False, "next_ticket": 1}

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -38,13 +38,14 @@ log = logging.getLogger("red.core.cogs.Streams")
 
 @cog_i18n(_)
 class Streams(commands.Cog):
-    """Various commands realting to streaming platforms.
+    """Various commands relating to streaming platforms.
 
     You can check if a Twitch, YouTube, Picarto or Mixer stream is
-    currently live. Alerts can also be configured to post in a
-    channel when a streamer goes live.
+    currently live. Stream alerts can also be configured to
+    automatically post in a channel when a streamer goes live.
 
-    Twitch and YouTube need API tokens.
+    Twitch and YouTube require access to their API, so you need to
+    set API tokens.
     """
 
     global_defaults = {"refresh_timer": 300, "tokens": {}, "streams": []}

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -46,7 +46,7 @@ class Streams(commands.Cog):
 
     Twitch and YouTube need API tokens to work.
     """
-    
+
     global_defaults = {"refresh_timer": 300, "tokens": {}, "streams": []}
 
     guild_defaults = {

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -38,7 +38,15 @@ log = logging.getLogger("red.core.cogs.Streams")
 
 @cog_i18n(_)
 class Streams(commands.Cog):
+    """Various commands realting to streaming platforms.
 
+    You can check if a Twitch, YouTube, Picarto or Mixer stream is
+    currently live. Alerts can also be configured to post in a
+    channel when a streamer goes live.
+
+    Twitch and YouTube need API tokens to work.
+    """
+    
     global_defaults = {"refresh_timer": 300, "tokens": {}, "streams": []}
 
     guild_defaults = {

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -41,11 +41,7 @@ class Streams(commands.Cog):
     """Various commands relating to streaming platforms.
 
     You can check if a Twitch, YouTube, Picarto or Mixer stream is
-    currently live. Stream alerts can also be configured to
-    automatically post in a channel when a streamer goes live.
-
-    Twitch and YouTube require access to their API, so you need to
-    set API tokens.
+    currently live.
     """
 
     global_defaults = {"refresh_timer": 300, "tokens": {}, "streams": []}

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -44,7 +44,7 @@ class Streams(commands.Cog):
     currently live. Alerts can also be configured to post in a
     channel when a streamer goes live.
 
-    Twitch and YouTube need API tokens to work.
+    Twitch and YouTube need API tokens.
     """
 
     global_defaults = {"refresh_timer": 300, "tokens": {}, "streams": []}


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Add the missing class docstrings in Downloader, Reports and Streams. Fixes #3232

~~Not tested (Windows 🙄), though only docstrings so nothing should break. I hope.~~
Edit: [Got Windows to work](https://discordapp.com/channels/133049272517001216/133251234164375552/716590583744954418) and this doesn't break anything (no surprises there then, phew).