### PR TITLE
[Core] Pagify cog unload output properly

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1385,7 +1385,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         if output:
             total_message = "\n\n".join(output)
-            for page in pagify(total_message):
+            for page in pagify(total_message, delims=[", "], page_length=1500):
+                if page.startswith(", "):
+                    page = page[2:]
                 await ctx.send(page)
 
     @commands.command()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1385,7 +1385,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         if output:
             total_message = "\n\n".join(output)
-            for page in pagify(total_message, delims=[", "], page_length=1500):
+            for page in pagify(
+                total_message, delims=["\n", ", "], priority=True, page_length=1500
+            ):
                 if page.startswith(", "):
                     page = page[2:]
                 await ctx.send(page)


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

When you unload a large amount of cogs (close to message limit on characters), the character count is easily pushed over 2k characters on the command response with the cog names each being wrapped in 2x backticks. The current implementation breaks in the middle of cog names or wherever else it feels like it. 1600 might have been a safe value for splitting but at 1500 I don't see how multiple short cog names could make it break at least.