### PR TITLE
Only trigger cooldown when message is parsed in `[p]contact`

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1570,7 +1570,7 @@ class Core(commands.Cog, CoreLogic):
         await ctx.bot._config.help.tagline.set(tagline)
         await ctx.send(_("The tagline has been set."))
 
-    @commands.command()
+    @commands.command(cooldown_after_parsing=True)
     @commands.cooldown(1, 60, commands.BucketType.user)
     async def contact(self, ctx: commands.Context, *, message: str):
         """Sends a message to the owner"""


### PR DESCRIPTION
### Type

- [x] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

As long as we receive the help message if no message is parsed, it's better to activate the cooldown only if the message is sent.