### PR TITLE
Properly iterate through dict's items in automatic multi channel unmute

### DIFF
--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -362,7 +362,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
             error_msg = _("{member} could not be unmuted for the following reasons:\n").format(
                 member=member
             )
-            for reason, channel_list in reasons:
+            for reason, channel_list in reasons.items():
                 error_msg += _("{reason} In the following channels: {channels}\n").format(
                     reason=reason,
                     channels=humanize_list([c.mention for c in channel_list]),


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
```
[2020-10-26 17:52:10] [ERROR] red.cogs.mutes: Dead task when trying to unmute
Traceback (most recent call last):
  File "C:\Users\Jakub\OneDrive\Dokumenty\Red-DiscordBot\redbot\cogs\mutes\mutes.py", line 184, in _clean_tasks
    r = task.result()
  File "C:\Users\Jakub\OneDrive\Dokumenty\Red-DiscordBot\redbot\cogs\mutes\mutes.py", line 367, in _auto_channel_unmute_user_multi
    for reason, channel_list in reasons:
ValueError: not enough values to unpack (expected 2, got 1)
```