### PR TITLE
[Docs] Add Oracle to VPS Hosting, new specific links 

### DIFF
--- a/docs/host-list.rst
+++ b/docs/host-list.rst
@@ -59,6 +59,9 @@ Others
 |`Microsoft Azure                     |Same as AWS, but it's Microsoft.                     |
 |<https://azure.microsoft.com>`_      |                                                     |
 +-------------------------------------+-----------------------------------------------------+
+|`Oracle Cloud                        |Same as AWS, but it's Oracle.                        |
+|<https://oracle.com/cloud/>`_        |                                                     |
++-------------------------------------+-----------------------------------------------------+
 |`LowEndBox <http://lowendbox.com/>`_ |A curator for lower specced servers.                 |
 +-------------------------------------+-----------------------------------------------------+
 
@@ -76,7 +79,10 @@ server. Any modern hardware should work 100% fine.
 Free hosting
 ------------
 
-Google Cloud and AWS both have free tier VPS suitable for small bots.
+`Google Cloud Free Tier <https://cloud.google.com/free/docs/gcp-free-tier>`_,
+`Oracle Cloud Always Free <https://oracle.com/cloud/free/#always-free>`_ and
+`AWS EC2 <https://aws.amazon.com/ec2/>`_ have free tier VPSes suitable for small bots.
+AWS EC2 is not *always* free—it's a 12 month free trial.
 Additionally, new Google Cloud customers get a $300 credit which is valid
 for 12 months.
 

--- a/docs/host-list.rst
+++ b/docs/host-list.rst
@@ -79,9 +79,9 @@ server. Any modern hardware should work 100% fine.
 Free hosting
 ------------
 
-`Google Cloud Free Tier <https://cloud.google.com/free/docs/gcp-free-tier>`_,
-`Oracle Cloud Always Free <https://oracle.com/cloud/free/#always-free>`_ and
-`AWS EC2 <https://aws.amazon.com/ec2/>`_ have free tier VPSes suitable for small bots.
+`Google Cloud Compute Free Tier <https://cloud.google.com/free/docs/gcp-free-tier>`_,
+`Oracle Cloud Compute Always Free <https://oracle.com/cloud/free/#always-free>`_ and
+`AWS EC2 Free Tier <https://aws.amazon.com/free/>`_ have free tier VPSes suitable for small bots.
 AWS EC2 is not *always* free—it's a 12 month free trial.
 Additionally, new Google Cloud customers get a $300 credit which is valid
 for 12 months.


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
- Adds Oracle in the table and also in the free hosting section, as this is now a cc in the server so it seems natural to have it in the docs as well
- Adds links in the free hosting section
- Change to specifically EC2, not just AWS, and mention it is only 12 months free

Build: [red-discordbot--3916.org.readthedocs.build/en/3916/host-list.html](https://red-discordbot--3916.org.readthedocs.build/en/3916/host-list.html#host-list)