### PR TITLE
Let the bot owners know what the origin of `send_to_owners` is.

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1407,6 +1407,7 @@ class RedBase(
 
         async def wrapped_send(location, content=None, **kwargs):
             try:
+                await location.send(f"The following message is from {cog_name}")
                 await location.send(content, **kwargs)
             except Exception as _exc:
                 log.error(
@@ -1417,9 +1418,6 @@ class RedBase(
                     exc_info=_exc,
                 )
 
-        content = "Message from {cog_name}:\n{content}".format(
-            cog_name=cog_name, content=content if content is not None else ""
-        )
         sends = [wrapped_send(d, content, **kwargs) for d in destinations]
         await asyncio.gather(*sends)
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1417,7 +1417,7 @@ class RedBase(
                     exc_info=_exc,
                 )
 
-        content = "Message from {cog_name}\n{content}".format(
+        content = "Message from {cog_name}:\n{content}".format(
             cog_name=cog_name, content=content if content is not None else ""
         )
         content = content[:1999]

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1393,7 +1393,7 @@ class RedBase(
 
         return destinations
 
-    def send_to_owners(self, content=None, **kwargs):
+    def send_to_owners(self, content=None, show_origin_message: bool = True, **kwargs):
         """
         This sends something to all owners and their configured extra destinations.
 
@@ -1401,10 +1401,15 @@ class RedBase(
 
         This logs failing sends
         """
-        cog_name = get_cog_by_call(self, "send_to_owners")
-        return self._send_to_owners(cog_name, content, **kwargs)
+        if show_origin_message:
+            cog_name = get_cog_by_call(self, "send_to_owners")
+        else:
+            cog_name = None
+        return self._send_to_owners(
+            cog_name, content, show_origin_message=show_origin_message, **kwargs
+        )
 
-    async def _send_to_owners(self, cog_name: str, content=None, **kwargs):
+    async def _send_to_owners(self, cog_name: Optional[str], content=None, **kwargs):
         """
         This sends something to all owners and their configured extra destinations.
 
@@ -1417,11 +1422,11 @@ class RedBase(
         async def wrapped_send(location, content=None, **kwargs):
             try:
                 await location.send(content, **kwargs)
-                await location.send(f"The message above came from: {cog_name}")
+                if cog_name:
+                    await location.send(f"The message above came from: {cog_name}")
             except Exception as _exc:
                 log.error(
-                    "I could not send an owner notification from cog '%s' to %s (%s)",
-                    cog_name,
+                    "I could not send an owner notification to %s (%s)",
                     location,
                     location.id,
                     exc_info=_exc,

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1407,8 +1407,8 @@ class RedBase(
 
         async def wrapped_send(location, content=None, **kwargs):
             try:
-                await location.send(f"The following message is from {cog_name}")
                 await location.send(content, **kwargs)
+                await location.send(f"The message above came from: {cog_name}")
             except Exception as _exc:
                 log.error(
                     "I could not send an owner notification from cog '%s' to %s (%s)",

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1393,7 +1393,7 @@ class RedBase(
 
         return destinations
 
-    async def send_to_owners(self, content=None, **kwargs):
+    def send_to_owners(self, content=None, **kwargs):
         """
         This sends something to all owners and their configured extra destinations.
 
@@ -1402,7 +1402,16 @@ class RedBase(
         This logs failing sends
         """
         cog_name = get_cog_by_call(self, "send_to_owners")
+        return self._send_to_owners(cog_name, content, **kwargs)
 
+    async def _send_to_owners(self, cog_name: str, content=None, **kwargs):
+        """
+        This sends something to all owners and their configured extra destinations.
+
+        This takes the same arguments as discord.abc.Messageable.send
+
+        This logs failing sends
+        """
         destinations = await self.get_owner_notification_destinations()
 
         async def wrapped_send(location, content=None, **kwargs):

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1420,7 +1420,6 @@ class RedBase(
         content = "Message from {cog_name}:\n{content}".format(
             cog_name=cog_name, content=content if content is not None else ""
         )
-        content = content[:1999]
         sends = [wrapped_send(d, content, **kwargs) for d in destinations]
         await asyncio.gather(*sends)
 

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -277,8 +277,9 @@ async def send_to_owners_with_preprocessor(
         try:
             if preprocessor is not None:
                 content = await preprocessor(bot, location, content)
-            await location.send(f"The following message is from {cog_name}")
             await location.send(content, **kwargs)
+            await location.send(f"The message above came from: {cog_name}")
+
         except Exception as _exc:
             main_log.error(
                 "I could not send an owner notification from cog '%s' to %s (%s)",

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -340,9 +340,13 @@ def get_cog_by_call(bot: Red, func: str) -> str:
         index = -2
     if index >= 0:
         frm = stack[index + 1]
-        caller_package = inspect.getmodule(frm[0]).__package__.split(".")[0]
-        if caller_package == "redbot":
-            return "Core"
+        full_caller_page = inspect.getmodule(frm[0]).__package__
+        if full_caller_page.startswith("redbot.cogs."):
+            cog_name = full_caller_page.split(".")[2]
+            return f"Red Core - `{cog_name}`"
+        elif full_caller_page.startswith("redbot"):
+            return "Red Core"
+        caller_package = full_caller_page.split(".")[0]
         for cog_name, cog in bot._BotBase__cogs.items():
             cog_package = inspect.getmodule(cog).__package__.split(".")[0]
             if cog_package == caller_package:

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -290,7 +290,6 @@ async def send_to_owners_with_preprocessor(
     content = "Message from {cog_name}:\n{content}".format(
         cog_name=cog_name, content=content if content is not None else ""
     )
-    content = content[:1999]
     sends = [wrapped_send(bot, d, content, content_preprocessor, **kwargs) for d in destinations]
     await asyncio.gather(*sends)
 

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -277,6 +277,7 @@ async def send_to_owners_with_preprocessor(
         try:
             if preprocessor is not None:
                 content = await preprocessor(bot, location, content)
+            await location.send(f"The following message is from {cog_name}")
             await location.send(content, **kwargs)
         except Exception as _exc:
             main_log.error(
@@ -287,9 +288,6 @@ async def send_to_owners_with_preprocessor(
                 exc_info=_exc,
             )
 
-    content = "Message from {cog_name}:\n{content}".format(
-        cog_name=cog_name, content=content if content is not None else ""
-    )
     sends = [wrapped_send(bot, d, content, content_preprocessor, **kwargs) for d in destinations]
     await asyncio.gather(*sends)
 

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -265,8 +265,8 @@ def send_to_owners_with_preprocessor(
         and returns the content that should be sent to given location.
     """
     try:
-        stack = inspect.stack()
-        if stack[1].function == "send_to_owners_with_prefix_replaced":
+        frame = inspect.currentframe().f_back
+        if frame.f_code.co_name == "send_to_owners_with_prefix_replaced":
             func = "send_to_owners_with_prefix_replaced"
         else:
             func = "send_to_owners_with_preprocessor"
@@ -394,7 +394,7 @@ def get_cog_by_call(bot: Red, func: str) -> str:
                 return "Red Core"
             caller_package = full_caller_page.split(".")[0]
             for cog_name, cog in bot._BotBase__cogs.items():
-                cog_package = inspect.getmodule(cog).__package__.split(".")[0]
+                cog_package = cog.__module__.split(".")[0]
                 if cog_package == caller_package:
                     valid = True
                     break

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -344,6 +344,8 @@ def get_cog_by_call(bot: Red, func: str) -> str:
     if index >= 0:
         frm = stack[index + 1]
         caller_package = inspect.getmodule(frm[0]).__package__.split(".")[0]
+        if caller_package == "redbot":
+            return "Core"
         for cog_name, cog in bot._BotBase__cogs.items():
             cog_package = inspect.getmodule(cog).__package__.split(".")[0]
             if cog_package == caller_package:

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -342,7 +342,9 @@ def get_cog_by_call(bot: Red, func: str) -> str:
     if index >= 0:
         frm = stack[index + 1]
         full_caller_page = inspect.getmodule(frm[0]).__package__
-        if full_caller_page.startswith("redbot.cogs."):
+        if full_caller_page.startswith("asyncio"):
+            return "A task, unable to pinpoint origin."
+        elif full_caller_page.startswith("redbot.cogs."):
             cog_name = full_caller_page.split(".")[2]
             return f"Red Core - `{cog_name}`"
         elif full_caller_page.startswith("redbot"):
@@ -354,5 +356,6 @@ def get_cog_by_call(bot: Red, func: str) -> str:
                 valid = True
                 break
     if not valid:
+        cog_name = "Unknown"
         main_log.warning("Red cannot figure out where the `%s` is being called from.", func)
     return cog_name

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -287,7 +287,7 @@ async def send_to_owners_with_preprocessor(
                 exc_info=_exc,
             )
 
-    content = "Message from {cog_name}\n{content}".format(
+    content = "Message from {cog_name}:\n{content}".format(
         cog_name=cog_name, content=content if content is not None else ""
     )
     content = content[:1999]


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

Since `send_to_owners` and its variations can be used from anywhere and by anything i can easily spam users with not very useful messages, this PR ensure that the user is always aware of where the message is originating from so that they can take appropriate action.
