### PR TITLE
Add `discord.com` to supported domains in `INVITE_URL_RE`

### DIFF
--- a/redbot/core/utils/common_filters.py
+++ b/redbot/core/utils/common_filters.py
@@ -16,7 +16,7 @@ __all__ = [
 # regexes
 URL_RE = re.compile(r"(https?|s?ftp)://(\S+)", re.I)
 
-INVITE_URL_RE = re.compile(r"(discord\.(?:gg|io|me|li)|discordapp\.com\/invite)\/(\S+)", re.I)
+INVITE_URL_RE = re.compile(r"(discord\.(?:gg|io|me|li|com)|discordapp\.com\/invite)\/(\S+)", re.I)
 
 MASS_MENTION_RE = re.compile(r"(@)(?=everyone|here)")  # This only matches the @ for sanitizing
 

--- a/redbot/core/utils/common_filters.py
+++ b/redbot/core/utils/common_filters.py
@@ -16,7 +16,7 @@ __all__ = [
 # regexes
 URL_RE = re.compile(r"(https?|s?ftp)://(\S+)", re.I)
 
-INVITE_URL_RE = re.compile(r"(discord\.(?:gg|io|me|li|com)|discordapp\.com\/invite)\/(\S+)", re.I)
+INVITE_URL_RE = re.compile(r"(discord\.(?:gg|io|me|li)|discord(app)?\.com\/invite)\/(\S+)", re.I)
 
 MASS_MENTION_RE = re.compile(r"(@)(?=everyone|here)")  # This only matches the @ for sanitizing
 

--- a/redbot/core/utils/common_filters.py
+++ b/redbot/core/utils/common_filters.py
@@ -16,7 +16,7 @@ __all__ = [
 # regexes
 URL_RE = re.compile(r"(https?|s?ftp)://(\S+)", re.I)
 
-INVITE_URL_RE = re.compile(r"(discord\.(?:gg|io|me|li)|discord(app)?\.com\/invite)\/(\S+)", re.I)
+INVITE_URL_RE = re.compile(r"(discord\.(?:gg|io|me|li)|discord(?:app)?\.com\/invite)\/(\S+)", re.I)
 
 MASS_MENTION_RE = re.compile(r"(@)(?=everyone|here)")  # This only matches the @ for sanitizing
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

Discord.com is now a discord domain, so added that as an option to an invite URL regex search.
Passed tests and formatted (though unsure if this is even in a test)