### PR TITLE
Fix `TypeError` in automatic multi channel unmutes

### DIFF
--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -332,7 +332,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
             if not result:
                 continue
             _mmeber, channel, reason = result
-            unmuted_channels.pop(channel)
+            unmuted_channels.remove(channel)
         modlog_reason = _("Automatic unmute")
 
         channel_list = humanize_list([c.mention for c in unmuted_channels if c is not None])


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
```
[2020-10-26 17:43:45] [ERROR] red.cogs.mutes: Dead task when trying to unmute
Traceback (most recent call last):
  File "C:\Users\Jakub\OneDrive\Dokumenty\Red-DiscordBot\redbot\cogs\mutes\mutes.py", line 184, in _clean_tasks
    r = task.result()
  File "C:\Users\Jakub\OneDrive\Dokumenty\Red-DiscordBot\redbot\cogs\mutes\mutes.py", line 337, in _auto_channel_unmute_user_multi
    unmuted_channels.pop(channel)
TypeError: 'TextChannel' object cannot be interpreted as an integer
```