### PR TITLE
Ask for confirmation before updating cogs

### DIFF
--- a/redbot/cogs/downloader/checks.py
+++ b/redbot/cogs/downloader/checks.py
@@ -4,7 +4,7 @@ from redbot.core import commands
 from redbot.core.i18n import Translator
 from redbot.core.utils.predicates import MessagePredicate
 
-__all__ = ["do_install_agreement"]
+__all__ = ["do_install_agreement", "do_update_confirmation"]
 
 T_ = Translator("DownloaderChecks", __file__)
 
@@ -17,6 +17,10 @@ REPO_INSTALL_MSG = _(
     " fully understand the above message. This message won't be "
     "shown again until the next reboot.\n\nYou have **30** seconds"
     " to reply to this message."
+)
+UPDATE_CONFIRM_MSG = _(
+    "Are you sure that you would like to update cogs? Reply with "
+    "'**update**' within 30 seconds to continue."
 )
 _ = T_
 
@@ -37,4 +41,18 @@ async def do_install_agreement(ctx: commands.Context) -> bool:
         return False
 
     downloader.already_agreed = True
+    return True
+
+
+async def do_update_confirmation(ctx: commands.Context, message: str) -> bool:
+    await ctx.send(message + "\n\n" + T_(UPDATE_CONFIRM_MSG))
+
+    try:
+        await ctx.bot.wait_for(
+            "message", check=MessagePredicate.lower_equal_to("update", ctx), timeout=30
+        )
+    except asyncio.TimeoutError:
+        await ctx.send(_("Your response has timed out, please try again."))
+        return False
+
     return True

--- a/redbot/cogs/downloader/checks.py
+++ b/redbot/cogs/downloader/checks.py
@@ -4,7 +4,7 @@ from redbot.core import commands
 from redbot.core.i18n import Translator
 from redbot.core.utils.predicates import MessagePredicate
 
-__all__ = ["do_install_agreement", "do_update_confirmation"]
+__all__ = ["do_install_agreement"]
 
 T_ = Translator("DownloaderChecks", __file__)
 
@@ -17,10 +17,6 @@ REPO_INSTALL_MSG = _(
     " fully understand the above message. This message won't be "
     "shown again until the next reboot.\n\nYou have **30** seconds"
     " to reply to this message."
-)
-UPDATE_CONFIRM_MSG = _(
-    "Are you sure that you would like to update cogs? Reply with "
-    "'**update**' within 30 seconds to continue."
 )
 _ = T_
 
@@ -41,18 +37,4 @@ async def do_install_agreement(ctx: commands.Context) -> bool:
         return False
 
     downloader.already_agreed = True
-    return True
-
-
-async def do_update_confirmation(ctx: commands.Context, message: str) -> bool:
-    await ctx.send(message + "\n\n" + T_(UPDATE_CONFIRM_MSG))
-
-    try:
-        await ctx.bot.wait_for(
-            "message", check=MessagePredicate.lower_equal_to("update", ctx), timeout=30
-        )
-    except asyncio.TimeoutError:
-        await ctx.send(_("Your response has timed out, please try again."))
-        return False
-
     return True

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -18,7 +18,7 @@ from redbot.core.utils.menus import start_adding_reactions
 from redbot.core.utils.predicates import MessagePredicate, ReactionPredicate
 
 from . import errors
-from .checks import do_install_agreement
+from .checks import do_install_agreement, do_update_confirmation
 from .converters import InstalledCog
 from .installable import InstallableType, Installable, InstalledModule
 from .log import log
@@ -1042,6 +1042,20 @@ class Downloader(commands.Cog):
                 cogs_to_update, filter_message = self._filter_incorrect_cogs(cogs_to_update)
 
                 if updates_available:
+                    cognames = [cog.name for cog in cogs_to_update]
+                    libnames = [lib.name for lib in libs_to_update]
+                    update_message = _("These cogs will be updated: ") + humanize_list(
+                        tuple(map(inline, cognames))
+                    )
+                    update_message += _(
+                        "\nThese shared libraries will be updated: "
+                    ) + humanize_list(tuple(map(inline, libnames)))
+
+                    confirmed = await do_update_confirmation(ctx, update_message)
+
+                    if not confirmed:
+                        return
+
                     updated_cognames, message = await self._update_cogs_and_libs(
                         ctx, cogs_to_update, libs_to_update, current_cog_versions=cogs_to_check
                     )

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -18,7 +18,7 @@ from redbot.core.utils.menus import start_adding_reactions
 from redbot.core.utils.predicates import MessagePredicate, ReactionPredicate
 
 from . import errors
-from .checks import do_install_agreement, do_update_confirmation
+from .checks import do_install_agreement
 from .converters import InstalledCog
 from .installable import InstallableType, Installable, InstalledModule
 from .log import log
@@ -1044,14 +1044,25 @@ class Downloader(commands.Cog):
                 if updates_available:
                     cognames = [cog.name for cog in cogs_to_update]
                     libnames = [lib.name for lib in libs_to_update]
-                    update_message = _("These cogs will be updated: ") + humanize_list(
-                        tuple(map(inline, cognames))
-                    )
-                    update_message += _(
-                        "\nThese shared libraries will be updated: "
-                    ) + humanize_list(tuple(map(inline, libnames)))
+                    if len(cognames) > 0:
+                        update_message = (
+                            _("These cogs will be updated: ")
+                            + humanize_list(tuple(map(inline, cognames)))
+                            + "\n"
+                        )
+                    else:
+                        update_message = _("There are no cogs to be updated.")
 
-                    confirmed = await do_update_confirmation(ctx, update_message)
+                    if len(libnames) > 0:
+                        update_message += _(
+                            "These shared libraries will be updated: "
+                        ) + humanize_list(tuple(map(inline, libnames)))
+                    else:
+                        update_message += _("There are no shared libraries to be updated.")
+
+                    update_message += _("\n\nWould you like to continue with updating?")
+
+                    confirmed = await self._ask(ctx, update_message)
 
                     if not confirmed:
                         return
@@ -1375,42 +1386,53 @@ class Downloader(commands.Cog):
             )
         return (updated_cognames, message)
 
+    async def _ask(self, ctx: commands.Context, message: str) -> bool:
+        if ctx.assume_yes:
+            return True
+
+        can_react = ctx.channel.permissions_for(ctx.me).add_reactions
+        if not can_react:
+            message += " (y/n)"
+        query: discord.Message = await ctx.send(message)
+        if can_react:
+            # noinspection PyAsyncCall
+            start_adding_reactions(query, ReactionPredicate.YES_OR_NO_EMOJIS)
+            pred = ReactionPredicate.yes_or_no(query, ctx.author)
+            event = "reaction_add"
+        else:
+            pred = MessagePredicate.yes_or_no(ctx)
+            event = "message"
+        try:
+            await ctx.bot.wait_for(event, check=pred, timeout=30)
+        except asyncio.TimeoutError:
+            await query.delete()
+            return
+
+        if not pred.result:
+            if can_react:
+                await query.delete()
+            else:
+                await ctx.send(_("OK then."))
+            return False
+        else:
+            if can_react:
+                with contextlib.suppress(discord.Forbidden):
+                    await query.clear_reactions()
+
+        return True
+
     async def _ask_for_cog_reload(self, ctx: commands.Context, updated_cognames: Set[str]) -> None:
         updated_cognames &= ctx.bot.extensions.keys()  # only reload loaded cogs
         if not updated_cognames:
             await ctx.send(_("None of the updated cogs were previously loaded. Update complete."))
             return
 
-        if not ctx.assume_yes:
-            message = _("Would you like to reload the updated cogs?")
-            can_react = ctx.channel.permissions_for(ctx.me).add_reactions
-            if not can_react:
-                message += " (y/n)"
-            query: discord.Message = await ctx.send(message)
-            if can_react:
-                # noinspection PyAsyncCall
-                start_adding_reactions(query, ReactionPredicate.YES_OR_NO_EMOJIS)
-                pred = ReactionPredicate.yes_or_no(query, ctx.author)
-                event = "reaction_add"
-            else:
-                pred = MessagePredicate.yes_or_no(ctx)
-                event = "message"
-            try:
-                await ctx.bot.wait_for(event, check=pred, timeout=30)
-            except asyncio.TimeoutError:
-                await query.delete()
-                return
+        message = _("Would you like to reload the updated cogs?")
 
-            if not pred.result:
-                if can_react:
-                    await query.delete()
-                else:
-                    await ctx.send(_("OK then."))
-                return
-            else:
-                if can_react:
-                    with contextlib.suppress(discord.Forbidden):
-                        await query.clear_reactions()
+        confimed = await self._ask(ctx, message)
+
+        if not confimed:
+            return
 
         await ctx.invoke(ctx.bot.get_cog("Core").reload, *updated_cognames)
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

When running `cog update` it prompts the owner about which cogs and libraries will be updated and then asks for a confirmation before updating them (fixes #3446).

Here is the confirmation that is shown before updating:
<img width="187" src="https://user-images.githubusercontent.com/10981005/94798950-4a588080-03da-11eb-8630-44422c575d62.PNG">

This is what happens after confirming:
<img width="188" src="https://user-images.githubusercontent.com/10981005/94798952-4c224400-03da-11eb-918f-6c4ce8ffda71.PNG">

This uses the same code as the prompt for reloading which has been moved into an `_ask()` function. _I also tried just asking the owner to type 'update' to confirm it ([code here](https://github.com/jake-walker/Red-DiscordBot/commit/15efa1269c4cf9070918e3f4ed6350e3f0ae3812)) which may work better?_
