### PR TITLE
[Core] add `[p]set api list` and `[p]set api remove`

### DIFF
--- a/docs/framework_apikeys.rst
+++ b/docs/framework_apikeys.rst
@@ -74,6 +74,4 @@ Additional References
 
 .. automethod:: Red.remove_shared_api_tokens
 
-.. automethod:: Red.get_shared_api_services
-
 .. automethod:: Red.remove_shared_api_services

--- a/docs/framework_apikeys.rst
+++ b/docs/framework_apikeys.rst
@@ -73,3 +73,7 @@ Additional References
 .. automethod:: Red.set_shared_api_tokens
 
 .. automethod:: Red.remove_shared_api_tokens
+
+.. automethod:: Red.get_shared_api_services
+
+.. automethod:: Red.remove_shared_api_services

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1057,6 +1057,25 @@ class RedBase(
             for name in token_names:
                 group.pop(name, None)
 
+    async def remove_shared_api_services(self, *service_names: str):
+        """
+        Removes shared API services, as well as keys and tokens associated with them.
+
+        Parameters
+        ----------
+        service_names: str
+            the services to remove
+
+        Examples
+        ----------
+        Removing the youtube service
+
+        >>> await ctx.bot.remove_shared_api_services("youtube")
+        """
+        async with self._config.custom(SHARED_API_TOKENS).all() as group:
+            for service in service_names:
+                group.clear_raw(service)
+
     async def get_context(self, message, *, cls=commands.Context):
         return await super().get_context(message, cls=cls)
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -986,9 +986,9 @@ class RedBase(
         """
         return await self._config.guild(discord.Object(id=guild_id)).mod_role()
 
-    async def get_shared_api_keys(self) -> List[str]:
+    async def get_shared_api_services(self) -> List[str]:
         """
-        Gets the shared API keys (services).
+        Gets the shared API service names.
         """
         return list((await self._config.custom(SHARED_API_TOKENS).all()).keys())
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -26,6 +26,7 @@ from typing import (
     Any,
     Literal,
     MutableMapping,
+    overload,
 )
 from types import MappingProxyType
 
@@ -986,20 +987,32 @@ class RedBase(
         """
         return await self._config.guild(discord.Object(id=guild_id)).mod_role()
 
-    async def get_shared_api_tokens(self, service_name: Optional[str] = None) -> Dict[str, str]:
+    @overload
+    async def get_shared_api_tokens(self, service_name: str = ...) -> Dict[str, str]:
+        ...
+
+    @overload
+    async def get_shared_api_tokens(self, service_name: None = ...) -> Dict[str, Dict[str, str]]:
+        ...
+
+    async def get_shared_api_tokens(
+        self, service_name: Optional[str] = None
+    ) -> Union[Dict[str, Dict[str, str]], Dict[str, str]]:
         """
         Gets the shared API tokens for a service, or all of them if no argument specified.
 
         Parameters
         ----------
-        service_name: str
-            The service to get tokens for.
+        service_name: str, optional
+            The service to get tokens for. Leave empty to get tokens for all services.
 
         Returns
         -------
-        Dict[str, str]
+        Dict[str, Dict[str, str]] or Dict[str, str]
             A Mapping of token names to tokens.
             This mapping exists because some services have multiple tokens.
+            If ``service_name`` is `None`, this method will return
+            a mapping with mappings for all services.
         """
         if service_name is None:
             return await self._config.custom(SHARED_API_TOKENS).all()
@@ -1060,7 +1073,7 @@ class RedBase(
 
         Parameters
         ----------
-        service_names: str
+        *service_names: str
             The services to remove.
 
         Examples

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -26,6 +26,7 @@ from typing import (
     Any,
     Literal,
     MutableMapping,
+    Iterable,
 )
 from types import MappingProxyType
 
@@ -1057,7 +1058,7 @@ class RedBase(
             for name in token_names:
                 group.pop(name, None)
 
-    async def remove_shared_api_services(self, service_names: List[str]):
+    async def remove_shared_api_services(self, service_names: Iterable[str]):
         """
         Removes shared API services, as well as keys and tokens associated with them.
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1057,7 +1057,7 @@ class RedBase(
             for name in token_names:
                 group.pop(name, None)
 
-    async def remove_shared_api_services(self, *service_names: str):
+    async def remove_shared_api_services(self, service_names: List[str]):
         """
         Removes shared API services, as well as keys and tokens associated with them.
 
@@ -1074,7 +1074,7 @@ class RedBase(
         """
         async with self._config.custom(SHARED_API_TOKENS).all() as group:
             for service in service_names:
-                group.clear_raw(service)
+                group.pop(service, None)
 
     async def get_context(self, message, *, cls=commands.Context):
         return await super().get_context(message, cls=cls)

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1058,7 +1058,7 @@ class RedBase(
             for name in token_names:
                 group.pop(name, None)
 
-    async def remove_shared_api_services(self, service_names: Iterable[str]):
+    async def remove_shared_api_services(self, *service_names: str):
         """
         Removes shared API services, as well as keys and tokens associated with them.
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1065,7 +1065,7 @@ class RedBase(
         Parameters
         ----------
         service_names: str
-            the services to remove
+            The services to remove.
 
         Examples
         ----------

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -987,15 +987,9 @@ class RedBase(
         """
         return await self._config.guild(discord.Object(id=guild_id)).mod_role()
 
-    async def get_shared_api_services(self) -> List[str]:
+    async def get_shared_api_tokens(self, service_name: Optional[str]=None) -> Dict[str, str]:
         """
-        Gets the shared API service names.
-        """
-        return list((await self._config.custom(SHARED_API_TOKENS).all()).keys())
-
-    async def get_shared_api_tokens(self, service_name: str) -> Dict[str, str]:
-        """
-        Gets the shared API tokens for a service
+        Gets the shared API tokens for a service, or all of them if no argument specified.
 
         Parameters
         ----------
@@ -1008,7 +1002,10 @@ class RedBase(
             A Mapping of token names to tokens.
             This mapping exists because some services have multiple tokens.
         """
-        return await self._config.custom(SHARED_API_TOKENS, service_name).all()
+        if service_name is None:
+            return await self._config.custom(SHARED_API_TOKENS).all()
+        else:
+            return await self._config.custom(SHARED_API_TOKENS, service_name).all()
 
     async def set_shared_api_tokens(self, service_name: str, **tokens: str):
         """

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -986,6 +986,12 @@ class RedBase(
         """
         return await self._config.guild(discord.Object(id=guild_id)).mod_role()
 
+    async def get_shared_api_keys(self) -> List[str]:
+        """
+        Gets the shared API keys (services).
+        """
+        return list((await self._config.custom(SHARED_API_TOKENS).all()).keys())
+
     async def get_shared_api_tokens(self, service_name: str) -> Dict[str, str]:
         """
         Gets the shared API tokens for a service

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -26,7 +26,6 @@ from typing import (
     Any,
     Literal,
     MutableMapping,
-    Iterable,
 )
 from types import MappingProxyType
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -987,7 +987,7 @@ class RedBase(
         """
         return await self._config.guild(discord.Object(id=guild_id)).mod_role()
 
-    async def get_shared_api_tokens(self, service_name: Optional[str]=None) -> Dict[str, str]:
+    async def get_shared_api_tokens(self, service_name: Optional[str] = None) -> Dict[str, str]:
         """
         Gets the shared API tokens for a service, or all of them if no argument specified.
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2080,19 +2080,19 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
     @api.command(name="list")
     async def api_list(self, ctx: commands.Context):
-        """Show all external API keys (services) that have been set.
+        """Show all external API services that have been set.
 
-        This command does not expose tokens associated with keys,
+        This command does not expose keys or tokens associated with services,
         but may expose them if tokens have been incorrectly set as keys."""
 
-        keys = await ctx.bot.get_shared_api_keys()
-        if not keys:
-            await ctx.send(_("No API keys have been set yet."))
+        services = await ctx.bot.get_shared_api_services()
+        if not services:
+            await ctx.send(_("No API services have been set yet."))
             return
 
-        sorted_keys = sorted(keys, key=lambda r: str.lower(r))
+        sorted_services = sorted(services, key=lambda r: str.lower(r))
         joined = _("Set API keys:\n")
-        for key in sorted_keys:
+        for key in sorted_services:
             joined += "{}\n".format(key)
         for page in pagify(joined, ["\n"], shorten_by=16):
             await ctx.send(box(page.lstrip(" "), lang="diff"))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2060,8 +2060,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             await ctx.send(_("Text must be fewer than 1024 characters long."))
 
-    @_set.command()
-    @commands.group(invoke_without_command=True)
+    @_set.group(invoke_without_command=True)
     @checks.is_owner()
     async def api(self, ctx: commands.Context, service: str, *, tokens: TokenConverter):
         """Set various external API tokens.

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2097,6 +2097,12 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         for page in pagify(joined, ["\n"], shorten_by=16):
             await ctx.send(box(page.lstrip(" "), lang="diff"))
 
+    @api.command(name="remove")
+    async def api_remove(self, ctx: commands.Context, *services: str):
+        """Remove the given services with all their keys and tokens."""
+        await self.bot.remove_shared_api_services(services)
+        await ctx.send(_("Services deleted successfully."))
+
     @commands.group()
     @checks.is_owner()
     async def helpset(self, ctx: commands.Context):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2107,8 +2107,15 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         if services:
             await self.bot.remove_shared_api_services(*services)
-            msg = humanize_list(services)
-            await ctx.send(_("Services deleted successfully:\n{}").format(msg))
+            if len(services) > 1:
+                msg = _("Services deleted successfully:\n{services_list}").format(
+                    services_list=humanize_list(services)
+                )
+            else:
+                msg = _("Service deleted successfully: {service_name}").format(
+                    service_name=services[0]
+                )
+            await ctx.send(msg)
         else:
             await ctx.send(_("The services you provided weren't set anyway."))
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2080,9 +2080,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
     @api.command(name="list")
     async def api_list(self, ctx: commands.Context):
-        """Show all external API services along with their keys and tokens that have been set.
+        """Show all external API services along with their keys that have been set.
 
-        API keys are sensitive information. Use with caution."""
+        Secrets are not shown."""
 
         services: dict = await ctx.bot.get_shared_api_tokens()
         if not services:

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2090,17 +2090,16 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             await ctx.send(_("No API services have been set yet."))
             return
 
-        sorted_services = sorted(services, key=lambda r: str.lower(r))
+        sorted_services = sorted(services, key=str.lower)
         joined = _("Set API services:\n")
         for key in sorted_services:
-            joined += "{}\n".format(key)
+            joined += "+ {}\n".format(key)
         for page in pagify(joined, ["\n"], shorten_by=16):
             await ctx.send(box(page.lstrip(" "), lang="diff"))
 
     @api.command(name="remove")
     async def api_remove(self, ctx: commands.Context, *services: str):
         """Remove the given services with all their keys and tokens."""
-        services = list(services)
         await self.bot.remove_shared_api_services(services)
         await ctx.send(_("Services deleted successfully."))
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2093,7 +2093,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         sorted_keys = sorted(keys, key=lambda r: str.lower(r))
         joined = _("Set API keys:\n")
-        for key in keys:
+        for key in sorted_keys:
             joined += "{}\n".format(key)
         for page in pagify(joined, ["\n"], shorten_by=16):
             await ctx.send(box(page.lstrip(" "), lang="diff"))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2102,8 +2102,15 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @api.command(name="remove")
     async def api_remove(self, ctx: commands.Context, *services: str):
         """Remove the given services with all their keys and tokens."""
-        await self.bot.remove_shared_api_services(services)
-        await ctx.send(_("Services deleted successfully."))
+        bot_services = (await ctx.bot.get_shared_api_tokens()).keys()
+        services = [s for s in services if s in bot_services]
+
+        if services:
+            await self.bot.remove_shared_api_services(*services)
+            msg = "".join([f"`{s}`, " for s in services])[:-2]
+            await ctx.send(_("Services deleted successfully:\n{}".format(msg)))
+        else:
+            await ctx.send(_("The services you provided weren't set anyway."))
 
     @commands.group()
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2078,7 +2078,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         await ctx.bot.set_shared_api_tokens(service, **tokens)
         await ctx.send(_("`{service}` API tokens have been set.").format(service=service))
 
-    # @commands.dm_only()
     @api.command(name="list")
     async def api_list(self, ctx: commands.Context):
         """Show all external API services along with their keys and tokens that have been set.
@@ -2096,7 +2095,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         for service_name in sorted_services:
             joined += "+ {}\n".format(service_name)
             for key_name in services[service_name].keys():
-                joined += "- {}: {}\n".format(key_name, services[service_name][key_name])
+                joined += "- {}\n".format(key_name)
         for page in pagify(joined, ["\n"], shorten_by=16):
             await ctx.send(box(page.lstrip(" "), lang="diff"))
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -23,6 +23,7 @@ import aiohttp
 import discord
 from babel import Locale as BabelLocale, UnknownLocaleError
 from redbot.core.data_manager import storage_type
+from redbot.core.utils.chat_formatting import box, pagify
 
 from . import (
     __version__,
@@ -2076,6 +2077,26 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             await ctx.message.delete()
         await ctx.bot.set_shared_api_tokens(service, **tokens)
         await ctx.send(_("`{service}` API tokens have been set.").format(service=service))
+
+    @_set.command()
+    @checks.is_owner()
+    async def listapi(self, ctx: commands.Context):
+        """Show all external API keys (services) that have been set.
+
+        This command does not expose tokens associated with keys,
+        but may expose them if tokens have been incorrectly set as keys."""
+
+        keys = await ctx.bot.get_shared_api_keys()
+        if not keys:
+            await ctx.send(_("No API keys have been set yet."))
+            return
+
+        sorted_keys = sorted(keys, key=lambda r: str.lower(r))
+        joined = _("Set API keys:\n")
+        for key in keys:
+            joined += "{}\n".format(key)
+        for page in pagify(joined, ["\n"], shorten_by=16):
+            await ctx.send(box(page.lstrip(" "), lang="diff"))
 
     @commands.group()
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2117,7 +2117,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 )
             await ctx.send(msg)
         else:
-            await ctx.send(_("The services you provided weren't set anyway."))
+            await ctx.send(_("None of the services you provided had any keys set."))
 
     @commands.group()
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2095,7 +2095,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         for service_name in sorted_services:
             joined += "+ {}\n".format(service_name)
             for key_name in services[service_name].keys():
-                joined += "- {}\n".format(key_name)
+                joined += "  - {}\n".format(key_name)
         for page in pagify(joined, ["\n"], shorten_by=16):
             await ctx.send(box(page.lstrip(" "), lang="diff"))
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2083,7 +2083,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """Show all external API services that have been set.
 
         This command does not expose keys or tokens associated with services,
-        but may expose them if tokens have been incorrectly set as keys."""
+        but may expose them if tokens have been incorrectly set as services."""
 
         services = await ctx.bot.get_shared_api_services()
         if not services:

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2061,6 +2061,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             await ctx.send(_("Text must be fewer than 1024 characters long."))
 
     @_set.command()
+    @commands.group(invoke_without_command=True)
     @checks.is_owner()
     async def api(self, ctx: commands.Context, service: str, *, tokens: TokenConverter):
         """Set various external API tokens.
@@ -2078,9 +2079,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         await ctx.bot.set_shared_api_tokens(service, **tokens)
         await ctx.send(_("`{service}` API tokens have been set.").format(service=service))
 
-    @_set.command()
+    @api.command(name="list")
     @checks.is_owner()
-    async def listapi(self, ctx: commands.Context):
+    async def api_list(self, ctx: commands.Context):
         """Show all external API keys (services) that have been set.
 
         This command does not expose tokens associated with keys,

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2108,7 +2108,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         if services:
             await self.bot.remove_shared_api_services(*services)
             msg = humanize_list(services)
-            await ctx.send(_("Services deleted successfully:\n{}".format(msg)))
+            await ctx.send(_("Services deleted successfully:\n{}").format(msg))
         else:
             await ctx.send(_("The services you provided weren't set anyway."))
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2080,7 +2080,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         await ctx.send(_("`{service}` API tokens have been set.").format(service=service))
 
     @api.command(name="list")
-    @checks.is_owner()
     async def api_list(self, ctx: commands.Context):
         """Show all external API keys (services) that have been set.
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2100,6 +2100,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @api.command(name="remove")
     async def api_remove(self, ctx: commands.Context, *services: str):
         """Remove the given services with all their keys and tokens."""
+        services = list(services)
         await self.bot.remove_shared_api_services(services)
         await ctx.send(_("Services deleted successfully."))
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2107,7 +2107,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         if services:
             await self.bot.remove_shared_api_services(*services)
-            msg = "".join([f"`{s}`, " for s in services])[:-2]
+            msg = humanize_list(services)
             await ctx.send(_("Services deleted successfully:\n{}".format(msg)))
         else:
             await ctx.send(_("The services you provided weren't set anyway."))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2091,7 +2091,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             return
 
         sorted_services = sorted(services, key=str.lower)
-        joined = _("Set API services:\n")
+        joined = _("Set API services:\n") if len(services) > 1 else _("Set API service:\n")
         for key in sorted_services:
             joined += "+ {}\n".format(key)
         for page in pagify(joined, ["\n"], shorten_by=16):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2063,7 +2063,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @_set.group(invoke_without_command=True)
     @checks.is_owner()
     async def api(self, ctx: commands.Context, service: str, *, tokens: TokenConverter):
-        """Set various external API tokens.
+        """Set, list or remove various external API tokens.
 
         This setting will be asked for by some 3rd party cogs and some core cogs.
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2091,7 +2091,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             return
 
         sorted_services = sorted(services, key=lambda r: str.lower(r))
-        joined = _("Set API keys:\n")
+        joined = _("Set API services:\n")
         for key in sorted_services:
             joined += "{}\n".format(key)
         for page in pagify(joined, ["\n"], shorten_by=16):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2078,22 +2078,25 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         await ctx.bot.set_shared_api_tokens(service, **tokens)
         await ctx.send(_("`{service}` API tokens have been set.").format(service=service))
 
+    # @commands.dm_only()
     @api.command(name="list")
     async def api_list(self, ctx: commands.Context):
-        """Show all external API services that have been set.
+        """Show all external API services along with their keys and tokens that have been set.
 
-        This command does not expose keys or tokens associated with services,
-        but may expose them if tokens have been incorrectly set as services."""
+        API keys are sensitive information. Use with caution."""
 
-        services = await ctx.bot.get_shared_api_services()
+        services: dict = await ctx.bot.get_shared_api_tokens()
         if not services:
             await ctx.send(_("No API services have been set yet."))
             return
 
-        sorted_services = sorted(services, key=str.lower)
+        sorted_services = sorted(services.keys(), key=str.lower)
+
         joined = _("Set API services:\n") if len(services) > 1 else _("Set API service:\n")
-        for key in sorted_services:
-            joined += "+ {}\n".format(key)
+        for service_name in sorted_services:
+            joined += "+ {}\n".format(service_name)
+            for key_name in services[service_name].keys():
+                joined += "- {}: {}\n".format(key_name, services[service_name][key_name])
         for page in pagify(joined, ["\n"], shorten_by=16):
             await ctx.send(box(page.lstrip(" "), lang="diff"))
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [X] New feature

### Description of the changes
Added new subcommands: `[p]set api list` and `[p]set api remove`.
`[p]set api list` causes the bot to send a message containing all currently set API services, without exposing tokens. The message is formatted similarly to `[p]repo list`.

`[p]set api remove` removes the provided services from config, including their associated tokens.

Should be useful for managing your API keys along with `[p]set api` and especially when removing api keys, since there were no easy-to-use tools for that.