### PR TITLE
Add `map()`, `find()` and `next()` methods to `AsyncIter`

### DIFF
--- a/redbot/core/utils/__init__.py
+++ b/redbot/core/utils/__init__.py
@@ -299,7 +299,7 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
         self._iterator = iter(iterable)
         self._i = 0
         self._steps = steps
-        self._map = lambda x: x
+        self._map = None
 
     def __aiter__(self) -> AsyncIter[_T]:
         return self
@@ -313,7 +313,7 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
             self._i = 0
             await asyncio.sleep(self._delay)
         self._i += 1
-        return await maybe_coroutine(self._map, item)
+        return await maybe_coroutine(self._map, item) if self._map is not None else item
 
     def __await__(self) -> Generator[Any, None, List[_T]]:
         """Returns a list of the iterable.

--- a/redbot/core/utils/__init__.py
+++ b/redbot/core/utils/__init__.py
@@ -476,7 +476,7 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
         Examples
         --------
         >>> from redbot.core.utils import AsyncIter
-        >>> async for value in AsyncIter(range(3)).map(bool)
+        >>> async for value in AsyncIter(range(3)).map(bool):
         ...     print(value)
         False
         True

--- a/redbot/core/utils/__init__.py
+++ b/redbot/core/utils/__init__.py
@@ -445,7 +445,7 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
         Examples
         --------
         >>> from redbot.core.utils import AsyncIter
-        >>> await AsyncIter(range(3)).find(lambda x: x == 1):
+        >>> await AsyncIter(range(3)).find(lambda x: x == 1)
         1
         """
         while True:
@@ -476,7 +476,7 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
         Examples
         --------
         >>> from redbot.core.utils import AsyncIter
-        >>> async for value in AsyncIter(range(3)).map(bool):
+        >>> async for value in AsyncIter(range(3)).map(bool)
         ...     print(value)
         False
         True

--- a/redbot/core/utils/__init__.py
+++ b/redbot/core/utils/__init__.py
@@ -428,7 +428,9 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
         del _temp
 
     async def find(
-        self, predicate: Union[Callable, Coroutine], default: Optional[Any] = None
+        self,
+        predicate: Callable[[_T], Union[bool, Awaitable[bool]]],
+        default: Optional[Any] = None,
     ) -> AsyncIterator[_T]:
         """Calls ``predicate`` over items in iterable and return first value to match.
 
@@ -437,7 +439,7 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
         predicate: Union[Callable, Coroutine]
             A function that returns a boolean-like result. The predicate provided can be a coroutine.
         default: Optional[Any]
-            The value to return if there is no matches.
+            The value to return if there are no matches.
 
         Raises
         ------
@@ -459,7 +461,7 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
             if ret:
                 return elem
 
-    def map(self, func: Union[Coroutine[..., _S], Callable[..., _S]]) -> AsyncIter[_S]:
+    def map(self, func: Callable[[_T], Union[_S, Awaitable[_S]]]) -> AsyncIter[_S]:
         """Set the mapping callable for this instance of `AsyncIter`.
 
         .. important::
@@ -486,7 +488,7 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
 
         """
 
-        if func and not callable(func):
+        if not callable(func):
             raise TypeError("Mapping must be a callable.")
         self._map = func
         return self

--- a/redbot/core/utils/__init__.py
+++ b/redbot/core/utils/__init__.py
@@ -26,7 +26,7 @@ __all__ = ("bounded_gather", "bounded_gather_iter", "deduplicate_iterables", "As
 
 
 _T = TypeVar("_T")
-
+_S = TypeVar("_S")
 
 # Benchmarked to be the fastest method.
 def deduplicate_iterables(*iterables):
@@ -426,19 +426,21 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
                 _temp.add(item)
         del _temp
 
-    async def find(self, predicate: Callable, default: Optional[Any] = None):
-        """Calls `predicate` over items in iterable and return first value to match.
+    async def find(self, predicate: Callable, default: Optional[Any] = None) -> AsyncIterator[_T]:
+        """Calls ``predicate`` over items in iterable and return first value to match.
 
         Parameters
         ----------
         predicate: Callable
             The function to to check values with, this function should return `True` or `False`
-            and accept only a single argument, which is the value in the iterrable.
+            and accept only a single argument, which is the value in the iterable.
+        default: Optional[Any]
+            The value to return if there is no matches.
 
         Raises
         ------
         TypeError
-            When ``func`` is not a callable.
+            When ``predicate`` is not a callable.
 
         Examples
         --------
@@ -454,9 +456,13 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
             ret = await maybe_coroutine(predicate, elem)
             if ret:
                 return elem
+            map()
 
-    def map(self, func: Callable):
+    def map(self, func: Callable[..., _S]) -> AsyncIter[_S]:
         """Set the mapping callable for this instance of `AsyncIter`.
+
+        .. important::
+            This should be called after AsyncIter initialization and before any other of its methods.
 
         Parameters
         ----------

--- a/redbot/core/utils/__init__.py
+++ b/redbot/core/utils/__init__.py
@@ -312,7 +312,7 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
             self._i = 0
             await asyncio.sleep(self._delay)
         self._i += 1
-        return self._map(item)
+        return await maybe_coroutine(self._map, item)
 
     def __await__(self) -> Generator[Any, None, List[_T]]:
         """Returns a list of the iterable.
@@ -431,9 +431,7 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
 
         Parameters
         ----------
-        predicate: Callable
-            The function to to check values with, this function should return `True` or `False`
-            and accept only a single argument, which is the value in the iterable.
+        predicate: A function that returns a boolean-like result. The predicate provided can be a coroutine.
         default: Optional[Any]
             The value to return if there is no matches.
 
@@ -466,7 +464,7 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
         Parameters
         ----------
         func: Callable
-            The function to map values to.
+            The function to map values to. The function provided can be a coroutine.
 
         Raises
         ------

--- a/redbot/core/utils/__init__.py
+++ b/redbot/core/utils/__init__.py
@@ -328,6 +328,37 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
         """
         return self.flatten().__await__()
 
+    async def next(self, default: Any = ...) -> _T:
+        """Returns a next entry of the iterable.
+
+        Parameters
+        ----------
+        default: Optional[Any]
+            The value to return if the iterator is exhausted.
+
+        Raises
+        ------
+        StopAsyncIteration
+            When ``default`` is not specified and the iterator has been exhausted.
+
+        Examples
+        --------
+        >>> from redbot.core.utils import AsyncIter
+        >>> iterator = AsyncIter(range(5))
+        >>> await iterator.next()
+        0
+        >>> await iterator.next()
+        1
+
+        """
+        try:
+            value = await self.__anext__()
+        except StopAsyncIteration:
+            if default is ...:
+                raise
+            value = default
+        return value
+
     async def flatten(self) -> List[_T]:
         """Returns a list of the iterable.
 

--- a/redbot/core/utils/__init__.py
+++ b/redbot/core/utils/__init__.py
@@ -456,7 +456,6 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
             ret = await maybe_coroutine(predicate, elem)
             if ret:
                 return elem
-            map()
 
     def map(self, func: Callable[..., _S]) -> AsyncIter[_S]:
         """Set the mapping callable for this instance of `AsyncIter`.

--- a/redbot/core/utils/__init__.py
+++ b/redbot/core/utils/__init__.py
@@ -18,6 +18,7 @@ from typing import (
     TypeVar,
     Union,
     Generator,
+    Coroutine,
 )
 
 from discord.utils import maybe_coroutine
@@ -426,12 +427,15 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
                 _temp.add(item)
         del _temp
 
-    async def find(self, predicate: Callable, default: Optional[Any] = None) -> AsyncIterator[_T]:
+    async def find(
+        self, predicate: Union[Callable, Coroutine], default: Optional[Any] = None
+    ) -> AsyncIterator[_T]:
         """Calls ``predicate`` over items in iterable and return first value to match.
 
         Parameters
         ----------
-        predicate: A function that returns a boolean-like result. The predicate provided can be a coroutine.
+        predicate: Union[Callable, Coroutine]
+            A function that returns a boolean-like result. The predicate provided can be a coroutine.
         default: Optional[Any]
             The value to return if there is no matches.
 
@@ -455,7 +459,7 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
             if ret:
                 return elem
 
-    def map(self, func: Callable[..., _S]) -> AsyncIter[_S]:
+    def map(self, func: Union[Coroutine[..., _S], Callable[..., _S]]) -> AsyncIter[_S]:
         """Set the mapping callable for this instance of `AsyncIter`.
 
         .. important::
@@ -463,7 +467,7 @@ class AsyncIter(AsyncIterator[_T], Awaitable[List[_T]]):  # pylint: disable=dupl
 
         Parameters
         ----------
-        func: Callable
+        func: Union[Callable, Coroutine]
             The function to map values to. The function provided can be a coroutine.
 
         Raises


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes

Adds `AsyncIter.map` which allows users to specify a callable to wrap returns in.
Adds `AsyncIter.find` which allows users to give a predicate and return the first value that matchs said predicate
Adds `AsyncIter.next()` which works similarly to how `next()` on regular iterator works - it returns next item from the iterator.

I intentionally did not Add `get` here as i can't think of sane way to implement that on something that may or may not have non class object.

fixes #3887 