### PR TITLE
Fix grammatical errors.

### DIFF
--- a/redbot/cogs/audio/core/commands/player.py
+++ b/redbot/cogs/audio/core/commands/player.py
@@ -323,7 +323,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
         )
         footer = None
         if not play_now and not guild_data["shuffle"] and queue_dur > 0:
-            footer = _("{time} until track playback: #1 in queue").format(
+            footer = _("{time} until track playback, #1 in queue.").format(
                 time=self.format_time(queue_dur)
             )
         await self.send_embed_msg(

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -587,7 +587,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             embed = discord.Embed(title=_("Track Enqueued"), description=description)
             if not guild_data["shuffle"] and queue_dur > 0:
                 embed.set_footer(
-                    text=_("{time} until track playback: #{position} in queue").format(
+                    text=_("{time} until track playback, #{position} in queue.").format(
                         time=queue_total_duration, position=before_queue_length + 1
                     )
                 )


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

In the sentence "mm:ss until track playback: #X in queue", it makes more sense to have a comma instead of a colon, as the "#X in queue" part is not dependent on the former part of the sentence. Also added a full stop at the end of the sentence.