### PR TITLE
Checking for temp bans

### DIFF
--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -334,6 +334,15 @@ class KickBanMixin(MixinMeta):
                         user_id=user_id
                     )
 
+        member = namedtuple("Member", "id guild")
+        async with self.settings.guild(guild).current_tempbans() as guild_tempbans:
+            for uid in guild_tempbans.copy():
+                for user_id in user_ids.copy:
+                    if not user_id:
+                        continue
+                await self.settings.member(member(uid, guild)).banned_until.clear()
+                guild_tempbans.remove(uid)
+
         user_ids = remove_processed(user_ids)
 
         if not user_ids:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Should fix #2898 - checks if user is tempbanned before hackban