### PR TITLE
Fix usage in `[p]filter`'s commands, make commands consistent

### DIFF
--- a/redbot/cogs/filter/filter.py
+++ b/redbot/cogs/filter/filter.py
@@ -162,7 +162,7 @@ class Filter(commands.Cog):
         except discord.Forbidden:
             await ctx.send(_("I can't send direct messages to you."))
 
-    @_filter_channel.command("add", require_var_positional=True)
+    @_filter_channel.command(name="add", require_var_positional=True)
     async def filter_channel_add(self, ctx: commands.Context, *words: str):
         """Add words to the filter.
 
@@ -180,7 +180,7 @@ class Filter(commands.Cog):
         else:
             await ctx.send(_("Words already in the filter."))
 
-    @_filter_channel.command("remove", require_var_positional=True)
+    @_filter_channel.command(name="delete", aliases=["remove", "del"], require_var_positional=True)
     async def filter_channel_remove(self, ctx: commands.Context, *words: str):
         """Remove words from the filter.
 

--- a/redbot/cogs/filter/filter.py
+++ b/redbot/cogs/filter/filter.py
@@ -162,7 +162,7 @@ class Filter(commands.Cog):
         except discord.Forbidden:
             await ctx.send(_("I can't send direct messages to you."))
 
-    @_filter_channel.command("add")
+    @_filter_channel.command("add", require_var_positional=True)
     async def filter_channel_add(self, ctx: commands.Context, *words: str):
         """Add words to the filter.
 
@@ -180,7 +180,7 @@ class Filter(commands.Cog):
         else:
             await ctx.send(_("Words already in the filter."))
 
-    @_filter_channel.command("remove")
+    @_filter_channel.command("remove", require_var_positional=True)
     async def filter_channel_remove(self, ctx: commands.Context, *words: str):
         """Remove words from the filter.
 
@@ -198,7 +198,7 @@ class Filter(commands.Cog):
         else:
             await ctx.send(_("Those words weren't in the filter."))
 
-    @_filter.command(name="add")
+    @_filter.command(name="add", require_var_positional=True)
     async def filter_add(self, ctx: commands.Context, *words: str):
         """Add words to the filter.
 
@@ -216,7 +216,7 @@ class Filter(commands.Cog):
         else:
             await ctx.send(_("Those words were already in the filter."))
 
-    @_filter.command(name="delete", aliases=["remove", "del"])
+    @_filter.command(name="delete", aliases=["remove", "del"], require_var_positional=True)
     async def filter_remove(self, ctx: commands.Context, *words: str):
         """Remove words from the filter.
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

`*words` was not a required argument, when it should be.
Additionally, `filter channel remove` and `filter remove` did not have consistent alias structures. This corrects it.