### PR TITLE
[Reports] Give friendly error if no report channel set

### DIFF
--- a/redbot/cogs/reports/reports.py
+++ b/redbot/cogs/reports/reports.py
@@ -271,9 +271,16 @@ class Reports(commands.Cog):
 
         with contextlib.suppress(discord.Forbidden, discord.HTTPException):
             if val is None:
-                await author.send(
-                    _("There was an error sending your report, please contact a server admin.")
-                )
+                if await self.config.guild(ctx.guild).output_channel() is None:
+                    await author.send(
+                        _(
+                            "This server has no reports channel set up. Please contact a server admin."
+                        )
+                    )
+                else:
+                    await author.send(
+                        _("There was an error sending your report, please contact a server admin.")
+                    )
             else:
                 await author.send(_("Your report was submitted. (Ticket #{})").format(val))
                 self.antispam[guild.id][author.id].stamp()


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Sends a friendlier error if the reports channel wasn't setup.
Closes #4125 