### PR TITLE
Ensure filenames are lowercase when uploading with `[p]triviaset custom`

### DIFF
--- a/redbot/cogs/trivia/trivia.py
+++ b/redbot/cogs/trivia/trivia.py
@@ -625,7 +625,7 @@ class Trivia(commands.Cog):
         -------
         None
         """
-        filename = attachment.filename.rsplit(".", 1)[0]
+        filename = attachment.filename.rsplit(".", 1)[0].lower()
 
         # Check if trivia filename exists in core files or if it is a command
         if filename in self.trivia.all_commands or any(

--- a/redbot/cogs/trivia/trivia.py
+++ b/redbot/cogs/trivia/trivia.py
@@ -625,7 +625,7 @@ class Trivia(commands.Cog):
         -------
         None
         """
-        filename = attachment.filename.rsplit(".", 1)[0].lower()
+        filename = attachment.filename.rsplit(".", 1)[0].casefold()
 
         # Check if trivia filename exists in core files or if it is a command
         if filename in self.trivia.all_commands or any(


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Resolves [#4570](https://github.com/Cog-Creators/Red-DiscordBot/issues/4570)

When a user uses the command `[p]triviaset custom upload` it now converts the filename to lowercase before saving it. 


