### PR TITLE
Add a provisional API for replacing the help formatter

### DIFF
--- a/docs/framework_commands.rst
+++ b/docs/framework_commands.rst
@@ -44,3 +44,17 @@ extend functionalities used throughout the bot, as outlined below.
     :no-undoc-members:
 
     .. autoclass:: APIToken
+
+==================
+Help Functionality
+==================
+
+.. warning::
+
+    The content in this section is provisional and may change
+    without prior notice or warning. Updates to this will be communicated
+    on `this issue <https://github.com/Cog-Creators/Red-DiscordBot/issues/4084>`_
+
+
+.. automodule:: redbot.core.commands.help
+    :members:

--- a/docs/framework_commands.rst
+++ b/docs/framework_commands.rst
@@ -45,9 +45,9 @@ extend functionalities used throughout the bot, as outlined below.
 
     .. autoclass:: APIToken
 
-==================
+******************
 Help Functionality
-==================
+******************
 
 .. warning::
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -208,6 +208,52 @@ class RedBase(
 
         self._deletion_requests: MutableMapping[int, asyncio.Lock] = weakref.WeakValueDictionary()
 
+    def set_help_formatter(self, formatter: commands.help.HelpFormatterABC):
+        """
+        Set's Red's help formatter.
+
+        The formatter must implement all methods in
+        ``commands.help.HelpFormatterABC``
+
+        Cogs which set a help formatter should inform users of this.
+        Users should not use multiple cogs which set a help formatter.
+
+        This should specifically be an instance of a formatter.
+        This allows cogs to pass a config object or similar to the
+        formatter prior to the bot using it.
+
+        See ``commands.help.HelpFormatterABC`` for more details.
+
+        Raises
+        ------
+        RuntimeError
+            If the default formatter has already been replaced
+        TypeError
+            If given an invalid formatter
+        """
+
+        if not isinstance(formatter, commands.help.HelpFormatterABC):
+            raise TypeError(
+                "Help formatters must inherit from `commands.help.HelpFormatterABC` "
+                "and implement the required interfaces."
+            )
+
+        # do not switch to isinstance, we want to know that this has not been overriden,
+        # even with a subclass.
+        if type(self._help_formatter) is commands.help.RedHelpFormatter:
+            self._help_formatter = formatter
+        else:
+            raise RuntimeError("The formatter has already been overriden.")
+
+    def reset_help_formatter(self):
+        """
+        Resets Red's help formatter.
+
+        This exits for use in cog_unload for cogs which replace the formatter
+        as well as for a rescue command in core_commands.
+        """
+        self._help_formatter = commands.help.RedHelpFormatter()
+
     def get_command(self, name: str) -> Optional[commands.Command]:
         com = super().get_command(name)
         assert com is None or isinstance(com, commands.Command)
@@ -786,12 +832,18 @@ class RedBase(
         return await super().start(*args, **kwargs)
 
     async def send_help_for(
-        self, ctx: commands.Context, help_for: Union[commands.Command, commands.GroupMixin, str]
+        self,
+        ctx: commands.Context,
+        help_for: Union[commands.Command, commands.GroupMixin, str],
+        *,
+        from_help_command: bool = False,
     ):
         """
         Invokes Red's helpformatter for a given context and object.
         """
-        return await self._help_formatter.send_help(ctx, help_for)
+        return await self._help_formatter.send_help(
+            ctx, help_for, from_help_command=from_help_command
+        )
 
     async def embed_requested(self, channel, user, command=None) -> bool:
         """

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -212,6 +212,10 @@ class RedBase(
         """
         Set's Red's help formatter.
 
+        .. warning::
+            This method is provisional.
+
+
         The formatter must implement all methods in
         ``commands.help.HelpFormatterABC``
 
@@ -249,8 +253,13 @@ class RedBase(
         """
         Resets Red's help formatter.
 
+        .. warning::
+            This method is provisional.
+
+
         This exists for use in ``cog_unload`` for cogs which replace the formatter
         as well as for a rescue command in core_commands.
+
         """
         self._help_formatter = commands.help.RedHelpFormatter()
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -249,7 +249,7 @@ class RedBase(
         """
         Resets Red's help formatter.
 
-        This exits for use in cog_unload for cogs which replace the formatter
+        This exists for use in ``cog_unload`` for cogs which replace the formatter
         as well as for a rescue command in core_commands.
         """
         self._help_formatter = commands.help.RedHelpFormatter()

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -9,7 +9,7 @@
 # with our needs for per-context help settings
 # see https://github.com/Rapptz/discord.py/issues/2123
 #
-# While the issue above discusses this as theoretical,merely interacting with config within
+# While the issue above discusses this as theoretical, merely interacting with config within
 # the help command preparation was enough to cause
 # demonstrable breakage in 150 help invokes in a 2 minute window.
 # This is not an unreasonable volume on some already existing Red instances,
@@ -123,7 +123,7 @@ class HelpFormatterABC(abc.ABC):
 
         This class is documented but provisional with expected changes.
 
-        In the future, this class will recieve changes to support
+        In the future, this class will receive changes to support
         invoking the help command without context.
     """
 
@@ -152,7 +152,7 @@ class RedHelpFormatter(HelpFormatterABC):
 
     .. warning::
 
-        This class is documented but may recieve changes between
+        This class is documented but may receive changes between
         versions without warning as needed.
         The supported way to modify help is to write a separate formatter.
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -27,7 +27,6 @@ from redbot.core.data_manager import storage_type
 from . import (
     __version__,
     version_info as red_version_info,
-    VersionInfo,
     checks,
     commands,
     errors,
@@ -2079,6 +2078,34 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     async def helpset(self, ctx: commands.Context):
         """Manage settings for the help command."""
         pass
+
+    @helpset.command(name="resetformatter")
+    async def helpset_resetformatter(self, ctx: commands.Context):
+        """ This resets [botname]'s help formatter to the default formatter """
+
+        ctx.bot.reset_help_formatter()
+        await ctx.send(
+            _(
+                "The help formatter has been reset. "
+                "This will not prevent cogs from modifying help, "
+                "you may need to remove a cog if this has been an issue."
+            )
+        )
+
+    @helpset.command(name="resetsettings")
+    async def helpset_resetsettings(self, ctx: commands.Context):
+        """
+        This resets [botname]'s help settings to their defaults.
+
+        This may not have an impact when using custom formatters from 3rd party cogs
+        """
+        await ctx.bot._config.help.clear()
+        await ctx.send(
+            _(
+                "The help settings have been reset to their defaults. "
+                "This may not have an impact when using 3rd party help formatters."
+            )
+        )
 
     @helpset.command(name="usemenus")
     async def helpset_usemenus(self, ctx: commands.Context, use_menus: bool = None):


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [X] New feature

### Description of the changes

- Adds an API for replacing the help formatter
- Defines which interfaces are required
- Adds some information for 3rd party developers
- Adds commands for resetting help behavior (to allow end users to fix issues with misbehaving cogs)

This is follow up from things which were planned originally in #2667 but tracked in #3601 and resolves a portion of that issue.
