### PR TITLE
Deprecate `is_allowed_by_hierarchy()` core util

### DIFF
--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -9,9 +9,10 @@ from redbot.core import commands, i18n, checks, modlog
 from redbot.core.commands import UserInputOptional
 from redbot.core.utils import AsyncIter
 from redbot.core.utils.chat_formatting import pagify, humanize_number, bold, humanize_list
-from redbot.core.utils.mod import is_allowed_by_hierarchy, get_audit_reason
+from redbot.core.utils.mod import get_audit_reason
 from .abc import MixinMeta
 from .converters import RawUserIds
+from .utils import is_allowed_by_hierarchy
 
 log = logging.getLogger("red.mod")
 _ = i18n.Translator("Mod", __file__)

--- a/redbot/cogs/mod/mutes.py
+++ b/redbot/cogs/mod/mutes.py
@@ -6,8 +6,9 @@ import discord
 from redbot.core import commands, checks, i18n, modlog
 from redbot.core.utils import AsyncIter
 from redbot.core.utils.chat_formatting import format_perms_list
-from redbot.core.utils.mod import get_audit_reason, is_allowed_by_hierarchy
+from redbot.core.utils.mod import get_audit_reason
 from .abc import MixinMeta
+from .utils import is_allowed_by_hierarchy
 
 T_ = i18n.Translator("Mod", __file__)
 

--- a/redbot/cogs/mod/utils.py
+++ b/redbot/cogs/mod/utils.py
@@ -1,0 +1,13 @@
+import discord
+
+from redbot.core.bot import Red
+from redbot.core.config import Config
+
+
+async def is_allowed_by_hierarchy(
+    bot: Red, config: Config, guild: discord.Guild, mod: discord.Member, user: discord.Member
+):
+    if not await config.guild(guild).respect_hierarchy():
+        return True
+    is_special = mod == guild.owner or await bot.is_owner(mod)
+    return mod.top_role.position > user.top_role.position or is_special

--- a/redbot/core/utils/mod.py
+++ b/redbot/core/utils/mod.py
@@ -1,4 +1,5 @@
 import asyncio
+import warnings
 from datetime import timedelta
 from typing import List, Iterable, Union, TYPE_CHECKING, Dict
 
@@ -92,6 +93,12 @@ def get_audit_reason(author: discord.Member, reason: str = None):
 async def is_allowed_by_hierarchy(
     bot: "Red", settings: "Config", guild: discord.Guild, mod: discord.Member, user: discord.Member
 ):
+    warnings.warn(
+        "`is_allowed_by_hierarchy()` is deprecated since Red 3.4.1"
+        " and will be removed in the first minor release after 2020-11-31.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if not await settings.guild(guild).respect_hierarchy():
         return True
     is_special = mod == guild.owner or await bot.is_owner(mod)


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature
- [x] Deprecation

### Description of the changes
This deprecates the utility that should been part of `redbot.cogs.mod` package to begin with and somehow ended up in our public core API.