### PR TITLE
Update the copyright symbol in the `[p]info` command

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -418,7 +418,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 "Red is backed by a passionate community who contributes and "
                 "creates content for everyone to enjoy. [Join us today]({}) "
                 "and help us improve!\n\n"
-                "(c) Cog Creators"
+                "© Cog Creators"
             ).format(red_repo, author_repo, org_repo, support_server_url)
 
             embed = discord.Embed(color=(await ctx.embed_colour()))


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

Switched from `(c)` to `©` in the info command. Red-DiscordBot requires at least Python 3.7, so has support for Unicode. I think the use of the proper Unicode copyright symbol would be a good shout.