### PR TITLE
[Mutes] Prevent modlog updates on unmute due to category channel sync

### DIFF
--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -359,7 +359,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
             modlog_reason,
             until=None,
         )
-        self._channel_mute_events[guild_id].set()
+        self._channel_mute_events[guild.id].set()
         if any(results):
             reasons = {}
             for result in results:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This fixes an issue where modlog can update from seeing channel overwrites change while unmuting multiple channels due to channel category sync.