### PR TITLE
Add per-command embed settings (`embed_requested`)

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1122,7 +1122,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         If set, this is used instead of the global default
         to determine whether or not to use embeds. This is
-        used for all commands done in a guild channel.
+        used for all commands done in a server channel.
         """
         await self.bot._config.guild(ctx.guild).embeds.set(enabled)
         if enabled is None:
@@ -1192,7 +1192,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
     @commands.guild_only()
     @embedset_command.command(name="server", aliases=["guild"])
-    async def embedset_command_server(
+    async def embedset_command_guild(
         self, ctx: commands.GuildContext, command_name: str, enabled: bool = None
     ):
         """

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1082,7 +1082,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             if command_name is not None:
                 scope = self.bot._config.custom("COMMAND", command_name, ctx.guild.id)
                 command_setting = await scope.embeds()
-                text += _("Guild command setting for {command} command: {}\n").format(
+                text += _("Server command setting for {command} command: {}\n").format(
                     command=inline(command_name), value=command_setting
                 )
 
@@ -1191,17 +1191,17 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             )
 
     @commands.guild_only()
-    @embedset_command.command(name="guild")
-    async def embedset_command_guild(
+    @embedset_command.command(name="server", aliases=["guild"])
+    async def embedset_command_server(
         self, ctx: commands.GuildContext, command_name: str, enabled: bool = None
     ):
         """
         Toggle the commmand's embed setting.
 
         If enabled is None, the setting will be unset and
-        the guild default will be used instead.
+        the server default will be used instead.
 
-        If set, this is used instead of the guild default
+        If set, this is used instead of the server default
         to determine whether or not to use embeds.
         """
         command_obj: Optional[commands.Command] = ctx.bot.get_command(command_name)
@@ -1215,7 +1215,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         await self.bot._config.custom("COMMAND", command_name, ctx.guild.id).embeds.set(enabled)
         if enabled is None:
-            await ctx.send(_("Embeds will now fall back to the guild setting."))
+            await ctx.send(_("Embeds will now fall back to the server setting."))
         elif enabled:
             await ctx.send(
                 _("Embeds are now enabled for {command_name} command.").format(

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1105,10 +1105,12 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         default is to use embeds.
         """
         current = await self.bot._config.embeds()
-        await self.bot._config.embeds.set(not current)
-        await ctx.send(
-            _("Embeds are now {} by default.").format(_("disabled") if current else _("enabled"))
-        )
+        if current:
+            await self.bot._config.embeds.set(False)
+            await ctx.send(_("Embeds are now disabled by default."))
+        else:
+            await self.bot._config.embeds.clear()
+            await ctx.send(_("Embeds are now enabled by default."))
 
     @embedset.command(name="server", aliases=["guild"])
     @checks.guildowner_or_permissions(administrator=True)
@@ -1124,15 +1126,17 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         to determine whether or not to use embeds. This is
         used for all commands done in a server channel.
         """
-        await self.bot._config.guild(ctx.guild).embeds.set(enabled)
         if enabled is None:
+            await self.bot._config.guild(ctx.guild).embeds.clear()
             await ctx.send(_("Embeds will now fall back to the global setting."))
-        else:
-            await ctx.send(
-                _("Embeds are now {} for this guild.").format(
-                    _("enabled") if enabled else _("disabled")
-                )
-            )
+            return
+
+        await self.bot._config.guild(ctx.guild).embeds.set(enabled)
+        await ctx.send(
+            _("Embeds are now enabled for this guild.")
+            if enabled
+            else _("Embeds are now disabled for this guild.")
+        )
 
     @checks.guildowner_or_permissions(administrator=True)
     @embedset.group(name="command", invoke_without_command=True)
@@ -1186,10 +1190,13 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         # qualified name might be different if alias was passed to this command
         command_name = command_obj.qualified_name
 
-        await self.bot._config.custom("COMMAND", command_name, 0).embeds.set(enabled)
         if enabled is None:
+            await self.bot._config.custom("COMMAND", command_name, 0).embeds.clear()
             await ctx.send(_("Embeds will now fall back to the global setting."))
-        elif enabled:
+            return
+
+        await self.bot._config.custom("COMMAND", command_name, 0).embeds.set(enabled)
+        if enabled:
             await ctx.send(
                 _("Embeds are now enabled for {command_name} command.").format(
                     command_name=inline(command_name)
@@ -1226,10 +1233,13 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         # qualified name might be different if alias was passed to this command
         command_name = command_obj.qualified_name
 
-        await self.bot._config.custom("COMMAND", command_name, ctx.guild.id).embeds.set(enabled)
         if enabled is None:
+            await self.bot._config.custom("COMMAND", command_name, ctx.guild.id).embeds.clear()
             await ctx.send(_("Embeds will now fall back to the server setting."))
-        elif enabled:
+            return
+
+        await self.bot._config.custom("COMMAND", command_name, ctx.guild.id).embeds.set(enabled)
+        if enabled:
             await ctx.send(
                 _("Embeds are now enabled for {command_name} command.").format(
                     command_name=inline(command_name)
@@ -1256,15 +1266,17 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         to determine whether or not to use embeds. This is
         used for all commands done in a channel.
         """
-        await self.bot._config.channel(ctx.channel).embeds.set(enabled)
         if enabled is None:
+            await self.bot._config.channel(ctx.channel).embeds.clear()
             await ctx.send(_("Embeds will now fall back to the global setting."))
-        else:
-            await ctx.send(
-                _("Embeds are now {} for this channel.").format(
-                    _("enabled") if enabled else _("disabled")
-                )
+            return
+
+        await self.bot._config.channel(ctx.channel).embeds.set(enabled)
+        await ctx.send(
+            _("Embeds are now {} for this channel.").format(
+                _("enabled") if enabled else _("disabled")
             )
+        )
 
     @embedset.command(name="user")
     async def embedset_user(self, ctx: commands.Context, enabled: bool = None):
@@ -1278,15 +1290,16 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         to determine whether or not to use embeds. This is
         used for all commands executed in a DM with the bot.
         """
-        await self.bot._config.user(ctx.author).embeds.set(enabled)
         if enabled is None:
+            await self.bot._config.user(ctx.author).embeds.clear()
             await ctx.send(_("Embeds will now fall back to the global setting."))
-        else:
-            await ctx.send(
-                _("Embeds are now enabled for you in DMs.")
-                if enabled
-                else _("Embeds are now disabled for you in DMs.")
-            )
+
+        await self.bot._config.user(ctx.author).embeds.set(enabled)
+        await ctx.send(
+            _("Embeds are now enabled for you in DMs.")
+            if enabled
+            else _("Embeds are now disabled for you in DMs.")
+        )
 
     @commands.command()
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1154,7 +1154,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     def _check_if_command_requires_embed_links(self, command_obj: commands.Command) -> None:
         for command in itertools.chain((command_obj,), command_obj.parents):
             if command_obj.requires.bot_perms.embed_links:
-                raise commands.BadArgument(
+                # a slight abuse of this exception to save myself two lines later...
+                raise commands.UserFeedbackCheckFailure(
                     _(
                         "The passed command requires Embed Links permission"
                         " and therefore cannot be set to not use embeds."

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1147,9 +1147,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """
         # Select the scope based on the author's privileges
         if await ctx.bot.is_owner(ctx.author):
-            await self.embedset_command_global(command_name, enabled)
+            await self.embedset_command_global(ctx, command_name, enabled)
         else:
-            await self.embedset_command_guild(command_name, enabled)
+            await self.embedset_command_guild(ctx, command_name, enabled)
 
     @commands.is_owner()
     @embedset_command.command(name="global")

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1116,6 +1116,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         This is used as a fallback if the user
         or guild hasn't set a preference. The
         default is to use embeds.
+
+        To see full evaluation order of embed settings, run `[p]help embedset`
         """
         current = await self.bot._config.embeds()
         if current:
@@ -1138,6 +1140,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         If set, this is used instead of the global default
         to determine whether or not to use embeds. This is
         used for all commands done in a server channel.
+
+        To see full evaluation order of embed settings, run `[p]help embedset`
         """
         if enabled is None:
             await self.bot._config.guild(ctx.guild).embeds.clear()
@@ -1161,6 +1165,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         If you're the bot owner, this will change command's embed setting
         globally by default.
+
+        To see full evaluation order of embed settings, run `[p]help embedset`
         """
         # Select the scope based on the author's privileges
         if await ctx.bot.is_owner(ctx.author):
@@ -1192,6 +1198,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         If set, this is used instead of the global default
         to determine whether or not to use embeds.
+
+        To see full evaluation order of embed settings, run `[p]help embedset`
         """
         command_obj: Optional[commands.Command] = ctx.bot.get_command(command_name)
         if command_obj is None:
@@ -1235,6 +1243,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         If set, this is used instead of the server default
         to determine whether or not to use embeds.
+
+        To see full evaluation order of embed settings, run `[p]help embedset`
         """
         command_obj: Optional[commands.Command] = ctx.bot.get_command(command_name)
         if command_obj is None:
@@ -1278,6 +1288,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         If set, this is used instead of the guild and command default
         to determine whether or not to use embeds. This is
         used for all commands done in a channel.
+
+        To see full evaluation order of embed settings, run `[p]help embedset`
         """
         if enabled is None:
             await self.bot._config.channel(ctx.channel).embeds.clear()
@@ -1302,6 +1314,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         If set, this is used instead of the global default
         to determine whether or not to use embeds. This is
         used for all commands executed in a DM with the bot.
+
+        To see full evaluation order of embed settings, run `[p]help embedset`
         """
         if enabled is None:
             await self.bot._config.user(ctx.author).embeds.clear()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1137,7 +1137,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @checks.guildowner_or_permissions(administrator=True)
     @embedset.group(name="command", invoke_without_command=True)
     async def embedset_command(
-        self, ctx: commands.Context, command: str, enabled: bool = None
+        self, ctx: commands.Context, command_name: str, enabled: bool = None
     ) -> None:
         """
         Toggle the command's embed setting.
@@ -1147,9 +1147,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """
         # Select the scope based on the author's privileges
         if await ctx.bot.is_owner(ctx.author):
-            await ctx.invoke(self.embedset_command_global, command=command, enabled=enabled)
+            await self.embedset_command_global(command_name, enabled)
         else:
-            await ctx.invoke(self.embedset_command_guild, command=command, enabled=enabled)
+            await self.embedset_command_guild(command_name, enabled)
 
     @commands.is_owner()
     @embedset_command.command(name="global")

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1151,6 +1151,14 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             await self.embedset_command_guild(ctx, command_name, enabled)
 
+    def _check_if_command_requires_embed_links(self, command_obj: commands.Command) -> None:
+        for command in itertools.chain((command_obj,), command_obj.parents):
+            if command_obj.requires.bot_perms.embed_links:
+                raise commands.BadArgument(
+                    "The passed command requires Embed Links permission"
+                    " and therefore cannot be set to not use embeds."
+                )
+
     @commands.is_owner()
     @embedset_command.command(name="global")
     async def embedset_command_global(
@@ -1171,6 +1179,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 _("I couldn't find that command. Please note that it is case sensitive.")
             )
             return
+        self._check_if_command_requires_embed_links(command_obj)
         # qualified name might be different if alias was passed to this command
         command_name = command_obj.qualified_name
 
@@ -1210,6 +1219,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 _("I couldn't find that command. Please note that it is case sensitive.")
             )
             return
+        self._check_if_command_requires_embed_links(command_obj)
         # qualified name might be different if alias was passed to this command
         command_name = command_obj.qualified_name
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1082,7 +1082,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             if command_name is not None:
                 scope = self.bot._config.custom("COMMAND", command_name, ctx.guild.id)
                 command_setting = await scope.embeds()
-                text += _("Server command setting for {command} command: {}\n").format(
+                text += _("Server command setting for {command} command: {value}\n").format(
                     command=inline(command_name), value=command_setting
                 )
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1052,19 +1052,30 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """
 
     @embedset.command(name="showsettings")
-    async def embedset_showsettings(self, ctx: commands.Context):
+    async def embedset_showsettings(self, ctx: commands.Context, command: str = None) -> None:
         """Show the current embed settings."""
         text = _("Embed settings:\n\n")
         global_default = await self.bot._config.embeds()
-        text += _("Global default: {}\n").format(global_default)
+        text += _("Global default: {value}\n").format(value=global_default)
+        if command is not None:
+            global_command_setting = await self.bot._config.custom("COMMAND", command, 0).embeds()
+            text += _("Global command setting for {command} command: {value}\n").format(
+                command=inline(command), value=global_command_setting
+            )
         if ctx.guild:
             guild_setting = await self.bot._config.guild(ctx.guild).embeds()
-            text += _("Guild setting: {}\n").format(guild_setting)
+            text += _("Guild setting: {value}\n").format(value=guild_setting)
+            if command is not None:
+                scope = self.bot._config.custom("COMMAND", command, ctx.guild.id)
+                command_setting = await scope.embeds()
+                text += _("Guild command setting for {command} command: {}\n").format(
+                    command=inline(command), value=command_setting
+                )
         if ctx.channel:
             channel_setting = await self.bot._config.channel(ctx.channel).embeds()
-            text += _("Channel setting: {}\n").format(channel_setting)
+            text += _("Channel setting: {value}\n").format(value=channel_setting)
         user_setting = await self.bot._config.user(ctx.author).embeds()
-        text += _("User setting: {}").format(user_setting)
+        text += _("User setting: {value}").format(value=user_setting)
         await ctx.send(box(text))
 
     @embedset.command(name="global")

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1049,6 +1049,19 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         use embeds as a response to a command (for
         commands that support it). The default is to
         use embeds.
+
+        The embed settings are checked until the first True/False in this order:
+        - In guild context:
+        1. Channel override ([p]embedset channel)
+        2. Server command override ([p]embedset command server)
+        3. Server override ([p]embedset server)
+        4. Global command override ([p]embedset command global)
+        5. Global setting ([p]embedset global)
+
+        - In DM context:
+        1. User override ([p]embedset user)
+        2. Global command override ([p]embedset command global)
+        3. Global setting ([p]embedset global)
         """
 
     @embedset.command(name="showsettings")

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1155,8 +1155,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         for command in itertools.chain((command_obj,), command_obj.parents):
             if command_obj.requires.bot_perms.embed_links:
                 raise commands.BadArgument(
-                    "The passed command requires Embed Links permission"
-                    " and therefore cannot be set to not use embeds."
+                    _(
+                        "The passed command requires Embed Links permission"
+                        " and therefore cannot be set to not use embeds."
+                    )
                 )
 
     @commands.is_owner()


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes
This uses the fact that `embed_requested()` already accepts `command` argument and adds per-command embed settings that can be modified with `[p]embedset command`. There's a global per-command setting as well as guild-specific per-command setting.

Currently, guild-specific command setting is checked after channel setting and before guild setting while global command setting is checked right before checking the global setting.
Full hierarchy looks as follows:

a) Guild context
  1. Channel override
  2. Guild command override
  3. Guild override
  4. Global command override
  5. Global setting

b) DM context:
  1. User override
  2. Global command override
  3. Global setting

Whether guild override and global command override in guild context should be in opposite order or not is imo debatable but I chose what made sense to me.

I can also add embed settings cache, but I would prefer to do that in separate PR and if needed (because of possible performance loss), this PR could be changed to depend on it.

---

This was brought up before, but somehow it didn't make its way into an issue so this is the place where this feature will be tracked.

// I have not tested this PR *yet*.