### PR TITLE
Fix a crash when calling `[p]modset showsettings`

### DIFF
--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -83,8 +83,8 @@ class ModSettings(MixinMeta):
             )
         else:
             msg += _("Default message history delete on ban: Don't delete any\n")
-        msg += _("Default tempban duration: {}").format(
-            humanize_timedelta(seconds=default_tempban_duration)
+        msg += _("Default tempban duration: {duration}").format(
+            duration=humanize_timedelta(seconds=default_tempban_duration)
         )
         await ctx.send(box(msg))
 

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -83,7 +83,7 @@ class ModSettings(MixinMeta):
             )
         else:
             msg += _("Default message history delete on ban: Don't delete any\n")
-        msg += _("Default tempban duration: {duration}").format(
+        msg += _("Default tempban duration: {seconds}").format(
             humanize_timedelta(seconds=default_tempban_duration)
         )
         await ctx.send(box(msg))

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -83,7 +83,7 @@ class ModSettings(MixinMeta):
             )
         else:
             msg += _("Default message history delete on ban: Don't delete any\n")
-        msg += _("Default tempban duration: {seconds}").format(
+        msg += _("Default tempban duration: {}").format(
             humanize_timedelta(seconds=default_tempban_duration)
         )
         await ctx.send(box(msg))


### PR DESCRIPTION
Fixes

```
Exception in command 'modset showsettings'
Traceback (most recent call last):
  File "/home/fixator/Red-V3/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/fixator/Red-V3/lib/python3.8/site-packages/redbot/cogs/mod/settings.py", line 86, in modset_showsettings
    msg += _("Default tempban duration: {duration}").format(
KeyError: 'duration'
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/home/fixator/Red-V3/lib/python3.8/site-packages/discord/ext/commands/bot.py", line 903, in invoke
    await ctx.command.invoke(ctx)
  File "/home/fixator/Red-V3/lib/python3.8/site-packages/redbot/core/commands/commands.py", line 825, in invoke
    await super().invoke(ctx)
  File "/home/fixator/Red-V3/lib/python3.8/site-packages/discord/ext/commands/core.py", line 1329, in invoke
    await ctx.invoked_subcommand.invoke(ctx)
  File "/home/fixator/Red-V3/lib/python3.8/site-packages/discord/ext/commands/core.py", line 859, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/home/fixator/Red-V3/lib/python3.8/site-packages/discord/ext/commands/core.py", line 94, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: KeyError: 'duration'
```