### PR TITLE
Add `wheel` to pre-requirements installed by make files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ bumpdeps:
 # Development environment
 newenv:
 	$(PYTHON) -m venv --clear .venv
-	.venv/bin/pip install -U pip setuptools
+	.venv/bin/pip install -U pip setuptools wheel
 	$(MAKE) syncenv
 syncenv:
 	.venv/bin/pip install -Ur ./tools/dev-requirements.txt

--- a/make.bat
+++ b/make.bat
@@ -21,7 +21,7 @@ exit /B %ERRORLEVEL%
 
 :newenv
 py -3.8 -m venv --clear .venv
-.\.venv\Scripts\python -m pip install -U pip setuptools
+.\.venv\Scripts\python -m pip install -U pip setuptools wheel
 goto syncenv
 
 :syncenv


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Makes building wheels faster. And also wheel is also used in docs. Instead of using legacy setup.py method. 