### PR TITLE
[General] Fix error on long titles in `[p]urban`

### DIFF
--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -505,9 +505,12 @@ class General(commands.Cog):
                 embeds = []
                 for ud in data["list"]:
                     embed = discord.Embed()
-                    embed.title = _("{word} by {author}").format(
+                    title = _("{word} by {author}").format(
                         word=ud["word"].capitalize(), author=ud["author"]
                     )
+                    if len(title) > 256:
+                        title = "{}...".format(title[:253])
+                    embed.title = title
                     embed.url = ud["permalink"]
 
                     description = _("{definition}\n\n**Example:** {example}").format(**ud)


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

There's a few titles that are greater than 256 characters which causes a console error. The example I saw was scrolling through the pages of `[p]urban Jackin' Off` which leads to http://synonyms-chokin-the-chicken-spanking-the-monkey-flogging-the-do.urbanup.com/3169366
