### PR TITLE
The big intents checklist.

### DIFF
--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -562,7 +562,7 @@ class CustomCommands(commands.Cog):
 
         if _aid == 0xDE1:
             author = _("Deleted User")
-        elif member := ctx.guild.get_member(_aid):
+        elif member := await self.bot.get_or_fetch_member(ctx.guild, _aid):
             author = f"{member} ({_aid})"
         else:
             author = f"{cmd['author']['name']} ({_aid})"

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -521,7 +521,8 @@ class Economy(commands.Cog):
         temp_msg = header
         for acc in bank_sorted:
             try:
-                name = guild.get_member(acc[0]).display_name
+                user_obj = await self.bot.get_or_fetch_member(ctx.guild, acc[0])
+                name = user_obj.display_name
             except AttributeError:
                 user_id = ""
                 if await ctx.bot.is_owner(ctx.author):

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -394,7 +394,7 @@ class Economy(commands.Cog):
                 # Sets the current time as the latest payday
                 await self.config.user(author).next_payday.set(cur_time)
 
-                pos = await bank.get_leaderboard_position(author)
+                pos = await bank.get_leaderboard_position(self.bot, author)
                 await ctx.send(
                     _(
                         "{author.mention} Here, take some {currency}. "
@@ -451,7 +451,7 @@ class Economy(commands.Cog):
                 next_payday = cur_time
 
                 await self.config.member(author).next_payday.set(next_payday)
-                pos = await bank.get_leaderboard_position(author)
+                pos = await bank.get_leaderboard_position(self.bot, author)
                 await ctx.send(
                     _(
                         "{author.mention} Here, take some {currency}. "
@@ -493,10 +493,10 @@ class Economy(commands.Cog):
         base_embed = discord.Embed(title=_("Economy Leaderboard"))
         if await bank.is_global() and show_global:
             # show_global is only applicable if bank is global
-            bank_sorted = await bank.get_leaderboard(positions=top, guild=None)
+            bank_sorted = await bank.get_leaderboard(bot=self.bot, positions=top, guild=None)
             base_embed.set_author(name=ctx.bot.user.name, icon_url=ctx.bot.user.avatar_url)
         else:
-            bank_sorted = await bank.get_leaderboard(positions=top, guild=guild)
+            bank_sorted = await bank.get_leaderboard(bot=self.bot, positions=top, guild=guild)
             if guild:
                 base_embed.set_author(name=guild.name, icon_url=guild.icon_url)
 

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -446,6 +446,7 @@ class KickBanMixin(MixinMeta):
         to_query: List[int] = []
 
         for user_id in user_ids:
+            # This get_member is okay here due to the query below
             member = guild.get_member(user_id)
             if member is not None:
                 members[user_id] = member

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -191,7 +191,9 @@ class ModInfo(MixinMeta):
         # Member intent
         if self.bot.intents.members:
             member_number = (
-                sorted(guild.members, key=lambda m: m.joined_at or ctx.message.created_at).index(user)
+                sorted(guild.members, key=lambda m: m.joined_at or ctx.message.created_at).index(
+                    user
+                )
                 + 1
             )
         else:

--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -230,8 +230,8 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
             delay = 0
         await asyncio.sleep(delay)
 
-        member = guild.get_member(data["member"])
-        author = guild.get_member(data["author"])
+        member = await self.bot.get_or_fetch_member(guild, data["member"])
+        author = await self.bot.get_or_fetch_member(guild, data["author"])
         if not member:
             async with self.config.guild(guild).muted_users() as muted_users:
                 if str(data["member"]) in muted_users:
@@ -308,7 +308,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
                     if task_name in self._unmute_tasks:
                         continue
                     log.debug(f"Creating task: {task_name}")
-                    member = guild.get_member(user)
+                    member = await self.bot.get_or_fetch_member(guild ,user)
                     self._unmute_tasks[task_name] = asyncio.create_task(
                         self._auto_channel_unmute_user_multi(member, guild, channels)
                     )
@@ -333,7 +333,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
             self._channel_mute_events[guild.id] = asyncio.Event()
         tasks = []
         for channel, mute_data in channels.items():
-            author = guild.get_member(mute_data["author"])
+            author = self.bot.get_or_fetch_member(guild, mute_data["author"])
             tasks.append(
                 self._auto_channel_unmute_user(guild.get_channel(channel), mute_data, False)
             )
@@ -399,8 +399,8 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
         if delay < 1:
             delay = 0
         await asyncio.sleep(delay)
-        member = channel.guild.get_member(data["member"])
-        author = channel.guild.get_member(data["author"])
+        member = await self.bot.get_or_fetch_member(channel.guild, data["member"])
+        author = await self.bot.get_or_fetch_member(channel.guild, data["author"])
         if not member:
             async with self.config.channel(channel).muted_users() as muted_users:
                 if str(data["member"]) in muted_users:
@@ -551,7 +551,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
                 if user_id in before_perms and (
                     user_id not in after_perms or any((send_messages, speak))
                 ):
-                    user = after.guild.get_member(user_id)
+                    user = await self.bot.get_or_fetch_member(after.guild, user_id)
                     if not user:
                         user = discord.Object(id=user_id)
                     log.debug(f"{user} - {type(user)}")
@@ -882,7 +882,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
                 for user_id, mutes in mutes_data.items():
                     if not mutes:
                         continue
-                    user = ctx.guild.get_member(user_id)
+                    user = await self.bot.get_or_fetch_member(ctx.guild, user_id)
                     if not user:
                         user_str = f"<@!{user_id}>"
                     else:
@@ -907,7 +907,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
                 for user_id, mutes in mutes_data.items():
                     if not mutes:
                         continue
-                    user = ctx.guild.get_member(user_id)
+                    user = await self.bot.get_or_fetch_member(ctx.guild, user_id)
                     if not user:
                         user_str = f"<@!{user_id}>"
                     else:

--- a/redbot/cogs/permissions/converters.py
+++ b/redbot/cogs/permissions/converters.py
@@ -90,7 +90,7 @@ class GuildUniqueObjectFinder(commands.Converter):
             if channel is not None:
                 return channel
 
-            member: discord.Member = guild.get_member(_id)
+            member: discord.Member = await ctx.bot.get_or_fetch_member(guild, _id)
             if member is not None:
                 return member
 

--- a/redbot/cogs/reports/reports.py
+++ b/redbot/cogs/reports/reports.py
@@ -156,7 +156,7 @@ class Reports(commands.Cog):
             perms = discord.Permissions(**permissions)
 
         async for guild in AsyncIter(self.bot.guilds, steps=100):
-            x = guild.get_member(author.id)
+            x = await self.bot.get_or_fetch_member(guild, author.id)
             if x is not None:
                 if await self.internal_filter(x, mod, perms):
                     shared_guilds.append(guild)
@@ -194,7 +194,7 @@ class Reports(commands.Cog):
 
     async def send_report(self, msg: discord.Message, guild: discord.Guild):
 
-        author = guild.get_member(msg.author.id)
+        author = await self.bot.get_or_fetch_member(guild, msg.author.id)
         report = msg.clean_content
 
         channel_id = await self.config.guild(guild).output_channel()
@@ -404,7 +404,7 @@ class Reports(commands.Cog):
         rec = await self.config.custom("REPORT", guild.id, ticket_number).report()
 
         try:
-            user = guild.get_member(rec.get("user_id"))
+            user = self.bot.get_or_fetch_member(guild, rec.get("user_id"))
         except KeyError:
             return await ctx.send(_("That ticket doesn't seem to exist"))
 

--- a/redbot/cogs/trivia/trivia.py
+++ b/redbot/cogs/trivia/trivia.py
@@ -406,7 +406,8 @@ class Trivia(commands.Cog):
             return
         guild = ctx.guild
         data = await self.config.all_members(guild)
-        data = {guild.get_member(u): d for u, d in data.items()}
+        # Possible optimisation here of using query, will re-evaluate later.
+        data = {await ctx.bot.get_or_fetch_member(guild, u): d for u, d in data.items()}
         data.pop(None, None)  # remove any members which aren't in the guild
         await self.send_leaderboard(ctx, data, key, top)
 
@@ -440,7 +441,7 @@ class Trivia(commands.Cog):
             if guild is None:
                 continue
             for member_id, member_data in guild_data.items():
-                member = guild.get_member(member_id)
+                member = await ctx.bot.get_or_fetch_member(guild, member_id)
                 if member is None:
                     continue
                 collated_member_data = collated_data.get(member, Counter())

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -525,7 +525,7 @@ class Warnings(commands.Cog):
             userid: int = user.id
         except AttributeError:
             userid: int = user
-            user = ctx.guild.get_member(userid)
+            user = await self.bot.get_or_fetch_member(ctx.guild, userid)
             user = user or namedtuple("Member", "id guild")(userid, ctx.guild)
 
         msg = ""
@@ -609,7 +609,7 @@ class Warnings(commands.Cog):
             member = user
         except AttributeError:
             user_id = user
-            member = guild.get_member(user_id)
+            member = await self.bot.get_or_fetch_member(guild, user_id)
             member = member or namedtuple("Member", "guild id")(guild, user_id)
 
         if user_id == ctx.author.id:

--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -520,7 +520,7 @@ async def bank_prune(bot: Red, guild: discord.Guild = None, user_id: int = None)
                 del bank_data[user_id]
 
 
-async def get_leaderboard(positions: int = None, guild: discord.Guild = None) -> List[tuple]:
+async def get_leaderboard(bot: Red, positions: int = None, guild: discord.Guild = None) -> List[tuple]:
     """
     Gets the bank's leaderboard
 
@@ -548,7 +548,7 @@ async def get_leaderboard(positions: int = None, guild: discord.Guild = None) ->
         if guild is not None:
             tmp = raw_accounts.copy()
             for acc in tmp:
-                if not guild.get_member(acc):
+                if not await bot.get_or_fetch_member(guild, acc):
                     del raw_accounts[acc]
     else:
         if guild is None:
@@ -562,6 +562,7 @@ async def get_leaderboard(positions: int = None, guild: discord.Guild = None) ->
 
 
 async def get_leaderboard_position(
+    bot: Red,
     member: Union[discord.User, discord.Member]
 ) -> Union[int, None]:
     """
@@ -588,7 +589,7 @@ async def get_leaderboard_position(
     else:
         guild = member.guild if hasattr(member, "guild") else None
     try:
-        leaderboard = await get_leaderboard(None, guild)
+        leaderboard = await get_leaderboard(bot, None, guild)
     except TypeError:
         raise
     else:

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -304,6 +304,20 @@ class RedBase(
                 return_exceptions=return_exceptions,
             )
 
+    def has_intents(self, **intents: bool) -> bool:
+        """Check if the bot has the specified intents."""
+
+        invalid_keys = set(intents.keys()) - set(discord.Intents.VALID_FLAGS)
+        if invalid_keys:
+            raise TypeError(f"Invalid intent name(s): {', '.join(invalid_keys)}")
+        for perm, value in intents.items():
+            if value is not True:
+                # We reject any Intent not specified as 'True', since this is the only value which
+                # makes practical sense.
+                raise TypeError(f"Intent {perm} may only be specified as 'True', not {value}")
+        missing = set(intents) - set(self.intents)
+        return not missing
+
     async def cog_disabled_in_guild(
         self, cog: commands.Cog, guild: Optional[discord.Guild]
     ) -> bool:


### PR DESCRIPTION
This PR goes over all member and presence intents to ensure that they don't break horrible on Red. While we normally said that we **don't** want to rely on fetching members. Discord is sadly forcing our hand here, and for now this is the simplest fix we can do.

Querying however makes this easier to handle in bulk and should be used when possible. One of those instances would be mute.

Gonna keep this as a draft for now as this is a big WIP with still several cogs needing manual checking of code and ensuring everything doesn't horrible break.