### PR TITLE
[General] change `boosters` to `boosts` in serverinfo

### DIFF
--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -455,7 +455,7 @@ class General(commands.Cog):
                 data.add_field(name=_("Server features:"), value="\n".join(guild_features_list))
             if guild.premium_tier != 0:
                 nitro_boost = _(
-                    "Tier {boostlevel} with {nitroboosters} boosters\n"
+                    "Tier {boostlevel} with {nitroboosters} boosts\n"
                     "File size limit: {filelimit}\n"
                     "Emoji limit: {emojis_limit}\n"
                     "VCs max bitrate: {bitrate}"


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

As per d.py docs, [`guild.premium_subscription_count`](https://discordpy.readthedocs.io/en/latest/api.html?highlight=premium_subscription_count#discord.Guild.premium_subscription_count) returns: The number of “boosts” a guild currently has.
As discussed in #advanced-coding few days ago.