### PR TITLE
Give friendlier error when package can't be found during bot startup

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -657,12 +657,19 @@ class RedBase(
             for package in packages:
                 try:
                     spec = await self._cog_mgr.find_cog(package)
+                    if spec is None:
+                        log.error(
+                            "Failed to load package %s (package was not found in any cog path)",
+                            package,
+                        )
+                        await self.remove_loaded_package(package)
+                        to_remove.append(package)
                     await asyncio.wait_for(self.load_extension(spec), 30)
                 except asyncio.TimeoutError:
                     log.exception("Failed to load package %s (timeout)", package)
                     to_remove.append(package)
                 except Exception as e:
-                    log.exception("Failed to load package {}".format(package), exc_info=e)
+                    log.exception("Failed to load package %s", package, exc_info=e)
                     await self.remove_loaded_package(package)
                     to_remove.append(package)
             for package in to_remove:

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -664,6 +664,7 @@ class RedBase(
                         )
                         await self.remove_loaded_package(package)
                         to_remove.append(package)
+                        continue
                     await asyncio.wait_for(self.load_extension(spec), 30)
                 except asyncio.TimeoutError:
                     log.exception("Failed to load package %s (timeout)", package)


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes the issue mentioned in comment on #3679 ([link](https://github.com/Cog-Creators/Red-DiscordBot/pull/3679#pullrequestreview-447968260))