### PR TITLE
[Core Commands] Fix `[p]set custominfo` error

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1384,7 +1384,7 @@ class Core(commands.Cog, CoreLogic):
             await ctx.send(_("The custom text has been set."))
             await ctx.invoke(self.info)
         else:
-            await ctx.bot.send(_("Characters must be fewer than 1024."))
+            await ctx.send(_("Text must be fewer than 1024 characters long."))
 
     @_set.command()
     @checks.is_owner()


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes an `AttributeError` trying to use `ctx.bot.send` instead of `ctx.send`.
Also makes the message a little clearer while I'm editing the code anyway.