### PR TITLE
Allow creating an instance non-interactively

### DIFF
--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -237,6 +237,11 @@ def parse_cli_flags(args):
     parser.add_argument(
         "--no-message-cache", action="store_true", help="Disable the internal message cache.",
     )
+    parser.add_argument(
+        "--make-instance",
+        action="store_true",
+        help="make an instance with the provided instance name and the default paths",
+    )
 
     args = parser.parse_args(args)
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [X] New feature

### Description of the changes

resolves 2396 and makes future work with containers more bearable.

example use
```
redbot somename --make-instance
```

further modification supported by use of edit, this just creates with defaults (allowing it to be used in conjunction with non-interactive editing of existing instances via edit for headless setup)