### PR TITLE
Remove protecting commands and cogs being removed with bot_remove_func

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1113,7 +1113,7 @@ class RedBase(
 
     def remove_cog(self, cogname: str):
         cog = self.get_cog(cogname)
-        if cog is None or isinstance(cog, commands.commands._RuleDropper):
+        if cog is None:
             return
 
         for cls in inspect.getmro(cog.__class__):
@@ -1270,9 +1270,6 @@ class RedBase(
                     subcommand.requires.ready_event.set()
 
     def remove_command(self, name: str) -> None:
-        command = self.get_command(name)
-        if isinstance(command, commands.commands._RuleDropper):
-            return
         command = super().remove_command(name)
         if not command:
             return


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Changes ruledropper so commands can always be removed and cogs as well, doesn't touch permisssions or disabling cogs. So functionality.
