### PR TITLE
Add `project_urls` and improve our use of classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,19 +8,25 @@ long_description_content_type = text/markdown; charset=UTF-8; variant=GFM
 author = Cog-Creators
 author_email = cogcreators@gmail.com
 url = https://github.com/Cog-Creators/Red-DiscordBot
+project_urls =
+    Discord Server = https://discord.gg/red
+    Documentation = https://docs.discord.red
+    Donate on Patreon = https://www.patreon.com/Red_Devs
+    Issue Tracker = https://github.com/Cog-Creators/Red-DiscordBot/issues
+    Source Code = https://github.com/Cog-Creators/Red-DiscordBot
 classifiers =
     # List at https://pypi.org/pypi?%3Aaction=list_classifiers
     Development Status :: 5 - Production/Stable
     Framework :: AsyncIO
-    Framework :: Pytest
     Intended Audience :: Developers
     Intended Audience :: End Users/Desktop
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Natural Language :: English
-    Operating System :: OS Independent
+    Operating System :: MacOS :: MacOS X
+    Operating System :: Microsoft :: Windows
+    Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3.8
     Topic :: Communications :: Chat
-    Topic :: Documentation :: Sphinx
 
 [options]
 packages = find_namespace:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
How it will look on pypi.org (Discord icon will be different once [this PR](https://github.com/pypa/warehouse/pull/8147) gets deployed):
![image](https://user-images.githubusercontent.com/6032823/85326155-1a413d80-b4cd-11ea-8cf6-65c8da65c66d.png)

Example project on PyPI that uses project URLs: https://pypi.org/project/rlapi/