### PR TITLE
[Mute] Indicate that a guild mute/unmute is currently being processed.

### DIFF
--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -254,22 +254,23 @@ class MuteMixin(MixinMeta):
         audit_reason = get_audit_reason(author, reason)
 
         mute_success = []
-        for channel in guild.channels:
-            success, issue = await self.mute_user(guild, channel, author, user, audit_reason)
-            mute_success.append((success, issue))
-            await asyncio.sleep(0.1)
-        await modlog.create_case(
-            self.bot,
-            guild,
-            ctx.message.created_at,
-            "smute",
-            user,
-            author,
-            reason,
-            until=None,
-            channel=None,
-        )
-        await ctx.send(_("User has been muted in this server."))
+        async with ctx.channel.typing():
+            for channel in guild.channels:
+                success, issue = await self.mute_user(guild, channel, author, user, audit_reason)
+                mute_success.append((success, issue))
+                await asyncio.sleep(0.1)
+            await modlog.create_case(
+                self.bot,
+                guild,
+                ctx.message.created_at,
+                "smute",
+                user,
+                author,
+                reason,
+                until=None,
+                channel=None,
+            )
+            await ctx.send(_("User has been muted in this server."))
 
     @commands.group()
     @commands.guild_only()
@@ -373,14 +374,24 @@ class MuteMixin(MixinMeta):
         audit_reason = get_audit_reason(author, reason)
 
         unmute_success = []
-        for channel in guild.channels:
-            success, message = await self.unmute_user(guild, channel, author, user, audit_reason)
-            unmute_success.append((success, message))
-            await asyncio.sleep(0.1)
-        await modlog.create_case(
-            self.bot, guild, ctx.message.created_at, "sunmute", user, author, reason, until=None,
-        )
-        await ctx.send(_("User has been unmuted in this server."))
+        async with ctx.channel.typing():
+            for channel in guild.channels:
+                success, message = await self.unmute_user(
+                    guild, channel, author, user, audit_reason
+                )
+                unmute_success.append((success, message))
+                await asyncio.sleep(0.1)
+            await modlog.create_case(
+                self.bot,
+                guild,
+                ctx.message.created_at,
+                "sunmute",
+                user,
+                author,
+                reason,
+                until=None,
+            )
+            await ctx.send(_("User has been unmuted in this server."))
 
     async def mute_user(
         self,

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -256,7 +256,7 @@ class MuteMixin(MixinMeta):
 
         mute_success = []
         async with ctx.channel.typing():
-            async for channel in AsyncIter(guild.channels):
+            for channel in guild.channels:
                 success, issue = await self.mute_user(guild, channel, author, user, audit_reason)
                 mute_success.append((success, issue))
             await modlog.create_case(
@@ -375,7 +375,7 @@ class MuteMixin(MixinMeta):
 
         unmute_success = []
         async with ctx.channel.typing():
-            async for channel in AsyncIter(guild.channels):
+            for channel in guild.channels:
                 success, message = await self.unmute_user(
                     guild, channel, author, user, audit_reason
                 )

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -259,7 +259,6 @@ class MuteMixin(MixinMeta):
             async for channel in AsyncIter(guild.channels):
                 success, issue = await self.mute_user(guild, channel, author, user, audit_reason)
                 mute_success.append((success, issue))
-                await asyncio.sleep(0.1)
             await modlog.create_case(
                 self.bot,
                 guild,
@@ -381,7 +380,6 @@ class MuteMixin(MixinMeta):
                     guild, channel, author, user, audit_reason
                 )
                 unmute_success.append((success, message))
-                await asyncio.sleep(0.1)
             await modlog.create_case(
                 self.bot,
                 guild,

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -255,7 +255,7 @@ class MuteMixin(MixinMeta):
         audit_reason = get_audit_reason(author, reason)
 
         mute_success = []
-        async with ctx.channel.typing():
+        async with ctx.typing():
             for channel in guild.channels:
                 success, issue = await self.mute_user(guild, channel, author, user, audit_reason)
                 mute_success.append((success, issue))
@@ -374,7 +374,7 @@ class MuteMixin(MixinMeta):
         audit_reason = get_audit_reason(author, reason)
 
         unmute_success = []
-        async with ctx.channel.typing():
+        async with ctx.typing():
             for channel in guild.channels:
                 success, message = await self.unmute_user(
                     guild, channel, author, user, audit_reason

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -3,6 +3,7 @@ from typing import cast, Optional
 
 import discord
 from redbot.core import commands, checks, i18n, modlog
+from redbot.core.utils import AsyncIter
 from redbot.core.utils.chat_formatting import format_perms_list
 from redbot.core.utils.mod import get_audit_reason, is_allowed_by_hierarchy
 from .abc import MixinMeta
@@ -255,7 +256,7 @@ class MuteMixin(MixinMeta):
 
         mute_success = []
         async with ctx.channel.typing():
-            for channel in guild.channels:
+            async for channel in AsyncIter(guild.channels):
                 success, issue = await self.mute_user(guild, channel, author, user, audit_reason)
                 mute_success.append((success, issue))
                 await asyncio.sleep(0.1)
@@ -375,7 +376,7 @@ class MuteMixin(MixinMeta):
 
         unmute_success = []
         async with ctx.channel.typing():
-            for channel in guild.channels:
+            async for channel in AsyncIter(guild.channels):
                 success, message = await self.unmute_user(
                     guild, channel, author, user, audit_reason
                 )


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Added a channel.typing() block around the for loop applying the mute per channel to indicate to a user that the bot is in the process of doing something. This closes #4066