### PR TITLE
[Docs] Add --edit to set Bot owner under Discord Teams.

### DIFF
--- a/docs/autostart_pm2.rst
+++ b/docs/autostart_pm2.rst
@@ -12,11 +12,11 @@ Installing PM2
 
 Start by installing Node.JS and NPM via your favorite package distributor.
 
-- Using Ubuntu run the following command.
+Using Ubuntu run the following command.
 :code:`curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
 sudo apt install -y nodejs`
 
-- Using Debian, run the following command as root.
+Using Debian, run the following command as root.
 :code:`curl -sL https://deb.nodesource.com/setup_14.x | bash -
 apt install -y nodejs`
 

--- a/docs/autostart_pm2.rst
+++ b/docs/autostart_pm2.rst
@@ -12,15 +12,15 @@ Installing PM2
 
 Start by installing Node.JS and NPM via your favorite package distributor.
 
-- Using Ubuntu run the following command:
+- Using Ubuntu run the following command.
 :code:`curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
 sudo apt install -y nodejs`
 
-- Using Debian, run the following command as root:
+- Using Debian, run the following command as root.
 :code:`curl -sL https://deb.nodesource.com/setup_14.x | bash -
 apt install -y nodejs`
 
-From there run the following command:
+From there run the following command.
 :code:`npm install pm2 -g`
 
 After PM2 is installed, run the following command to enable your Red instance to be managed by PM2. Replace the brackets with the required information.

--- a/docs/autostart_pm2.rst
+++ b/docs/autostart_pm2.rst
@@ -10,8 +10,17 @@ Setting up auto-restart using pm2 on Linux
 Installing PM2
 --------------
 
-Start by installing Node.JS and NPM via your favorite package distributor. From there run the following command:
+Start by installing Node.JS and NPM via your favorite package distributor.
 
+- Using Ubuntu run the following command:
+:code:`curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+sudo apt-get install -y nodejs`
+
+- Using Debian, run the following command as root:
+:code:`curl -sL https://deb.nodesource.com/setup_14.x | bash -
+apt-get install -y nodejs`
+
+From there run the following command:
 :code:`npm install pm2 -g`
 
 After PM2 is installed, run the following command to enable your Red instance to be managed by PM2. Replace the brackets with the required information.

--- a/docs/autostart_pm2.rst
+++ b/docs/autostart_pm2.rst
@@ -14,11 +14,11 @@ Start by installing Node.JS and NPM via your favorite package distributor.
 
 - Using Ubuntu run the following command:
 :code:`curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
-sudo apt-get install -y nodejs`
+sudo apt install -y nodejs`
 
 - Using Debian, run the following command as root:
 :code:`curl -sL https://deb.nodesource.com/setup_14.x | bash -
-apt-get install -y nodejs`
+apt install -y nodejs`
 
 From there run the following command:
 :code:`npm install pm2 -g`

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -201,6 +201,21 @@ or system files.
 
 *You* are the owner by default.
 
+.. note::
+
+    If your Discord application(bot) is tied to a "Team" in the Discord 
+    Developer Console, by default Red will have no set Owner.  To set 
+    bot owner follow the steps below:
+    
+    To set owner manually, launch Red using 
+          ``redbot --edit instance_name``
+
+    To make all team members bot owners, when launching Red pass
+         ``--team-members-are-owners``
+
+    You may specify individual team members to be bot owner by passing
+         ``--owner`` and ``--co-owner`` when launching Red.
+
 ~~~~~~~~~~~~
 Server owner
 ~~~~~~~~~~~~

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -556,11 +556,11 @@ section "Creating a Bot Account".
     Developer Console, by default no owner will be set to Red.  To set 
     bot owner follow the steps below:
         - To set owner manually, launch Red using 
-        ``redbot --edit instance_name``
+            ``redbot --edit instance_name``
 
         - To make all team members bot owners, when launching Red pass
            ``--team-members-are-owners``
-           
+
         - You may specify individual team members to be bot owner by passing
            ``--owner`` and ``--co-owner`` when launching Red.
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -555,13 +555,14 @@ section "Creating a Bot Account".
     If your Discord application(bot) is tied to a "Team" in the Discord 
     Developer Console, by default no owner will be set to Red.  To set 
     bot owner follow the steps below:
-        To set owner manually, launch Red using 
+    
+    To set owner manually, launch Red using 
           ``redbot --edit instance_name``
 
-        To make all team members bot owners, when launching Red pass
+    To make all team members bot owners, when launching Red pass
          ``--team-members-are-owners``
 
-        You may specify individual team members to be bot owner by passing
+    You may specify individual team members to be bot owner by passing
          ``--owner`` and ``--co-owner`` when launching Red.
 
           

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -553,7 +553,7 @@ section "Creating a Bot Account".
 .. note::
 
     If your Discord application(bot) is tied to a "Team" in the Discord 
-    Developer Console, by default no owner will be set to Red.  To set 
+    Developer Console, by default Red will have no set Owner.  To set 
     bot owner follow the steps below:
     
     To set owner manually, launch Red using 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -555,14 +555,14 @@ section "Creating a Bot Account".
     If your Discord application(bot) is tied to a "Team" in the Discord 
     Developer Console, by default no owner will be set to Red.  To set 
     bot owner follow the steps below:
-        - To set owner manually, launch Red using 
-            ``redbot --edit instance_name``
+        To set owner manually, launch Red using 
+          ``redbot --edit instance_name``
 
-        - To make all team members bot owners, when launching Red pass
-           ``--team-members-are-owners``
+        To make all team members bot owners, when launching Red pass
+         ``--team-members-are-owners``
 
-        - You may specify individual team members to be bot owner by passing
-           ``--owner`` and ``--co-owner`` when launching Red.
+        You may specify individual team members to be bot owner by passing
+         ``--owner`` and ``--co-owner`` when launching Red.
 
           
 .. tip::

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -550,6 +550,20 @@ You can find out how to obtain a token with
 :dpy_docs:`this guide <discord.html#creating-a-bot-account>`,
 section "Creating a Bot Account".
 
+.. note::
+
+    If your Discord application(bot) is tied to a "Team" in the Discord 
+    Developer Console, by default no owner will be set to Red.  To set 
+    bot owner follow the steps below:
+        A) To set owner manually, launch Red using 
+        `redbot --edit instance_name`.
+        
+        B) To make all team members bot owners, when launching Red pass
+           `--team-members-are-owners`
+           
+        C) You may specify individual team members to be bot owner by passing
+           `--owner` and `--co-owner` when launching Red.
+          
 .. tip::
    If it's the first time you're using Red, you should check our `getting-started` guide
    that will walk you through all essential information on how to interact with Red.

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -556,13 +556,12 @@ section "Creating a Bot Account".
     Developer Console, by default no owner will be set to Red.  To set 
     bot owner follow the steps below:
         A) To set owner manually, launch Red using 
-        `redbot --edit instance_name`.
-        
+        ``redbot --edit instance_name``
         B) To make all team members bot owners, when launching Red pass
-           `--team-members-are-owners`
-           
+           ``--team-members-are-owners``
         C) You may specify individual team members to be bot owner by passing
-           `--owner` and `--co-owner` when launching Red.
+           ``--owner`` and ``--co-owner`` when launching Red.
+
           
 .. tip::
    If it's the first time you're using Red, you should check our `getting-started` guide

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -555,11 +555,13 @@ section "Creating a Bot Account".
     If your Discord application(bot) is tied to a "Team" in the Discord 
     Developer Console, by default no owner will be set to Red.  To set 
     bot owner follow the steps below:
-        A) To set owner manually, launch Red using 
+        - To set owner manually, launch Red using 
         ``redbot --edit instance_name``
-        B) To make all team members bot owners, when launching Red pass
+
+        - To make all team members bot owners, when launching Red pass
            ``--team-members-are-owners``
-        C) You may specify individual team members to be bot owner by passing
+           
+        - You may specify individual team members to be bot owner by passing
            ``--owner`` and ``--co-owner`` when launching Red.
 
           

--- a/docs/install_windows.rst
+++ b/docs/install_windows.rst
@@ -174,6 +174,21 @@ You can find out how to obtain a token with
 :dpy_docs:`this guide <discord.html#creating-a-bot-account>`,
 section "Creating a Bot Account".
 
+.. note::
+
+    If your Discord application(bot) is tied to a "Team" in the Discord 
+    Developer Console, by default Red will have no set Owner.  To set 
+    bot owner follow the steps below:
+    
+    To set owner manually, launch Red using 
+          ``redbot --edit instance_name``
+
+    To make all team members bot owners, when launching Red pass
+         ``--team-members-are-owners``
+
+    You may specify individual team members to be bot owner by passing
+         ``--owner`` and ``--co-owner`` when launching Red.
+         
 .. tip::
    If it's the first time you're using Red, you should check our `getting-started` guide
    that will walk you through all essential information on how to interact with Red.


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
When Discord Bot is a Team application, by default Red has no owner set.  This does not restrict the use however has at times locked users out.  Added a note section in two locations in the documentation to potential good locations.

This is known information from the Discord server, however, After a few installs in the last couple months for friends and others.  I have found myself running into this quite often.  Seems like it shows value in being noted during install or at least in the getting started section.  I leave it to the group to decide.  No hurt feelings regardless.