### PR TITLE
[Mod] Correctly log and store the previous (nick)name

### DIFF
--- a/redbot/cogs/mod/events.py
+++ b/redbot/cogs/mod/events.py
@@ -104,10 +104,10 @@ class Events(MixinMeta):
             async with self.config.user(before).past_names() as name_list:
                 while None in name_list:  # clean out null entries from a bug
                     name_list.remove(None)
-                if after.name in name_list:
+                if before.name in name_list:
                     # Ensure order is maintained without duplicates occurring
-                    name_list.remove(after.name)
-                name_list.append(after.name)
+                    name_list.remove(before.name)
+                name_list.append(before.name)
                 while len(name_list) > 20:
                     name_list.pop(0)
 
@@ -120,8 +120,8 @@ class Events(MixinMeta):
             async with self.config.member(before).past_nicks() as nick_list:
                 while None in nick_list:  # clean out null entries from a bug
                     nick_list.remove(None)
-                if after.nick in nick_list:
-                    nick_list.remove(after.nick)
-                nick_list.append(after.nick)
+                if before.nick in nick_list:
+                    nick_list.remove(before.nick)
+                nick_list.append(before.nick)
                 while len(nick_list) > 20:
                     nick_list.pop(0)


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

So it appears we had this bug in Red for the past 3 years, where we didn't store the correct past (nick)name. Lets fix that.