### PR TITLE
Fix the copyright in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -632,7 +632,8 @@ state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     Red - A fully customizable Discord bot
-    Copyright (C) 2015-2020  Cog Creators
+    Copyright (C) 2017-2020  Cog Creators
+    Copyright (C) 2015-2017  Twentysix
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/LICENSE
+++ b/LICENSE
@@ -653,7 +653,8 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    Red-DiscordBot  Copyright (C) 2015-2020  Cog Creators
+    Red-DiscordBot  Copyright (C) 2017-2020  Cog Creators
+    Red-DiscordBot  Copyright (C) 2015-2017  Twentysix
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/LICENSE
+++ b/LICENSE
@@ -632,7 +632,7 @@ state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     Red - A fully customizable Discord bot
-    Copyright (C) 2015-2020  Twentysix
+    Copyright (C) 2015-2020  Cog Creators
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    Red-DiscordBot  Copyright (C) 2015-2020  Twentysix
+    Red-DiscordBot  Copyright (C) 2015-2020  Cog Creators
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6032823/85035804-dfb16b00-b183-11ea-8f6a-d73ab556b8e9.png)

Twentysix is part of Cog Creators so I'm guessing it's fine to just replace "Twentysix" with "Cog Creators"?