### PR TITLE
Fix `KeyError` in `[p]muteset role`

### DIFF
--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -651,7 +651,8 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
         """
         if not role:
             await self.config.guild(ctx.guild).mute_role.set(None)
-            del self.mute_role_cache[ctx.guild.id]
+            if ctx.guild.id in self.mute_role_cache:
+                del self.mute_role_cache[ctx.guild.id]
             await self.config.guild(ctx.guild).sent_instructions.set(False)
             # reset this to warn users next time they may have accidentally
             # removed the mute role


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
```
Traceback (most recent call last):
  File "/home/ubuntu/red-venv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/ubuntu/red-venv/lib/python3.8/site-packages/redbot/cogs/mutes/mutes.py", line 654, in mute_role
    del self.mute_role_cache[ctx.guild.id]
KeyError: 504291561824059392
```