### PR TITLE
fix `[p]set nickname` when no nickname specified

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1953,7 +1953,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     async def _nickname(self, ctx: commands.Context, *, nickname: str = None):
         """Sets [botname]'s nickname."""
         try:
-            if len(nickname) > 32:
+            if nickname and len(nickname) > 32:
                 await ctx.send(_("Failed to change nickname. Must be 32 characters or fewer."))
                 return
             await ctx.guild.me.edit(nick=nickname)


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Fix `[p]set nickname` when no nickname is specified.
Currently, `[p]set nickname` without nickname arg raises `TypeError: object of type 'NoneType' has no len()`