### PR TITLE
[Core] Strip commas on cog command when pagified

### DIFF
--- a/redbot/core/cog_manager.py
+++ b/redbot/core/cog_manager.py
@@ -456,10 +456,14 @@ class CogManagerUI(commands.Cog):
             unloaded = _("**{} unloaded:**\n").format(len(unloaded)) + ", ".join(unloaded)
 
             for page in pagify(loaded, delims=[", ", "\n"], page_length=1800):
+                if page.startswith(", "):
+                    page = page[2:]
                 e = discord.Embed(description=page, colour=discord.Colour.dark_green())
                 await ctx.send(embed=e)
 
             for page in pagify(unloaded, delims=[", ", "\n"], page_length=1800):
+                if page.startswith(", "):
+                    page = page[2:]
                 e = discord.Embed(description=page, colour=discord.Colour.dark_red())
                 await ctx.send(embed=e)
         else:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
If you use [p]cogs when the loaded or unloaded content is pagified, the pages will start with `, ` if you are using embeds. This uses the same stripping that non-embed cog pages have already.