### PR TITLE
[Streams] Resolve bug with `[p]streamalert youtube`

### DIFF
--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -408,7 +408,10 @@ class Streams(commands.Cog):
                     bearer=self.ttv_bearer_cache.get("access_token", None),
                 )
             else:
-                stream = _class(name=channel_name, token=token)
+                if is_yt:
+                    stream = _class(name=channel_name, token=token, config=self.config)
+                else:
+                    stream = _class(name=channel_name, token=token)
             try:
                 exists = await self.check_exists(stream)
             except InvalidTwitchCredentials:


### PR DESCRIPTION
The command didn't handle channels that were not provided as IDs

### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Resolves #4625 

Basically we only tested providing channel IDs, *didn't even know simple channels were possible*, so I added that little config key.