### PR TITLE
Use timedelta converter for ban duration and add option to pass delete days to [p]tempban

### DIFF
--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -398,15 +398,19 @@ class KickBanMixin(MixinMeta):
         self,
         ctx: commands.Context,
         user: discord.Member,
-        duration: Optional[int] = 1,
+        duration: Optional[
+            commands.TimedeltaConverter(
+                minimum=timedelta(days=0), maximum=timedelta(days=7), default_unit="days"
+            )
+        ] = timedelta(days=1),
+        days: Optional[int] = 0,
         *,
         reason: str = None,
     ):
         """Temporarily ban a user from this server."""
         guild = ctx.guild
         author = ctx.author
-        days_delta = timedelta(days=int(duration))
-        unban_time = datetime.utcnow() + days_delta
+        unban_time = datetime.utcnow() + duration
 
         if author == user:
             return _("I cannot let you do that. Self-harm is bad {}").format("\N{PENSIVE FACE}")
@@ -420,7 +424,7 @@ class KickBanMixin(MixinMeta):
             return _("I cannot do that due to discord hierarchy rules")
         elif not (0 <= days <= 7):
             return _("Invalid days. Must be between 0 and 7.")
-        invite = await self.get_invite_for_reinvite(ctx, int(days_delta.total_seconds() + 86400))
+        invite = await self.get_invite_for_reinvite(ctx, int(duration.total_seconds() + 86400))
         if invite is None:
             invite = ""
 

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -409,17 +409,21 @@ class KickBanMixin(MixinMeta):
         unban_time = datetime.utcnow() + duration
 
         if author == user:
-            return _("I cannot let you do that. Self-harm is bad {}").format("\N{PENSIVE FACE}")
+            await ctx.send(
+                _("I cannot let you do that. Self-harm is bad {}").format("\N{PENSIVE FACE}")
+            )
         elif not await is_allowed_by_hierarchy(self.bot, self.config, guild, author, user):
-            return _(
-                "I cannot let you do that. You are "
-                "not higher than the user in the role "
-                "hierarchy."
+            await ctx.send(
+                _(
+                    "I cannot let you do that. You are "
+                    "not higher than the user in the role "
+                    "hierarchy."
+                )
             )
         elif guild.me.top_role <= user.top_role or user == guild.owner:
-            return _("I cannot do that due to discord hierarchy rules")
+            await ctx.send(_("I cannot do that due to discord hierarchy rules"))
         elif not (0 <= days <= 7):
-            return _("Invalid days. Must be between 0 and 7.")
+            await ctx.send(_("Invalid days. Must be between 0 and 7."))
         invite = await self.get_invite_for_reinvite(ctx, int(duration.total_seconds() + 86400))
         if invite is None:
             invite = ""

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -395,14 +395,31 @@ class KickBanMixin(MixinMeta):
     @commands.bot_has_permissions(ban_members=True)
     @checks.admin_or_permissions(ban_members=True)
     async def tempban(
-        self, ctx: commands.Context,duration: Optional[int] = 1,user: discord.Member, days: Optional[int]=0, *, reason: str = None
+        self,
+        ctx: commands.Context,
+        user: discord.Member,
+        duration: Optional[int] = 1,
+        *,
+        reason: str = None,
     ):
         """Temporarily ban a user from this server."""
         guild = ctx.guild
         author = ctx.author
-        days_delta = timedelta(days=int(days))
+        days_delta = timedelta(days=int(duration))
         unban_time = datetime.utcnow() + days_delta
 
+        if author == user:
+            return _("I cannot let you do that. Self-harm is bad {}").format("\N{PENSIVE FACE}")
+        elif not await is_allowed_by_hierarchy(self.bot, self.config, guild, author, user):
+            return _(
+                "I cannot let you do that. You are "
+                "not higher than the user in the role "
+                "hierarchy."
+            )
+        elif guild.me.top_role <= user.top_role or user == guild.owner:
+            return _("I cannot do that due to discord hierarchy rules")
+        elif not (0 <= days <= 7):
+            return _("Invalid days. Must be between 0 and 7.")
         invite = await self.get_invite_for_reinvite(ctx, int(days_delta.total_seconds() + 86400))
         if invite is None:
             invite = ""

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -394,16 +394,12 @@ class KickBanMixin(MixinMeta):
     @commands.guild_only()
     @commands.bot_has_permissions(ban_members=True)
     @checks.admin_or_permissions(ban_members=True)
-    async def tempban(
+   async def tempban(
         self,
         ctx: commands.Context,
         user: discord.Member,
-        duration: Optional[
-            commands.TimedeltaConverter(
-                minimum=timedelta(days=0), maximum=timedelta(days=7), default_unit="days"
-            )
-        ] = timedelta(days=1),
-        days: Optional[int] = 0,
+        duration: Optional[commands.TimedeltaConverter] = timedelta(days=1),
+        days: Optional[int]=0,
         *,
         reason: str = None,
     ):
@@ -446,7 +442,7 @@ class KickBanMixin(MixinMeta):
                 )
             )
         try:
-            await guild.ban(user)
+            await guild.ban(user,reason=reason, delete_message_days=days)
         except discord.Forbidden:
             await ctx.send(_("I can't do that for some reason."))
         except discord.HTTPException:

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -395,7 +395,7 @@ class KickBanMixin(MixinMeta):
     @commands.bot_has_permissions(ban_members=True)
     @checks.admin_or_permissions(ban_members=True)
     async def tempban(
-        self, ctx: commands.Context, user: discord.Member, days: int = 1, *, reason: str = None
+        self, ctx: commands.Context,duration: Optional[int] = 1,user: discord.Member, days: Optional[int]=0, *, reason: str = None
     ):
         """Temporarily ban a user from this server."""
         guild = ctx.guild

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -394,12 +394,12 @@ class KickBanMixin(MixinMeta):
     @commands.guild_only()
     @commands.bot_has_permissions(ban_members=True)
     @checks.admin_or_permissions(ban_members=True)
-   async def tempban(
+    async def tempban(
         self,
         ctx: commands.Context,
         user: discord.Member,
         duration: Optional[commands.TimedeltaConverter] = timedelta(days=1),
-        days: Optional[int]=0,
+        days: Optional[int] = 0,
         *,
         reason: str = None,
     ):
@@ -442,7 +442,7 @@ class KickBanMixin(MixinMeta):
                 )
             )
         try:
-            await guild.ban(user,reason=reason, delete_message_days=days)
+            await guild.ban(user, reason=reason, delete_message_days=days)
         except discord.Forbidden:
             await ctx.send(_("I can't do that for some reason."))
         except discord.HTTPException:

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -412,6 +412,7 @@ class KickBanMixin(MixinMeta):
             await ctx.send(
                 _("I cannot let you do that. Self-harm is bad {}").format("\N{PENSIVE FACE}")
             )
+            return
         elif not await is_allowed_by_hierarchy(self.bot, self.config, guild, author, user):
             await ctx.send(
                 _(
@@ -420,10 +421,13 @@ class KickBanMixin(MixinMeta):
                     "hierarchy."
                 )
             )
+            return
         elif guild.me.top_role <= user.top_role or user == guild.owner:
             await ctx.send(_("I cannot do that due to discord hierarchy rules"))
+            return
         elif not (0 <= days <= 7):
             await ctx.send(_("Invalid days. Must be between 0 and 7."))
+            return
         invite = await self.get_invite_for_reinvite(ctx, int(duration.total_seconds() + 86400))
         if invite is None:
             invite = ""


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

Adds option to pass days argument to tempban which will delete the specified amount of messages. This works similar to all the other ban commands.
Also, bot now doesn't ignore the passed reason when banning.

~~Will resolve merge conflicts tomorrow.~~