### PR TITLE
Add bundled install extras.

### DIFF
--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -119,15 +119,14 @@ def init_events(bot, cli_flags):
                 if expected_version(current_python, py_version_req):
                     installed_extras = []
                     for extra, reqs in red_pkg._dep_map.items():
-                        if extra is None:
+                        if extra is None or extra in {"dev", "all"}:
                             continue
                         try:
                             pkg_resources.require(req.name for req in reqs)
                         except pkg_resources.DistributionNotFound:
                             pass
                         else:
-                            if extra not in {"dev", "all"}:
-                                installed_extras.append(extra)
+                            installed_extras.append(extra)
 
                     if installed_extras:
                         package_extras = f"[{','.join(installed_extras)}]"

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -126,7 +126,8 @@ def init_events(bot, cli_flags):
                         except pkg_resources.DistributionNotFound:
                             pass
                         else:
-                            installed_extras.append(extra)
+                            if extra not in {"dev", "all"}:
+                                installed_extras.append(extra)
 
                     if installed_extras:
                         package_extras = f"[{','.join(installed_extras)}]"

--- a/setup.cfg
+++ b/setup.cfg
@@ -112,8 +112,10 @@ test =
     toml==0.10.1
     wrapt==1.12.1
 all =
-    %(docs)s
     %(postgres)s
+dev =
+    %(all)s
+    %(docs)s
     %(style)s
     %(test)s
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,6 +111,11 @@ test =
     six==1.15.0
     toml==0.10.1
     wrapt==1.12.1
+all =
+    %(docs)s
+    %(postgres)s
+    %(style)s
+    %(test)s
 
 [options.entry_points]
 console_scripts =

--- a/tools/dev-requirements.txt
+++ b/tools/dev-requirements.txt
@@ -1,3 +1,3 @@
 packaging
 tox
--e .[docs,postgres,style,test]
+-e .[all]

--- a/tools/dev-requirements.txt
+++ b/tools/dev-requirements.txt
@@ -1,3 +1,3 @@
 packaging
 tox
--e .[all]
+-e .[dev]


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Allow red and all its dependencies to be installed with `pip install Red-DiscordBot[all]` 