### PR TITLE
Make `[p]tempban` respect `default_days` setting

### DIFF
--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -399,7 +399,7 @@ class KickBanMixin(MixinMeta):
         ctx: commands.Context,
         user: discord.Member,
         duration: Optional[commands.TimedeltaConverter] = timedelta(days=1),
-        days: Optional[int] = 0,
+        days: Optional[int] = None,
         *,
         reason: str = None,
     ):
@@ -425,7 +425,11 @@ class KickBanMixin(MixinMeta):
         elif guild.me.top_role <= user.top_role or user == guild.owner:
             await ctx.send(_("I cannot do that due to discord hierarchy rules"))
             return
-        elif not (0 <= days <= 7):
+
+        if days is None:
+            days = await self.config.guild(guild).default_days()
+
+        if not (0 <= days <= 7):
             await ctx.send(_("Invalid days. Must be between 0 and 7."))
             return
         invite = await self.get_invite_for_reinvite(ctx, int(duration.total_seconds() + 86400))


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This might need an additional note in changelog as this can change the expected default behavior of `[p]tempban` - up to 3.3.9 `[p]tempban` did not delete any user's messages on ban but if we now make it respect `default_days` setting, someone might get surprised by it.

If anyone has any concerns about this, please comment.
And I'm guessing that some feedback from people that actually use `[p]tempban` could be helpful too.

↑ is also something reviewer should probably consider when reviewing, as I don't think anyone looked at this.