### PR TITLE
Bump versions of actions used by our workflows

### DIFF
--- a/.github/workflows/auto_labeler.yml
+++ b/.github/workflows/auto_labeler.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply Triage Label
-        uses: actions/github-script@0.4.0
+        uses: actions/github-script@v3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/lint_python.yaml
+++ b/.github/workflows/lint_python.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.ref }}
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: "3.8"
       - run: "python -m pip install git+https://github.com/pycqa/pyflakes@1911c20#egg=pyflakes git+https://github.com/pycqa/pycodestyle@d219c68#egg=pycodestyle git+https://gitlab.com/pycqa/flake8@3.7.9#egg=flake8"

--- a/.github/workflows/publish_crowdin.yml
+++ b/.github/workflows/publish_crowdin.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.8'
     - name: Install dependencies
@@ -37,7 +37,7 @@ jobs:
       run: |
         make download_translations
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v2
+      uses: peter-evans/create-pull-request@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: Automated Crowdin downstream
@@ -47,3 +47,4 @@ jobs:
           Please ensure that there are no errors or invalid files are in the PR.
         labels: "Automated PR, Category: i18n, Changelog Entry: Skipped"
         branch: "automated/i18n"
+        author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.8'
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           with:
             ref: ${{ env.ref }}
         - name: Set up Python
-          uses: actions/setup-python@v1
+          uses: actions/setup-python@v2
           with:
             python-version: ${{ matrix.python_version }}
         - name: Install tox
@@ -68,7 +68,7 @@ jobs:
           with:
             ref: ${{ env.ref }}
         - name: Set up Python
-          uses: actions/setup-python@v1
+          uses: actions/setup-python@v2
           with:
             python-version: ${{ matrix.python_version }}
         - name: Install tox


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature
- [x] Dependency update

### Description of the changes
Our Crowdin workflow is gonna break in a week if we don't bump the used version of create-pull-request action:
https://github.blog/changelog/2020-11-09-github-actions-removing-set-env-and-add-path-commands-on-november-16

I went ahead and just bumped versions of all actions we use.