### PR TITLE
Use NONE privilege level in has_permissions check

### DIFF
--- a/redbot/core/commands/requires.py
+++ b/redbot/core/commands/requires.py
@@ -553,9 +553,10 @@ class Requires:
             if user_perms.administrator or user_perms >= self.user_perms:
                 return True
 
-        privilege_level = await PrivilegeLevel.from_ctx(ctx)
-        if privilege_level >= self.privilege_level:
-            return True
+        if self.privilege_level is not PrivilegeLevel.NONE:
+            privilege_level = await PrivilegeLevel.from_ctx(ctx)
+            if privilege_level >= self.privilege_level:
+                return True
 
         return False
 

--- a/redbot/core/commands/requires.py
+++ b/redbot/core/commands/requires.py
@@ -294,10 +294,10 @@ class Requires:
         `Command.checks` if you would like them to never be overridden.
     privilege_level : PrivilegeLevel
         The required privilege level (bot owner, admin, etc.) for users
-        to execute the command. Can be ``None``, in which case the
-        `user_perms` will be used exclusively, otherwise, for levels
-        other than bot owner, the user can still run the command if
-        they have the required `user_perms`.
+        to execute the command. Can be ``PrivilegeLevel.NONE``, in which
+        case the `user_perms` will be used exclusively, otherwise, for
+        levels other than bot owner, the user can still run the command
+        if they have the required `user_perms`.
     ready_event : asyncio.Event
         Event for when this Requires object has had its rules loaded.
         If permissions is loaded, this should be set when permissions
@@ -553,10 +553,9 @@ class Requires:
             if user_perms.administrator or user_perms >= self.user_perms:
                 return True
 
-        if self.privilege_level is not None:
-            privilege_level = await PrivilegeLevel.from_ctx(ctx)
-            if privilege_level >= self.privilege_level:
-                return True
+        privilege_level = await PrivilegeLevel.from_ctx(ctx)
+        if privilege_level >= self.privilege_level:
+            return True
 
         return False
 

--- a/redbot/core/commands/requires.py
+++ b/redbot/core/commands/requires.py
@@ -325,13 +325,13 @@ class Requires:
 
     def __init__(
         self,
-        privilege_level: Optional[PrivilegeLevel],
+        privilege_level: PrivilegeLevel,
         user_perms: Union[Dict[str, bool], discord.Permissions, None],
         bot_perms: Union[Dict[str, bool], discord.Permissions],
         checks: List[CheckPredicate],
     ):
         self.checks: List[CheckPredicate] = checks
-        self.privilege_level: Optional[PrivilegeLevel] = privilege_level
+        self.privilege_level: PrivilegeLevel = privilege_level
         self.ready_event = asyncio.Event()
 
         if isinstance(user_perms, dict):
@@ -352,7 +352,7 @@ class Requires:
 
     @staticmethod
     def get_decorator(
-        privilege_level: Optional[PrivilegeLevel], user_perms: Optional[Dict[str, bool]]
+        privilege_level: PrivilegeLevel, user_perms: Optional[Dict[str, bool]]
     ) -> Callable[["_CommandOrCoro"], "_CommandOrCoro"]:
         if not user_perms:
             user_perms = None
@@ -708,7 +708,7 @@ def has_permissions(**perms: bool):
     """
     if perms is None:
         raise TypeError("Must provide at least one keyword argument to has_permissions")
-    return Requires.get_decorator(None, perms)
+    return Requires.get_decorator(PrivilegeLevel.NONE, perms)
 
 
 def is_owner():


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Currently a command that doesn't have any privilege level will return a None, while we already have an NONE value in PrivilegeLevel enum, that PR fixes that.