### PR TITLE
Bump black to 20.8b1 (and reformat)

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -319,7 +319,7 @@ def handle_edit(cli_flags: Namespace):
 async def run_bot(red: Red, cli_flags: Namespace) -> None:
     """
     This runs the bot.
-    
+
     Any shutdown which is a result of not being able to log in needs to raise
     a SystemExit exception.
 

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -76,7 +76,8 @@ class Admin(commands.Cog):
         self.config.register_global(serverlocked=False, schema_version=0)
 
         self.config.register_guild(
-            announce_channel=None, selfroles=[],  # Integer ID  # List of integer ID's
+            announce_channel=None,  # Integer ID
+            selfroles=[],  # List of integer ID's
         )
 
         self.__current_announcer = None

--- a/redbot/cogs/alias/alias_entry.py
+++ b/redbot/cogs/alias/alias_entry.py
@@ -24,7 +24,7 @@ class AliasEntry:
     uses: int
 
     def __init__(
-        self, name: str, command: Union[Tuple[str], str], creator: int, guild: Optional[int],
+        self, name: str, command: Union[Tuple[str], str], creator: int, guild: Optional[int]
     ):
         super().__init__()
         self.name = name
@@ -161,7 +161,7 @@ class AliasCache:
         return aliases
 
     async def get_alias(
-        self, guild: Optional[discord.Guild], alias_name: str,
+        self, guild: Optional[discord.Guild], alias_name: str
     ) -> Optional[AliasEntry]:
         """Returns an AliasEntry object if the provided alias_name is a registered alias"""
         server_aliases: List[AliasEntry] = []

--- a/redbot/cogs/audio/apis/interface.py
+++ b/redbot/cogs/audio/apis/interface.py
@@ -102,7 +102,9 @@ class AudioAPIInterface:
         return track
 
     async def route_tasks(
-        self, action_type: str = None, data: Union[List[MutableMapping], MutableMapping] = None,
+        self,
+        action_type: str = None,
+        data: Union[List[MutableMapping], MutableMapping] = None,
     ) -> None:
         """Separate the tasks and run them in the appropriate functions"""
 

--- a/redbot/cogs/audio/apis/youtube.py
+++ b/redbot/cogs/audio/apis/youtube.py
@@ -33,7 +33,7 @@ class YouTubeWrapper:
     def update_token(self, new_token: Mapping[str, str]):
         self._token = new_token
 
-    async def _get_api_key(self,) -> str:
+    async def _get_api_key(self) -> str:
         """Get the stored youtube token"""
         if not self._token:
             self._token = await self.bot.get_shared_api_tokens("youtube")

--- a/redbot/cogs/audio/core/events/dpy.py
+++ b/redbot/cogs/audio/core/events/dpy.py
@@ -78,12 +78,12 @@ class DpyEvents(MixinMeta, metaclass=CompositeMetaClass):
         if isinstance(error, commands.ArgParserFailure):
             handled = True
             msg = _("`{user_input}` is not a valid value for `{command}`").format(
-                user_input=error.user_input, command=error.cmd,
+                user_input=error.user_input, command=error.cmd
             )
             if error.custom_help_msg:
                 msg += f"\n{error.custom_help_msg}"
             await self.send_embed_msg(
-                ctx, title=_("Unable To Parse Argument"), description=msg, error=True,
+                ctx, title=_("Unable To Parse Argument"), description=msg, error=True
             )
             if error.send_cmd_help:
                 await ctx.send_help()
@@ -101,7 +101,7 @@ class DpyEvents(MixinMeta, metaclass=CompositeMetaClass):
                     )
                 else:
                     await self.send_embed_msg(
-                        ctx, title=_("Invalid Argument"), description=error.args[0], error=True,
+                        ctx, title=_("Invalid Argument"), description=error.args[0], error=True
                     )
             else:
                 await ctx.send_help()

--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -146,8 +146,10 @@ class ServerManager:
     @staticmethod
     async def _get_java_version() -> Tuple[int, int]:
         """This assumes we've already checked that java exists."""
-        _proc: asyncio.subprocess.Process = await asyncio.create_subprocess_exec(  # pylint:disable=no-member
-            "java", "-version", stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        _proc: asyncio.subprocess.Process = (
+            await asyncio.create_subprocess_exec(  # pylint:disable=no-member
+                "java", "-version", stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+            )
         )
         # java -version outputs to stderr
         _, err = await _proc.communicate()

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -416,10 +416,9 @@ class Cleanup(commands.Cog):
             is_cc = lambda name: False
         alias_cog = self.bot.get_cog("Alias")
         if alias_cog is not None:
-            alias_names: Set[str] = (
-                set((a.name for a in await alias_cog._aliases.get_global_aliases()))
-                | set(a.name for a in await alias_cog._aliases.get_guild_aliases(ctx.guild))
-            )
+            alias_names: Set[str] = set(
+                a.name for a in await alias_cog._aliases.get_global_aliases()
+            ) | set(a.name for a in await alias_cog._aliases.get_guild_aliases(ctx.guild))
             is_alias = lambda name: name in alias_names
         else:
             is_alias = lambda name: False
@@ -559,7 +558,7 @@ class Cleanup(commands.Cog):
                 return False
 
         to_delete = await self.get_messages_for_deletion(
-            channel=ctx.channel, limit=number, check=check, before=ctx.message,
+            channel=ctx.channel, limit=number, check=check, before=ctx.message
         )
 
         if len(to_delete) > 100:

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -40,7 +40,7 @@ class Downloader(commands.Cog):
 
     Community cogs, also called third party cogs, are not included
     in the default Red install.
-    
+
     Community cogs come in repositories. Repos are a group of cogs
     you can install. You always need to add the creator's repository
     using the `[p]repo` command before you can install one or more
@@ -545,7 +545,9 @@ class Downloader(commands.Cog):
             )
         except OSError:
             log.exception(
-                "Something went wrong trying to add repo %s under name %s", repo_url, name,
+                "Something went wrong trying to add repo %s under name %s",
+                repo_url,
+                name,
             )
             await ctx.send(
                 _(

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -1153,11 +1153,11 @@ class RepoManager:
     async def update_repos(
         self, repos: Optional[Iterable[Repo]] = None
     ) -> Tuple[Dict[Repo, Tuple[str, str]], List[str]]:
-        """Calls `Repo.update` on passed repositories and 
+        """Calls `Repo.update` on passed repositories and
         catches failing ones.
-        
+
         Calling without params updates all currently installed repos.
-        
+
         Parameters
         ----------
         repos: Iterable
@@ -1168,7 +1168,7 @@ class RepoManager:
         tuple of Dict and list
             A mapping of `Repo` objects that received new commits to
             a 2-`tuple` of `str` containing old and new commit hashes.
-            
+
             `list` of failed `Repo` names
         """
         failed = []

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -550,7 +550,8 @@ class Economy(commands.Cog):
                     embed.description = box(temp_msg, lang="md")
                     embed.set_footer(
                         text=footer_message.format(
-                            page_num=len(highscores) + 1, page_len=ceil(len(bank_sorted) / 10),
+                            page_num=len(highscores) + 1,
+                            page_len=ceil(len(bank_sorted) / 10),
                         )
                     )
                     highscores.append(embed)
@@ -565,7 +566,8 @@ class Economy(commands.Cog):
                 embed.description = box(temp_msg, lang="md")
                 embed.set_footer(
                     text=footer_message.format(
-                        page_num=len(highscores) + 1, page_len=ceil(len(bank_sorted) / 10),
+                        page_num=len(highscores) + 1,
+                        page_len=ceil(len(bank_sorted) / 10),
                     )
                 )
                 highscores.append(embed)

--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -248,14 +248,15 @@ class General(commands.Cog):
     async def serverinfo(self, ctx, details: bool = False):
         """
         Show server information.
-    
+
         `details`: Shows more information when set to `True`.
         Default to False.
         """
         guild = ctx.guild
         passed = (ctx.message.created_at - guild.created_at).days
         created_at = _("Created on {date}. That's over {num} days ago!").format(
-            date=guild.created_at.strftime("%d %b %Y %H:%M"), num=humanize_number(passed),
+            date=guild.created_at.strftime("%d %b %Y %H:%M"),
+            num=humanize_number(passed),
         )
         online = humanize_number(
             len([m.status for m in guild.members if m.status != discord.Status.offline])

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -194,7 +194,7 @@ class Mod(
     @commands.is_owner()
     async def movedeletedelay(self, ctx: commands.Context) -> None:
         """
-            Move deletedelay settings to core
+        Move deletedelay settings to core
         """
         all_guilds = await self.config.all_guilds()
         for guild_id, settings in all_guilds.items():

--- a/redbot/cogs/permissions/converters.py
+++ b/redbot/cogs/permissions/converters.py
@@ -48,7 +48,7 @@ class GlobalUniqueObjectFinder(commands.Converter):
             async for guild in AsyncIter(bot.guilds, steps=100)
         ]
 
-        objects = itertools.chain(bot.get_all_channels(), bot.users, bot.guilds, *all_roles,)
+        objects = itertools.chain(bot.get_all_channels(), bot.users, bot.guilds, *all_roles)
 
         maybe_matches = []
         async for obj in AsyncIter(objects, steps=100):

--- a/redbot/cogs/permissions/permissions.py
+++ b/redbot/cogs/permissions/permissions.py
@@ -453,7 +453,7 @@ class Permissions(commands.Cog):
         `<cog_or_command>` is the cog or command to remove the rule
         from. This is case sensitive.
 
-       `<who_or_what>` is one or more users, channels or roles the rule is for.
+        `<who_or_what>` is one or more users, channels or roles the rule is for.
         """
         if not who_or_what:
             await ctx.send_help()

--- a/redbot/cogs/reports/reports.py
+++ b/redbot/cogs/reports/reports.py
@@ -27,7 +27,7 @@ class Reports(commands.Cog):
 
     Users can open reports using `[p]report`. These are then sent
     to a channel in the server for staff, and the report creator
-    gets a DM. Both can be used to communicate. 
+    gets a DM. Both can be used to communicate.
     """
 
     default_guild_settings = {"output_channel": None, "active": False, "next_ticket": 1}

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -207,7 +207,9 @@ class Streams(commands.Cog):
         await self.maybe_renew_twitch_bearer_token()
         token = (await self.bot.get_shared_api_tokens("twitch")).get("client_id")
         stream = TwitchStream(
-            name=channel_name, token=token, bearer=self.ttv_bearer_cache.get("access_token", None),
+            name=channel_name,
+            token=token,
+            bearer=self.ttv_bearer_cache.get("access_token", None),
         )
         await self.check_online(ctx, stream)
 

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -314,7 +314,8 @@ class Warnings(commands.Cog):
             for r, v in registered_reasons.items():
                 if await ctx.embed_requested():
                     em = discord.Embed(
-                        title=_("Reason: {name}").format(name=r), description=v["description"],
+                        title=_("Reason: {name}").format(name=r),
+                        description=v["description"],
                     )
                     em.add_field(name=_("Points"), value=str(v["points"]))
                     msg_list.append(em)
@@ -343,7 +344,9 @@ class Warnings(commands.Cog):
                     em = discord.Embed(title=_("Action: {name}").format(name=r["action_name"]))
                     em.add_field(name=_("Points"), value="{}".format(r["points"]), inline=False)
                     em.add_field(
-                        name=_("Exceed command"), value=r["exceed_command"], inline=False,
+                        name=_("Exceed command"),
+                        value=r["exceed_command"],
+                        inline=False,
                     )
                     em.add_field(name=_("Drop command"), value=r["drop_command"], inline=False)
                     msg_list.append(em)
@@ -436,7 +439,10 @@ class Warnings(commands.Cog):
                 title = _("Warning from {user}").format(user=ctx.author)
             else:
                 title = _("Warning")
-            em = discord.Embed(title=title, description=reason_type["description"],)
+            em = discord.Embed(
+                title=title,
+                description=reason_type["description"],
+            )
             em.add_field(name=_("Points"), value=str(reason_type["points"]))
             try:
                 await user.send(
@@ -462,14 +468,18 @@ class Warnings(commands.Cog):
                 title = _("Warning from {user}").format(user=ctx.author)
             else:
                 title = _("Warning")
-            em = discord.Embed(title=title, description=reason_type["description"],)
+            em = discord.Embed(
+                title=title,
+                description=reason_type["description"],
+            )
             em.add_field(name=_("Points"), value=str(reason_type["points"]))
             warn_channel = self.bot.get_channel(guild_settings["warn_channel"])
             if warn_channel:
                 if warn_channel.permissions_for(guild.me).send_messages:
                     with contextlib.suppress(discord.HTTPException):
                         await warn_channel.send(
-                            _("{user} has been warned.").format(user=user.mention), embed=em,
+                            _("{user} has been warned.").format(user=user.mention),
+                            embed=em,
                         )
 
             if not dm_failed:

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1422,8 +1422,10 @@ class RedBase(
         await self._red_ready.wait()
 
     async def _delete_delay(self, ctx: commands.Context):
-        """Currently used for:
-            * delete delay"""
+        """
+        Currently used for:
+          * delete delay
+        """
         guild = ctx.guild
         if guild is None:
             return

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -235,7 +235,7 @@ def parse_cli_flags(args):
         help="Set the maximum number of messages to store in the internal message cache.",
     )
     parser.add_argument(
-        "--no-message-cache", action="store_true", help="Disable the internal message cache.",
+        "--no-message-cache", action="store_true", help="Disable the internal message cache."
     )
 
     args = parser.parse_args(args)

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -1026,7 +1026,7 @@ class Cog(CogMixin, DPYCog, metaclass=DPYCogMeta):
 
     .. warning::
 
-        None of your methods should start with ``red_`` or 
+        None of your methods should start with ``red_`` or
         be dunder names which start with red (eg. ``__red_test_thing__``)
         unless to override behavior in a method designed to be overriden,
         as this prefix is reserved for future methods in order to be

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -75,7 +75,7 @@ def parse_timedelta(
     """
     This converts a user provided string into a timedelta
 
-    The units should be in order from largest to smallest. 
+    The units should be in order from largest to smallest.
     This works with or without whitespace.
 
     Parameters

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -623,7 +623,10 @@ class RedHelpFormatter(HelpFormatterABC):
 
     @staticmethod
     async def help_filter_func(
-        ctx, objects: Iterable[SupportsCanSee], help_settings: HelpSettings, bypass_hidden=False,
+        ctx,
+        objects: Iterable[SupportsCanSee],
+        help_settings: HelpSettings,
+        bypass_hidden=False,
     ) -> AsyncIterator[SupportsCanSee]:
         """
         This does most of actual filtering.

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -443,7 +443,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             await ctx.send(embed=embed)
         else:
             python_version = "{}.{}.{}".format(*sys.version_info[:3])
-            dpy_version = "{}".format(discord.__version__,)
+            dpy_version = "{}".format(discord.__version__)
             red_version = "{}".format(__version__)
 
             about = _(

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -124,7 +124,7 @@ def cog_data_path(cog_instance=None, raw_name: str = None) -> Path:
     Parameters
     ----------
     cog_instance
-        The instance of the cog you wish to get a data path for. 
+        The instance of the cog you wish to get a data path for.
         If calling from a command or method of your cog, this should be ``self``.
     raw_name : str
         The name of the cog to get a data path for.

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -115,7 +115,7 @@ def init_events(bot, cli_flags):
                     "**we highly recommend you to read the update docs at <{docs}> and "
                     "make sure there is nothing else that "
                     "needs to be done during the update.**"
-                ).format(docs="https://docs.discord.red/en/stable/update_red.html",)
+                ).format(docs="https://docs.discord.red/en/stable/update_red.html")
                 if expected_version(current_python, py_version_req):
                     installed_extras = []
                     for extra, reqs in red_pkg._dep_map.items():
@@ -142,8 +142,10 @@ def init_events(bot, cli_flags):
                         if platform.system() == "Windows"
                         else _("Terminal")
                     )
-                    extra_update += '```"{python}" -m pip install -U Red-DiscordBot{package_extras}```'.format(
-                        python=sys.executable, package_extras=package_extras
+                    extra_update += (
+                        '```"{python}" -m pip install -U Red-DiscordBot{package_extras}```'.format(
+                            python=sys.executable, package_extras=package_extras
+                        )
                     )
 
                 else:
@@ -222,7 +224,7 @@ def init_events(bot, cli_flags):
             await ctx.send_help()
         elif isinstance(error, commands.ArgParserFailure):
             msg = _("`{user_input}` is not a valid value for `{command}`").format(
-                user_input=error.user_input, command=error.cmd,
+                user_input=error.user_input, command=error.cmd
             )
             if error.custom_help_msg:
                 msg += f"\n{error.custom_help_msg}"

--- a/redbot/core/settings_caches.py
+++ b/redbot/core/settings_caches.py
@@ -14,9 +14,9 @@ from .utils import AsyncIter
 class PrefixManager:
     def __init__(self, config: Config, cli_flags: Namespace):
         self._config: Config = config
-        self._global_prefix_overide: Optional[List[str]] = sorted(
-            cli_flags.prefix, reverse=True
-        ) or None
+        self._global_prefix_overide: Optional[List[str]] = (
+            sorted(cli_flags.prefix, reverse=True) or None
+        )
         self._cached: Dict[Optional[int], List[str]] = {}
 
     async def get_prefixes(self, guild: Optional[discord.Guild] = None) -> List[str]:

--- a/redbot/core/utils/__init__.py
+++ b/redbot/core/utils/__init__.py
@@ -154,7 +154,7 @@ async def _sem_wrapper(sem, task):
 
 
 def bounded_gather_iter(
-    *coros_or_futures, limit: int = 4, semaphore: Optional[Semaphore] = None,
+    *coros_or_futures, limit: int = 4, semaphore: Optional[Semaphore] = None
 ) -> Iterator[Awaitable[Any]]:
     """
     An iterator that returns tasks as they are ready, but limits the

--- a/redbot/core/utils/menus.py
+++ b/redbot/core/utils/menus.py
@@ -169,7 +169,7 @@ async def close_menu(
 
 
 def start_adding_reactions(
-    message: discord.Message, emojis: Iterable[_ReactableEmoji],
+    message: discord.Message, emojis: Iterable[_ReactableEmoji]
 ) -> asyncio.Task:
     """Start adding reactions to a message.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,7 +87,8 @@ docs =
 postgres =
     asyncpg==0.20.1
 style =
-    black==19.10b0
+    black==20.8b1
+    mypy-extensions==0.4.3
     pathspec==0.8.0
     regex==2020.7.14
     toml==0.10.1


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature
- [x] Dependency update

### Description of the changes
Bumps black version and reformats with it. The biggest fix (but also style/behavior change) in Black 20.8b is proper handling of "magic trailing comma", which you can notice in the diffs.

So Black will now explode collections and any bracket pair **if** a trailing comma is present in it.
Since previous version had some issues with how it handled this, you can see in the diffs that there are places where Black now explodes the collection/bracket pair. There were few places where exploding didn't make sense so I removed the wrongly placed commas there.

As for other changes, Black now formats docstrings and handles some multiline things a bit differently which is what rest of the things in the diff are about.

// It might be worth to wait few days with this as it's very much possible that Black will need some hotfix releases.
There's not that much of reformatting and I don't see anything that could make existing PRs conflict so there's probably no need to postpone this more than aforementioned few days.