### PR TITLE
Fix setting guild prefixes when the prefixes aren't in cache

### DIFF
--- a/redbot/core/settings_caches.py
+++ b/redbot/core/settings_caches.py
@@ -49,7 +49,7 @@ class PrefixManager:
             self._cached.clear()
             await self._config.prefix.set(prefixes)
         else:
-            del self._cached[gid]
+            self._cached.pop(gid, None)
             await self._config.guild_from_id(gid).prefix.set(prefixes)
 
 


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
I really love these one line PRs.

Fix for if you're a person who likes to repeatedly spam bot internals.  Before, would raise KeyError when trying to delete it from cache, since it wasn't in cache.  Now, it ignores it if it isn't in the cache.