### PR TITLE
[Mod] `[p]mute|unmute voice` now take action instantly

### DIFF
--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -207,6 +207,14 @@ class MuteMixin(MixinMeta):
             await ctx.send(
                 _("Muted {user} in channel {channel.name}").format(user=user, channel=channel)
             )
+            try:
+                await user.move_to(channel)
+            except discord.Forbidden:
+                await ctx.send(
+                    _(
+                        "Because I don't have the move members permission, this will take into effect when the user rejoins."
+                    )
+                )
         else:
             await ctx.send(_("Mute failed. Reason: {}").format(issue))
 
@@ -322,6 +330,14 @@ class MuteMixin(MixinMeta):
             await ctx.send(
                 _("Unmuted {user} in channel {channel.name}").format(user=user, channel=channel)
             )
+            try:
+                await user.move_to(channel)
+            except discord.Forbidden:
+                await ctx.send(
+                    _(
+                        "Because I don't have the move members permission, this will take into effect when the user rejoins."
+                    )
+                )
         else:
             await ctx.send(_("Unmute failed. Reason: {}").format(message))
 

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -216,7 +216,7 @@ class MuteMixin(MixinMeta):
                     )
                 )
         else:
-            await ctx.send(_("Mute failed. Reason: {}").format(issue))
+            await ctx.send(issue)
 
     @mute.command(name="channel")
     @commands.guild_only()

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -208,7 +208,7 @@ class MuteMixin(MixinMeta):
                 _("Muted {user} in channel {channel.name}").format(user=user, channel=channel)
             )
         else:
-            await ctx.send(issue)
+            await ctx.send(_("Mute failed. Reason: {}").format(issue))
 
     @mute.command(name="channel")
     @commands.guild_only()

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -208,11 +208,14 @@ class MuteMixin(MixinMeta):
                 _("Muted {user} in channel {channel.name}").format(user=user, channel=channel)
             )
             try:
-                await user.move_to(channel)
-            except discord.Forbidden:
+                if channel.permissions_for(ctx.me).move_members:
+                    await user.move_to(channel)
+                else:
+                    raise RuntimeError
+            except (discord.Forbidden, RuntimeError):
                 await ctx.send(
                     _(
-                        "Because I don't have the move members permission, this will take into effect when the user rejoins."
+                        "Because I don't have the Move Members permission, this will take into effect when the user rejoins."
                     )
                 )
         else:
@@ -331,11 +334,14 @@ class MuteMixin(MixinMeta):
                 _("Unmuted {user} in channel {channel.name}").format(user=user, channel=channel)
             )
             try:
-                await user.move_to(channel)
-            except discord.Forbidden:
+                if channel.permissions_for(ctx.me).move_members:
+                    await user.move_to(channel)
+                else:
+                    raise RuntimeError
+            except (discord.Forbidden, RuntimeError):
                 await ctx.send(
                     _(
-                        "Because I don't have the move members permission, this will take into effect when the user rejoins."
+                        "Because I don't have the Move Members permission, this will take into effect when the user rejoins."
                     )
                 )
         else:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature


### Description of the changes
When `[p]mute|unmute voice` is run, now the changes will take into effect instantly, instead of when the user rejoins. This is done via the move members permission, moving the user into the channel they are already in. Fixes #4028. However, as jack said in #4028:

>  I don't know if it's intended, but as long as nobody in Discord says it isn't, we could just use that.
