### PR TITLE
[Docs] Update framework_i18n.rst

### DIFF
--- a/docs/framework_i18n.rst
+++ b/docs/framework_i18n.rst
@@ -33,21 +33,16 @@ Tutorial
 
 After making your cog, generate a :code:`messages.pot` file
 
-The process of generating this will depend on the operating system
-you are using
+We recommend using redgettext a modified version of pygettext for Red.
+You can install redgettext by running :code:`pip install redgettext` in a command prompt.
 
-In a command prompt in your cog's package (where yourcog.py is),
-create a directory called "locales".
-Then do one of the following:
-
-Windows: :code:`python <your python install path>\Tools\i18n\pygettext.py -D -n -p locales`
-
-Mac: ?
-
-Linux: :code:`pygettext3 -D -n -p locales`
-
-This will generate a messages.pot file with strings to be translated, including
+To generate the :code:`messages.pot` file, you will now need to run
+:code:`python -m redgettext -D [path_to_cog]`
+This file will contain all strings to be translated, including
 docstrings.
+
+You can now use a tool like `poedit
+<https://poedit.net/>`_ to translate the strings in your messages.pot file.
 
 -------------
 API Reference

--- a/docs/framework_i18n.rst
+++ b/docs/framework_i18n.rst
@@ -33,7 +33,7 @@ Tutorial
 
 After making your cog, generate a :code:`messages.pot` file
 
-We recommend using redgettext a modified version of pygettext for Red.
+We recommend using redgettext - a modified version of pygettext for Red.
 You can install redgettext by running :code:`pip install redgettext` in a command prompt.
 
 To generate the :code:`messages.pot` file, you will now need to run

--- a/docs/framework_i18n.rst
+++ b/docs/framework_i18n.rst
@@ -37,7 +37,7 @@ We recommend using redgettext a modified version of pygettext for Red.
 You can install redgettext by running :code:`pip install redgettext` in a command prompt.
 
 To generate the :code:`messages.pot` file, you will now need to run
-:code:`python -m redgettext -D [path_to_cog]`
+:code:`python -m redgettext -c [path_to_cog]`
 This file will contain all strings to be translated, including
 docstrings.
 

--- a/docs/framework_i18n.rst
+++ b/docs/framework_i18n.rst
@@ -40,6 +40,7 @@ To generate the :code:`messages.pot` file, you will now need to run
 :code:`python -m redgettext -c [path_to_cog]`
 This file will contain all strings to be translated, including
 docstrings.
+(For advanced usage check :code:`python -m redgettext -h`)
 
 You can now use a tool like `poedit
 <https://poedit.net/>`_ to translate the strings in your messages.pot file.


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Updates the Internationalization framework docs to explain how to get the ``messages.pot`` file using redgettext which works reliably across operating systems.

Rendered page here: https://red-discordbot--4018.org.readthedocs.build/en/4018/framework_i18n.html