### PR TITLE
Fix missing `self` argument in `[p]licenseinfo`

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3359,7 +3359,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         aliases=["licenceinfo"],
         i18n=_,
     )
-    async def license_info_command(ctx):
+    async def license_info_command(self, ctx):
         """
         Get info about Red's licenses.
         """


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
