### PR TITLE
[Utils] Fix regex for role mentions in `MessagePredicate`

### DIFF
--- a/redbot/core/utils/predicates.py
+++ b/redbot/core/utils/predicates.py
@@ -10,7 +10,7 @@ from redbot.core import commands
 _ID_RE = re.compile(r"([0-9]{15,21})$")
 _USER_MENTION_RE = re.compile(r"<@!?([0-9]{15,21})>$")
 _CHAN_MENTION_RE = re.compile(r"<#([0-9]{15,21})>$")
-_ROLE_MENTION_RE = re.compile(r"<&([0-9]{15,21})>$")
+_ROLE_MENTION_RE = re.compile(r"<@&([0-9]{15,21})>$")
 
 
 class MessagePredicate(Callable[[discord.Message], bool]):


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
The MessagePredicate.valid_role() predicate was not matching a role mention, specifically in the _find_role function via the regex match.

This condition can be tested by loading Audio with a blank/new settings file, or on a bot that has not had a DJ role specified for a guild, by using `[p]audioset dj` with no role specified, the bot prompts for a role name, and the user uses a role mention in the response to the bot.