### PR TITLE
Change wording in VPS providers document

### DIFF
--- a/docs/host-list.rst
+++ b/docs/host-list.rst
@@ -82,9 +82,10 @@ Free hosting
 | `Google Cloud Compute Engine <https://cloud.google.com/free/docs/gcp-free-tier>`_,
   `Oracle Cloud Compute <https://oracle.com/cloud/free/#always-free>`_ and
   `AWS EC2 <https://aws.amazon.com/free/>`_ have free tier VPSes suitable for small bots.
+
 | **Note:** AWS EC2's free tier does not last forever - it's a 12 month trial.
 | Additionally, new Google Cloud customers get a $300 credit which is valid
-for 12 months.
+  for 12 months.
 
 Other than that... no. There is no good free VPS hoster, outside of
 persuading somebody to host for you, which is incredibly unlikely.

--- a/docs/host-list.rst
+++ b/docs/host-list.rst
@@ -79,11 +79,11 @@ server. Any modern hardware should work 100% fine.
 Free hosting
 ------------
 
-`Google Cloud Compute Engine <https://cloud.google.com/free/docs/gcp-free-tier>`_,
-`Oracle Cloud Compute <https://oracle.com/cloud/free/#always-free>`_ and
-`AWS EC2 <https://aws.amazon.com/free/>`_ have free tier VPSes suitable for small bots.
-Note: AWS EC2's free tier does not last forever - it's a 12 month trial.
-Additionally, new Google Cloud customers get a $300 credit which is valid
+| `Google Cloud Compute Engine <https://cloud.google.com/free/docs/gcp-free-tier>`_,
+  `Oracle Cloud Compute <https://oracle.com/cloud/free/#always-free>`_ and
+  `AWS EC2 <https://aws.amazon.com/free/>`_ have free tier VPSes suitable for small bots.
+| **Note:** AWS EC2's free tier does not last forever - it's a 12 month trial.
+| Additionally, new Google Cloud customers get a $300 credit which is valid
 for 12 months.
 
 Other than that... no. There is no good free VPS hoster, outside of

--- a/docs/host-list.rst
+++ b/docs/host-list.rst
@@ -81,8 +81,8 @@ Free hosting
 
 `Google Cloud Compute Free Tier <https://cloud.google.com/free/docs/gcp-free-tier>`_,
 `Oracle Cloud Compute Always Free <https://oracle.com/cloud/free/#always-free>`_ and
-`AWS EC2 Free Tier <https://aws.amazon.com/free/>`_ have free tier VPSes suitable for small bots.
-AWS EC2 is not *always* free—it's a 12 month free trial.
+`AWS EC2 Free Tier <https://aws.amazon.com/free/>`_ are free VPSes suitable for small bots.
+Note AWS EC2 is not *always* free—it's a 12 month free trial.
 Additionally, new Google Cloud customers get a $300 credit which is valid
 for 12 months.
 

--- a/docs/host-list.rst
+++ b/docs/host-list.rst
@@ -81,7 +81,7 @@ Free hosting
 
 `Google Cloud Compute Free Tier <https://cloud.google.com/free/docs/gcp-free-tier>`_,
 `Oracle Cloud Compute Always Free <https://oracle.com/cloud/free/#always-free>`_ and
-`AWS EC2 Free Tier <https://aws.amazon.com/free/>`_ are free VPSes suitable for small bots.
+`AWS EC2 Free Tier <https://aws.amazon.com/free/>`_ are suitable for small bots.
 Note AWS EC2 is not *always* free—it's a 12 month free trial.
 Additionally, new Google Cloud customers get a $300 credit which is valid
 for 12 months.

--- a/docs/host-list.rst
+++ b/docs/host-list.rst
@@ -82,7 +82,7 @@ Free hosting
 `Google Cloud Compute Engine <https://cloud.google.com/free/docs/gcp-free-tier>`_,
 `Oracle Cloud Compute <https://oracle.com/cloud/free/#always-free>`_ and
 `AWS EC2 <https://aws.amazon.com/free/>`_ have free tier VPSes suitable for small bots.
-Note AWS EC2 is not *always* free—it's a 12 month free trial.
+Note: AWS EC2's free tier does not last forever - it's a 12 month trial.
 Additionally, new Google Cloud customers get a $300 credit which is valid
 for 12 months.
 

--- a/docs/host-list.rst
+++ b/docs/host-list.rst
@@ -79,9 +79,9 @@ server. Any modern hardware should work 100% fine.
 Free hosting
 ------------
 
-`Google Cloud Compute Free Tier <https://cloud.google.com/free/docs/gcp-free-tier>`_,
-`Oracle Cloud Compute Always Free <https://oracle.com/cloud/free/#always-free>`_ and
-`AWS EC2 Free Tier <https://aws.amazon.com/free/>`_ are suitable for small bots.
+`Google Cloud Compute Engine <https://cloud.google.com/free/docs/gcp-free-tier>`_,
+`Oracle Cloud Compute <https://oracle.com/cloud/free/#always-free>`_ and
+`AWS EC2 <https://aws.amazon.com/free/>`_ have free tier VPSes suitable for small bots.
 Note AWS EC2 is not *always* free—it's a 12 month free trial.
 Additionally, new Google Cloud customers get a $300 credit which is valid
 for 12 months.


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Looking at this it doesn't make complete sense. The company and tier are listed, then it says that those companies have free tier VPSes which has already been mentioned.

https://red-discordbot--4050.org.readthedocs.build/en/4050/host-list.html#free-hosting

_Stupid author and reviewer of #3916..._