### PR TITLE
[Trivia] whosthatpokemon2 trivia - Generation 2 Pokémons

### DIFF
--- a/redbot/cogs/trivia/data/lists/whosthatpokemon2.yaml
+++ b/redbot/cogs/trivia/data/lists/whosthatpokemon2.yaml
@@ -1,0 +1,201 @@
+AUTHOR: aikaterna, owo
+Who's that pokemon? https://cdn.discord.red/i/161fDs6.png:
+- Chikorita
+Who's that pokemon? https://cdn.discord.red/i/9mBd4k5.png:
+- Bayleef
+Who's that pokemon? https://cdn.discord.red/i/JK6EdFS.png:
+- Meganium
+Who's that pokemon? https://cdn.discord.red/i/VANqEey.png:
+- Cyndaquil
+Who's that pokemon? https://cdn.discord.red/i/wo3W5f8.png:
+- Quilava
+Who's that pokemon? https://cdn.discord.red/i/la2mCq5.png:
+- Typhlosion
+Who's that pokemon? https://cdn.discord.red/i/NOE3zVe.png:
+- Totodile
+Who's that pokemon? https://cdn.discord.red/i/7mIaKvA.png:
+- Croconaw
+Who's that pokemon? https://cdn.discord.red/i/pkRCy4p.png:
+- Feraligatr
+Who's that pokemon? https://cdn.discord.red/i/R2RQJJD.png:
+- Sentret
+Who's that pokemon? https://cdn.discord.red/i/zVeD6jY.png:
+- Furret
+Who's that pokemon? https://cdn.discord.red/i/tu0igAj.png:
+- Hoothoot
+Who's that pokemon? https://cdn.discord.red/i/qokx2sz.png:
+- Noctowl
+Who's that pokemon? https://cdn.discord.red/i/LqBvwkd.png:
+- Ledyba
+Who's that pokemon? https://cdn.discord.red/i/Ri77MSO.png:
+- Ledian
+Who's that pokemon? https://cdn.discord.red/i/GvFKVrG.png:
+- Spinarak
+Who's that pokemon? https://cdn.discord.red/i/MN7OIfR.png:
+- Ariados
+Who's that pokemon? https://cdn.discord.red/i/e5hYFQF.png:
+- Crobat
+Who's that pokemon? https://cdn.discord.red/i/YOyKw1M.png:
+- Chinchou
+Who's that pokemon? https://cdn.discord.red/i/WZEHcW2.png:
+- Lanturn
+Who's that pokemon? https://cdn.discord.red/i/1YqVBUU.png:
+- Pichu
+Who's that pokemon? https://cdn.discord.red/i/BzyRRM6.png:
+- Cleffa
+Who's that pokemon? https://cdn.discord.red/i/HLzHnoR.png:
+- Igglybuff
+Who's that pokemon? https://cdn.discord.red/i/7eIACOx.png:
+- Togepi
+Who's that pokemon? https://cdn.discord.red/i/Wihw9ed.png:
+- Togetic
+Who's that pokemon? https://cdn.discord.red/i/sEcT1wG.png:
+- Natu
+Who's that pokemon? https://cdn.discord.red/i/WP50IsH.png:
+- Xatu
+Who's that pokemon? https://cdn.discord.red/i/aeU3eLQ.png:
+- Mareep
+Who's that pokemon? https://cdn.discord.red/i/CMjVBM2.png:
+- Flaaffy
+Who's that pokemon? https://cdn.discord.red/i/0rL21y3.png:
+- Ampharos
+Who's that pokemon? https://cdn.discord.red/i/r83gWqG.png:
+- Bellossom
+Who's that pokemon? https://cdn.discord.red/i/nDX9cFZ.png:
+- Marill
+Who's that pokemon? https://cdn.discord.red/i/i8MzcBG.png:
+- Azumarill
+Who's that pokemon? https://cdn.discord.red/i/9lvsmrK.png:
+- Sudowoodo
+Who's that pokemon? https://cdn.discord.red/i/1MOC4py.png:
+- Politoed
+Who's that pokemon? https://cdn.discord.red/i/MtHPKHY.png:
+- Hoppip
+Who's that pokemon? https://cdn.discord.red/i/G3B7gou.png:
+- Skiploom
+Who's that pokemon? https://cdn.discord.red/i/3PqW6d4.png:
+- Jumpluff
+Who's that pokemon? https://cdn.discord.red/i/7E4uSrM.png:
+- Aipom
+Who's that pokemon? https://cdn.discord.red/i/TQp3Nm6.png:
+- Sunkern
+Who's that pokemon? https://cdn.discord.red/i/uz2MQ0c.png:
+- Sunflora
+Who's that pokemon? https://cdn.discord.red/i/NiC8tpF.png:
+- Yanma
+Who's that pokemon? https://cdn.discord.red/i/yvgjiCQ.png:
+- Wooper
+Who's that pokemon? https://cdn.discord.red/i/7NSgVte.png:
+- Quagsire
+Who's that pokemon? https://cdn.discord.red/i/d6xPUYS.png:
+- Espeon
+Who's that pokemon? https://cdn.discord.red/i/1D2T81X.png:
+- Umbreon
+Who's that pokemon? https://cdn.discord.red/i/mdOMOgS.png:
+- Murkrow
+Who's that pokemon? https://cdn.discord.red/i/6ReUa0W.png:
+- Slowking
+Who's that pokemon? https://cdn.discord.red/i/JA1k4GF.png:
+- Misdreavus
+Who's that pokemon? https://cdn.discord.red/i/sLKauTP.png:
+- Unown
+Who's that pokemon? https://cdn.discord.red/i/gtzSsQh.png:
+- Wobbuffet
+Who's that pokemon? https://cdn.discord.red/i/Zz1hdae.png:
+- Girafarig
+Who's that pokemon? https://cdn.discord.red/i/7v0ktVt.png:
+- Pineco
+Who's that pokemon? https://cdn.discord.red/i/dGt2LtM.png:
+- Forretress
+Who's that pokemon? https://cdn.discord.red/i/3d7i0nA.png:
+- Dunsparce
+Who's that pokemon? https://cdn.discord.red/i/EZFfXGQ.png:
+- Gligar
+Who's that pokemon? https://cdn.discord.red/i/FicMmX2.png:
+- Steelix
+Who's that pokemon? https://cdn.discord.red/i/EWlbb3g.png:
+- Snubbull
+Who's that pokemon? https://cdn.discord.red/i/Es7SFIu.png:
+- Granbull
+Who's that pokemon? https://cdn.discord.red/i/qWvJSNs.png:
+- Qwilfish
+Who's that pokemon? https://cdn.discord.red/i/zl9gJ8s.png:
+- Scizor
+Who's that pokemon? https://cdn.discord.red/i/ZSkIWg1.png:
+- Shuckle
+Who's that pokemon? https://cdn.discord.red/i/ivmNVBQ.png:
+- Heracross
+Who's that pokemon? https://cdn.discord.red/i/cVNGBvn.png:
+- Sneasel
+Who's that pokemon? https://cdn.discord.red/i/gwKceRk.png:
+- Teddiursa
+Who's that pokemon? https://cdn.discord.red/i/mShUvcr.png:
+- Ursaring
+Who's that pokemon? https://cdn.discord.red/i/QnOMvBY.png:
+- Slugma
+Who's that pokemon? https://cdn.discord.red/i/rHUlbZ7.png:
+- Magcargo
+Who's that pokemon? https://cdn.discord.red/i/SLVkdUf.png:
+- Swinub
+Who's that pokemon? https://cdn.discord.red/i/rMgYSAy.png:
+- Piloswine
+Who's that pokemon? https://cdn.discord.red/i/fYLQexl.png:
+- Corsola
+Who's that pokemon? https://cdn.discord.red/i/LFKLE7w.png:
+- Remoraid
+Who's that pokemon? https://cdn.discord.red/i/YxMYn4W.png:
+- Octillery
+Who's that pokemon? https://cdn.discord.red/i/QFaIdNN.png:
+- Delibird
+Who's that pokemon? https://cdn.discord.red/i/tRT4c6d.png:
+- Mantine
+Who's that pokemon? https://cdn.discord.red/i/zaFbLo8.png:
+- Skarmory
+Who's that pokemon? https://cdn.discord.red/i/sqAekho.png:
+- Houndour
+Who's that pokemon? https://cdn.discord.red/i/mijoGZI.png:
+- Houndoom
+Who's that pokemon? https://cdn.discord.red/i/XNCoyFy.png:
+- Kingdra
+Who's that pokemon? https://cdn.discord.red/i/2yXKuEh.png:
+- Phanpy
+Who's that pokemon? https://cdn.discord.red/i/eAodrXb.png:
+- Donphan
+Who's that pokemon? https://cdn.discord.red/i/JJkzySs.png:
+- Porygon2
+Who's that pokemon? https://cdn.discord.red/i/FOK8Yla.png:
+- Stantler
+Who's that pokemon? https://cdn.discord.red/i/o2Hb9ck.png:
+- Smeargle
+Who's that pokemon? https://cdn.discord.red/i/NjCcsZh.png:
+- Tyrogue
+Who's that pokemon? https://cdn.discord.red/i/mpUCBUn.png:
+- Hitmontop
+Who's that pokemon? https://cdn.discord.red/i/GPpT5pn.png:
+- Smoochum
+Who's that pokemon? https://cdn.discord.red/i/ELqP5eZ.png:
+- Elekid
+Who's that pokemon? https://cdn.discord.red/i/V7iMoJ4.png:
+- Magby
+Who's that pokemon? https://cdn.discord.red/i/xXU0CvW.png:
+- Miltank
+Who's that pokemon? https://cdn.discord.red/i/QUO0wOi.png:
+- Blissey
+Who's that pokemon? https://cdn.discord.red/i/lC2VuSh.png:
+- Raikou
+Who's that pokemon? https://cdn.discord.red/i/5eIF2yf.png:
+- Entei
+Who's that pokemon? https://cdn.discord.red/i/wRv6jf7.png:
+- Suicune
+Who's that pokemon? https://cdn.discord.red/i/tJJvIYK.png:
+- Larvitar
+Who's that pokemon? https://cdn.discord.red/i/9GZXyuU.png:
+- Pupitar
+Who's that pokemon? https://cdn.discord.red/i/A2ZWKBK.png:
+- Tyranitar
+Who's that pokemon? https://cdn.discord.red/i/QQGb5yJ.png:
+- Lugia
+Who's that pokemon? https://cdn.discord.red/i/d3x47sk.png:
+- Ho-Oh
+Who's that pokemon? https://cdn.discord.red/i/B6oIkT4.png:
+- Celebi

--- a/redbot/cogs/trivia/data/lists/whosthatpokemon2.yaml
+++ b/redbot/cogs/trivia/data/lists/whosthatpokemon2.yaml
@@ -1,201 +1,201 @@
 AUTHOR: aikaterna, owo
-Who's that pokemon? https://cdn.discord.red/i/161fDs6.png:
+Who's that Pokémon? https://cdn.discord.red/i/161fDs6.png:
 - Chikorita
-Who's that pokemon? https://cdn.discord.red/i/9mBd4k5.png:
+Who's that Pokémon? https://cdn.discord.red/i/9mBd4k5.png:
 - Bayleef
-Who's that pokemon? https://cdn.discord.red/i/JK6EdFS.png:
+Who's that Pokémon? https://cdn.discord.red/i/JK6EdFS.png:
 - Meganium
-Who's that pokemon? https://cdn.discord.red/i/VANqEey.png:
+Who's that Pokémon? https://cdn.discord.red/i/VANqEey.png:
 - Cyndaquil
-Who's that pokemon? https://cdn.discord.red/i/wo3W5f8.png:
+Who's that Pokémon? https://cdn.discord.red/i/wo3W5f8.png:
 - Quilava
-Who's that pokemon? https://cdn.discord.red/i/la2mCq5.png:
+Who's that Pokémon? https://cdn.discord.red/i/la2mCq5.png:
 - Typhlosion
-Who's that pokemon? https://cdn.discord.red/i/NOE3zVe.png:
+Who's that Pokémon? https://cdn.discord.red/i/NOE3zVe.png:
 - Totodile
-Who's that pokemon? https://cdn.discord.red/i/7mIaKvA.png:
+Who's that Pokémon? https://cdn.discord.red/i/7mIaKvA.png:
 - Croconaw
-Who's that pokemon? https://cdn.discord.red/i/pkRCy4p.png:
+Who's that Pokémon? https://cdn.discord.red/i/pkRCy4p.png:
 - Feraligatr
-Who's that pokemon? https://cdn.discord.red/i/R2RQJJD.png:
+Who's that Pokémon? https://cdn.discord.red/i/R2RQJJD.png:
 - Sentret
-Who's that pokemon? https://cdn.discord.red/i/zVeD6jY.png:
+Who's that Pokémon? https://cdn.discord.red/i/zVeD6jY.png:
 - Furret
-Who's that pokemon? https://cdn.discord.red/i/tu0igAj.png:
+Who's that Pokémon? https://cdn.discord.red/i/tu0igAj.png:
 - Hoothoot
-Who's that pokemon? https://cdn.discord.red/i/qokx2sz.png:
+Who's that Pokémon? https://cdn.discord.red/i/qokx2sz.png:
 - Noctowl
-Who's that pokemon? https://cdn.discord.red/i/LqBvwkd.png:
+Who's that Pokémon? https://cdn.discord.red/i/LqBvwkd.png:
 - Ledyba
-Who's that pokemon? https://cdn.discord.red/i/Ri77MSO.png:
+Who's that Pokémon? https://cdn.discord.red/i/Ri77MSO.png:
 - Ledian
-Who's that pokemon? https://cdn.discord.red/i/GvFKVrG.png:
+Who's that Pokémon? https://cdn.discord.red/i/GvFKVrG.png:
 - Spinarak
-Who's that pokemon? https://cdn.discord.red/i/MN7OIfR.png:
+Who's that Pokémon? https://cdn.discord.red/i/MN7OIfR.png:
 - Ariados
-Who's that pokemon? https://cdn.discord.red/i/e5hYFQF.png:
+Who's that Pokémon? https://cdn.discord.red/i/e5hYFQF.png:
 - Crobat
-Who's that pokemon? https://cdn.discord.red/i/YOyKw1M.png:
+Who's that Pokémon? https://cdn.discord.red/i/YOyKw1M.png:
 - Chinchou
-Who's that pokemon? https://cdn.discord.red/i/WZEHcW2.png:
+Who's that Pokémon? https://cdn.discord.red/i/WZEHcW2.png:
 - Lanturn
-Who's that pokemon? https://cdn.discord.red/i/1YqVBUU.png:
+Who's that Pokémon? https://cdn.discord.red/i/1YqVBUU.png:
 - Pichu
-Who's that pokemon? https://cdn.discord.red/i/BzyRRM6.png:
+Who's that Pokémon? https://cdn.discord.red/i/BzyRRM6.png:
 - Cleffa
-Who's that pokemon? https://cdn.discord.red/i/HLzHnoR.png:
+Who's that Pokémon? https://cdn.discord.red/i/HLzHnoR.png:
 - Igglybuff
-Who's that pokemon? https://cdn.discord.red/i/7eIACOx.png:
+Who's that Pokémon? https://cdn.discord.red/i/7eIACOx.png:
 - Togepi
-Who's that pokemon? https://cdn.discord.red/i/Wihw9ed.png:
+Who's that Pokémon? https://cdn.discord.red/i/Wihw9ed.png:
 - Togetic
-Who's that pokemon? https://cdn.discord.red/i/sEcT1wG.png:
+Who's that Pokémon? https://cdn.discord.red/i/sEcT1wG.png:
 - Natu
-Who's that pokemon? https://cdn.discord.red/i/WP50IsH.png:
+Who's that Pokémon? https://cdn.discord.red/i/WP50IsH.png:
 - Xatu
-Who's that pokemon? https://cdn.discord.red/i/aeU3eLQ.png:
+Who's that Pokémon? https://cdn.discord.red/i/aeU3eLQ.png:
 - Mareep
-Who's that pokemon? https://cdn.discord.red/i/CMjVBM2.png:
+Who's that Pokémon? https://cdn.discord.red/i/CMjVBM2.png:
 - Flaaffy
-Who's that pokemon? https://cdn.discord.red/i/0rL21y3.png:
+Who's that Pokémon? https://cdn.discord.red/i/0rL21y3.png:
 - Ampharos
-Who's that pokemon? https://cdn.discord.red/i/r83gWqG.png:
+Who's that Pokémon? https://cdn.discord.red/i/r83gWqG.png:
 - Bellossom
-Who's that pokemon? https://cdn.discord.red/i/nDX9cFZ.png:
+Who's that Pokémon? https://cdn.discord.red/i/nDX9cFZ.png:
 - Marill
-Who's that pokemon? https://cdn.discord.red/i/i8MzcBG.png:
+Who's that Pokémon? https://cdn.discord.red/i/i8MzcBG.png:
 - Azumarill
-Who's that pokemon? https://cdn.discord.red/i/9lvsmrK.png:
+Who's that Pokémon? https://cdn.discord.red/i/9lvsmrK.png:
 - Sudowoodo
-Who's that pokemon? https://cdn.discord.red/i/1MOC4py.png:
+Who's that Pokémon? https://cdn.discord.red/i/1MOC4py.png:
 - Politoed
-Who's that pokemon? https://cdn.discord.red/i/MtHPKHY.png:
+Who's that Pokémon? https://cdn.discord.red/i/MtHPKHY.png:
 - Hoppip
-Who's that pokemon? https://cdn.discord.red/i/G3B7gou.png:
+Who's that Pokémon? https://cdn.discord.red/i/G3B7gou.png:
 - Skiploom
-Who's that pokemon? https://cdn.discord.red/i/3PqW6d4.png:
+Who's that Pokémon? https://cdn.discord.red/i/3PqW6d4.png:
 - Jumpluff
-Who's that pokemon? https://cdn.discord.red/i/7E4uSrM.png:
+Who's that Pokémon? https://cdn.discord.red/i/7E4uSrM.png:
 - Aipom
-Who's that pokemon? https://cdn.discord.red/i/TQp3Nm6.png:
+Who's that Pokémon? https://cdn.discord.red/i/TQp3Nm6.png:
 - Sunkern
-Who's that pokemon? https://cdn.discord.red/i/uz2MQ0c.png:
+Who's that Pokémon? https://cdn.discord.red/i/uz2MQ0c.png:
 - Sunflora
-Who's that pokemon? https://cdn.discord.red/i/NiC8tpF.png:
+Who's that Pokémon? https://cdn.discord.red/i/NiC8tpF.png:
 - Yanma
-Who's that pokemon? https://cdn.discord.red/i/yvgjiCQ.png:
+Who's that Pokémon? https://cdn.discord.red/i/yvgjiCQ.png:
 - Wooper
-Who's that pokemon? https://cdn.discord.red/i/7NSgVte.png:
+Who's that Pokémon? https://cdn.discord.red/i/7NSgVte.png:
 - Quagsire
-Who's that pokemon? https://cdn.discord.red/i/d6xPUYS.png:
+Who's that Pokémon? https://cdn.discord.red/i/d6xPUYS.png:
 - Espeon
-Who's that pokemon? https://cdn.discord.red/i/1D2T81X.png:
+Who's that Pokémon? https://cdn.discord.red/i/1D2T81X.png:
 - Umbreon
-Who's that pokemon? https://cdn.discord.red/i/mdOMOgS.png:
+Who's that Pokémon? https://cdn.discord.red/i/mdOMOgS.png:
 - Murkrow
-Who's that pokemon? https://cdn.discord.red/i/6ReUa0W.png:
+Who's that Pokémon? https://cdn.discord.red/i/6ReUa0W.png:
 - Slowking
-Who's that pokemon? https://cdn.discord.red/i/JA1k4GF.png:
+Who's that Pokémon? https://cdn.discord.red/i/JA1k4GF.png:
 - Misdreavus
-Who's that pokemon? https://cdn.discord.red/i/sLKauTP.png:
+Who's that Pokémon? https://cdn.discord.red/i/sLKauTP.png:
 - Unown
-Who's that pokemon? https://cdn.discord.red/i/gtzSsQh.png:
+Who's that Pokémon? https://cdn.discord.red/i/gtzSsQh.png:
 - Wobbuffet
-Who's that pokemon? https://cdn.discord.red/i/Zz1hdae.png:
+Who's that Pokémon? https://cdn.discord.red/i/Zz1hdae.png:
 - Girafarig
-Who's that pokemon? https://cdn.discord.red/i/7v0ktVt.png:
+Who's that Pokémon? https://cdn.discord.red/i/7v0ktVt.png:
 - Pineco
-Who's that pokemon? https://cdn.discord.red/i/dGt2LtM.png:
+Who's that Pokémon? https://cdn.discord.red/i/dGt2LtM.png:
 - Forretress
-Who's that pokemon? https://cdn.discord.red/i/3d7i0nA.png:
+Who's that Pokémon? https://cdn.discord.red/i/3d7i0nA.png:
 - Dunsparce
-Who's that pokemon? https://cdn.discord.red/i/EZFfXGQ.png:
+Who's that Pokémon? https://cdn.discord.red/i/EZFfXGQ.png:
 - Gligar
-Who's that pokemon? https://cdn.discord.red/i/FicMmX2.png:
+Who's that Pokémon? https://cdn.discord.red/i/FicMmX2.png:
 - Steelix
-Who's that pokemon? https://cdn.discord.red/i/EWlbb3g.png:
+Who's that Pokémon? https://cdn.discord.red/i/EWlbb3g.png:
 - Snubbull
-Who's that pokemon? https://cdn.discord.red/i/Es7SFIu.png:
+Who's that Pokémon? https://cdn.discord.red/i/Es7SFIu.png:
 - Granbull
-Who's that pokemon? https://cdn.discord.red/i/qWvJSNs.png:
+Who's that Pokémon? https://cdn.discord.red/i/qWvJSNs.png:
 - Qwilfish
-Who's that pokemon? https://cdn.discord.red/i/zl9gJ8s.png:
+Who's that Pokémon? https://cdn.discord.red/i/zl9gJ8s.png:
 - Scizor
-Who's that pokemon? https://cdn.discord.red/i/ZSkIWg1.png:
+Who's that Pokémon? https://cdn.discord.red/i/ZSkIWg1.png:
 - Shuckle
-Who's that pokemon? https://cdn.discord.red/i/ivmNVBQ.png:
+Who's that Pokémon? https://cdn.discord.red/i/ivmNVBQ.png:
 - Heracross
-Who's that pokemon? https://cdn.discord.red/i/cVNGBvn.png:
+Who's that Pokémon? https://cdn.discord.red/i/cVNGBvn.png:
 - Sneasel
-Who's that pokemon? https://cdn.discord.red/i/gwKceRk.png:
+Who's that Pokémon? https://cdn.discord.red/i/gwKceRk.png:
 - Teddiursa
-Who's that pokemon? https://cdn.discord.red/i/mShUvcr.png:
+Who's that Pokémon? https://cdn.discord.red/i/mShUvcr.png:
 - Ursaring
-Who's that pokemon? https://cdn.discord.red/i/QnOMvBY.png:
+Who's that Pokémon? https://cdn.discord.red/i/QnOMvBY.png:
 - Slugma
-Who's that pokemon? https://cdn.discord.red/i/rHUlbZ7.png:
+Who's that Pokémon? https://cdn.discord.red/i/rHUlbZ7.png:
 - Magcargo
-Who's that pokemon? https://cdn.discord.red/i/SLVkdUf.png:
+Who's that Pokémon? https://cdn.discord.red/i/SLVkdUf.png:
 - Swinub
-Who's that pokemon? https://cdn.discord.red/i/rMgYSAy.png:
+Who's that Pokémon? https://cdn.discord.red/i/rMgYSAy.png:
 - Piloswine
-Who's that pokemon? https://cdn.discord.red/i/fYLQexl.png:
+Who's that Pokémon? https://cdn.discord.red/i/fYLQexl.png:
 - Corsola
-Who's that pokemon? https://cdn.discord.red/i/LFKLE7w.png:
+Who's that Pokémon? https://cdn.discord.red/i/LFKLE7w.png:
 - Remoraid
-Who's that pokemon? https://cdn.discord.red/i/YxMYn4W.png:
+Who's that Pokémon? https://cdn.discord.red/i/YxMYn4W.png:
 - Octillery
-Who's that pokemon? https://cdn.discord.red/i/QFaIdNN.png:
+Who's that Pokémon? https://cdn.discord.red/i/QFaIdNN.png:
 - Delibird
-Who's that pokemon? https://cdn.discord.red/i/tRT4c6d.png:
+Who's that Pokémon? https://cdn.discord.red/i/tRT4c6d.png:
 - Mantine
-Who's that pokemon? https://cdn.discord.red/i/zaFbLo8.png:
+Who's that Pokémon? https://cdn.discord.red/i/zaFbLo8.png:
 - Skarmory
-Who's that pokemon? https://cdn.discord.red/i/sqAekho.png:
+Who's that Pokémon? https://cdn.discord.red/i/sqAekho.png:
 - Houndour
-Who's that pokemon? https://cdn.discord.red/i/mijoGZI.png:
+Who's that Pokémon? https://cdn.discord.red/i/mijoGZI.png:
 - Houndoom
-Who's that pokemon? https://cdn.discord.red/i/XNCoyFy.png:
+Who's that Pokémon? https://cdn.discord.red/i/XNCoyFy.png:
 - Kingdra
-Who's that pokemon? https://cdn.discord.red/i/2yXKuEh.png:
+Who's that Pokémon? https://cdn.discord.red/i/2yXKuEh.png:
 - Phanpy
-Who's that pokemon? https://cdn.discord.red/i/eAodrXb.png:
+Who's that Pokémon? https://cdn.discord.red/i/eAodrXb.png:
 - Donphan
-Who's that pokemon? https://cdn.discord.red/i/JJkzySs.png:
+Who's that Pokémon? https://cdn.discord.red/i/JJkzySs.png:
 - Porygon2
-Who's that pokemon? https://cdn.discord.red/i/FOK8Yla.png:
+Who's that Pokémon? https://cdn.discord.red/i/FOK8Yla.png:
 - Stantler
-Who's that pokemon? https://cdn.discord.red/i/o2Hb9ck.png:
+Who's that Pokémon? https://cdn.discord.red/i/o2Hb9ck.png:
 - Smeargle
-Who's that pokemon? https://cdn.discord.red/i/NjCcsZh.png:
+Who's that Pokémon? https://cdn.discord.red/i/NjCcsZh.png:
 - Tyrogue
-Who's that pokemon? https://cdn.discord.red/i/mpUCBUn.png:
+Who's that Pokémon? https://cdn.discord.red/i/mpUCBUn.png:
 - Hitmontop
-Who's that pokemon? https://cdn.discord.red/i/GPpT5pn.png:
+Who's that Pokémon? https://cdn.discord.red/i/GPpT5pn.png:
 - Smoochum
-Who's that pokemon? https://cdn.discord.red/i/ELqP5eZ.png:
+Who's that Pokémon? https://cdn.discord.red/i/ELqP5eZ.png:
 - Elekid
-Who's that pokemon? https://cdn.discord.red/i/V7iMoJ4.png:
+Who's that Pokémon? https://cdn.discord.red/i/V7iMoJ4.png:
 - Magby
-Who's that pokemon? https://cdn.discord.red/i/xXU0CvW.png:
+Who's that Pokémon? https://cdn.discord.red/i/xXU0CvW.png:
 - Miltank
-Who's that pokemon? https://cdn.discord.red/i/QUO0wOi.png:
+Who's that Pokémon? https://cdn.discord.red/i/QUO0wOi.png:
 - Blissey
-Who's that pokemon? https://cdn.discord.red/i/lC2VuSh.png:
+Who's that Pokémon? https://cdn.discord.red/i/lC2VuSh.png:
 - Raikou
-Who's that pokemon? https://cdn.discord.red/i/5eIF2yf.png:
+Who's that Pokémon? https://cdn.discord.red/i/5eIF2yf.png:
 - Entei
-Who's that pokemon? https://cdn.discord.red/i/wRv6jf7.png:
+Who's that Pokémon? https://cdn.discord.red/i/wRv6jf7.png:
 - Suicune
-Who's that pokemon? https://cdn.discord.red/i/tJJvIYK.png:
+Who's that Pokémon? https://cdn.discord.red/i/tJJvIYK.png:
 - Larvitar
-Who's that pokemon? https://cdn.discord.red/i/9GZXyuU.png:
+Who's that Pokémon? https://cdn.discord.red/i/9GZXyuU.png:
 - Pupitar
-Who's that pokemon? https://cdn.discord.red/i/A2ZWKBK.png:
+Who's that Pokémon? https://cdn.discord.red/i/A2ZWKBK.png:
 - Tyranitar
-Who's that pokemon? https://cdn.discord.red/i/QQGb5yJ.png:
+Who's that Pokémon? https://cdn.discord.red/i/QQGb5yJ.png:
 - Lugia
-Who's that pokemon? https://cdn.discord.red/i/d3x47sk.png:
+Who's that Pokémon? https://cdn.discord.red/i/d3x47sk.png:
 - Ho-Oh
-Who's that pokemon? https://cdn.discord.red/i/B6oIkT4.png:
+Who's that Pokémon? https://cdn.discord.red/i/B6oIkT4.png:
 - Celebi


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes

This PR adds Generation 2 Pokémons (total 100 of them) for whosthatpokemon trivia series. Main credits to aika for batch processing these. I have other remaining Generations (Gen 3 to Gen 8) also in queue and I am co-ordinating with aika for the same and will PR once aika gets to them in order, because the images needs to be hosted on `https://cdn.discord.red`