### PR TITLE
Add allowed_mentions and mention everyone check to stream alerts

### DIFF
--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -747,11 +747,6 @@ class Streams(commands.Cog):
                             allowed_mentions=discord.AllowedMentions(roles=True, everyone=True),
                         )
                         stream._messages_cache.append(m)
-                        guild = channel.guild
-                        can_mention_everyone = guild.me.guild_permissions.mention_everyone
-                        if can_mention_everyone:
-                            await self.save_streams()
-                            return
                         if edited_roles:
                             for role in edited_roles:
                                 await role.edit(mentionable=False)

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -765,10 +765,6 @@ class Streams(commands.Cog):
             mentions.append("@here")
         can_manage_roles = guild.me.guild_permissions.manage_roles
         can_mention_everyone = channel.permissions_for(guild.me).mention_everyone
-        if can_mention_everyone:
-            for role in guild.roles:
-                mentions.append(role.mention)
-                return
         for role in guild.roles:
             if await self.config.role(role).mention():
                 if not can_mention_everyone and can_manage_roles and not role.mentionable:

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -764,7 +764,7 @@ class Streams(commands.Cog):
         if await settings.mention_here():
             mentions.append("@here")
         can_manage_roles = guild.me.guild_permissions.manage_roles
-        can_mention_everyone = guild.me.guild_permissions.mention_everyone
+        can_mention_everyone = channel.permissions_for(guild.me).mention_everyone
         if can_mention_everyone:
             for role in guild.roles:
                 mentions.append(role.mention)

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -773,7 +773,7 @@ class Streams(commands.Cog):
         if can_mention_everyone:
             for role in guild.roles:
                 mentions.append(role.mention)
-            return
+                return
         for role in guild.roles:
             if await self.config.role(role).mention():
                 if can_manage_roles and not role.mentionable:

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -764,7 +764,8 @@ class Streams(commands.Cog):
         if await settings.mention_here():
             mentions.append("@here")
         can_manage_roles = guild.me.guild_permissions.manage_roles
-        can_mention_everyone = channel.permissions_for(guild.me).mention_everyone
+        for channel in guild.channels
+            can_mention_everyone = channel.permissions_for(guild.me).mention_everyone
         for role in guild.roles:
             if await self.config.role(role).mention():
                 if not can_mention_everyone and can_manage_roles and not role.mentionable:

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -713,8 +713,8 @@ class Streams(commands.Cog):
                         ignore_reruns = await self.config.guild(channel.guild).ignore_reruns()
                         if ignore_reruns and is_rerun:
                             continue
-                        mention_str, channel, edited_roles = await self._get_mention_str(
-                            channel.guild
+                        mention_str, edited_roles = await self._get_mention_str(
+                            channel.guild, channel
                         )
 
                         if mention_str:

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -713,7 +713,7 @@ class Streams(commands.Cog):
                         ignore_reruns = await self.config.guild(channel.guild).ignore_reruns()
                         if ignore_reruns and is_rerun:
                             continue
-                        mention_str, edited_roles = await self._get_mention_str(channel.guild)
+                        mention_str, channel, edited_roles = await self._get_mention_str(channel.guild)
 
                         if mention_str:
                             alert_msg = await self.config.guild(

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -747,6 +747,10 @@ class Streams(commands.Cog):
                             allowed_mentions=discord.AllowedMentions(roles=True, everyone=True),
                         )
                         stream._messages_cache.append(m)
+                        can_mention_everyone = guild.me.guild_permissions.mention_everyone
+                        if can_mention_everyone:
+                            await self.save_streams()
+                            return # if bot can mention everyone already, let's stop here
                         if edited_roles:
                             for role in edited_roles:
                                 await role.edit(mentionable=False)
@@ -764,6 +768,10 @@ class Streams(commands.Cog):
         if await settings.mention_here():
             mentions.append("@here")
         can_manage_roles = guild.me.guild_permissions.manage_roles
+        can_mention_everyone = guild.me.guild_permissions.mention_everyone
+        if can_mention_everyone:
+            mentions.append(role.mention)
+            return
         for role in guild.roles:
             if await self.config.role(role).mention():
                 if can_manage_roles and not role.mentionable:

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -741,7 +741,11 @@ class Streams(commands.Cog):
                                     )
                                 )
 
-                        m = await channel.send(content, embed=embed)
+                        m = await channel.send(
+                            content,
+                            embed=embed,
+                            allowed_mentions=discord.AllowedMentions(roles=True),
+                        )
                         stream._messages_cache.append(m)
                         if edited_roles:
                             for role in edited_roles:

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -747,6 +747,7 @@ class Streams(commands.Cog):
                             allowed_mentions=discord.AllowedMentions(roles=True, everyone=True),
                         )
                         stream._messages_cache.append(m)
+                        guild = channel.guild
                         can_mention_everyone = guild.me.guild_permissions.mention_everyone
                         if can_mention_everyone:
                             await self.save_streams()

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -771,7 +771,7 @@ class Streams(commands.Cog):
                 return
         for role in guild.roles:
             if await self.config.role(role).mention():
-                if can_manage_roles and not role.mentionable:
+                if not can_mention_everyone and can_manage_roles and not role.mentionable:
                     try:
                         await role.edit(mentionable=True)
                     except discord.Forbidden:

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -750,7 +750,7 @@ class Streams(commands.Cog):
                         can_mention_everyone = guild.me.guild_permissions.mention_everyone
                         if can_mention_everyone:
                             await self.save_streams()
-                            return # if bot can mention everyone already, let's stop here
+                            return
                         if edited_roles:
                             for role in edited_roles:
                                 await role.edit(mentionable=False)
@@ -770,7 +770,8 @@ class Streams(commands.Cog):
         can_manage_roles = guild.me.guild_permissions.manage_roles
         can_mention_everyone = guild.me.guild_permissions.mention_everyone
         if can_mention_everyone:
-            mentions.append(role.mention)
+            for role in guild.roles:
+                mentions.append(role.mention)
             return
         for role in guild.roles:
             if await self.config.role(role).mention():

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -744,7 +744,7 @@ class Streams(commands.Cog):
                         m = await channel.send(
                             content,
                             embed=embed,
-                            allowed_mentions=discord.AllowedMentions(roles=True),
+                            allowed_mentions=discord.AllowedMentions(roles=True, everyone=True),
                         )
                         stream._messages_cache.append(m)
                         if edited_roles:

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -752,7 +752,9 @@ class Streams(commands.Cog):
                                 await role.edit(mentionable=False)
                         await self.save_streams()
 
-    async def _get_mention_str(self, guild: discord.Guild) -> Tuple[str, List[discord.Role]]:
+    async def _get_mention_str(
+        self, guild: discord.Guild, channel: discord.TextChannel
+    ) -> Tuple[str, List[discord.Role]]:
         """Returns a 2-tuple with the string containing the mentions, and a list of
         all roles which need to have their `mentionable` property set back to False.
         """
@@ -764,8 +766,7 @@ class Streams(commands.Cog):
         if await settings.mention_here():
             mentions.append("@here")
         can_manage_roles = guild.me.guild_permissions.manage_roles
-        for channel in guild.channels:
-            can_mention_everyone = channel.permissions_for(guild.me).mention_everyone
+        can_mention_everyone = channel.permissions_for(guild.me).mention_everyone
         for role in guild.roles:
             if await self.config.role(role).mention():
                 if not can_mention_everyone and can_manage_roles and not role.mentionable:

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -713,7 +713,9 @@ class Streams(commands.Cog):
                         ignore_reruns = await self.config.guild(channel.guild).ignore_reruns()
                         if ignore_reruns and is_rerun:
                             continue
-                        mention_str, channel, edited_roles = await self._get_mention_str(channel.guild)
+                        mention_str, channel, edited_roles = await self._get_mention_str(
+                            channel.guild
+                        )
 
                         if mention_str:
                             alert_msg = await self.config.guild(

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -764,7 +764,7 @@ class Streams(commands.Cog):
         if await settings.mention_here():
             mentions.append("@here")
         can_manage_roles = guild.me.guild_permissions.manage_roles
-        for channel in guild.channels
+        for channel in guild.channels:
             can_mention_everyone = channel.permissions_for(guild.me).mention_everyone
         for role in guild.roles:
             if await self.config.role(role).mention():


### PR DESCRIPTION
Allows role mentions for discord.py 1.4+

### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Referencing line `747` in commit. Gives permissions to mention role on stream announcement.