### PR TITLE
Remove unused try except blocks in `modlog.create_case()` usage

### DIFF
--- a/redbot/cogs/mod/events.py
+++ b/redbot/cogs/mod/events.py
@@ -56,21 +56,17 @@ class Events(MixinMeta):
                         "Failed to ban member for mention spam in server {}.".format(guild.id)
                     )
                 else:
-                    try:
-                        await modlog.create_case(
-                            self.bot,
-                            guild,
-                            message.created_at,
-                            "ban",
-                            author,
-                            guild.me,
-                            _("Mention spam (Autoban)"),
-                            until=None,
-                            channel=None,
-                        )
-                    except RuntimeError as e:
-                        print(e)
-                        return False
+                    await modlog.create_case(
+                        self.bot,
+                        guild,
+                        message.created_at,
+                        "ban",
+                        author,
+                        guild.me,
+                        _("Mention spam (Autoban)"),
+                        until=None,
+                        channel=None,
+                    )
                     return True
         return False
 

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -116,23 +116,17 @@ class KickBanMixin(MixinMeta):
             return _("An unexpected error occurred.")
 
         if create_modlog_case:
-            try:
-                await modlog.create_case(
-                    self.bot,
-                    guild,
-                    ctx.message.created_at,
-                    "ban",
-                    user,
-                    author,
-                    reason,
-                    until=None,
-                    channel=None,
-                )
-            except RuntimeError as e:
-                return _(
-                    "The user was banned but an error occurred when trying to "
-                    "create the modlog entry: {reason}"
-                ).format(reason=e)
+            await modlog.create_case(
+                self.bot,
+                guild,
+                ctx.message.created_at,
+                "ban",
+                user,
+                author,
+                reason,
+                until=None,
+                channel=None,
+            )
 
         return True
 
@@ -227,20 +221,17 @@ class KickBanMixin(MixinMeta):
                 )
             )
         else:
-            try:
-                await modlog.create_case(
-                    self.bot,
-                    guild,
-                    ctx.message.created_at,
-                    "kick",
-                    user,
-                    author,
-                    reason,
-                    until=None,
-                    channel=None,
-                )
-            except RuntimeError as e:
-                await ctx.send(e)
+            await modlog.create_case(
+                self.bot,
+                guild,
+                ctx.message.created_at,
+                "kick",
+                user,
+                author,
+                reason,
+                until=None,
+                channel=None,
+            )
             await ctx.send(_("Done. That felt good."))
 
     @commands.command()
@@ -412,20 +403,17 @@ class KickBanMixin(MixinMeta):
                     else:
                         banned.append(user_id)
 
-            try:
-                await modlog.create_case(
-                    self.bot,
-                    guild,
-                    ctx.message.created_at,
-                    "hackban",
-                    user_id,
-                    author,
-                    reason,
-                    until=None,
-                    channel=None,
-                )
-            except RuntimeError as e:
-                errors["0"] = _("Failed to create modlog case: {reason}").format(reason=e)
+            await modlog.create_case(
+                self.bot,
+                guild,
+                ctx.message.created_at,
+                "hackban",
+                user_id,
+                author,
+                reason,
+                until=None,
+                channel=None,
+            )
         await show_results()
 
     @commands.command()
@@ -496,19 +484,16 @@ class KickBanMixin(MixinMeta):
         except discord.HTTPException:
             await ctx.send(_("Something went wrong while banning."))
         else:
-            try:
-                await modlog.create_case(
-                    self.bot,
-                    guild,
-                    ctx.message.created_at,
-                    "tempban",
-                    user,
-                    author,
-                    reason,
-                    unban_time,
-                )
-            except RuntimeError as e:
-                await ctx.send(e)
+            await modlog.create_case(
+                self.bot,
+                guild,
+                ctx.message.created_at,
+                "tempban",
+                user,
+                author,
+                reason,
+                unban_time,
+            )
             await ctx.send(_("Done. Enough chaos for now."))
 
     @commands.command()
@@ -582,20 +567,17 @@ class KickBanMixin(MixinMeta):
                 "{}({}) softbanned {}({}), deleting 1 day worth "
                 "of messages.".format(author.name, author.id, user.name, user.id)
             )
-            try:
-                await modlog.create_case(
-                    self.bot,
-                    guild,
-                    ctx.message.created_at,
-                    "softban",
-                    user,
-                    author,
-                    reason,
-                    until=None,
-                    channel=None,
-                )
-            except RuntimeError as e:
-                await ctx.send(e)
+            await modlog.create_case(
+                self.bot,
+                guild,
+                ctx.message.created_at,
+                "softban",
+                user,
+                author,
+                reason,
+                until=None,
+                channel=None,
+            )
             await ctx.send(_("Done. Enough chaos."))
 
     @commands.command()
@@ -632,20 +614,17 @@ class KickBanMixin(MixinMeta):
             await ctx.send(_("Something went wrong while attempting to kick that member."))
             return
         else:
-            try:
-                await modlog.create_case(
-                    self.bot,
-                    guild,
-                    ctx.message.created_at,
-                    "vkick",
-                    member,
-                    author,
-                    reason,
-                    until=None,
-                    channel=case_channel,
-                )
-            except RuntimeError as e:
-                await ctx.send(e)
+            await modlog.create_case(
+                self.bot,
+                guild,
+                ctx.message.created_at,
+                "vkick",
+                member,
+                author,
+                reason,
+                until=None,
+                channel=case_channel,
+            )
 
     @commands.command()
     @commands.guild_only()
@@ -674,20 +653,17 @@ class KickBanMixin(MixinMeta):
             await ctx.send(_("Something went wrong while attempting to unban that user."))
             return
         else:
-            try:
-                await modlog.create_case(
-                    self.bot,
-                    guild,
-                    ctx.message.created_at,
-                    "unban",
-                    user,
-                    author,
-                    reason,
-                    until=None,
-                    channel=None,
-                )
-            except RuntimeError as e:
-                await ctx.send(e)
+            await modlog.create_case(
+                self.bot,
+                guild,
+                ctx.message.created_at,
+                "unban",
+                user,
+                author,
+                reason,
+                until=None,
+                channel=None,
+            )
             await ctx.send(_("Unbanned that user from this server."))
 
         if await self.config.guild(guild).reinvite_on_unban():

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -103,20 +103,17 @@ class MuteMixin(MixinMeta):
 
         guild = ctx.guild
         author = ctx.author
-        try:
-            await modlog.create_case(
-                self.bot,
-                guild,
-                ctx.message.created_at,
-                "voiceunban",
-                user,
-                author,
-                reason,
-                until=None,
-                channel=None,
-            )
-        except RuntimeError as e:
-            await ctx.send(e)
+        await modlog.create_case(
+            self.bot,
+            guild,
+            ctx.message.created_at,
+            "voiceunban",
+            user,
+            author,
+            reason,
+            until=None,
+            channel=None,
+        )
         await ctx.send(_("User is now allowed to speak and listen in voice channels"))
 
     @commands.command()
@@ -147,20 +144,17 @@ class MuteMixin(MixinMeta):
             await ctx.send(_("That user is already muted and deafened server-wide!"))
             return
 
-        try:
-            await modlog.create_case(
-                self.bot,
-                guild,
-                ctx.message.created_at,
-                "voiceban",
-                user,
-                author,
-                reason,
-                until=None,
-                channel=None,
-            )
-        except RuntimeError as e:
-            await ctx.send(e)
+        await modlog.create_case(
+            self.bot,
+            guild,
+            ctx.message.created_at,
+            "voiceban",
+            user,
+            author,
+            reason,
+            until=None,
+            channel=None,
+        )
         await ctx.send(_("User has been banned from speaking or listening in voice channels"))
 
     @commands.group()
@@ -190,20 +184,17 @@ class MuteMixin(MixinMeta):
         success, issue = await self.mute_user(guild, channel, author, user, audit_reason)
 
         if success:
-            try:
-                await modlog.create_case(
-                    self.bot,
-                    guild,
-                    ctx.message.created_at,
-                    "vmute",
-                    user,
-                    author,
-                    reason,
-                    until=None,
-                    channel=channel,
-                )
-            except RuntimeError as e:
-                await ctx.send(e)
+            await modlog.create_case(
+                self.bot,
+                guild,
+                ctx.message.created_at,
+                "vmute",
+                user,
+                author,
+                reason,
+                until=None,
+                channel=channel,
+            )
             await ctx.send(
                 _("Muted {user} in channel {channel.name}").format(user=user, channel=channel)
             )
@@ -237,20 +228,17 @@ class MuteMixin(MixinMeta):
         success, issue = await self.mute_user(guild, channel, author, user, audit_reason)
 
         if success:
-            try:
-                await modlog.create_case(
-                    self.bot,
-                    guild,
-                    ctx.message.created_at,
-                    "cmute",
-                    user,
-                    author,
-                    reason,
-                    until=None,
-                    channel=channel,
-                )
-            except RuntimeError as e:
-                await ctx.send(e)
+            await modlog.create_case(
+                self.bot,
+                guild,
+                ctx.message.created_at,
+                "cmute",
+                user,
+                author,
+                reason,
+                until=None,
+                channel=channel,
+            )
             await channel.send(_("User has been muted in this channel."))
         else:
             await channel.send(issue)
@@ -270,20 +258,17 @@ class MuteMixin(MixinMeta):
             success, issue = await self.mute_user(guild, channel, author, user, audit_reason)
             mute_success.append((success, issue))
             await asyncio.sleep(0.1)
-        try:
-            await modlog.create_case(
-                self.bot,
-                guild,
-                ctx.message.created_at,
-                "smute",
-                user,
-                author,
-                reason,
-                until=None,
-                channel=None,
-            )
-        except RuntimeError as e:
-            await ctx.send(e)
+        await modlog.create_case(
+            self.bot,
+            guild,
+            ctx.message.created_at,
+            "smute",
+            user,
+            author,
+            reason,
+            until=None,
+            channel=None,
+        )
         await ctx.send(_("User has been muted in this server."))
 
     @commands.group()
@@ -316,20 +301,17 @@ class MuteMixin(MixinMeta):
         success, message = await self.unmute_user(guild, channel, author, user, audit_reason)
 
         if success:
-            try:
-                await modlog.create_case(
-                    self.bot,
-                    guild,
-                    ctx.message.created_at,
-                    "vunmute",
-                    user,
-                    author,
-                    reason,
-                    until=None,
-                    channel=channel,
-                )
-            except RuntimeError as e:
-                await ctx.send(e)
+            await modlog.create_case(
+                self.bot,
+                guild,
+                ctx.message.created_at,
+                "vunmute",
+                user,
+                author,
+                reason,
+                until=None,
+                channel=channel,
+            )
             await ctx.send(
                 _("Unmuted {user} in channel {channel.name}").format(user=user, channel=channel)
             )
@@ -363,20 +345,17 @@ class MuteMixin(MixinMeta):
         success, message = await self.unmute_user(guild, channel, author, user, audit_reason)
 
         if success:
-            try:
-                await modlog.create_case(
-                    self.bot,
-                    guild,
-                    ctx.message.created_at,
-                    "cunmute",
-                    user,
-                    author,
-                    reason,
-                    until=None,
-                    channel=channel,
-                )
-            except RuntimeError as e:
-                await ctx.send(e)
+            await modlog.create_case(
+                self.bot,
+                guild,
+                ctx.message.created_at,
+                "cunmute",
+                user,
+                author,
+                reason,
+                until=None,
+                channel=channel,
+            )
             await ctx.send(_("User unmuted in this channel."))
         else:
             await ctx.send(_("Unmute failed. Reason: {}").format(message))
@@ -398,19 +377,16 @@ class MuteMixin(MixinMeta):
             success, message = await self.unmute_user(guild, channel, author, user, audit_reason)
             unmute_success.append((success, message))
             await asyncio.sleep(0.1)
-        try:
-            await modlog.create_case(
-                self.bot,
-                guild,
-                ctx.message.created_at,
-                "sunmute",
-                user,
-                author,
-                reason,
-                until=None,
-            )
-        except RuntimeError as e:
-            await ctx.send(e)
+        await modlog.create_case(
+            self.bot,
+            guild,
+            ctx.message.created_at,
+            "sunmute",
+            user,
+            author,
+            reason,
+            until=None,
+        )
         await ctx.send(_("User has been unmuted in this server."))
 
     async def mute_user(

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -378,14 +378,7 @@ class MuteMixin(MixinMeta):
             unmute_success.append((success, message))
             await asyncio.sleep(0.1)
         await modlog.create_case(
-            self.bot,
-            guild,
-            ctx.message.created_at,
-            "sunmute",
-            user,
-            author,
-            reason,
-            until=None,
+            self.bot, guild, ctx.message.created_at, "sunmute", user, author, reason, until=None,
         )
         await ctx.send(_("User has been unmuted in this server."))
 

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -443,30 +443,27 @@ class Warnings(commands.Cog):
         else:
             if not dm_failed:
                 await ctx.tick()
-        try:
-            reason_msg = _(
-                "{reason}\n\nUse `{prefix}unwarn {user} {message}` to remove this warning."
-            ).format(
-                reason=_("{description}\nPoints: {points}").format(
-                    description=reason_type["description"], points=reason_type["points"]
-                ),
-                prefix=ctx.clean_prefix,
-                user=user.id,
-                message=ctx.message.id,
-            )
-            await modlog.create_case(
-                self.bot,
-                ctx.guild,
-                ctx.message.created_at,
-                "warning",
-                user,
-                ctx.message.author,
-                reason_msg,
-                until=None,
-                channel=None,
-            )
-        except RuntimeError:
-            pass
+        reason_msg = _(
+            "{reason}\n\nUse `{prefix}unwarn {user} {message}` to remove this warning."
+        ).format(
+            reason=_("{description}\nPoints: {points}").format(
+                description=reason_type["description"], points=reason_type["points"]
+            ),
+            prefix=ctx.clean_prefix,
+            user=user.id,
+            message=ctx.message.id,
+        )
+        await modlog.create_case(
+            self.bot,
+            ctx.guild,
+            ctx.message.created_at,
+            "warning",
+            user,
+            ctx.message.author,
+            reason_msg,
+            until=None,
+            channel=None,
+        )
 
     @commands.command()
     @commands.guild_only()
@@ -570,19 +567,16 @@ class Warnings(commands.Cog):
                 current_point_count -= user_warnings[warn_id]["points"]
                 await member_settings.total_points.set(current_point_count)
                 user_warnings.pop(warn_id)
-        try:
-            await modlog.create_case(
-                self.bot,
-                ctx.guild,
-                ctx.message.created_at,
-                "unwarned",
-                member,
-                ctx.message.author,
-                reason,
-                until=None,
-                channel=None,
-            )
-        except RuntimeError:
-            pass
+        await modlog.create_case(
+            self.bot,
+            ctx.guild,
+            ctx.message.created_at,
+            "unwarned",
+            member,
+            ctx.message.author,
+            reason,
+            until=None,
+            channel=None,
+        )
 
         await ctx.tick()


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
`modlog.create_case()` doesn't raise since 3.0.0b15 (#1717) but these try except block were never removed.