### PR TITLE
Allow `menu()` to listen to both adding and removing reactions

### DIFF
--- a/redbot/core/utils/menus.py
+++ b/redbot/core/utils/menus.py
@@ -88,11 +88,20 @@ async def menu(
             return
 
     try:
-        react, user = await ctx.bot.wait_for(
-            "reaction_add",
-            check=ReactionPredicate.with_emojis(tuple(controls.keys()), message, ctx.author),
-            timeout=timeout,
+        predicates = ReactionPredicate.with_emojis(tuple(controls.keys()), message, ctx.author)
+        tasks = [
+            asyncio.ensure_future(ctx.bot.wait_for("reaction_add", check=predicates)),
+            asyncio.ensure_future(ctx.bot.wait_for("reaction_remove", check=predicates)),
+        ]
+        done, pending = await asyncio.wait(
+            tasks, timeout=timeout, return_when=asyncio.FIRST_COMPLETED
         )
+        for task in pending:
+            task.cancel()
+
+        if len(done) == 0:
+            raise asyncio.TimeoutError()
+        react, user = done.pop().result()
     except asyncio.TimeoutError:
         if not ctx.me:
             return
@@ -126,10 +135,6 @@ async def next_page(
     timeout: float,
     emoji: str,
 ):
-    perms = message.channel.permissions_for(ctx.me)
-    if perms.manage_messages:  # Can manage messages, so remove react
-        with contextlib.suppress(discord.NotFound):
-            await message.remove_reaction(emoji, ctx.author)
     if page == len(pages) - 1:
         page = 0  # Loop around to the first item
     else:
@@ -146,10 +151,6 @@ async def prev_page(
     timeout: float,
     emoji: str,
 ):
-    perms = message.channel.permissions_for(ctx.me)
-    if perms.manage_messages:  # Can manage messages, so remove react
-        with contextlib.suppress(discord.NotFound):
-            await message.remove_reaction(emoji, ctx.author)
     if page == 0:
         page = len(pages) - 1  # Loop around to the last item
     else:


### PR DESCRIPTION
This will reduce the number of API calls the bot does when it has `manage_message` permissions as it will no longer make API calls to unreact.
The menu will accept unreact as a valid input in the menu, bringing it in like with Toby and Dpy behaviour.