### PR TITLE
Ensure Bank API only works with Integers.

### DIFF
--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -203,16 +203,16 @@ async def can_spend(member: discord.Member, amount: int) -> bool:
     return await get_balance(member) >= amount
 
 
-async def set_balance(member: Union[discord.Member, discord.User], amount: float) -> int:
+async def set_balance(member: Union[discord.Member, discord.User], amount: Union[int, float]) -> int:
     """Set an account balance.
 
     Parameters
     ----------
     member : Union[discord.Member, discord.User]
         The member whose balance to set.
-    amount : int
-        The amount to set the balance to.
-
+    amount : Union[int, float]
+        The amount to set the balance to. [This gets converted to an integer]
+    
     Returns
     -------
     int

--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -203,7 +203,7 @@ async def can_spend(member: discord.Member, amount: int) -> bool:
     return await get_balance(member) >= amount
 
 
-async def set_balance(member: Union[discord.Member, discord.User], amount: int) -> int:
+async def set_balance(member: Union[discord.Member, discord.User], amount: float) -> int:
     """Set an account balance.
 
     Parameters
@@ -229,6 +229,7 @@ async def set_balance(member: Union[discord.Member, discord.User], amount: int) 
         ``bank._MAX_BALANCE``.
 
     """
+    amount = int(amount)
     if amount < 0:
         raise ValueError("Not allowed to have negative balance.")
     guild = getattr(member, "guild", None)

--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -191,6 +191,11 @@ async def can_spend(member: discord.Member, amount: int) -> bool:
     amount : int
         The amount the member wants to spend.
 
+    Raises
+    ------
+    TypeError
+        If the amount is not an `int`.
+
     Returns
     -------
     bool
@@ -198,21 +203,22 @@ async def can_spend(member: discord.Member, amount: int) -> bool:
         amount, else :code:`False`.
 
     """
+    if not isinstance(amount, int):
+        raise TypeError("Amount must be of type int, not {}.".format(type(amount)))
     if _invalid_amount(amount):
         return False
     return await get_balance(member) >= amount
 
 
-async def set_balance(member: Union[discord.Member, discord.User], amount: Union[int, float]) -> int:
+async def set_balance(member: Union[discord.Member, discord.User], amount: int) -> int:
     """Set an account balance.
 
     Parameters
     ----------
     member : Union[discord.Member, discord.User]
         The member whose balance to set.
-    amount : Union[int, float]
-        The amount to set the balance to. [This gets converted to an integer]
-    
+    amount : int
+        The amount to set the balance to.
     Returns
     -------
     int
@@ -227,9 +233,12 @@ async def set_balance(member: Union[discord.Member, discord.User], amount: Union
     BalanceTooHigh
         If attempting to set the balance to a value greater than
         ``bank._MAX_BALANCE``.
+    TypeError
+        If the amount is not an `int`.
 
     """
-    amount = int(amount)
+    if not isinstance(amount, int):
+        raise TypeError("Amount must be of type int, not {}.".format(type(amount)))
     if amount < 0:
         raise ValueError("Not allowed to have negative balance.")
     guild = getattr(member, "guild", None)
@@ -800,7 +809,12 @@ async def set_max_balance(amount: int, guild: discord.Guild = None) -> int:
         If the bank is guild-specific and guild was not provided.
     ValueError
         If the amount is less than 0 or higher than 2 ** 63 - 1.
+    TypeError
+        If the amount is not an `int`.
+
     """
+    if not isinstance(amount, int):
+        raise TypeError("Amount must be of type int, not {}.".format(type(amount)))
     if not (0 < amount <= _MAX_BALANCE):
         raise ValueError(
             "Amount must be greater than zero and less than {max}.".format(
@@ -869,9 +883,12 @@ async def set_default_balance(amount: int, guild: discord.Guild = None) -> int:
         If the bank is guild-specific and guild was not provided.
     ValueError
         If the amount is less than 0 or higher than the max allowed balance.
+    TypeError
+        If the amount is not an `int`.
 
     """
-    amount = int(amount)
+    if not isinstance(amount, int):
+        raise TypeError("Amount must be of type int, not {}.".format(type(amount)))
     max_bal = await get_max_balance(guild)
 
     if not (0 <= amount <= max_bal):
@@ -906,6 +923,8 @@ def cost(amount: int):
 
     Other exceptions will propagate and will be handled by Red's (and/or
     any other configured) error handling.
+
+    TODO: Add documentation for input/output/exceptions
     """
     if not isinstance(amount, int) or amount < 0:
         raise ValueError("This decorator requires an integer cost greater than or equal to zero")

--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -924,8 +924,8 @@ def cost(amount: int):
     Other exceptions will propagate and will be handled by Red's (and/or
     any other configured) error handling.
 
-    TODO: Add documentation for input/output/exceptions
     """
+    # TODO: Add documentation for input/output/exceptions
     if not isinstance(amount, int) or amount < 0:
         raise ValueError("This decorator requires an integer cost greater than or equal to zero")
 


### PR DESCRIPTION
### Type

- [X ] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Per PR #4372  from @Drapersniper in Testing for Red Discord. https://discord.com/channels/133049272517001216/171665724262055936/748529319759970325
Change bank.set_balance amount typehint to float and cast to int later.
https://github.com/Cog-Creators/Red-DiscordBot/pull/4372/commits/6199653670ed25387da51ff6b9da5cc29535e9f1#diff-88a9ebbf67d6343dee1a7d2255998245R367