### PR TITLE
[Menus] Handle ctx.me that can be None when clearing reactions

### DIFF
--- a/redbot/core/utils/menus.py
+++ b/redbot/core/utils/menus.py
@@ -95,6 +95,8 @@ async def menu(
             timeout=timeout,
         )
     except asyncio.TimeoutError:
+        if not ctx.me:
+            return
         try:
             if message.channel.permissions_for(ctx.me).manage_messages:
                 await message.clear_reactions()


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
It is happening when the bot leave a guild where a menu was still opened. Which raise that error:
```py
  File "/venv/lib/python3.8/site-packages/redbot/core/utils/menus.py", line 100, in menu
    if message.channel.permissions_for(ctx.me).manage_messages:
  File "/venv/lib/python3.8/site-packages/discord/channel.py", line 146, in permissions_for
    base = super().permissions_for(member)
  File "/venv/lib/python3.8/site-packages/discord/abc.py", line 456, in permissions_for
    if self.guild.owner_id == member.id:
AttributeError: 'NoneType' object has no attribute 'id'
```