### PR TITLE
[Core] Add default embed colour to `[p]set showsettings`

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1579,6 +1579,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         global_data = await ctx.bot._config.all()
         locale = global_data["locale"]
         regional_format = global_data["regional_format"] or _("Same as bot's locale")
+        colour = discord.Colour(global_data["color"])
 
         prefix_string = " ".join(prefixes)
         settings = _(
@@ -1586,13 +1587,15 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             "Prefixes: {prefixes}\n"
             "{guild_settings}"
             "Locale: {locale}\n"
-            "Regional format: {regional_format}"
+            "Regional format: {regional_format}\n"
+            "Default colour: {colour}"
         ).format(
             bot_name=ctx.bot.user.name,
             prefixes=prefix_string,
             guild_settings=guild_settings,
             locale=locale,
             regional_format=regional_format,
+            colour=colour,
         )
         for page in pagify(settings):
             await ctx.send(box(page))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1588,7 +1588,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             "{guild_settings}"
             "Locale: {locale}\n"
             "Regional format: {regional_format}\n"
-            "Default colour: {colour}"
+            "Default embed colour: {colour}"
         ).format(
             bot_name=ctx.bot.user.name,
             prefixes=prefix_string,


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Adds a field "Default colour" which shows the hex value of the configured bot color.
Note: I don't know whether to use color or colour, and it seems core can't decide either, so we might need to scrub the user-facing parts of the bot to have a consistent default.

Resolves #4497