### PR TITLE
Bump pytest to version 6.0.1 and yarl to 1.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,7 @@
         | redbot\/vendored
     )/
     '''
+
+[tool.pytest.ini_options]
+    minversion = "6.0"
+    addopts = "--import-mode=importlib"

--- a/redbot/pytest/core.py
+++ b/redbot/pytest/core.py
@@ -4,13 +4,11 @@ from pathlib import Path
 import weakref
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 from redbot.core import Config
 from redbot.core.bot import Red
 from redbot.core import config as config_module, drivers
 
 __all__ = [
-    "monkeysession",
     "override_data_path",
     "coroutine",
     "driver",
@@ -28,13 +26,6 @@ __all__ = [
     "user_factory",
     "ctx",
 ]
-
-
-@pytest.fixture(scope="session")
-def monkeysession(request):
-    mpatch = MonkeyPatch()
-    yield mpatch
-    mpatch.undo()
 
 
 @pytest.fixture(autouse=True)

--- a/redbot/pytest/downloader.py
+++ b/redbot/pytest/downloader.py
@@ -10,7 +10,6 @@ from redbot.cogs.downloader.repo_manager import RepoManager, Repo, ProcessFormat
 from redbot.cogs.downloader.installable import Installable, InstalledModule
 
 __all__ = [
-    "patch_relative_to",
     "repo_manager",
     "repo",
     "bot_repo",
@@ -36,14 +35,6 @@ async def fake_run_noprint(*args, **kwargs):
 
 async def fake_current_commit(*args, **kwargs):
     return "fake_result"
-
-
-@pytest.fixture(scope="module", autouse=True)
-def patch_relative_to(monkeysession):
-    def fake_relative_to(self, some_path: Path):
-        return self
-
-    monkeysession.setattr("pathlib.Path.relative_to", fake_relative_to)
 
 
 @pytest.fixture

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     typing-extensions==3.7.4.2
     uvloop==0.14.0; sys_platform != "win32" and platform_python_implementation == "CPython"
     websockets==8.1
-    yarl==1.5.0
+    yarl==1.5.1
 
 [options.extras_require]
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,6 +94,7 @@ style =
     typed-ast==1.4.1
 test =
     astroid==2.4.2
+    iniconfig==1.0.1
     isort==4.3.21
     lazy-object-proxy==1.4.3
     mccabe==0.6.1
@@ -103,12 +104,11 @@ test =
     py==1.9.0
     pylint==2.5.3
     pyparsing==2.4.7
-    pytest==5.4.3
+    pytest==6.0.1
     pytest-asyncio==0.14.0
     pytest-mock==3.2.0
     six==1.15.0
     toml==0.10.1
-    wcwidth==0.2.5
     wrapt==1.12.1
 
 [options.entry_points]


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
As in title.
This also removes an awful `monkeysession` fixture that had `pathlib` patching applied to it which resulted in [13MB log of errors](https://github.com/pytest-dev/pytest/issues/7560)
The thing that required `pathlib` patching is not in Downloader since 2018 (#1313), so this is entirely safe to do here as can also be seen by tests passing.
This PR also switches us to new import mode that was introduced with pytest 6.0.0.