### PR TITLE
[Docs] Trigger update on `sudo add-apt-repository ...` v2

### DIFF
--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -299,13 +299,13 @@ We recommend adding the ``git-core`` ppa to install Git 2.11 or greater:
 
     sudo apt update
     sudo apt -y install software-properties-common
-    sudo add-apt-repository -y ppa:git-core/ppa
+    sudo add-apt-repository -yu ppa:git-core/ppa
 
 We recommend adding the ``deadsnakes`` ppa to install Python 3.8.1 or greater:
 
 .. code-block:: none
 
-    sudo add-apt-repository -y ppa:deadsnakes/ppa
+    sudo add-apt-repository -yu ppa:deadsnakes/ppa
 
 Now install the pre-requirements with apt:
 
@@ -330,7 +330,7 @@ We recommend adding the ``git-core`` ppa to install Git 2.11 or greater:
 
     sudo apt update
     sudo apt -y install software-properties-common
-    sudo add-apt-repository -y ppa:git-core/ppa
+    sudo add-apt-repository -yu ppa:git-core/ppa
 
 Now install the pre-requirements with apt:
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Adds the `-u` flag back to `add-apt-repository` to force the cache update (for 18.04 and 20.04). Someone in #support had wasn't able to get Python from deadsnakes as he didn't run `apt update` after adding it (they claim they had 18.04)