### PR TITLE
[Core] Change `[p]embedset user` docstring and message to explicitly say DMs only

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -549,7 +549,7 @@ class Core(commands.Cog, CoreLogic):
 
         If set, this is used instead of the global default
         to determine whether or not to use embeds. This is
-        used for all commands done in a DM with the bot.
+        used for all commands executed in a DM with the bot.
         """
         await self.bot._config.user(ctx.author).embeds.set(enabled)
         if enabled is None:

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -556,7 +556,9 @@ class Core(commands.Cog, CoreLogic):
             await ctx.send(_("Embeds will now fall back to the global setting."))
         else:
             await ctx.send(
-                _("Embeds are now {} for you, in DMs.").format(_("enabled") if enabled else _("disabled"))
+                _("Embeds are now {} for you, in DMs.").format(
+                    _("enabled") if enabled else _("disabled")
+                )
             )
 
     @commands.command()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -556,9 +556,7 @@ class Core(commands.Cog, CoreLogic):
             await ctx.send(_("Embeds will now fall back to the global setting."))
         else:
             await ctx.send(
-                _("Embeds are now {} for you, in DMs.").format(
-                    _("enabled") if enabled else _("disabled")
-                )
+                _("Embeds are now {} for you, in DMs.").format(_("enabled") if enabled else _("disabled"))
             )
 
     @commands.command()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -542,22 +542,21 @@ class Core(commands.Cog, CoreLogic):
     @embedset.command(name="user")
     async def embedset_user(self, ctx: commands.Context, enabled: bool = None):
         """
-        Toggle the user's embed setting.
+        Toggle the user's embed setting for DMs.
 
         If enabled is None, the setting will be unset and
         the global default will be used instead.
 
         If set, this is used instead of the global default
         to determine whether or not to use embeds. This is
-        used for all commands done in a DM with the bot, as
-        well as all help commands everywhere.
+        used for all commands done in a DM with the bot.
         """
         await self.bot._config.user(ctx.author).embeds.set(enabled)
         if enabled is None:
             await ctx.send(_("Embeds will now fall back to the global setting."))
         else:
             await ctx.send(
-                _("Embeds are now {} for you.").format(_("enabled") if enabled else _("disabled"))
+                _("Embeds are now {} for you, in DMs.").format(_("enabled") if enabled else _("disabled"))
             )
 
     @commands.command()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -556,9 +556,9 @@ class Core(commands.Cog, CoreLogic):
             await ctx.send(_("Embeds will now fall back to the global setting."))
         else:
             await ctx.send(
-                _("Embeds are now {} for you, in DMs.").format(
-                    _("enabled") if enabled else _("disabled")
-                )
+                _("Embeds are now enabled for you in DMs.")
+                if enabled
+                else _("Embeds are now disabled for you in DMs.")
             )
 
     @commands.command()


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Update outdated docstring to remove `help` special case and add an explicit DMs only in docstring title, as well as the response in Discord. Fixes #3953.