### PR TITLE
Plurality matters (use correct variable name)

### DIFF
--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -370,7 +370,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
                 if reason not in reasons:
                     reasons[reason] = [channel]
                 else:
-                    reason[reason].append(channel)
+                    reasons[reason].append(channel)
             error_msg = _("{member} could not be unmuted for the following reasons:\n").format(
                 member=member
             )


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
```
[2020-10-27 01:35:29] [ERROR] red.cogs.mutes: Dead task when trying to unmute
Traceback (most recent call last):
  File "C:\Users\Jakub\OneDrive\Dokumenty\Red-DiscordBot\redbot\cogs\mutes\mutes.py", line 189, in _clean_tasks
    r = task.result()
  File "C:\Users\Jakub\OneDrive\Dokumenty\Red-DiscordBot\redbot\cogs\mutes\mutes.py", line 373, in _auto_channel_unmute_user_multi
    reason[reason].append(channel)
TypeError: string indices must be integers
```