### PR TITLE
[Admin] fix erroneous await in _ready.set()

### DIFF
--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -99,7 +99,7 @@ class Admin(commands.Cog):
                 await self.migrate_config_from_0_to_1()
                 await self.config.schema_version.set(1)
 
-        await self._ready.set()
+        self._ready.set()
 
     async def migrate_config_from_0_to_1(self):
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
self._ready.set() should not be awaited in handle_migrations.