### PR TITLE
[Core] Add `[p]set mentionhelp` command to the bot

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -916,13 +916,25 @@ class RedBase(
             and message.clean_content.strip() == f"@{message.mentions[0].display_name}"
             and message.mentions[0].id == self.user.id
         ):
-            prefixes = await self._prefix_cache.get_prefixes(message.guild)
+            prefixes = await self.get_valid_prefixes(guild=message.guild)
+            prefixes = sorted(prefixes, key=len)
+            counter = 0
+            prefixes_string = humanize_list(
+                [
+                    pf
+                    for p in prefixes
+                    if (pf := f"`{p}`")
+                    and len(pf) < 1800
+                    and ((counter + len(pf)) < 1800)
+                    and (counter := counter + len(pf))
+                ]
+            )
             await message.channel.send(
                 _(
-                    "Hello there, my prefix here are the following:\n{}"
+                    "Hello there, my prefix here are the following:\n{}\n"
                     "Why don't you try `{}help` to see everything I can do."
                     # There's a chance help is disabled ... but that's a gray area anyways so dont think supporting it is necessary.
-                ).format(humanize_list([f"`{i}`\n" for i in prefixes]), prefixes[0])
+                ).format(prefixes_string, prefixes[0])
             )
             return
         if ctx is None or ctx.valid is False:

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -47,7 +47,7 @@ from .settings_caches import (
     PrefixManager,
     IgnoreManager,
     WhitelistBlacklistManager,
-    MentionPredixManager,
+    MentionPrefixManager,
 )
 
 from .rpc import RPCMixin
@@ -153,7 +153,7 @@ class RedBase(
         self._prefix_cache = PrefixManager(self._config, cli_flags)
         self._ignored_cache = IgnoreManager(self._config)
         self._whiteblacklist_cache = WhitelistBlacklistManager(self._config)
-        self._mention_prefix_cache = MentionPredixManager(self._config)
+        self._mention_prefix_cache = MentionPrefixManager(self._config)
 
         async def prefix_manager(bot, message) -> List[str]:
             prefixes = await self._prefix_cache.get_prefixes(message.guild)

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -911,8 +911,10 @@ class RedBase(
             and len(message.mentions) == 1
             and message.clean_content.strip() == f"@{message.mentions[0].display_name}"
             and message.mentions[0].id == self.user.id
+            and not await self.ignored_channel_or_guild(ctx=ctx)
+            and await self.allowed_by_whitelist_blacklist(who=message.author)
         ):
-            self.dispatch("message_bot_mention", message)
+            self.dispatch("red_message_bot_mention", message)
             return
         if ctx is None or ctx.valid is False:
             self.dispatch("message_without_command", message)

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -920,7 +920,7 @@ class RedBase(
             await message.channel.send(
                 _(
                     "Hello there, my prefix here are the following:\n{}"
-                    "Why don't you try `{}help` a try to see everything I can do."
+                    "Why don't you try `{}help` to see everything I can do."
                     # There's a chance help is disabled ... but that's a gray area anyways so dont think supporting it is necessary.
                 ).format(humanize_list([f"`{i}`\n" for i in prefixes]), prefixes[0])
             )

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -916,26 +916,7 @@ class RedBase(
             and message.clean_content.strip() == f"@{message.mentions[0].display_name}"
             and message.mentions[0].id == self.user.id
         ):
-            prefixes = await self.get_valid_prefixes(guild=message.guild)
-            prefixes = sorted(prefixes, key=len)
-            counter = 0
-            prefixes_string = humanize_list(
-                [
-                    pf
-                    for p in prefixes
-                    if (pf := f"`{p}`")
-                    and len(pf) < 1800
-                    and ((counter + len(pf)) < 1800)
-                    and (counter := counter + len(pf))
-                ]
-            )
-            await message.channel.send(
-                _(
-                    "Hello there, my prefix here are the following:\n{}\n"
-                    "Why don't you try `{}help` to see everything I can do."
-                    # There's a chance help is disabled ... but that's a gray area anyways so dont think supporting it is necessary.
-                ).format(prefixes_string, prefixes[0])
-            )
+            self.dispatch("message_bot_mention", message)
             return
         if ctx is None or ctx.valid is False:
             self.dispatch("message_without_command", message)

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -31,9 +31,6 @@ import discord
 from discord.ext import commands as dpy_commands
 from discord.ext.commands import when_mentioned_or
 from discord.ext.commands.bot import BotBase
-from redbot.core.utils.chat_formatting import humanize_list
-
-from redbot.core.i18n import Translator
 
 from . import Config, i18n, commands, errors, drivers, modlog, bank
 from .cog_manager import CogManager, CogManagerUI
@@ -65,7 +62,6 @@ NotMessage = namedtuple("NotMessage", "guild")
 
 PreInvokeCoroutine = Callable[[commands.Context], Awaitable[Any]]
 T_BIC = TypeVar("T_BIC", bound=PreInvokeCoroutine)
-_ = Translator("Red", __file__)
 
 
 def _is_submodule(parent, child):

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -906,11 +906,13 @@ class RedBase(
         else:
             ctx = None
         if (
-            not message.author.bot
-            and await self._mention_prefix_cache.get_context_value(message.guild)
+            ctx
+            and ctx.valid
+            and ctx.channel.permissions_for(ctx.me).send_messages
             and len(message.mentions) == 1
-            and message.clean_content.strip() == f"@{message.mentions[0].display_name}"
             and message.mentions[0].id == self.user.id
+            and message.clean_content.strip() == f"@{message.mentions[0].display_name}"
+            and await self._mention_prefix_cache.get_context_value(message.guild)
             and not await self.ignored_channel_or_guild(ctx=ctx)
             and await self.allowed_by_whitelist_blacklist(who=message.author)
         ):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1360,6 +1360,19 @@ class Core(commands.Cog, CoreLogic):
         await ctx.bot.set_prefixes(guild=ctx.guild, prefixes=prefixes)
         await ctx.send(_("Prefix set."))
 
+    @_set.command(aliases=["mentionhelp"])
+    @checks.admin()
+    @commands.guild_only()
+    async def _mentionhelp(self, ctx: commands.Context):
+        """Make mentioning [botname] show a help message."""
+        value = await ctx.bot._mention_prefix_cache.get_context_value(guild=ctx.guild)
+        if value is False:
+            await ctx.bot._mention_prefix_cache.set_guild(guild=ctx.guild, set_to=True)
+            await ctx.send(_("Mentioning the bot will now send a help message."))
+            return
+        await ctx.bot._mention_prefix_cache.set_guild(guild=ctx.guild, set_to=False)
+        await ctx.send(_("Mentioning the bot will no longer send a help message."))
+
     @_set.command()
     @checks.is_owner()
     async def locale(self, ctx: commands.Context, language_code: str):

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -34,6 +34,7 @@ from .utils.chat_formatting import (
     humanize_list,
     humanize_timedelta,
 )
+
 log = logging.getLogger("red")
 init()
 

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -27,8 +27,13 @@ from .utils._internal_utils import (
     expected_version,
     fetch_latest_red_version_info,
 )
-from .utils.chat_formatting import inline, bordered, format_perms_list, humanize_timedelta
-
+from .utils.chat_formatting import (
+    inline,
+    bordered,
+    format_perms_list,
+    humanize_list,
+    humanize_timedelta,
+)
 log = logging.getLogger("red")
 init()
 
@@ -317,6 +322,29 @@ def init_events(bot, cli_flags):
                     diff,
                 )
             bot._checked_time_accuracy = discord_now
+
+    @bot.event
+    async def on_red_message_bot_mention(message):
+        prefixes = await bot.get_valid_prefixes(guild=message.guild)
+        prefixes = sorted(prefixes, key=len)
+        counter = 0
+        prefixes_string = humanize_list(
+            [
+                pf
+                for p in prefixes
+                if (pf := f"`{p}`")
+                and len(pf) < 1800
+                and ((counter + len(pf)) < 1800)
+                and (counter := counter + len(pf))
+            ]
+        )
+        await message.channel.send(
+            _(
+                "Hello there, my prefix here are the following:\n{}\n"
+                "Why don't you try `{}help` to see everything I can do."
+                # There's a chance help is disabled ... but that's a gray area anyways so dont think supporting it is necessary.
+            ).format(prefixes_string, prefixes[0])
+        )
 
     @bot.event
     async def on_command_add(command: commands.Command):

--- a/redbot/core/settings_caches.py
+++ b/redbot/core/settings_caches.py
@@ -278,7 +278,7 @@ class WhitelistBlacklistManager:
                         curr_list.remove(obj_id)
 
 
-class MentionPredixManager:
+class MentionPrefixManager:
     def __init__(self, config: Config, enable_cache: bool = True):
         self._config: Config = config
         self.enable_cache = enable_cache

--- a/redbot/core/settings_caches.py
+++ b/redbot/core/settings_caches.py
@@ -276,3 +276,32 @@ class WhitelistBlacklistManager:
                     self._cached_blacklist[gid].remove(obj_id)
                     async with self._config.guild_from_id(gid).blacklist() as curr_list:
                         curr_list.remove(obj_id)
+
+
+class MentionPredixManager:
+    def __init__(self, config: Config, enable_cache: bool = True):
+        self._config: Config = config
+        self.enable_cache = enable_cache
+        self._cached_guild: Dict[int, bool] = {}
+
+    async def get_guild(self, guild: discord.Guild) -> bool:
+        ret: bool
+        gid: int = guild.id
+        if self.enable_cache and gid in self._cached_guild:
+            ret = self._cached_guild[gid]
+        else:
+            ret = await self._config.guild_from_id(gid).prefix_on_mention()
+            self._cached_guild[gid] = ret
+        return ret
+
+    async def set_guild(self, guild: discord.Guild, set_to: Optional[bool]) -> None:
+        gid: int = guild.id
+        if set_to is not None:
+            await self._config.guild_from_id(gid).prefix_on_mention.set(set_to)
+            self._cached_guild[gid] = set_to
+        else:
+            await self._config.guild_from_id(gid).prefix_on_mentionprefix_on_mention.clear()
+            self._cached_guild[gid] = self._config.defaults["GUILD"]["prefix_on_mention"]
+
+    async def get_context_value(self, guild: Optional[discord.Guild]) -> bool:
+        return await self.get_guild(guild) if guild else True


### PR DESCRIPTION

### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes
fixes #3912
- Bot will now respond to a blank mention of itself with the available prefixes.