### PR TITLE
[Filter] Fix confusing behavior detecting quotes

### DIFF
--- a/redbot/cogs/filter/filter.py
+++ b/redbot/cogs/filter/filter.py
@@ -1,5 +1,6 @@
 import discord
 import re
+import shlex
 from typing import Union, Set
 
 from redbot.core import checks, Config, modlog, commands
@@ -150,21 +151,11 @@ class Filter(commands.Cog):
         - `[p]filter channel add "This is a sentence"`
         """
         channel = ctx.channel
-        split_words = words.split()
-        word_list = []
-        tmp = ""
-        for word in split_words:
-            if not word.startswith('"') and not word.endswith('"') and not tmp:
-                word_list.append(word)
-            else:
-                if word.startswith('"'):
-                    tmp += word[1:] + " "
-                elif word.endswith('"'):
-                    tmp += word[:-1]
-                    word_list.append(tmp)
-                    tmp = ""
-                else:
-                    tmp += word + " "
+        try:
+            word_list = shlex.split(words)
+        except ValueError:
+            await ctx.send(_("I could not parse your words. Double check your quotes."))
+            return
         added = await self.add_to_filter(channel, word_list)
         if added:
             self.invalidate_cache(ctx.guild, ctx.channel)
@@ -183,21 +174,11 @@ class Filter(commands.Cog):
         - `[p]filter channel remove "This is a sentence"`
         """
         channel = ctx.channel
-        split_words = words.split()
-        word_list = []
-        tmp = ""
-        for word in split_words:
-            if not word.startswith('"') and not word.endswith('"') and not tmp:
-                word_list.append(word)
-            else:
-                if word.startswith('"'):
-                    tmp += word[1:] + " "
-                elif word.endswith('"'):
-                    tmp += word[:-1]
-                    word_list.append(tmp)
-                    tmp = ""
-                else:
-                    tmp += word + " "
+        try:
+            word_list = shlex.split(words)
+        except ValueError:
+            await ctx.send(_("I could not parse your words. Double check your quotes."))
+            return
         removed = await self.remove_from_filter(channel, word_list)
         if removed:
             await ctx.send(_("Words removed from filter."))
@@ -216,21 +197,11 @@ class Filter(commands.Cog):
         - `[p]filter add "This is a sentence"`
         """
         server = ctx.guild
-        split_words = words.split()
-        word_list = []
-        tmp = ""
-        for word in split_words:
-            if not word.startswith('"') and not word.endswith('"') and not tmp:
-                word_list.append(word)
-            else:
-                if word.startswith('"'):
-                    tmp += word[1:] + " "
-                elif word.endswith('"'):
-                    tmp += word[:-1]
-                    word_list.append(tmp)
-                    tmp = ""
-                else:
-                    tmp += word + " "
+        try:
+            word_list = shlex.split(words)
+        except ValueError:
+            await ctx.send(_("I could not parse your words. Double check your quotes."))
+            return
         added = await self.add_to_filter(server, word_list)
         if added:
             self.invalidate_cache(ctx.guild)
@@ -249,21 +220,11 @@ class Filter(commands.Cog):
         - `[p]filter remove "This is a sentence"`
         """
         server = ctx.guild
-        split_words = words.split()
-        word_list = []
-        tmp = ""
-        for word in split_words:
-            if not word.startswith('"') and not word.endswith('"') and not tmp:
-                word_list.append(word)
-            else:
-                if word.startswith('"'):
-                    tmp += word[1:] + " "
-                elif word.endswith('"'):
-                    tmp += word[:-1]
-                    word_list.append(tmp)
-                    tmp = ""
-                else:
-                    tmp += word + " "
+        try:
+            word_list = shlex.split(words)
+        except ValueError:
+            await ctx.send(_("I could not parse your words. Double check your quotes."))
+            return
         removed = await self.remove_from_filter(server, word_list)
         if removed:
             self.invalidate_cache(ctx.guild)

--- a/redbot/cogs/filter/filter.py
+++ b/redbot/cogs/filter/filter.py
@@ -1,6 +1,5 @@
 import discord
 import re
-import shlex
 from typing import Union, Set
 
 from redbot.core import checks, Config, modlog, commands
@@ -141,7 +140,7 @@ class Filter(commands.Cog):
                     await ctx.send(_("I can't send direct messages to you."))
 
     @_filter_channel.command("add")
-    async def filter_channel_add(self, ctx: commands.Context, *, words: str):
+    async def filter_channel_add(self, ctx: commands.Context, *words: str):
         """Add words to the filter.
 
         Use double quotes to add sentences.
@@ -151,12 +150,7 @@ class Filter(commands.Cog):
         - `[p]filter channel add "This is a sentence"`
         """
         channel = ctx.channel
-        try:
-            word_list = shlex.split(words)
-        except ValueError:
-            await ctx.send(_("I could not parse your words. Double check your quotes."))
-            return
-        added = await self.add_to_filter(channel, word_list)
+        added = await self.add_to_filter(channel, words)
         if added:
             self.invalidate_cache(ctx.guild, ctx.channel)
             await ctx.send(_("Words added to filter."))
@@ -164,7 +158,7 @@ class Filter(commands.Cog):
             await ctx.send(_("Words already in the filter."))
 
     @_filter_channel.command("remove")
-    async def filter_channel_remove(self, ctx: commands.Context, *, words: str):
+    async def filter_channel_remove(self, ctx: commands.Context, *words: str):
         """Remove words from the filter.
 
         Use double quotes to remove sentences.
@@ -174,12 +168,7 @@ class Filter(commands.Cog):
         - `[p]filter channel remove "This is a sentence"`
         """
         channel = ctx.channel
-        try:
-            word_list = shlex.split(words)
-        except ValueError:
-            await ctx.send(_("I could not parse your words. Double check your quotes."))
-            return
-        removed = await self.remove_from_filter(channel, word_list)
+        removed = await self.remove_from_filter(channel, words)
         if removed:
             await ctx.send(_("Words removed from filter."))
             self.invalidate_cache(ctx.guild, ctx.channel)
@@ -187,7 +176,7 @@ class Filter(commands.Cog):
             await ctx.send(_("Those words weren't in the filter."))
 
     @_filter.command(name="add")
-    async def filter_add(self, ctx: commands.Context, *, words: str):
+    async def filter_add(self, ctx: commands.Context, *words: str):
         """Add words to the filter.
 
         Use double quotes to add sentences.
@@ -197,12 +186,7 @@ class Filter(commands.Cog):
         - `[p]filter add "This is a sentence"`
         """
         server = ctx.guild
-        try:
-            word_list = shlex.split(words)
-        except ValueError:
-            await ctx.send(_("I could not parse your words. Double check your quotes."))
-            return
-        added = await self.add_to_filter(server, word_list)
+        added = await self.add_to_filter(server, words)
         if added:
             self.invalidate_cache(ctx.guild)
             await ctx.send(_("Words successfully added to filter."))
@@ -210,7 +194,7 @@ class Filter(commands.Cog):
             await ctx.send(_("Those words were already in the filter."))
 
     @_filter.command(name="delete", aliases=["remove", "del"])
-    async def filter_remove(self, ctx: commands.Context, *, words: str):
+    async def filter_remove(self, ctx: commands.Context, *words: str):
         """Remove words from the filter.
 
         Use double quotes to remove sentences.
@@ -220,12 +204,7 @@ class Filter(commands.Cog):
         - `[p]filter remove "This is a sentence"`
         """
         server = ctx.guild
-        try:
-            word_list = shlex.split(words)
-        except ValueError:
-            await ctx.send(_("I could not parse your words. Double check your quotes."))
-            return
-        removed = await self.remove_from_filter(server, word_list)
+        removed = await self.remove_from_filter(server, words)
         if removed:
             self.invalidate_cache(ctx.guild)
             await ctx.send(_("Words successfully removed from filter."))


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Certain strings passed to filter command would give unexpected responses.
`"word"` / `"word` / `"many words` would get interpreted as the start of a quoted phrase, but because the phrase never ended, they would be ignored. This would output the standard response when no words are added to the filter list, "Those words were already in the filter.".
~This PR solves that issue by using `shlex.split()` instead of the funky custom logic that was there before.~
This PR solves that issue by using `*arg` instead of `*, arg` and funky custom logic.

~@jack1142~
~1. Should it use `posix=False`? I don't think so, but Draper doesn't know so I'll ask you.~
~2. For some reason, `shlex.split("here are a\" few \" words")` returns `['here', 'are', 'a few', 'words']`, which I didn't expect. What's the deal with that?~