### PR TITLE
[General] URL encode user input for [p]urban and [p]lmgtfy

### DIFF
--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -215,9 +215,7 @@ class General(commands.Cog):
     @commands.command()
     async def lmgtfy(self, ctx, *, search_terms: str):
         """Create a lmgtfy link."""
-        search_terms = escape(
-            urllib.parse.quote_plus(search_terms), mass_mentions=True
-        )
+        search_terms = escape(urllib.parse.quote_plus(search_terms), mass_mentions=True)
         await ctx.send("https://lmgtfy.com/?q={}".format(search_terms))
 
     @commands.command(hidden=True)
@@ -483,7 +481,7 @@ class General(commands.Cog):
 
         try:
             url = "https://api.urbandictionary.com/v0/define"
-            
+
             params = {"term": str(word).lower()}
 
             headers = {"content-type": "application/json"}

--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -3,6 +3,7 @@ import time
 from enum import Enum
 from random import randint, choice
 from typing import Final
+import urllib.parse
 import aiohttp
 import discord
 from redbot.core import commands
@@ -215,7 +216,7 @@ class General(commands.Cog):
     async def lmgtfy(self, ctx, *, search_terms: str):
         """Create a lmgtfy link."""
         search_terms = escape(
-            search_terms.replace("+", "%2B").replace(" ", "+"), mass_mentions=True
+            urllib.parse.quote_plus(search_terms), mass_mentions=True
         )
         await ctx.send("https://lmgtfy.com/?q={}".format(search_terms))
 
@@ -481,12 +482,14 @@ class General(commands.Cog):
         """
 
         try:
-            url = "https://api.urbandictionary.com/v0/define?term=" + str(word).lower()
+            url = "https://api.urbandictionary.com/v0/define"
+            
+            params = {"term": str(word).lower()}
 
             headers = {"content-type": "application/json"}
 
             async with aiohttp.ClientSession() as session:
-                async with session.get(url, headers=headers) as response:
+                async with session.get(url, headers=headers, params=params) as response:
                     data = await response.json()
 
         except aiohttp.ClientError:


### PR DESCRIPTION
Adds URL encoding to `[p]lmgtfy` via `urllib.parse.quote_plus()`
and to `[p]urban` via `aiohttp.ClientSession.get`'s `params` argument

### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

User input for the `[p]urban` and `[p]lmgtfy` wasn't URL-encoded previously, which could mess up results.

Edit: For the record, I explicitly license the contributions authored in this pull request under [`GPL-3.0-or-later`], just in case the seemingly conflicting notices in the `LICENSE` file and the README would suggest [`GPL-3.0-only`].

[`GPL-3.0-or-later`]: https://spdx.org/licenses/GPL-3.0-or-later.html
[`GPL-3.0-only`]: https://spdx.org/licenses/GPL-3.0-only.html