### PR TITLE
[Dev] Automatically import modules

### DIFF
--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -68,9 +68,12 @@ class EnvImporter(dict):
     async def send_imports(self, ctx: commands.Context):
         if not self.imported:
             return
-        message = "\n".join(f"import {key}" for key in self.imported)
+        message = [
+            "# These modules were automatically imported when running your code:",
+            *map("import {}".format, self.imported),
+        ]
         self.imported.clear()
-        for page in pagify(message, shorten_by=10):
+        for page in pagify("\n".join(message), shorten_by=10):
             await ctx.send(box(page, lang="py"))
 
 

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -137,6 +137,7 @@ class Dev(commands.Cog):
             channel  - the current channel object
             author   - command author's member object
             message  - the command's message object
+            asyncio  - the asyncio standard library
             aiohttp  - aiohttp library
             discord  - discord.py library
             commands - redbot.core.commands
@@ -181,6 +182,7 @@ class Dev(commands.Cog):
             channel  - the current channel object
             author   - command author's member object
             message  - the command's message object
+            asyncio  - the asyncio standard library
             aiohttp  - aiohttp library
             discord  - discord.py library
             commands - redbot.core.commands


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [X] New feature

### Description of the changes
Allows Dev's commands to attempt to import modules before throwing NameErrors.

There are a couple minor, unrelated changes that are in this PR; feel free to let me know if you'd rather theses be in a separate PR.
- Docstrings have been updated with the fact that `asyncio` and `aiohttp` are included in the environment (this was missed in #3508)
- repl will now take in _last_result when first called for easily continuing from a debug / eval statement. It does not set _last_result.