### PR TITLE
[Downloader] Show more specific message, when repo can't be found (#2749)

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -514,6 +514,8 @@ class Downloader(commands.Cog):
             await ctx.send(
                 _("The repo name you provided is already in use. Please choose another name.")
             )
+        except errors.MissingRemoteGitRepo as err:
+            await ctx.send(_(err.message))
         except errors.CloningError as err:
             await ctx.send(
                 _(

--- a/redbot/cogs/downloader/errors.py
+++ b/redbot/cogs/downloader/errors.py
@@ -13,6 +13,7 @@ __all__ = [
     "CopyingError",
     "ExistingGitRepo",
     "MissingGitRepo",
+    "MissingRemoteGitRepo",
     "CloningError",
     "CurrentHashError",
     "HardResetError",
@@ -77,6 +78,16 @@ class MissingGitRepo(DownloaderException):
     """
 
     pass
+
+
+class MissingRemoteGitRepo(DownloaderException):
+    """
+    Thrown when a remote git repo is not found or
+    returns an error code
+    """
+
+    def __init__(self, message: str):
+        self.message = message
 
 
 class CloningError(GitException):


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
I tried solving the isse #2749 with this PR, regarding repo add:
* Validates server response code to give a more specific message when the repo is not found(404) and handles other request errors as well. I opted for the aiohttp module for this, since it was already in the project requirements.
* I created a new error class to differentiate this new error from the existing MissingGitRepo, which is used for repos that are missing locally(not sure if I should have)
* I made two tests based on the existing clone tests, but trying to clone a non-existing repo and checking if they raise the correct exception
This is my first PR ever in a open-source project, and I don't have much experience programming with Python and especially pytest, so let me know what I can improve! :)