### PR TITLE
Make `docs` tox workflow not stop after first warning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -51,8 +51,8 @@ setenv =
 basepython = python3.8
 extras = docs
 commands =
-    sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out/html" -W -bhtml
-    sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out/doctest" -W -bdoctest
+    sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out/html" -W --keep-going -bhtml
+    sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out/doctest" -W --keep-going -bdoctest
 
 [testenv:style]
 description = Stylecheck the code with black to see if anything needs changes.


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Simple change that will make the docs tests fully finish before failing so that contributors can fix all things at once.