### PR TITLE
Fixed possible exception thrown when balance field is missing during schema conversion

### DIFF
--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -119,8 +119,6 @@ async def _schema_0_to_1():
         for member_config in guild_data.values():
             if "balance" in member_config:
                 member_config["balance"] = int(member_config["balance"])
-            else:
-                member_config["balance"] = 0
     await group.set(bank_member_data)
 
 

--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -109,14 +109,20 @@ async def _schema_0_to_1():
     group = _config._get_base_group(_config.USER)
     bank_user_data = await group.all()
     for user_config in bank_user_data.values():
-        user_config["balance"] = int(user_config["balance"])
+        if "balance" in user_config:
+            user_config["balance"] = int(user_config["balance"])
+        else:
+            user_config["balance"] = 0
     await group.set(bank_user_data)
 
     group = _config._get_base_group(_config.MEMBER)
     bank_member_data = await group.all()
     for guild_data in bank_member_data.values():
         for member_config in guild_data.values():
-            member_config["balance"] = int(member_config["balance"])
+            if "balance" in member_config:
+                member_config["balance"] = int(member_config["balance"])
+            else:
+                member_config["balance"] = 0
     await group.set(bank_member_data)
 
 

--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -111,8 +111,6 @@ async def _schema_0_to_1():
     for user_config in bank_user_data.values():
         if "balance" in user_config:
             user_config["balance"] = int(user_config["balance"])
-        else:
-            user_config["balance"] = 0
     await group.set(bank_user_data)
 
     group = _config._get_base_group(_config.MEMBER)


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Upgrading to 3.4.1.dev1 would previously prevent my Red instance from starting because, for whatever deeply arcane and unholy reason, a few user entries lacked balance fields in my bank settings. This can be reproduced by running the current schema migration code against a bank database where a user or member entry somehow lacks a balance field.

With this change, cases where the balance field is missing during schema conversion are now handled properly.