### PR TITLE
[Economy] Prevent forbidden error when blocked by user

### DIFF
--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -532,7 +532,10 @@ class Economy(commands.Cog):
     @guild_only_check()
     async def payouts(self, ctx: commands.Context):
         """Show the payouts for the slot machine."""
-        await ctx.author.send(SLOT_PAYOUTS_MSG)
+        try:
+            await ctx.author.send(SLOT_PAYOUTS_MSG)
+        except discord.Forbidden:
+            await ctx.send(_("I can't send direct messages to you."))
 
     @commands.command()
     @guild_only_check()


### PR DESCRIPTION
Stops `[p]payouts` throwing a console error if the user has blocked the bot. Probably too spammy to put the payout message in chat.

### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature