### PR TITLE
Update `.gitignore` with `.vscode` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Pipfile.lock
 # User-specific stuff:
 .idea/
 *.iws
+.vscode/
 
 ## Plugin-specific files:
 


### PR DESCRIPTION
Apparently there was some use case for ignoring all `*.json` files in `.gitignore`. Added `.vscode` folder to ignored folders.