### PR TITLE
Use mod/admin_or_permissions instead of just mod/admin.

### DIFF
--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -280,7 +280,7 @@ class Streams(commands.Cog):
 
     @commands.group()
     @commands.guild_only()
-    @checks.mod()
+    @checks.mod_or_permissions(manage_channels=True)
     async def streamalert(self, ctx: commands.Context):
         """Manage automated stream alerts."""
         pass
@@ -431,9 +431,9 @@ class Streams(commands.Cog):
         await self.add_or_remove(ctx, stream)
 
     @commands.group()
-    @checks.mod()
+    @checks.mod_or_permissions(manage_channels=True)
     async def streamset(self, ctx: commands.Context):
-        """Set tokens for accessing streams."""
+        """Manage stream alert settings."""
         pass
 
     @streamset.command(name="timer")

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1333,7 +1333,7 @@ class Core(commands.Cog, CoreLogic):
             await ctx.send(_("Done."))
 
     @_set.command(name="nickname")
-    @checks.admin()
+    @checks.admin_or_permissions(manage_nicknames=True)
     @commands.guild_only()
     async def _nickname(self, ctx: commands.Context, *, nickname: str = None):
         """Sets [botname]'s nickname."""
@@ -1355,7 +1355,7 @@ class Core(commands.Cog, CoreLogic):
         await ctx.send(_("Prefix set."))
 
     @_set.command(aliases=["serverprefixes"])
-    @checks.admin()
+    @checks.admin_or_permissions(manage_guild=True)
     @commands.guild_only()
     async def serverprefix(self, ctx: commands.Context, *prefixes: str):
         """Sets [botname]'s server prefix(es)."""


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

Commands locked to just mod role can be confusing at first especially if those don't understand them, this brings streams in line with a lot of other core cogs which uses _or_permissions.

This also updates the streamset docstring as that does more than just managing tokens.
