### PR TITLE
[Core] Catch errors about blocked DMs in `[p]traceback`

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1139,7 +1139,14 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         if self.bot._last_exception:
             for page in pagify(self.bot._last_exception, shorten_by=10):
-                await destination.send(box(page, lang="py"))
+                try:
+                    await destination.send(box(page, lang="py"))
+                except discord.HTTPException:
+                    await ctx.channel.send(
+                        "I couldn't send the traceback message to you in DM. "
+                        "Either you blocked me or you disabled DMs in this server."
+                    )
+                    return
         else:
             await ctx.send(_("No exception has occurred yet"))
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Catches exceptions when a user blocked the bot or disabled DMs from server members and runs `[p]traceback false`