### PR TITLE
[Mod] Account for duplicated mentions

### DIFF
--- a/redbot/cogs/mod/events.py
+++ b/redbot/cogs/mod/events.py
@@ -45,7 +45,11 @@ class Events(MixinMeta):
         guild, author = message.guild, message.author
         mention_spam = await self.config.guild(guild).mention_spam.all()
 
-        mentions = set(message.mentions)
+        if mention_spam["strict"]:  # if strict is enabled
+            mentions = message.raw_mentions
+        else:  # if not enabled
+            mentions = set(message.mentions)
+
         if mention_spam["ban"]:
             if len(mentions) >= mention_spam["ban"]:
                 try:

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -49,7 +49,7 @@ class Mod(
     default_global_settings = {"version": ""}
 
     default_guild_settings = {
-        "mention_spam": {"ban": None, "kick": None, "warn": None},
+        "mention_spam": {"ban": None, "kick": None, "warn": None, "strict": False},
         "delete_repeats": -1,
         "ignored": False,
         "respect_hierarchy": True,

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -125,7 +125,7 @@ class ModSettings(MixinMeta):
         """
         guild = ctx.guild
         if enabled is None:
-            state = await self.config(guild).mention_spam.strict()
+            state = await self.config.guild(guild).mention_spam.strict()
             if state:
                 msg = _("Mention spam currently accounts for multiple mentions of the same user.")
             else:

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -132,7 +132,7 @@ class ModSettings(MixinMeta):
                 msg = _("Mention spam currently only accounts for mentions of different users.")
             await ctx.send(msg)
             return
-        
+
         if enabled:
             msg = _("Mention spam will now account for multiple mentions of the same user.")
         else:

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -137,7 +137,7 @@ class ModSettings(MixinMeta):
             msg = _("Mention spam will now account for multiple mentions of the same user.")
         else:
             msg = _("Mention spam will only account for mentions of different users.")
-        await self.config.guild(ctx.guild).mention_spam.strict.set(enabled)
+        await self.config.guild(guild).mention_spam.strict.set(enabled)
         await ctx.send(msg)
 
     @mentionspam.command(name="warn")

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -125,10 +125,14 @@ class ModSettings(MixinMeta):
         """
         if toggle is True:
             await self.config.guild(ctx.guild).mention_spam.strict.set(True)
-            return await ctx.send(_("Mention spam will now account for multiple mentions of the same user."))
+            return await ctx.send(
+                _("Mention spam will now account for multiple mentions of the same user.")
+            )
         elif toggle is False:
             await self.config.guild(ctx.guild).mention_spam.strict.set(False)
-            return await ctx.send(_("Mention spam will only account for mentions of different users."))
+            return await ctx.send(
+                _("Mention spam will only account for mentions of different users.")
+            )
 
     @mentionspam.command(name="warn")
     @commands.guild_only()

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -28,6 +28,7 @@ class ModSettings(MixinMeta):
         warn_mention_spam = data["mention_spam"]["warn"]
         kick_mention_spam = data["mention_spam"]["kick"]
         ban_mention_spam = data["mention_spam"]["ban"]
+        strict_mention_spam = data["mention_spam"]["strict"]
         respect_hierarchy = data["respect_hierarchy"]
         delete_delay = data["delete_delay"]
         reinvite_on_unban = data["reinvite_on_unban"]
@@ -53,6 +54,11 @@ class ModSettings(MixinMeta):
             num_mentions=_("{num} mentions").format(num=ban_mention_spam)
             if ban_mention_spam
             else _("No")
+        )
+        msg += (
+            _("Mention Spam Strict: All mentions will count including duplicates\n")
+            if strict_mention_spam
+            else _("Mention Spam Strict: Only unique mention will count\n")
         )
         msg += _("Respects hierarchy: {yes_or_no}\n").format(
             yes_or_no=_("Yes") if respect_hierarchy else _("No")
@@ -106,6 +112,24 @@ class ModSettings(MixinMeta):
         Manage the automoderation settings for mentionspam.
         """
 
+    @mentionspam.command(name="strict")
+    @commands.guild_only()
+    async def mentionspam_strict(self, ctx: commands.Context, toggle: bool):
+        """
+        Sets settings to allow for duplicate or only different mentions.
+
+        If enabled all mentions will count including duplicated mentions.
+        If disabled only unique mentions will count.
+
+        Default is settings is False.
+        """
+        if toggle is True:
+            await self.config.guild(ctx.guild).mention_spam.strict.set(True)
+            return await ctx.send(_("Mention spam wll now account for same mentions."))
+        elif toggle is False:
+            await self.config.guild(ctx.guild).mention_spam.strict.set(False)
+            return await ctx.send(_("Mention spam will only account for different mentions."))
+
     @mentionspam.command(name="warn")
     @commands.guild_only()
     async def mentionspam_warn(self, ctx: commands.Context, max_mentions: int):
@@ -141,7 +165,7 @@ class ModSettings(MixinMeta):
         await ctx.send(
             _(
                 "Autowarn for mention spam enabled. "
-                "Anyone mentioning {max_mentions} or more different people "
+                "Anyone mentioning {max_mentions} or more people "
                 "in a single message will be autowarned.\n{mismatch_message}"
             ).format(max_mentions=max_mentions, mismatch_message=mismatch_message)
         )
@@ -181,7 +205,7 @@ class ModSettings(MixinMeta):
         await ctx.send(
             _(
                 "Autokick for mention spam enabled. "
-                "Anyone mentioning {max_mentions} or more different people "
+                "Anyone mentioning {max_mentions} or more people "
                 "in a single message will be autokicked.\n{mismatch_message}"
             ).format(max_mentions=max_mentions, mismatch_message=mismatch_message)
         )
@@ -220,7 +244,7 @@ class ModSettings(MixinMeta):
         await ctx.send(
             _(
                 "Autoban for mention spam enabled. "
-                "Anyone mentioning {max_mentions} or more different people "
+                "Anyone mentioning {max_mentions} or more people "
                 "in a single message will be autobanned.\n{mismatch_message}"
             ).format(max_mentions=max_mentions, mismatch_message=mismatch_message)
         )

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -58,7 +58,7 @@ class ModSettings(MixinMeta):
         msg += (
             _("Mention Spam Strict: All mentions will count including duplicates\n")
             if strict_mention_spam
-            else _("Mention Spam Strict: Only unique mention will count\n")
+            else _("Mention Spam Strict: Only unique mentions will count\n")
         )
         msg += _("Respects hierarchy: {yes_or_no}\n").format(
             yes_or_no=_("Yes") if respect_hierarchy else _("No")
@@ -114,9 +114,9 @@ class ModSettings(MixinMeta):
 
     @mentionspam.command(name="strict")
     @commands.guild_only()
-    async def mentionspam_strict(self, ctx: commands.Context, toggle: bool):
+    async def mentionspam_strict(self, ctx: commands.Context, toggle: bool = False):
         """
-        Sets settings to allow for duplicate or only different mentions.
+        Setting to account for duplicate mentions.
 
         If enabled all mentions will count including duplicated mentions.
         If disabled only unique mentions will count.
@@ -125,10 +125,10 @@ class ModSettings(MixinMeta):
         """
         if toggle is True:
             await self.config.guild(ctx.guild).mention_spam.strict.set(True)
-            return await ctx.send(_("Mention spam will now account for same mentions."))
+            return await ctx.send(_("Mention spam will now account for multiple mentions of the same user."))
         elif toggle is False:
             await self.config.guild(ctx.guild).mention_spam.strict.set(False)
-            return await ctx.send(_("Mention spam will only account for different mentions."))
+            return await ctx.send(_("Mention spam will only account for mentions of different users."))
 
     @mentionspam.command(name="warn")
     @commands.guild_only()

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -121,11 +121,11 @@ class ModSettings(MixinMeta):
         If enabled all mentions will count including duplicated mentions.
         If disabled only unique mentions will count.
 
-        Default is settings is False.
+        Default setting is False.
         """
         if toggle is True:
             await self.config.guild(ctx.guild).mention_spam.strict.set(True)
-            return await ctx.send(_("Mention spam wll now account for same mentions."))
+            return await ctx.send(_("Mention spam will now account for same mentions."))
         elif toggle is False:
             await self.config.guild(ctx.guild).mention_spam.strict.set(False)
             return await ctx.send(_("Mention spam will only account for different mentions."))

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -114,25 +114,31 @@ class ModSettings(MixinMeta):
 
     @mentionspam.command(name="strict")
     @commands.guild_only()
-    async def mentionspam_strict(self, ctx: commands.Context, toggle: bool = False):
+    async def mentionspam_strict(self, ctx: commands.Context, enabled: bool = None):
         """
         Setting to account for duplicate mentions.
 
         If enabled all mentions will count including duplicated mentions.
         If disabled only unique mentions will count.
 
-        Default setting is False.
+        Use this command without any parameter to see current setting.
         """
-        if toggle is True:
-            await self.config.guild(ctx.guild).mention_spam.strict.set(True)
-            return await ctx.send(
-                _("Mention spam will now account for multiple mentions of the same user.")
-            )
-        elif toggle is False:
-            await self.config.guild(ctx.guild).mention_spam.strict.set(False)
-            return await ctx.send(
-                _("Mention spam will only account for mentions of different users.")
-            )
+        guild = ctx.guild
+        if enabled is None:
+            state = await self.config(guild).mention_spam.strict()
+            if state:
+                msg = _("Mention spam currently accounts for multiple mentions of the same user.")
+            else:
+                msg = _("Mention spam currently only accounts for mentions of different users.")
+            await ctx.send(msg)
+            return
+        
+        if enabled:
+            msg = _("Mention spam will now account for multiple mentions of the same user.")
+        else:
+            msg = _("Mention spam will only account for mentions of different users.")
+        await self.config.guild(ctx.guild).mention_spam.strict.set(enabled)
+        await ctx.send(msg)
 
     @mentionspam.command(name="warn")
     @commands.guild_only()


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Allow for mention spam to account for duplicated mentions.
Added `modset mentionspam strict` bool to toggle the system to account for duplicates or only uniques.
Added settings information in showsettings.
Fixed wording when you adjust warn/kick/ban settings (removed `different`)