### PR TITLE
Support added to return leaderboard size per issue 4200 + revised with Drapersnipers feedback on naming

### DIFF
--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -559,8 +559,8 @@ async def get_leaderboard(positions: int = None, guild: discord.Guild = None) ->
 
 
 async def get_leaderboard_position(
-    member: Union[discord.User, discord.Member]
-) -> Union[int, None]:
+    member: Union[discord.User, discord.Member], return_lb_size: bool = False
+) -> Union[Optional[int], Tuple[Optional[int], int]]:
     """
     Get the leaderboard position for the specified user
 
@@ -569,10 +569,15 @@ async def get_leaderboard_position(
     member : `discord.User` or `discord.Member`
         The user to get the leaderboard position of
 
+    return_lb_size : bool
+        Whether or not to return a tuple with position and size of leaderboard
+
+
     Returns
     -------
-    `int`
-        The position of the user on the leaderboard
+     Tuple[Optional[int], int]
+        The position of the user on the leaderboard and the leaderboard size if it was requested
+
 
     Raises
     ------
@@ -580,6 +585,7 @@ async def get_leaderboard_position(
         If the bank is currently guild-specific and a `discord.User` object was passed in
 
     """
+
     if await is_global():
         guild = None
     else:
@@ -591,9 +597,13 @@ async def get_leaderboard_position(
     else:
         pos = discord.utils.find(lambda x: x[1][0] == member.id, enumerate(leaderboard, 1))
         if pos is None:
-            return None
+            return_pos = None
         else:
-            return pos[0]
+            return_pos = pos[0]
+    if return_lb_size is True:
+        return return_pos, len(leaderboard)
+    else:
+        return return_pos
 
 
 async def get_account(member: Union[discord.Member, discord.User]) -> Account:


### PR DESCRIPTION
…ypes

### Type

- [ ] Bugfix
- [ X] Enhancement
- [ ] New feature

### Description of the changes
Support added to return leaderboard size per issue 4200 + revised with Drapersnipers feedback on naming