### PR TITLE
[Mod] Fix + more info for modset defaultduration

### DIFF
--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -377,13 +377,22 @@ class ModSettings(MixinMeta):
     async def defaultduration(
         self,
         ctx: commands.Context,
-        duration: Optional[commands.TimedeltaConverter] = timedelta(days=0),
+        *,
+        duration: commands.TimedeltaConverter,
     ):
-        """Set the default time to be used when a user is tempbanned."""
+        """Set the default time to be used when a user is tempbanned.
+
+        Accepts: seconds, minutes, hours, days, weeks
+        Use `0` with a unit of measure to set the time to zero.
+        Examples:
+            `[p]modset defaultduration 0 minutes`
+            `[p]modset defaultduration 7d12h10m`
+            `[p]modset defaultduration 7 days 12 hours 10 minutes`
+        """
         guild = ctx.guild
         await self.config.guild(guild).default_tempban_duration.set(duration.total_seconds())
         await ctx.send(
-            _("The default duration for tempbanning a user is now {duration}.").format(
+            _(f"The default duration for tempbanning a user is now {duration}.").format(
                 duration=humanize_timedelta(timedelta=duration)
             )
         )

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -378,14 +378,16 @@ class ModSettings(MixinMeta):
         self,
         ctx: commands.Context,
         *,
-        duration: commands.TimedeltaConverter,
+        duration: commands.TimedeltaConverter(
+            minimum=timedelta(seconds=1), default_unit="seconds"
+        ),
     ):
         """Set the default time to be used when a user is tempbanned.
 
         Accepts: seconds, minutes, hours, days, weeks
-        Use `0` with a unit of measure to set the time to zero.
+        `duration` must be greater than zero.
+
         Examples:
-            `[p]modset defaultduration 0 minutes`
             `[p]modset defaultduration 7d12h10m`
             `[p]modset defaultduration 7 days 12 hours 10 minutes`
         """
@@ -393,6 +395,6 @@ class ModSettings(MixinMeta):
         await self.config.guild(guild).default_tempban_duration.set(duration.total_seconds())
         await ctx.send(
             _("The default duration for tempbanning a user is now {duration}.").format(
-                duration=(humanize_timedelta(timedelta=duration) or _("0 seconds"))
+                duration=(humanize_timedelta(timedelta=duration))
             )
         )

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -392,7 +392,7 @@ class ModSettings(MixinMeta):
         guild = ctx.guild
         await self.config.guild(guild).default_tempban_duration.set(duration.total_seconds())
         await ctx.send(
-            _(f"The default duration for tempbanning a user is now {duration}.").format(
-                duration=humanize_timedelta(timedelta=duration)
+            _("The default duration for tempbanning a user is now {duration}.").format(
+                duration=(humanize_timedelta(timedelta=duration) or _("0 seconds"))
             )
         )

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -395,6 +395,6 @@ class ModSettings(MixinMeta):
         await self.config.guild(guild).default_tempban_duration.set(duration.total_seconds())
         await ctx.send(
             _("The default duration for tempbanning a user is now {duration}.").format(
-                duration=(humanize_timedelta(timedelta=duration))
+                duration=humanize_timedelta(timedelta=duration)
             )
         )


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This fixes a text response invoked via the modset defaultduration command.
The input was also not consuming rest and would not accept values with spaces like `1 week 2 days`.
Also provides the user a more friendly response in the docstring to help figure out what's expected for the input.