### PR TITLE
Add `[p]listcases` command and typing indicator to `[p]casesfor`

### DIFF
--- a/redbot/cogs/modlog/modlog.py
+++ b/redbot/cogs/modlog/modlog.py
@@ -38,7 +38,7 @@ class ModLog(commands.Cog):
         await modlog.handle_auditype_key()
         await ctx.tick()
 
-    @modlogset.command()
+    @modlogset.command(aliases=["channel"])
     @commands.guild_only()
     async def modlog(self, ctx: commands.Context, channel: discord.TextChannel = None):
         """Set a channel as the modlog.

--- a/redbot/cogs/modlog/modlog.py
+++ b/redbot/cogs/modlog/modlog.py
@@ -7,7 +7,7 @@ import discord
 from redbot.core import checks, commands, modlog
 from redbot.core.bot import Red
 from redbot.core.i18n import Translator, cog_i18n
-from redbot.core.utils.chat_formatting import box
+from redbot.core.utils.chat_formatting import box, pagify
 from redbot.core.utils.menus import DEFAULT_CONTROLS, menu
 
 _ = Translator("ModLog", __file__)
@@ -38,7 +38,7 @@ class ModLog(commands.Cog):
         await modlog.handle_auditype_key()
         await ctx.tick()
 
-    @modlogset.command(aliases=["channel"])
+    @modlogset.command()
     @commands.guild_only()
     async def modlog(self, ctx: commands.Context, channel: discord.TextChannel = None):
         """Set a channel as the modlog.
@@ -129,39 +129,76 @@ class ModLog(commands.Cog):
     @commands.guild_only()
     async def casesfor(self, ctx: commands.Context, *, member: Union[discord.Member, int]):
         """Display cases for the specified member."""
-        try:
-            if isinstance(member, int):
-                cases = await modlog.get_cases_for_member(
-                    bot=ctx.bot, guild=ctx.guild, member_id=member
+        async with ctx.typing():
+            try:
+                if isinstance(member, int):
+                    cases = await modlog.get_cases_for_member(
+                        bot=ctx.bot, guild=ctx.guild, member_id=member
+                    )
+                else:
+                    cases = await modlog.get_cases_for_member(
+                        bot=ctx.bot, guild=ctx.guild, member=member
+                    )
+            except discord.NotFound:
+                return await ctx.send(_("That user does not exist."))
+            except discord.HTTPException:
+                return await ctx.send(
+                    _("Something unexpected went wrong while fetching that user by ID.")
                 )
-            else:
-                cases = await modlog.get_cases_for_member(
-                    bot=ctx.bot, guild=ctx.guild, member=member
+
+            if not cases:
+                return await ctx.send(_("That user does not have any cases."))
+
+            embed_requested = await ctx.embed_requested()
+            if embed_requested:
+                rendered_cases = [await case.message_content(embed=True) for case in cases]
+            elif not embed_requested:
+                rendered_cases = []
+                for case in cases:
+                    message = _("{case}\n**Timestamp:** {timestamp}").format(
+                        case=await case.message_content(embed=False),
+                        timestamp=datetime.utcfromtimestamp(case.created_at).strftime(
+                            "%Y-%m-%d %H:%M:%S UTC"
+                        ),
+                    )
+                    rendered_cases.append(message)
+
+        await menu(ctx, rendered_cases, DEFAULT_CONTROLS)
+
+    @commands.command()
+    @commands.guild_only()
+    async def listcases(self, ctx: commands.Context, *, member: Union[discord.Member, int]):
+        """List cases for the specified member."""
+        async with ctx.typing():
+            try:
+                if isinstance(member, int):
+                    cases = await modlog.get_cases_for_member(
+                        bot=ctx.bot, guild=ctx.guild, member_id=member
+                    )
+                else:
+                    cases = await modlog.get_cases_for_member(
+                        bot=ctx.bot, guild=ctx.guild, member=member
+                    )
+            except discord.NotFound:
+                return await ctx.send(_("That user does not exist."))
+            except discord.HTTPException:
+                return await ctx.send(
+                    _("Something unexpected went wrong while fetching that user by ID.")
                 )
-        except discord.NotFound:
-            return await ctx.send(_("That user does not exist."))
-        except discord.HTTPException:
-            return await ctx.send(
-                _("Something unexpected went wrong while fetching that user by ID.")
-            )
+            if not cases:
+                return await ctx.send(_("That user does not have any cases."))
 
-        if not cases:
-            return await ctx.send(_("That user does not have any cases."))
-
-        embed_requested = await ctx.embed_requested()
-        if embed_requested:
-            rendered_cases = [await case.message_content(embed=True) for case in cases]
-        elif not embed_requested:
             rendered_cases = []
+            message = ""
             for case in cases:
-                message = _("{case}\n**Timestamp:** {timestamp}").format(
+                message += _("{case}\n**Timestamp:** {timestamp}\n").format(
                     case=await case.message_content(embed=False),
                     timestamp=datetime.utcfromtimestamp(case.created_at).strftime(
                         "%Y-%m-%d %H:%M:%S UTC"
                     ),
                 )
-                rendered_cases.append(message)
-
+            for page in pagify(message):
+                rendered_cases.append(page)
         await menu(ctx, rendered_cases, DEFAULT_CONTROLS)
 
     @commands.command()

--- a/redbot/cogs/modlog/modlog.py
+++ b/redbot/cogs/modlog/modlog.py
@@ -197,7 +197,7 @@ class ModLog(commands.Cog):
                         "%Y-%m-%d %H:%M:%S UTC"
                     ),
                 )
-            for page in pagify(message, ["\n\n", "\n"]):
+            for page in pagify(message, ["\n\n", "\n"], priority=True):
                 rendered_cases.append(page)
         await menu(ctx, rendered_cases, DEFAULT_CONTROLS)
 

--- a/redbot/cogs/modlog/modlog.py
+++ b/redbot/cogs/modlog/modlog.py
@@ -191,13 +191,13 @@ class ModLog(commands.Cog):
             rendered_cases = []
             message = ""
             for case in cases:
-                message += _("{case}\n**Timestamp:** {timestamp}\n").format(
+                message += _("{case}\n**Timestamp:** {timestamp}\n\n").format(
                     case=await case.message_content(embed=False),
                     timestamp=datetime.utcfromtimestamp(case.created_at).strftime(
                         "%Y-%m-%d %H:%M:%S UTC"
                     ),
                 )
-            for page in pagify(message):
+            for page in pagify(message, ["\n\n", "\n"]):
                 rendered_cases.append(page)
         await menu(ctx, rendered_cases, DEFAULT_CONTROLS)
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [x] New feature

### Description of the changes
This adds a `[p]listcases` command to show multiple cases for a user in a single message rather than trying to utilize the menu for each individual case. This also adds a typing indicator to casesfor so you know the bot is working when there's a lot of modlog cases to gather.