### PR TITLE
[Core] Change all toggles in core commands to setters

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1040,16 +1040,15 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
     @embedset.command(name="global")
     @checks.is_owner()
-    async def embedset_global(self, ctx: commands.Context):
+    async def embedset_global(self, ctx: commands.Context,enabled: bool):
         """
-        Toggle the global embed setting.
+        Set the global embed setting.
 
         This is used as a fallback if the user
         or guild hasn't set a preference. The
         default is to use embeds.
         """
-        current = await self.bot._config.embeds()
-        await self.bot._config.embeds.set(not current)
+        await self.bot._config.embeds.set(enabled)
         await ctx.send(
             _("Embeds are now {} by default.").format(_("disabled") if current else _("enabled"))
         )
@@ -1059,7 +1058,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @commands.guild_only()
     async def embedset_guild(self, ctx: commands.Context, enabled: bool = None):
         """
-        Toggle the guild's embed setting.
+        Set the guild's embed setting.
 
         If enabled is None, the setting will be unset and
         the global default will be used instead.
@@ -1084,7 +1083,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @commands.guild_only()
     async def embedset_channel(self, ctx: commands.Context, enabled: bool = None):
         """
-        Toggle the channel's embed setting.
+        Set the channel's embed setting.
 
         If enabled is None, the setting will be unset and
         the guild default will be used instead.
@@ -1107,7 +1106,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @embedset.command(name="user")
     async def embedset_user(self, ctx: commands.Context, enabled: bool = None):
         """
-        Toggle the user's embed setting for DMs.
+        Set the user's embed setting for DMs.
 
         If enabled is None, the setting will be unset and
         the global default will be used instead.
@@ -1722,33 +1721,31 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @_set.command()
     @checks.guildowner()
     @commands.guild_only()
-    async def serverfuzzy(self, ctx: commands.Context):
+    async def serverfuzzy(self, ctx: commands.Context,enabled:bool):
         """
-        Toggle whether to enable fuzzy command search for the server.
+        Set whether to enable fuzzy command search for the server.
 
         Default is for fuzzy command search to be disabled.
         """
-        current_setting = await ctx.bot._config.guild(ctx.guild).fuzzy()
-        await ctx.bot._config.guild(ctx.guild).fuzzy.set(not current_setting)
+        await ctx.bot._config.guild(ctx.guild).fuzzy.set(enabled)
         await ctx.send(
             _("Fuzzy command search has been {} for this server.").format(
-                _("disabled") if current_setting else _("enabled")
+                _("enabled") if enabled else _("disabled")
             )
         )
 
     @_set.command()
     @checks.is_owner()
-    async def fuzzy(self, ctx: commands.Context):
+    async def fuzzy(self, ctx: commands.Context, enabled:bool):
         """
-        Toggle whether to enable fuzzy command search in DMs.
+        Set whether to enable fuzzy command search in DMs.
 
         Default is for fuzzy command search to be disabled.
         """
-        current_setting = await ctx.bot._config.fuzzy()
-        await ctx.bot._config.fuzzy.set(not current_setting)
+        await ctx.bot._config.fuzzy.set(enabled)
         await ctx.send(
             _("Fuzzy command search has been {} in DMs.").format(
-                _("disabled") if current_setting else _("enabled")
+                _("enabled") if enabled else _("disabled")
             )
         )
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1050,7 +1050,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """
         await self.bot._config.embeds.set(enabled)
         await ctx.send(
-            _("Embeds are now {} by default.").format(_("disabled") if current else _("enabled"))
+            _("Embeds are now {} by default.").format(_("disabled") if enabled else _("enabled"))
         )
 
     @embedset.command(name="server", aliases=["guild"])

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1040,7 +1040,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
     @embedset.command(name="global")
     @checks.is_owner()
-    async def embedset_global(self, ctx: commands.Context,enabled: bool):
+    async def embedset_global(self, ctx: commands.Context, enabled: bool):
         """
         Set the global embed setting.
 
@@ -1721,7 +1721,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @_set.command()
     @checks.guildowner()
     @commands.guild_only()
-    async def serverfuzzy(self, ctx: commands.Context,enabled:bool):
+    async def serverfuzzy(self, ctx: commands.Context, enabled: bool):
         """
         Set whether to enable fuzzy command search for the server.
 
@@ -1736,7 +1736,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
     @_set.command()
     @checks.is_owner()
-    async def fuzzy(self, ctx: commands.Context, enabled:bool):
+    async def fuzzy(self, ctx: commands.Context, enabled: bool):
         """
         Set whether to enable fuzzy command search in DMs.
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1040,7 +1040,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
     @embedset.command(name="global")
     @checks.is_owner()
-    async def embedset_global(self, ctx: commands.Context, enabled: bool):
+    async def embedset_global(self, ctx: commands.Context, enabled: Optional[bool] = None):
         """
         Set the global embed setting.
 
@@ -1048,6 +1048,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         or guild hasn't set a preference. The
         default is to use embeds.
         """
+        if enabled is None:
+        	enabled = not (await self.bot._config.embeds())
         await self.bot._config.embeds.set(enabled)
         await ctx.send(
             _("Embeds are now {} by default.").format(_("disabled") if enabled else _("enabled"))
@@ -1056,7 +1058,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @embedset.command(name="server", aliases=["guild"])
     @checks.guildowner_or_permissions(administrator=True)
     @commands.guild_only()
-    async def embedset_guild(self, ctx: commands.Context, enabled: bool = None):
+    async def embedset_guild(self, ctx: commands.Context, enabled: Optional[bool] = None):
         """
         Set the guild's embed setting.
 
@@ -1081,7 +1083,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @embedset.command(name="channel")
     @checks.guildowner_or_permissions(administrator=True)
     @commands.guild_only()
-    async def embedset_channel(self, ctx: commands.Context, enabled: bool = None):
+    async def embedset_channel(self, ctx: commands.Context, enabled: Optional[bool] = None):
         """
         Set the channel's embed setting.
 
@@ -1104,7 +1106,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             )
 
     @embedset.command(name="user")
-    async def embedset_user(self, ctx: commands.Context, enabled: bool = None):
+    async def embedset_user(self, ctx: commands.Context, enabled: Optional[bool] = None):
         """
         Set the user's embed setting for DMs.
 
@@ -1721,12 +1723,12 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @_set.command()
     @checks.guildowner()
     @commands.guild_only()
-    async def serverfuzzy(self, ctx: commands.Context, enabled: bool):
+    async def serverfuzzy(self, ctx: commands.Context, enabled: Optional[bool] = None):
         """
         Set whether to enable fuzzy command search for the server.
-
-        Default is for fuzzy command search to be disabled.
         """
+        if enabled is None:
+            enabled = not (await ctx.bot._config.guild.fuzzy())
         await ctx.bot._config.guild(ctx.guild).fuzzy.set(enabled)
         await ctx.send(
             _("Fuzzy command search has been {} for this server.").format(
@@ -1736,12 +1738,12 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
     @_set.command()
     @checks.is_owner()
-    async def fuzzy(self, ctx: commands.Context, enabled: bool):
+    async def fuzzy(self, ctx: commands.Context, enabled: Optional[bool] = None):
         """
         Set whether to enable fuzzy command search in DMs.
-
-        Default is for fuzzy command search to be disabled.
-        """
+         """
+        if enabled is None:
+            enabled = not (await ctx.bot._config.fuzzy())
         await ctx.bot._config.fuzzy.set(enabled)
         await ctx.send(
             _("Fuzzy command search has been {} in DMs.").format(

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1049,7 +1049,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         default is to use embeds.
         """
         if enabled is None:
-        	enabled = not (await self.bot._config.embeds())
+            enabled = not (await self.bot._config.embeds())
         await self.bot._config.embeds.set(enabled)
         await ctx.send(
             _("Embeds are now {} by default.").format(_("disabled") if enabled else _("enabled"))
@@ -1741,7 +1741,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     async def fuzzy(self, ctx: commands.Context, enabled: Optional[bool] = None):
         """
         Set whether to enable fuzzy command search in DMs.
-         """
+        """
         if enabled is None:
             enabled = not (await ctx.bot._config.fuzzy())
         await ctx.bot._config.fuzzy.set(enabled)


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This changes all toggles in core commands to be bool setters to be consistent with
- The rest of core
- Other core cogs (e.g. Warnings)

I also updated the wording in the docstrings for these commands to reflect that they are not toggles anymore.