### PR TITLE
Fix typo in lint python workflow

### DIFF
--- a/.github/workflows/lint_python.yaml
+++ b/.github/workflows/lint_python.yaml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ env.ref }}
       - uses: actions/setup-python@v1
         with:
-          python_version: "3.8"
+          python-version: "3.8"
       - run: "python -m pip install git+https://github.com/pycqa/pyflakes@1911c20#egg=pyflakes git+https://github.com/pycqa/pycodestyle@d219c68#egg=pycodestyle git+https://gitlab.com/pycqa/flake8@3.7.9#egg=flake8"
         name: Install Flake8
       - run: "python -m flake8 . --count --select=E9,F7,F82 --show-source"


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Typo in Lint Python workflow

Caused:
![image](https://user-images.githubusercontent.com/955640/90549232-31fb1200-e15c-11ea-9719-b09813be6203.png)

See Annotations in example
Example: https://github.com/Cog-Creators/Red-DiscordBot/actions/runs/213693430