### PR TITLE
avoid issue with not having before_invoke called

### DIFF
--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -786,7 +786,9 @@ class Group(GroupMixin, Command, CogGroupMixin, DPYGroup):
             if self.autohelp and not self.invoke_without_command:
                 if not await self.can_run(ctx, change_permission_state=True):
                     raise CheckFailure()
-                await ctx.send_help()
+                # This ordering prevents sending help before checking `before_invoke` hooks
+                await super().invoke(ctx)
+                return await ctx.send_help()
         elif self.invoke_without_command:
             # So invoke_without_command when a subcommand of this group is invoked
             # will skip the the invokation of *this* command. However, because of


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Technically speaking, this also puts after_invoke in an odd spot instead, but after_invoke doesn't have potential to be used as a check that can't take place in checks or other important things like wait_until_ready, and the help sent doesn't need to interact with after_invoke.