### PR TITLE
[Streams] Support Youtube stream schedules

### DIFF
--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -209,7 +209,9 @@ class Streams(commands.Cog):
         await self.maybe_renew_twitch_bearer_token()
         token = (await self.bot.get_shared_api_tokens("twitch")).get("client_id")
         stream = TwitchStream(
-            name=channel_name, token=token, bearer=self.ttv_bearer_cache.get("access_token", None),
+            name=channel_name,
+            token=token,
+            bearer=self.ttv_bearer_cache.get("access_token", None),
         )
         await self.check_online(ctx, stream)
 

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -6,7 +6,6 @@ from random import choice
 from string import ascii_letters
 import xml.etree.ElementTree as ET
 from typing import ClassVar, Optional, List, Tuple
-from datetime import datetime
 
 import aiohttp
 import discord
@@ -178,12 +177,16 @@ class YoutubeStream(Stream):
                 is_schedule = True
             else:
                 # repost message
+                to_remove = []
                 for message in self._messages_cache:
+                    if message.embeds[0].description is discord.Embed.Empty:
+                        continue
                     with contextlib.suppress(Exception):
                         autodelete = await self._config.guild(message.guild).autodelete()
                         if autodelete:
                             await message.delete()
-                self._messages_cache.clear()
+                    to_remove.append(message.id)
+                self._messages_cache = [x for x in self._messages_cache if x.id not in to_remove]
         embed.set_author(name=channel_title)
         embed.set_image(url=rnd(thumbnail))
         embed.colour = 0x9255A5

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ install_requires =
     idna==2.10
     markdown==3.2.2
     multidict==4.7.6
+    python-dateutil==2.8.1
     python-Levenshtein-wheels==0.13.1
     pytz==2020.1
     PyYAML==5.3.1


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes

Add support for YouTube stream schedules.

- The `[p]youtubealert` command will show the start time of a scheduled stream
- The bot will perform two announcements, one when we receive the schedule, a second one when the stream actually start.
- If autodelete is enabled, the bot will delete the message announcing the stream schedule before announcing the stream
- This can be disabled with `[p]streamset ignoreschedule`, similar to `[p]streamset ignorereruns`

### To do

- ~~I just noticed the bot gets stuck in a loop deleting its message and reannouncing when the stream is online :eyes: not much to fix, omw~~ Fixed
- Maybe add a setting for a different message when the announcement is a schedule?

Fixes #3691 