### PR TITLE
Fix unnecessary typing before running commands in Downloader

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -77,8 +77,9 @@ class Downloader(commands.Cog):
                 pass
 
     async def cog_before_invoke(self, ctx: commands.Context) -> None:
-        async with ctx.typing():
-            await self._ready.wait()
+        if not self._ready.is_set():
+            async with ctx.typing():
+                await self._ready.wait()
         if self._ready_raised:
             await ctx.send(
                 "There was an error during Downloader's initialization."


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #3948
Technically it doesn't directly fix whatever causes this but it makes it impossible for the bot to start typing when cog is ready therefore fixing the issue 😛 
I had that done before but I thought I could figure out exactly what causes it. It doesn't really matter in the end so I'm just creating this PR now instead of who knows when...