### PR TITLE
Add `quote()` function to chat formatting utilities

### DIFF
--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -327,17 +327,13 @@ def underline(text: str, escape_formatting: bool = True) -> str:
     return "__{}__".format(text)
 
 
-def quote(text: str, escape_formatting: bool = False) -> str:
+def quote(text: str) -> str:
     """Quotes the given text.
-
-    Note: By default, this function will **not** escape ``text`` prior to quoting.
 
     Parameters
     ----------
     text : str
         The text to be marked up.
-    escape_formatting : `bool`, optional
-        Set to :code:`True` to escape markdown formatting in the text.
 
     Returns
     -------
@@ -345,7 +341,6 @@ def quote(text: str, escape_formatting: bool = False) -> str:
         The marked up text.
 
     """
-    text = escape(text, formatting=escape_formatting)
     return textwrap.indent(text, "> ", lambda l: True)
 
 

--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -330,7 +330,7 @@ def underline(text: str, escape_formatting: bool = True) -> str:
 def quote(text: str, escape_formatting: bool = False) -> str:
     """Quotes the given text.
 
-    Note: By default, this function will **not** escape ``text`` prior to underlining.
+    Note: By default, this function will **not** escape ``text`` prior to quoting.
 
     Parameters
     ----------

--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -1,5 +1,6 @@
 import datetime
 import itertools
+import textwrap
 from io import BytesIO
 from typing import Iterator, List, Optional, Sequence, SupportsInt, Union
 
@@ -324,6 +325,28 @@ def underline(text: str, escape_formatting: bool = True) -> str:
     """
     text = escape(text, formatting=escape_formatting)
     return "__{}__".format(text)
+
+
+def quote(text: str, escape_formatting: bool = False) -> str:
+    """Quotes the given text.
+
+    Note: By default, this function will **not** escape ``text`` prior to underlining.
+
+    Parameters
+    ----------
+    text : str
+        The text to be marked up.
+    escape_formatting : `bool`, optional
+        Set to :code:`True` to escape markdown formatting in the text.
+
+    Returns
+    -------
+    str
+        The marked up text.
+
+    """
+    text = escape(text, formatting=escape_formatting)
+    return textwrap.indent(text, "> ", lambda l: True)
 
 
 def escape(text: str, *, mass_mentions: bool = False, formatting: bool = False) -> str:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [X] New feature

### Description of the changes
Note that, unlike other methods in this module, this method does *not* escape formatting by default at current.