### PR TITLE
EUD things for Downloader

### DIFF
--- a/docs/guide_publish_cogs.rst
+++ b/docs/guide_publish_cogs.rst
@@ -55,6 +55,9 @@ Keys common to both repo and cog info.json (case sensitive)
 Keys specific to the cog info.json (case sensitive)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- ``end_user_data_statement`` (string) - A statement explaining what end user data the cog is storing.
+  This is displayed when a user executes ``[p]cog info``. If the statement has changed since last update, user will be informed during the update.
+
 - ``min_bot_version`` (string) - Min version number of Red in the format ``MAJOR.MINOR.MICRO``
 
 - ``max_bot_version`` (string) - Max version number of Red in the format ``MAJOR.MINOR.MICRO``,

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1138,7 +1138,8 @@ class Downloader(commands.Cog):
             author=", ".join(cog.author) or _("Missing from info.json"),
             requirements=", ".join(cog.requirements) or "None",
         )
-        await ctx.send(box(msg))
+        for page in pagify(msg):
+            await ctx.send(box(page))
 
     async def is_installed(
         self, cog_name: str

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -775,8 +775,12 @@ class Downloader(commands.Cog):
                         if rev is not None
                         else ""
                     )
-                    + _("\nYou can load them using `{prefix}load <cogs>`").format(
-                        prefix=ctx.clean_prefix
+                    + _(
+                        "\nYou can load them using {command_1}."
+                        " To see end user data statements, you can use {command_2}."
+                    ).format(
+                        command_1=inline(f"{ctx.clean_prefix}load <cogs>"),
+                        command_2=inline(f"{ctx.clean_prefix}cog info <repo_name> <cog_name>"),
                     )
                     + message
                 )
@@ -1037,7 +1041,7 @@ class Downloader(commands.Cog):
 
                 if updates_available:
                     updated_cognames, message = await self._update_cogs_and_libs(
-                        cogs_to_update, libs_to_update
+                        ctx, cogs_to_update, libs_to_update, current_cog_versions=cogs_to_check
                     )
                 else:
                     if repos:
@@ -1118,11 +1122,19 @@ class Downloader(commands.Cog):
             return
 
         msg = _(
-            "Information on {cog_name}:\n{description}\n\n"
-            "Made by: {author}\nRequirements: {requirements}"
+            "Information on {cog_name}:\n"
+            "{description}\n\n"
+            "End user data statement:\n"
+            "{end_user_data_statement}\n\n"
+            "Made by: {author}\n"
+            "Requirements: {requirements}"
         ).format(
             cog_name=cog.name,
             description=cog.description or "",
+            end_user_data_statement=(
+                cog.end_user_data_statement
+                or _("Author of the cog didn't provide end user data statement.")
+            ),
             author=", ".join(cog.author) or _("Missing from info.json"),
             requirements=", ".join(cog.requirements) or "None",
         )
@@ -1292,8 +1304,13 @@ class Downloader(commands.Cog):
         return (cogs_to_check, failed)
 
     async def _update_cogs_and_libs(
-        self, cogs_to_update: Iterable[Installable], libs_to_update: Iterable[Installable]
+        self,
+        ctx: commands.Context,
+        cogs_to_update: Iterable[Installable],
+        libs_to_update: Iterable[Installable],
+        current_cog_versions: Iterable[InstalledModule],
     ) -> Tuple[Set[str], str]:
+        current_cog_versions_map = {cog.name: cog for cog in current_cog_versions}
         failed_reqs = await self._install_requirements(cogs_to_update)
         if failed_reqs:
             return (
@@ -1308,8 +1325,22 @@ class Downloader(commands.Cog):
 
         updated_cognames: Set[str] = set()
         if installed_cogs:
-            updated_cognames = {cog.name for cog in installed_cogs}
+            updated_cognames = set()
+            cogs_with_changed_eud_statement = set()
+            for cog in installed_cogs:
+                updated_cognames.add(cog.name)
+                current_eud_statement = current_cog_versions_map[cog.name].end_user_data_statement
+                if current_eud_statement != cog.end_user_data_statement:
+                    cogs_with_changed_eud_statement.add(cog.name)
             message += _("\nUpdated: ") + humanize_list(tuple(map(inline, updated_cognames)))
+            if cogs_with_changed_eud_statement:
+                message += (
+                    _("\nEnd user data statements of these cogs have changed: ")
+                    + humanize_list(tuple(map(inline, cogs_with_changed_eud_statement)))
+                    + _("\nYou can use {command} to see the updated statements.\n").format(
+                        command=inline(f"{ctx.clean_prefix}cog info <repo_name> <cog_name>")
+                    )
+                )
         if failed_cogs:
             cognames = [cog.name for cog in failed_cogs]
             message += _("\nFailed to update cogs: ") + humanize_list(tuple(map(inline, cognames)))

--- a/redbot/cogs/downloader/info_schemas.py
+++ b/redbot/cogs/downloader/info_schemas.py
@@ -220,6 +220,7 @@ INSTALLABLE_SCHEMA: SchemaType = {
     "requirements": ensure_tuple_of_str,
     "tags": ensure_tuple_of_str,
     "type": ensure_installable_type,
+    "end_user_data_statement": ensure_str,
 }
 
 

--- a/redbot/cogs/downloader/installable.py
+++ b/redbot/cogs/downloader/installable.py
@@ -43,6 +43,8 @@ class Installable(RepoJSONMixin):
         Installable's commit. This is not the same as ``repo.commit``
     author : `tuple` of `str`
         Name(s) of the author(s).
+    end_user_data_statement : `str`
+        End user data statement of the module.
     min_bot_version : `VersionInfo`
         The minimum bot version required for this Installable.
     max_bot_version : `VersionInfo`
@@ -85,6 +87,7 @@ class Installable(RepoJSONMixin):
         self.repo_name = self._location.parent.stem
         self.commit = commit
 
+        self.end_user_data_statement: str
         self.min_bot_version: VersionInfo
         self.max_bot_version: VersionInfo
         self.min_python_version: Tuple[int, int, int]


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes
Adds support for `end_user_data_statement` key in `info.json`.
What this functionality brings:
- end user data statement is shown by `[p]cog info` command
- user is informed about being able to check end user data statement with `[p]cog info` during cog install
- if end user data statement changes, user will be informed during cog update

// diff is small, but the `_update_cogs_and_libs` got a little bit messy (in my view anyway); it should all work, but I don't think I can make the code much better without rewriting more stuff

**Things in this PR may still change.**
