### PR TITLE
Remove operating systems that reached EOL

### DIFF
--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -96,33 +96,6 @@ Complete the rest of the installation by `installing Python 3.8 with pyenv <inst
 
 ----
 
-.. _install-debian-stretch:
-
-~~~~~~~~~~~~~~
-Debian Stretch
-~~~~~~~~~~~~~~
-
-.. note::
-
-    This guide is only for Debian Stretch users, these instructions won't work with
-    Raspbian Stretch. Raspbian Buster is the only version of Raspbian supported by Red.
-
-We recommend installing pyenv as a method of installing non-native versions of python on
-Debian Stretch. This guide will tell you how. First, run the following commands:
-
-.. code-block:: none
-
-    sudo echo "deb http://deb.debian.org/debian stretch-backports main" >> /etc/apt/sources.list.d/red-sources.list
-    sudo apt update
-    sudo apt -y install make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev \
-      libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
-      libffi-dev liblzma-dev libgdbm-dev uuid-dev python3-openssl git openjdk-11-jre-headless
-    CXX=/usr/bin/g++
-
-Complete the rest of the installation by `installing Python 3.8 with pyenv <install-python-pyenv>`.
-
-----
-
 .. _install-debian:
 .. _install-raspbian:
 
@@ -151,7 +124,7 @@ Complete the rest of the installation by `installing Python 3.8 with pyenv <inst
 Fedora Linux
 ~~~~~~~~~~~~
 
-Fedora Linux 30 and above has all required packages available in official repositories. Install
+Fedora Linux 31 and above has all required packages available in official repositories. Install
 them with dnf:
 
 .. code-block:: none
@@ -196,10 +169,10 @@ Continue by `creating-venv-linux`.
 openSUSE
 ~~~~~~~~
 
-openSUSE Leap
-*************
+openSUSE Leap 15.1+
+*******************
 
-We recommend installing a community package to get Python 3.8 on openSUSE Leap. This package will
+We recommend installing a community package to get Python 3.8 on openSUSE Leap 15.1+. This package will
 be installed to the ``/opt`` directory.
 
 First, add the Opt-Python community repository:


### PR DESCRIPTION
This PR removes Debian Stretch ([EOL since 2020-07-06](https://wiki.debian.org/DebianReleases#Production_Releases)) from install guides, changes minimum Fedora version to 31 ([EOL since 2020-05-26](https://fedoraproject.org/wiki/End_of_life)), and specifies that OpenSUSE Leap instructions apply to 15.1+