### PR TITLE
[Modlog API] Handle deleted channels in `Case.message_content()`

### DIFF
--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -427,7 +427,10 @@ class Case:
             if until and duration:
                 case_text += _("**Until:** {}\n**Duration:** {}\n").format(until, duration)
             if self.channel:
-                case_text += _("**Channel**: {}\n").format(self.channel.name)
+                if isinstance(self.channel,int):
+                    case_text += _("**Channel**: {} (Deleted)\n").format(self.channel)
+                else:
+                    case_text += _("**Channel**: {}\n").format(self.channel.name)
             if amended_by:
                 case_text += _("**Amended by:** {}\n").format(amended_by)
             if last_modified:

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -388,12 +388,10 @@ class Case:
                 user = f"[{translated}] ({self.user})"
             else:
                 user = f"{self.last_known_username} ({self.user})"
-            avatar_url = None
         else:
             user = escape_spoilers(
                 filter_invites(f"{self.user} ({self.user.id})")
             )  # Invites and spoilers get rendered even in embeds.
-            avatar_url = self.user.avatar_url
 
         if embed:
             emb = discord.Embed(title=title, description=reason)
@@ -427,7 +425,7 @@ class Case:
             if until and duration:
                 case_text += _("**Until:** {}\n**Duration:** {}\n").format(until, duration)
             if self.channel:
-                if isinstance(self.channel,int):
+                if isinstance(self.channel, int):
                     case_text += _("**Channel**: {} (Deleted)\n").format(self.channel)
                 else:
                     case_text += _("**Channel**: {}\n").format(self.channel.name)


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Modlog now doesn't error in non-embedded version when a channel doesn't exist anymore.