### PR TITLE
Use `bot.get_user()` instead of `get_all_members()` in `[p]dm`

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2451,7 +2451,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         'Appearance' tab. Enable 'Developer Mode', then right click
         a user and click on 'Copy ID'.
         """
-        destination = discord.utils.get(ctx.bot.get_all_members(), id=user_id)
+        destination = self.bot.get_user(user_id)
         if destination is None or destination.bot:
             await ctx.send(
                 _(


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This just avoid iterate all guild members while we can just use get_user directly.