### PR TITLE
Typo fixes on es-ES locations core cog

### DIFF
--- a/redbot/core/locales/es-ES.po
+++ b/redbot/core/locales/es-ES.po
@@ -654,11 +654,11 @@ msgstr "Descargando paquetes."
 
 #: redbot/core/core_commands.py:1409
 msgid "The following package was unloaded: {pack}."
-msgstr "El siguiente paquete ya está cargado: {pack}."
+msgstr "El siguiente paquete ya no está cargado: {pack}."
 
 #: redbot/core/core_commands.py:1413
 msgid "The following packages were unloaded: {packs}."
-msgstr "El siguiente paquete ya está descargado: {packs}."
+msgstr "Los siguientes paquetes ya no están cargados: {packs}."
 
 #: redbot/core/core_commands.py:1420
 msgid "The following package was not loaded: {pack}."
@@ -666,7 +666,7 @@ msgstr "El siguiente paquete no está cargado: {pack}."
 
 #: redbot/core/core_commands.py:1424
 msgid "The following packages were not loaded: {packs}."
-msgstr "El siguiente paquete no está descargado: {packs}."
+msgstr "Los siguientes paquetes no estaban cargados: {packs}."
 
 #: redbot/core/core_commands.py:1437
 #, docstring


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Fixes for some core cog locations es-ES and syntax improvements. Looks `unload` translations are wrong and apparently users are loading new packages. 