### PR TITLE
[Announce] No error message

### DIFF
--- a/redbot/cogs/admin/announcer.py
+++ b/redbot/cogs/admin/announcer.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import Optional
 
 import discord

--- a/redbot/cogs/admin/announcer.py
+++ b/redbot/cogs/admin/announcer.py
@@ -56,7 +56,7 @@ class Announcer:
             failed_reason = None
 
             if channel is None:
-                failed_reason = _("Channel removed or not set.")
+                failed_reason = _("The announcement channel was removed or not set.")
             else:
                 if channel.permissions_for(g.me).send_messages:
                     try:
@@ -79,7 +79,7 @@ class Announcer:
                 else _("I could not announce to the following servers: ")
             )
             errors_list = [
-                _("\n{guild}. Reason: {reason}").format(guild=inline(guild_id), reason=reason)
+                _("\nServer ID: {guild}. Reason: {reason}").format(guild=inline(guild_id), reason=reason)
                 for guild_id, reason in zip(failed_guilds, fail_reasons)
             ]
             msg += "".join(errors_list)

--- a/redbot/cogs/admin/announcer.py
+++ b/redbot/cogs/admin/announcer.py
@@ -4,7 +4,7 @@ import discord
 from redbot.core import commands
 from redbot.core.i18n import Translator
 from redbot.core.utils import AsyncIter
-from redbot.core.utils.chat_formatting import humanize_list, inline
+from redbot.core.utils.chat_formatting import inline
 
 _ = Translator("Announcer", __file__)
 

--- a/redbot/cogs/admin/announcer.py
+++ b/redbot/cogs/admin/announcer.py
@@ -79,9 +79,12 @@ class Announcer:
                 else _("I could not announce to the following servers: ")
             )
             errors_list = [
-                _("\nServer ID: {guild}. Reason: {reason}").format(guild=inline(guild_id), reason=reason)
+                _("\nServer ID: {guild}. Reason: {reason}").format(
+                    guild=inline(guild_id), reason=reason
+                )
                 for guild_id, reason in zip(failed_guilds, fail_reasons)
             ]
             msg += "".join(errors_list)
             await self.ctx.bot.send_to_owners(msg)
+
         self.active = False

--- a/redbot/cogs/admin/announcer.py
+++ b/redbot/cogs/admin/announcer.py
@@ -53,14 +53,17 @@ class Announcer:
 
             channel = await self._get_announce_channel(g)
 
-            if channel:
-                if channel.permissions_for(g.me).send_messages:
-                    try:
-                        await channel.send(self.message)
-                    except discord.Forbidden:
-                        failed.append(str(g.id))
-                else:
+            if channel is None:
+                failed.append(str(g.id))
+                continue
+
+            if channel.permissions_for(g.me).send_messages:
+                try:
+                    await channel.send(self.message)
+                except discord.Forbidden:
                     failed.append(str(g.id))
+            else:
+                failed.append(str(g.id))
 
         if failed:
             msg = (

--- a/redbot/cogs/admin/announcer.py
+++ b/redbot/cogs/admin/announcer.py
@@ -79,7 +79,7 @@ class Announcer:
                 else _("I could not announce to the following servers: ")
             )
             errors_list = [
-                f"\n{inline(guild_id)}. Reason: {reason}"
+                _("\n{guild}. Reason: {reason}").format(guild=inline(guild_id), reason=reason)
                 for guild_id, reason in zip(failed_guilds, fail_reasons)
             ]
             msg += "".join(errors_list)

--- a/redbot/cogs/admin/announcer.py
+++ b/redbot/cogs/admin/announcer.py
@@ -53,24 +53,24 @@ class Announcer:
                 return
 
             channel = await self._get_announce_channel(g)
-            failed_reason = None
+            fail_reason = None
 
             if channel is None:
-                failed_reason = _("The announcement channel was removed or not set.")
+                fail_reason = _("The announcement channel was removed or not set.")
             else:
                 if channel.permissions_for(g.me).send_messages:
                     try:
                         await channel.send(self.message)
                     except discord.Forbidden:
-                        failed_reason = _("I'm not allowed to do that.")
+                        fail_reason = _("I'm not allowed to do that.")
                 else:
-                    failed_reason = _(
+                    fail_reason = _(
                         "I do not have permissions to send messages in {channel}!"
                     ).format(channel=channel.mention)
 
-            if failed_reason is not None:
+            if fail_reason is not None:
                 failed_guilds.append(str(g.id))
-                fail_reasons.append(failed_reason)
+                fail_reasons.append(fail_reason)
 
         if failed_guilds:
             msg = (

--- a/redbot/core/commands/requires.py
+++ b/redbot/core/commands/requires.py
@@ -473,7 +473,7 @@ class Requires:
         Parameters
         ----------
         ctx : "Context"
-            The invkokation context to check with.
+            The invocation context to check with.
 
         Returns
         -------
@@ -486,7 +486,7 @@ class Requires:
             If the bot is missing required permissions to run the
             command.
         CommandError
-            Propogated from any permissions checks.
+            Propagated from any permissions checks.
 
         """
         if not self.ready_event.is_set():


### PR DESCRIPTION
### Type

- [X] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
 Bot now sends a error message to the owners after trying to announce on a server where the announcement channel was not set/deleted.
 I also added a specific message to the exception discord.Forbidden and to when the bot does not have permission to send messages on the channel, and fixed two typos I found in a docstring on another module.
 Closes #4196.