### PR TITLE
Update the link to 3rd-party cogs in README to use Red-Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ plugins directly from Discord! A few examples are:
 - AniList
 - And much, much more!
 
-Feel free to take a [peek](https://cogboard.red/t/approved-repositories/210) at a list of
+Feel free to take a [peek](https://index.discord.red) at a list of
 available 3rd party cogs!
 
 # Join the community!


### PR DESCRIPTION
Just changing the link to the index.