### PR TITLE
[Downloader] Embed version of `findcog`

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1363,7 +1363,7 @@ class Downloader(commands.Cog):
             installed, cog_installable = await self.is_installed(cog_name)
             if installed:
                 is_installable = True
-                made_by = ", ".join(cog_installable.author) or _("Missing from info.json")
+                made_by = humanize_list(cog_installable.author) or _("Missing from info.json")
                 repo_url = (
                     _("Missing from installed repos")
                     if cog_installable.repo is None
@@ -1383,13 +1383,13 @@ class Downloader(commands.Cog):
 
         if await ctx.embed_requested():
             embed = discord.Embed(color=(await ctx.embed_colour()))
-            embed.add_field(name="Command:", value="`%s`" % (command_name), inline=True)
-            embed.add_field(name="Cog Name:", value="`%s`" % (cog_name), inline=True)
-            embed.add_field(name="Made by:", value="`%s`" % (made_by), inline=True)
-            embed.add_field(name="Repo URL:", value=repo_url)
+            embed.add_field(name="Command:", value=command_name, inline=False)
+            embed.add_field(name="Cog Name:", value=cog_name, inline=False)
+            embed.add_field(name="Made by:", value=made_by, inline=False)
+            embed.add_field(name="Repo URL:", value=repo_url, inline=False)
             if is_installable and cog_installable.repo is not None and cog_installable.repo.branch:
                 embed.add_field(
-                    name="Repo branch:", value="`%s`" % (cog_installable.repo.branch), inline=False
+                    name="Repo branch:", value=cog_installable.repo.branch, inline=False
                 )
             await ctx.send(embed=embed)
 

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1388,7 +1388,9 @@ class Downloader(commands.Cog):
             embed.add_field(name="Made by:", value="`%s`" % (made_by), inline=True)
             embed.add_field(name="Repo URL:", value=repo_url)
             if is_installable and cog_installable.repo is not None and cog_installable.repo.branch:
-                embed.add_field(name="Repo branch:", value="`%s`" % (cog_installable.repo.branch), inline=False)
+                embed.add_field(
+                    name="Repo branch:", value="`%s`" % (cog_installable.repo.branch), inline=False
+                )
 
             await ctx.send(embed=embed)
         else:

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1325,49 +1325,6 @@ class Downloader(commands.Cog):
 
         await ctx.invoke(ctx.bot.get_cog("Core").reload, *updated_cognames)
 
-    def format_findcog_info(
-        self, command_name: str, cog_installable: Union[Installable, object] = None
-    ) -> str:
-        """Format a cog's info for output to discord.
-
-        Parameters
-        ----------
-        command_name : str
-            Name of the command which belongs to the cog.
-        cog_installable : `Installable` or `object`
-            Can be an `Installable` instance or a Cog instance.
-
-        Returns
-        -------
-        str
-            A formatted message for the user.
-
-        """
-        if isinstance(cog_installable, Installable):
-            is_installable = True
-            made_by = ", ".join(cog_installable.author) or _("Missing from info.json")
-            repo_url = (
-                _("Missing from installed repos")
-                if cog_installable.repo is None
-                else cog_installable.repo.clean_url
-            )
-            cog_name = cog_installable.name
-        else:
-            is_installable = False
-            made_by = "26 & co."
-            repo_url = "https://github.com/Cog-Creators/Red-DiscordBot"
-            cog_name = cog_installable.__class__.__name__
-
-        msg = _(
-            "Command: {command}\nCog name: {cog}\nMade by: {author}\nRepo: {repo_url}\n"
-        ).format(command=command_name, author=made_by, repo_url=repo_url, cog=cog_name)
-        if is_installable and cog_installable.repo is not None and cog_installable.repo.branch:
-            msg += _("Repo branch: {branch_name}\n").format(
-                branch_name=cog_installable.repo.branch
-            )
-
-        return msg
-
     def cog_name_from_instance(self, instance: object) -> str:
         """Determines the cog name that Downloader knows from the cog instance.
 
@@ -1405,14 +1362,44 @@ class Downloader(commands.Cog):
             cog_name = self.cog_name_from_instance(cog)
             installed, cog_installable = await self.is_installed(cog_name)
             if installed:
-                msg = self.format_findcog_info(command_name, cog_installable)
+                is_installable = True
+                made_by = ", ".join(cog_installable.author) or _("Missing from info.json")
+                repo_url = (
+                    _("Missing from installed repos")
+                    if cog_installable.repo is None
+                    else cog_installable.repo.clean_url
+                )
+                cog_name = cog_installable.name
             else:
                 # Assume it's in a base cog
-                msg = self.format_findcog_info(command_name, cog)
+                is_installable = False
+                made_by = "26 & co."
+                repo_url = "https://github.com/Cog-Creators/Red-DiscordBot"
+                cog_name = cog.__class__.__name__
         else:
             msg = _("This command is not provided by a cog.")
+            await ctx.send(msg)
+            return
 
-        await ctx.send(box(msg))
+        if await ctx.embed_requested():
+            embed = discord.Embed()
+            embed.add_field(name="Command:", value="`%s`" % (command_name), inline=True)
+            embed.add_field(name="Cog Name:", value="`%s`" % (cog_name), inline=True)
+            embed.add_field(name="Made by:", value="`%s`" % (made_by), inline=True)
+            embed.add_field(name="Repo URL:", value=repo_url)
+            if is_installable and cog_installable.repo is not None and cog_installable.repo.branch:
+                embed.add_field(name="Repo branch:", value="`%s`" % (cog_installable.repo.branch), inline=False)
+
+            await ctx.send(embed=embed)
+        else:
+            msg = _(
+                "Command: {command}\nCog name: {cog}\nMade by: {author}\nRepo URL: {repo_url}\n"
+            ).format(command=command_name, author=made_by, repo_url=repo_url, cog=cog_name)
+            if is_installable and cog_installable.repo is not None and cog_installable.repo.branch:
+                msg += _("Repo branch: {branch_name}\n").format(
+                    branch_name=cog_installable.repo.branch
+                )
+            await ctx.send(box(msg))
 
     @staticmethod
     def format_failed_repos(failed: Collection[str]) -> str:

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1391,8 +1391,8 @@ class Downloader(commands.Cog):
                 embed.add_field(
                     name="Repo branch:", value="`%s`" % (cog_installable.repo.branch), inline=False
                 )
-
             await ctx.send(embed=embed)
+
         else:
             msg = _(
                 "Command: {command}\nCog name: {cog}\nMade by: {author}\nRepo URL: {repo_url}\n"

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1382,7 +1382,7 @@ class Downloader(commands.Cog):
             return
 
         if await ctx.embed_requested():
-            embed = discord.Embed()
+            embed = discord.Embed(color=(await ctx.embed_colour()))
             embed.add_field(name="Command:", value="`%s`" % (command_name), inline=True)
             embed.add_field(name="Cog Name:", value="`%s`" % (cog_name), inline=True)
             embed.add_field(name="Made by:", value="`%s`" % (made_by), inline=True)

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1383,13 +1383,13 @@ class Downloader(commands.Cog):
 
         if await ctx.embed_requested():
             embed = discord.Embed(color=(await ctx.embed_colour()))
-            embed.add_field(name="Command:", value=command_name, inline=False)
-            embed.add_field(name="Cog Name:", value=cog_name, inline=False)
-            embed.add_field(name="Made by:", value=made_by, inline=False)
-            embed.add_field(name="Repo URL:", value=repo_url, inline=False)
+            embed.add_field(name=_("Command:"), value=command_name, inline=False)
+            embed.add_field(name=_("Cog Name:"), value=cog_name, inline=False)
+            embed.add_field(name=_("Made by:"), value=made_by, inline=False)
+            embed.add_field(name=_("Repo URL:"), value=repo_url, inline=False)
             if is_installable and cog_installable.repo is not None and cog_installable.repo.branch:
                 embed.add_field(
-                    name="Repo branch:", value=cog_installable.repo.branch, inline=False
+                    name=_("Repo branch:"), value=cog_installable.repo.branch, inline=False
                 )
             await ctx.send(embed=embed)
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Add an embed version of `[p]findcog` whilst retaining the non-embed version.
Closes #3944 
![http://i.vex.my.to/icROFE](http://i.vex.my.to/icROFE)
To clarify, the third retrigger simulates a local install,

Errors that were never in a code block remain unchanged.
![http://i.vex.my.to/dcHGsV](http://i.vex.my.to/dcHGsV)