### PR TITLE
Fix the error for empty author list in `[p]findcog`

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1387,7 +1387,11 @@ class Downloader(commands.Cog):
             cog_name = self.cog_name_from_instance(cog)
             installed, cog_installable = await self.is_installed(cog_name)
             if installed:
-                made_by = humanize_list(cog_installable.author) or _("Missing from info.json")
+                made_by = (
+                    humanize_list(cog_installable.author)
+                    if cog_installable.author
+                    else _("Missing from info.json")
+                )
                 repo_url = (
                     _("Missing from installed repos")
                     if cog_installable.repo is None


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #4032
I figured that if we're gonna have 3.3.10 before 3.4 and it might be the last in 3.3.x series, it would be good not to introduce new regressions.