### PR TITLE
[Announcer] Don't die with a lack of channels

### DIFF
--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -75,9 +75,7 @@ class Admin(commands.Cog):
         self.config.register_global(serverlocked=False)
 
         self.config.register_guild(
-            announce_ignore=False,
-            announce_channel=None,  # Integer ID
-            selfroles=[],  # List of integer ID's
+            announce_channel=None, selfroles=[],  # Integer ID  # List of integer ID's
         )
 
         self.__current_announcer = None
@@ -320,7 +318,7 @@ class Admin(commands.Cog):
     async def announceset_channel(self, ctx, *, channel: discord.TextChannel = None):
         """
         Change the channel where the bot will send announcements.
-        
+
         If channel is left blank it defaults to the current channel.
         """
         if channel is None:
@@ -330,21 +328,11 @@ class Admin(commands.Cog):
             _("The announcement channel has been set to {channel.mention}").format(channel=channel)
         )
 
-    @announceset.command(name="ignore")
-    async def announceset_ignore(self, ctx):
-        """Toggle announcements being enabled this server."""
-        ignored = await self.config.guild(ctx.guild).announce_ignore()
-        await self.config.guild(ctx.guild).announce_ignore.set(not ignored)
-        if ignored:
-            await ctx.send(
-                _("The server {guild.name} will receive announcements.").format(guild=ctx.guild)
-            )
-        else:
-            await ctx.send(
-                _("The server {guild.name} will not receive announcements.").format(
-                    guild=ctx.guild
-                )
-            )
+    @announceset.command(name="clearchannel")
+    async def announceset_clear_channel(self, ctx):
+        """Unsets the channel for announcements."""
+        await self.config.guild(ctx.guild).announce_channel.clear()
+        await ctx.tick()
 
     async def _valid_selfroles(self, guild: discord.Guild) -> Tuple[discord.Role]:
         """

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -107,8 +107,9 @@ class Admin(commands.Cog):
 
         for guild_id, guild_data in all_guilds.items():
             if guild_data.get("announce_ignore", False):
-                await self.config.guild_from_id(guild_id).announce_channel.clear()
-                await self.config.guild_from_id(guild_id).clear_raw("announce_ignore")
+                async with self.config.guild_from_id(guild_id).all(acquire_lock=False) as guild_config:
+                    guild_config.pop("announce_channel", None)
+                    guild_config.pop("announce_ignore", None)
 
     def cog_unload(self):
         try:

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -107,7 +107,9 @@ class Admin(commands.Cog):
 
         for guild_id, guild_data in all_guilds.items():
             if guild_data.get("announce_ignore", False):
-                async with self.config.guild_from_id(guild_id).all(acquire_lock=False) as guild_config:
+                async with self.config.guild_from_id(guild_id).all(
+                    acquire_lock=False
+                ) as guild_config:
                     guild_config.pop("announce_channel", None)
                     guild_config.pop("announce_ignore", None)
 

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -108,6 +108,7 @@ class Admin(commands.Cog):
         for guild_id, guild_data in all_guilds.items():
             if guild_data.get("announce_ignore", False):
                 await self.config.guild_from_id(guild_id).announce_channel.clear()
+                await self.config.guild_from_id(guild_id).clear_raw("announce_ignore")
 
     def cog_unload(self):
         try:

--- a/redbot/cogs/admin/announcer.py
+++ b/redbot/cogs/admin/announcer.py
@@ -50,9 +50,6 @@ class Announcer:
             if not self.active:
                 return
 
-            if await self.config.guild(g).announce_ignore():
-                continue
-
             channel = await self._get_announce_channel(g)
 
             if channel:

--- a/redbot/cogs/admin/announcer.py
+++ b/redbot/cogs/admin/announcer.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Optional
 
 import discord
 from redbot.core import commands
@@ -38,20 +39,9 @@ class Announcer:
         """
         self.active = False
 
-    async def _get_announce_channel(self, guild: discord.Guild) -> discord.TextChannel:
+    async def _get_announce_channel(self, guild: discord.Guild) -> Optional[discord.TextChannel]:
         channel_id = await self.config.guild(guild).announce_channel()
-        channel = None
-
-        if channel_id is not None:
-            channel = guild.get_channel(channel_id)
-
-        if channel is None:
-            channel = guild.system_channel
-
-        if channel is None:
-            channel = guild.text_channels[0]
-
-        return channel
+        return guild.get_channel(channel_id)
 
     async def announcer(self):
         guild_list = self.ctx.bot.guilds
@@ -65,10 +55,14 @@ class Announcer:
 
             channel = await self._get_announce_channel(g)
 
-            try:
-                await channel.send(self.message)
-            except discord.Forbidden:
-                failed.append(str(g.id))
+            if channel:
+                if channel.permissions_for(g.me).send_messages:
+                    try:
+                        await channel.send(self.message)
+                    except discord.Forbidden:
+                        failed.append(str(g.id))
+                else:
+                    failed.append(str(g.id))
 
         if failed:
             msg = (


### PR DESCRIPTION
### Type

- [X] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
fixes #4088 by not trying to guess channels
This also assumes that a channel not being set means the server doesn't want an announcement, and isn't a failure.