### PR TITLE
[Dev] Add repl pause

### DIFF
--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -238,13 +238,24 @@ class Dev(commands.Cog):
         }
 
         if ctx.channel.id in self.sessions:
-            await ctx.send(
-                _("Already running a REPL session in this channel. Exit it with `quit`.")
-            )
+            if self.sessions[ctx.channel.id]:
+                await ctx.send(
+                    _("Already running a REPL session in this channel. Exit it with `quit`.")
+                )
+            else:
+                await ctx.send(
+                    _(
+                        "Already running a REPL session in this channel. Resume the REPL with `{}repl resume`."
+                    ).format(ctx.prefix)
+                )
             return
 
         self.sessions[ctx.channel.id] = True
-        await ctx.send(_("Enter code to execute or evaluate. `exit()` or `quit` to exit."))
+        await ctx.send(
+            _(
+                "Enter code to execute or evaluate. `exit()` or `quit` to exit. `{}repl pause` to pause."
+            ).format(ctx.prefix)
+        )
 
         while True:
             response = await ctx.bot.wait_for("message", check=MessagePredicate.regex(r"^`", ctx))

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -9,11 +9,11 @@ import types
 import re
 from contextlib import redirect_stdout
 from copy import copy
-from typing import Optional
 
 import discord
 
 from . import checks, commands
+from .commands import NoParseOptional as Optional
 from .i18n import Translator
 from .utils.chat_formatting import box, pagify
 from .utils.predicates import MessagePredicate
@@ -309,9 +309,9 @@ class Dev(commands.Cog):
             except discord.HTTPException as e:
                 await ctx.send(_("Unexpected error: `{}`").format(e))
 
-    @repl.command()
+    @repl.command(aliases=["resume"])
     async def pause(self, ctx, toggle: Optional[bool] = None):
-        """Pauses the REPL running in the current channel"""
+        """Pauses/resumes the REPL running in the current channel"""
         if not ctx.channel.id in self.sessions:
             await ctx.send(_("There is no currently running REPL session in this channel."))
             return

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -312,7 +312,7 @@ class Dev(commands.Cog):
     @repl.command()
     async def pause(self, ctx, toggle: Optional[bool] = None):
         """Pauses the REPL running in the current channel"""
-        if not ctx.channel.id in self.sessions:
+        if ctx.channel.id not in self.sessions:
             await ctx.send(_("There is no currently running REPL session in this channel."))
             return
 

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -332,9 +332,9 @@ class Dev(commands.Cog):
         self.sessions[ctx.channel.id] = toggle
 
         if toggle:
-            await ctx.send(_("The REPL session in this channel is now enabled."))
+            await ctx.send(_("The REPL session in this channel has been resumed."))
         else:
-            await ctx.send(_("The REPL session in this channel is now disabled."))
+            await ctx.send(_("The REPL session in this channel is now paused."))
 
     @commands.command()
     @checks.is_owner()


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Adds a command to pause the REPL in the current channel, so that you can peacefully write codeblocks without your bot sending an error, and yet retain the variables of the REPL instead of having to restart.