### PR TITLE
[Modlog] Fix error when the bot can't read message history in the modlog channel

### DIFF
--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -554,7 +554,7 @@ class Case:
                 if message is None:
                     try:
                         message = await mod_channel.fetch_message(message_id)
-                    except (discord.NotFound, AttributeError):
+                    except (discord.HTTPException, AttributeError):
                         message = None
             else:
                 message = None


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #4587