### PR TITLE
Document prefix preservation

### DIFF
--- a/docs/version_guarantees.rst
+++ b/docs/version_guarantees.rst
@@ -20,6 +20,11 @@ which is not private (even if not documented) should not break without notice.
 Anything in the ``redbot.cogs`` and ``redbot.vendored`` modules or any of their submodules is specifically
 excluded from being guaranteed.
 
+Method names and names of attributes of classes, functions, extensions, and modules
+provided by or provided to the bot should not begin with 
+``red_`` or be of the form ``__red_*__`` except as documented.
+This allows us to add certain optional features non-breakingly without a name conflict.
+
 Any RPC method exposed by Red may break without notice.
 
 If you would like something in here to be guaranteed,

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -255,8 +255,8 @@ class Command(CogCommandMixin, DPYCommand):
         If you subclass this command, attributes and methods
         must remain compatible.
 
-        None of your methods should start with ``red_`` or 
-        be dunder methods which start with red (eg. ``__red_test_thing__``)
+        None of your methods should start with ``red_`` or
+        be dunder names which start with red (eg. ``__red_test_thing__``)
         unless to override behavior in a method designed to be overriden,
         as this prefix is reserved for future methods in order to be
         able to add features non-breakingly.
@@ -879,7 +879,7 @@ class Cog(CogMixin, DPYCog, metaclass=DPYCogMeta):
     .. warning::
 
         None of your methods should start with ``red_`` or 
-        be dunder methods which start with red (eg. ``__red_test_thing__``)
+        be dunder names which start with red (eg. ``__red_test_thing__``)
         unless to override behavior in a method designed to be overriden,
         as this prefix is reserved for future methods in order to be
         able to add features non-breakingly.

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -250,6 +250,12 @@ class Command(CogCommandMixin, DPYCommand):
     attributes listed below are simply additions to the ones listed
     with that class.
 
+    .. warning::
+
+        If you subclass this command, attributes and methods
+        must remain compatible.
+        Additionally, the prefix `red_` for names is reserved for future use.
+
     Attributes
     ----------
     checks : List[`coroutine function`]
@@ -657,7 +663,7 @@ class Command(CogCommandMixin, DPYCommand):
 
         See ``format_text_for_context`` for the actual implementation details
 
-        Cog creators may override this in their own command classes
+        Cog creators may override this in their own command and cog classes
         as long as the method signature stays the same.
 
         Parameters
@@ -871,6 +877,9 @@ class Cog(CogMixin, DPYCog, metaclass=DPYCogMeta):
         to override behavior in a method designed to be overriden,
         as this prefix is reserved for future methods in order to be
         able to add features non-breakingly.
+
+        Attributes and methods must remain compatible
+        with discord.py and with any of red's methods and attributes.
 
     """
 

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -254,7 +254,7 @@ class Command(CogCommandMixin, DPYCommand):
 
         If you subclass this command, attributes and methods
         must remain compatible.
-        Additionally, the prefix `red_` for names is reserved for future use.
+        Additionally, the prefix ``red_`` for names is reserved for future use.
 
     Attributes
     ----------

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -864,6 +864,14 @@ class Cog(CogMixin, DPYCog, metaclass=DPYCogMeta):
     Red's Cog base class
 
     This includes a metaclass from discord.py
+
+    .. warning::
+
+        None of your methods should start with ``red_`` unless
+        to override behavior in a method designed to be overriden,
+        as this prefix is reserved for future methods in order to be
+        able to add features non-breakingly.
+
     """
 
     __cog_commands__: Tuple[Command]

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -254,7 +254,12 @@ class Command(CogCommandMixin, DPYCommand):
 
         If you subclass this command, attributes and methods
         must remain compatible.
-        Additionally, the prefix ``red_`` for names is reserved for future use.
+
+        None of your methods should start with ``red_`` or 
+        be dunder methods which start with red (eg. ``__red_test_thing__``)
+        unless to override behavior in a method designed to be overriden,
+        as this prefix is reserved for future methods in order to be
+        able to add features non-breakingly.
 
     Attributes
     ----------
@@ -873,8 +878,9 @@ class Cog(CogMixin, DPYCog, metaclass=DPYCogMeta):
 
     .. warning::
 
-        None of your methods should start with ``red_`` unless
-        to override behavior in a method designed to be overriden,
+        None of your methods should start with ``red_`` or 
+        be dunder methods which start with red (eg. ``__red_test_thing__``)
+        unless to override behavior in a method designed to be overriden,
         as this prefix is reserved for future methods in order to be
         able to add features non-breakingly.
 


### PR DESCRIPTION
### Description of the changes

Reserves a prefix so that things like #4043 will not be a breaking addition in the future.
