### PR TITLE
[Docs] Fix CustomCommands URL mistake

### DIFF
--- a/docs/cog_guides/customcommands.rst
+++ b/docs/cog_guides/customcommands.rst
@@ -105,7 +105,7 @@ Create custom commands.
 
 If a type is not specified, a simple CC will be created.
 CCs can be enhanced with arguments, see the guide
-here: https://docs.discord.red/en/stable/cog_customcom.html.
+:ref:`here <cog_customcom>`.
 
 .. _customcommands-command-customcom-create-random:
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixed a bug in doc generation that missed URLs. This is the regenerated version that handles the URL correctly.

Original version:
![image](https://user-images.githubusercontent.com/955640/98724311-9267ad00-2361-11eb-89ee-3ac83807c170.png)

Fixed version:
![image](https://user-images.githubusercontent.com/955640/98724196-5fbdb480-2361-11eb-9d93-e4773922aa2e.png)
