### PR TITLE
[Image] Update instructions for setting the GIPHY API

### DIFF
--- a/redbot/cogs/image/image.py
+++ b/redbot/cogs/image/image.py
@@ -250,7 +250,11 @@ class Image(commands.Cog):
             "6. Add an app description, for example *Used for Red's image cog*.\n"
             "7. Click *Create App*. You'll need to agree to the GIPHY API Terms.\n"
             "8. Copy the API Key.\n"
-            "9. In Discord, run the command `{prefix}set api GIPHY api_key <your_api_key_here>`.\n"
-        ).format(prefix=ctx.clean_prefix)
+            "9. In Discord, run the command {command}.\n"
+        ).format(
+            command="`{prefix}set api GIPHY api_key <your_api_key_here>`".format(
+                prefix=ctx.clean_prefix
+            )
+        )
 
         await ctx.maybe_send_embed(message)

--- a/redbot/cogs/image/image.py
+++ b/redbot/cogs/image/image.py
@@ -242,7 +242,7 @@ class Image(commands.Cog):
 
         message = _(
             "To get a GIPHY API Key:\n"
-            "1. Login to, or create, a GIPHY account.\n"
+            "1. Login to (or create) a GIPHY account.\n"
             "2. Visit this page: https://developers.giphy.com/dashboard.\n"
             "3. Press *Create an App*.\n"
             "4. Click *Select API*, then *Next Step*.\n"

--- a/redbot/cogs/image/image.py
+++ b/redbot/cogs/image/image.py
@@ -238,17 +238,19 @@ class Image(commands.Cog):
     @checks.is_owner()
     @commands.command()
     async def giphycreds(self, ctx):
-        """Explain how to set Giphy API tokens."""
+        """Explains how to set GIPHY API tokens."""
 
         message = _(
-            "To get a Giphy API Key:\n"
-            "1. Login to a Giphy account.\n"
-            "2. Visit this page https://developers.giphy.com/dashboard.\n"
+            "To get a GIPHY API Key:\n"
+            "1. Login to, or create, a GIPHY account.\n"
+            "2. Visit this page: https://developers.giphy.com/dashboard.\n"
             "3. Press *Create an App*.\n"
-            "4. Write an app name, example: *Red Bot*.\n"
-            "5. Write an app description, example: *Used for Red Bot*.\n"
-            "6. Copy the API key shown.\n"
-            "7. Run the command `{prefix}set api GIPHY api_key <your_api_key_here>`.\n"
+            "4. Click *Select API*, then *Next Step*.\n"
+            "5. Add an app name, for example *Red*.\n"
+            "6. Add an app description, for example *Used for Red's image cog*.\n"
+            "7. Click *Create App*. You'll need to agree to the GIPHY API Terms.\n"
+            "8. Copy the API Key.\n"
+            "9. In Discord, run the command `{prefix}set api GIPHY api_key <your_api_key_here>`.\n"
         ).format(prefix=ctx.clean_prefix)
 
         await ctx.maybe_send_embed(message)

--- a/redbot/cogs/image/image.py
+++ b/redbot/cogs/image/image.py
@@ -252,8 +252,8 @@ class Image(commands.Cog):
             "8. Copy the API Key.\n"
             "9. In Discord, run the command {command}.\n"
         ).format(
-            command="`{prefix}set api GIPHY api_key <your_api_key_here>`".format(
-                prefix=ctx.clean_prefix
+            command="`{prefix}set api GIPHY api_key {placeholder}`".format(
+                prefix=ctx.clean_prefix, placeholder=_("<your_api_key_here>")
             )
         )
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
GIPHY has changed how to register API keys, so the instructions under `[p]giphycreds` should be updated as well.
This is how it looks as an embed:
![http://i.vex.my.to/ZOclyj](http://i.vex.my.to/ZOclyj)