### PR TITLE
[CogManagerUI] Fix error when removing path from other OS

### DIFF
--- a/redbot/core/cog_manager.py
+++ b/redbot/core/cog_manager.py
@@ -177,7 +177,8 @@ class CogManager:
             Path to remove.
 
         """
-        path = self._ensure_path_obj(path).resolve()
+        if type(path) is str:
+            path = self._ensure_path_obj(path).resolve()
         paths = await self.user_defined_paths()
 
         paths.remove(path)

--- a/redbot/core/cog_manager.py
+++ b/redbot/core/cog_manager.py
@@ -127,11 +127,7 @@ class CogManager:
         pathlib.Path
 
         """
-        try:
-            path.exists()
-        except AttributeError:
-            path = Path(path)
-        return path
+        return Path(path)
 
     async def add_path(self, path: Union[Path, str]) -> None:
         """Add a cog path to current list.
@@ -177,8 +173,7 @@ class CogManager:
             Path to remove.
 
         """
-        if type(path) is str:
-            path = self._ensure_path_obj(path).resolve()
+        path = self._ensure_path_obj(path)
         paths = await self.user_defined_paths()
 
         paths.remove(path)


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Currently. when transferring a bot to another machine, paths are brought with it, and you are not allowed to remove them because it posts an error:
```py
[2020-10-04 19:12:45] [ERROR] red: Exception in command 'removepath'
Traceback (most recent call last):
  File "/home/ubuntu/redfork/.venv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/ubuntu/redfork/redbot/core/cog_manager.py", line 384, in removepath
    await ctx.bot._cog_mgr.remove_path(to_remove)
  File "/home/ubuntu/redfork/redbot/core/cog_manager.py", line 184, in remove_path
    paths.remove(path)
ValueError: list.remove(x): x not in list
```
This is due to pathlib resolving the path and making an incorrect path.  However, we only call the method with a path that is already set in `cog_manager.user_defined_paths`, so ensuring that the path object is already a path object provided proves no use.

**Steps to reproduce** (OSs should be able to be changed):
1. Start on Windows, add a windows path
2. Backup your bot and move to Linux
3. Attempt to remove the windows path.

Closes #4662, closes #2609