### PR TITLE
[General] Change PUBLIC feature to COMMUNITY in serverinfo

### DIFF
--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -364,7 +364,7 @@ class General(commands.Cog):
                 "VERIFIED": _("Verified"),
                 "DISCOVERABLE": _("Server Discovery"),
                 "FEATURABLE": _("Featurable"),
-                "PUBLIC": _("Public"),
+                "COMMUNITY": _("Community"),
                 "PUBLIC_DISABLED": _("Public disabled"),
                 "INVITE_SPLASH": _("Splash Invite"),
                 "VIP_REGIONS": _("VIP Voice Servers"),


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
That PR replace PUBLIC feature to COMMUNITY in serverinfo command, since PUBLIC has been deprecated to COMMUNITY as stated here https://github.com/discord/discord-api-docs/issues/1757#issuecomment-652079149.