### PR TITLE
Add data path and metadata file to `[p]debuginfo`, add missing info to non-embed version

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2610,12 +2610,12 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             )
             e.add_field(
                 name="Data path",
-                value=escape(data_path, formatting=True),
+                value=escape(str(data_path), formatting=True),
                 inline=False,
             )
             e.add_field(
                 name="Metadata file",
-                value=escape(config_file, formatting=True),
+                value=escape(str(config_file), formatting=True),
                 inline=False,
             )
             await ctx.send(embed=e)

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2579,6 +2579,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             osver = "Could not parse OS, report this on Github."
         user_who_ran = getpass.getuser()
         driver = storage_type()
+
+        from redbot.core.data_manager import basic_config
+
+        data_path = Path(basic_config["DATA_PATH"])
         disabled_intents = (
             ", ".join(
                 intent_name.replace("_", " ").title()
@@ -2603,6 +2607,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 inline=False,
             )
             e.add_field(name="Storage type", value=driver, inline=False)
+            e.add_field(name="Data path", value=data_path, inline=False)
             e.add_field(name="Disabled intents", value=disabled_intents, inline=False)
             await ctx.send(embed=e)
         else:
@@ -2617,6 +2622,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 + "User: {}\n".format(user_who_ran)
                 + "OS version: {}\n".format(osver)
                 + "Storage type: {}\n".format(driver)
+                + "Data path: {}\n".format(data_path)
+                + "Disabled intents: {}\n".format(disabled_intents)
             )
             await ctx.send(box(info))
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2600,9 +2600,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             e.add_field(name="Pip version", value=pipver, inline=True)
             e.add_field(name="System arch", value=platform.machine(), inline=True)
             e.add_field(name="User", value=user_who_ran, inline=True)
-            e.add_field(name="OS version", value=osver, inline=False)
             e.add_field(name="Storage type", value=driver, inline=True)
             e.add_field(name="Disabled intents", value=disabled_intents, inline=True)
+            e.add_field(name="OS version", value=osver, inline=False)
             e.add_field(
                 name="Python executable",
                 value=escape(sys.executable, formatting=True),

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2580,7 +2580,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         user_who_ran = getpass.getuser()
         driver = storage_type()
 
-        from redbot.core.data_manager import basic_config
+        from redbot.core.data_manager import basic_config, config_file
 
         data_path = Path(basic_config["DATA_PATH"])
         disabled_intents = (
@@ -2601,29 +2601,39 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             e.add_field(name="System arch", value=platform.machine(), inline=True)
             e.add_field(name="User", value=user_who_ran, inline=True)
             e.add_field(name="OS version", value=osver, inline=False)
+            e.add_field(name="Storage type", value=driver, inline=True)
+            e.add_field(name="Disabled intents", value=disabled_intents, inline=True)
             e.add_field(
                 name="Python executable",
                 value=escape(sys.executable, formatting=True),
                 inline=False,
             )
-            e.add_field(name="Storage type", value=driver, inline=False)
-            e.add_field(name="Data path", value=data_path, inline=False)
-            e.add_field(name="Disabled intents", value=disabled_intents, inline=False)
+            e.add_field(
+                name="Data path",
+                value=escape(data_path, formatting=True),
+                inline=False,
+            )
+            e.add_field(
+                name="Metadata file",
+                value=escape(config_file, formatting=True),
+                inline=False,
+            )
             await ctx.send(embed=e)
         else:
             info = (
                 "Debug Info for Red\n\n"
                 + "Red version: {}\n".format(redver)
                 + "Python version: {}\n".format(pyver)
-                + "Python executable: {}\n".format(sys.executable)
                 + "Discord.py version: {}\n".format(dpy_version)
                 + "Pip version: {}\n".format(pipver)
                 + "System arch: {}\n".format(platform.machine())
                 + "User: {}\n".format(user_who_ran)
                 + "OS version: {}\n".format(osver)
                 + "Storage type: {}\n".format(driver)
-                + "Data path: {}\n".format(data_path)
                 + "Disabled intents: {}\n".format(disabled_intents)
+                + "Python executable: {}\n".format(sys.executable)
+                + "Data path: {}\n".format(data_path)
+                + "Metadata file: {}\n".format(config_file)
             )
             await ctx.send(box(info))
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Adds info about data path and metadata file (`config.json`) to `[p]debuginfo` and adds missing info about disabled intents to non-embed version.