### PR TITLE
Add `workflow_dispatch` trigger to Crowdin workflow

### DIFF
--- a/.github/workflows/publish_crowdin.yml
+++ b/.github/workflows/publish_crowdin.yml
@@ -2,6 +2,7 @@ name: Publish to Crowdin
 on:
   schedule:
     - cron: '0 12 * * THU'
+  workflow_dispatch:
   repository_dispatch:
     types: crowdin
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Adds a `workflow_dispatch` event which allows to trigger the workflow using GitHub's UI:
![image](https://user-images.githubusercontent.com/6032823/88454390-a4374a00-ce6f-11ea-863a-e7bc1dc90db4.png)
