### PR TITLE
Cleanup reactions

### DIFF
--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -586,7 +586,7 @@ class Cleanup(commands.Cog):
         """Clear reactions from the specified number of messages."""
         msgs = 0
 
-        async for message in ctx. channel.history(limit=positive_int):
+        async for message in ctx.channel.history(limit=number):
             if message.reactions:
                 await message.clear_reactions()
                 msgs += 1

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -583,13 +583,18 @@ class Cleanup(commands.Cog):
     @commands.guild_only()
     @commands.bot_has_permissions(manage_messages=True, read_message_history=True)
     async def cleanup_reactions(self, ctx: commands.Context, number: positive_int):
-        """Clear reactions from the specified number of messages."""
+        """Clear reactions from the specified number of messages.
+        
+        You can clear reactions from 100 messages at most."""
         msgs = 0
-
-        async for message in ctx.channel.history(limit=number):
+        if number > 100:
+            number = 100
+        async for message in ctx.channel.history(limit=300):
             if message.reactions:
                 await message.clear_reactions()
                 msgs += 1
+            if msgs == number:
+                break
 
         if msgs > 1:
             log.info(

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -578,3 +578,27 @@ class Cleanup(commands.Cog):
 
         to_delete.append(ctx.message)
         await mass_purge(to_delete, ctx.channel)
+
+    @cleanup.command(name="reactions")
+    @commands.guild_only()
+    @commands.bot_has_permissions(manage_messages=True, read_message_history=True)
+    async def cleanup_reactions(self, ctx: commands.Context, number: positive_int):
+        """Clear reactions from the specified number of messages."""
+        msgs = 0
+
+        async for message in ctx. channel.history(limit=positive_int):
+            if message.reactions:
+                await message.clear_reactions()
+                msgs += 1
+
+        if msgs > 1:
+            log.info(
+                "%s (%s) cleared reactions from %s messages in channel %s (%s).",
+                ctx.author,
+                ctx.author.id,
+                msgs,
+                ctx.channel,
+                ctx.channel.id,
+            )
+
+        await ctx.message.delete()


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes
Adds a `[p]cleanup reactions <number>` command which searches the messages provided and clears reactions from them if there are any.