### PR TITLE
[Streams] Handle streams with past schedules

### DIFF
--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -408,7 +408,10 @@ class Streams(commands.Cog):
                     bearer=self.ttv_bearer_cache.get("access_token", None),
                 )
             else:
-                stream = _class(name=channel_name, token=token)
+                if is_yt:
+                    stream = _class(name=channel_name, token=token, config=self.config)
+                else:
+                    stream = _class(name=channel_name, token=token)
             try:
                 exists = await self.check_exists(stream)
             except InvalidTwitchCredentials:

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -133,11 +133,17 @@ class YoutubeStream(Stream):
                         stream_data
                         and stream_data != "None"
                         and stream_data.get("actualEndTime", None) is None
-                        and (
-                            stream_data.get("actualStartTime", None) is not None
-                            or stream_data.get("scheduledStartTime", None) is not None
-                        )
                     ):
+                        actual_start_time = stream_data.get("actualStartTime", None)
+                        scheduled = stream_data.get("scheduledStartTime", None)
+                        if scheduled is not None and actual_start_time is None:
+                            scheduled = parse_time(scheduled)
+                            if (
+                                scheduled.replace(tzinfo=None) - datetime.now()
+                            ).total_seconds() < -3600:
+                                continue
+                        elif actual_start_time is None:
+                            continue
                         if video_id not in self.livestreams:
                             self.livestreams.append(data["items"][0]["id"])
                     else:
@@ -169,7 +175,7 @@ class YoutubeStream(Stream):
         channel_title = vid_data["snippet"]["channelTitle"]
         embed = discord.Embed(title=title, url=video_url)
         is_schedule = False
-        if vid_data["liveStreamingDetails"]["scheduledStartTime"] is not None:
+        if vid_data["liveStreamingDetails"].get("scheduledStartTime", None) is not None:
             if "actualStartTime" not in vid_data["liveStreamingDetails"]:
                 start_time = parse_time(vid_data["liveStreamingDetails"]["scheduledStartTime"])
                 start_in = start_time.replace(tzinfo=None) - datetime.now()

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -173,11 +173,16 @@ class YoutubeStream(Stream):
             if "actualStartTime" not in vid_data["liveStreamingDetails"]:
                 start_time = parse_time(vid_data["liveStreamingDetails"]["scheduledStartTime"])
                 start_in = start_time.replace(tzinfo=None) - datetime.now()
-                embed.description = _("This stream will start in {time}").format(
-                    time=humanize_timedelta(
-                        timedelta=timedelta(minutes=start_in.total_seconds() // 60)
-                    )  # getting rid of seconds
-                )
+                if start_in.total_seconds() > 0:
+                    embed.description = _("This stream will start in {time}").format(
+                        time=humanize_timedelta(
+                            timedelta=timedelta(minutes=start_in.total_seconds() // 60)
+                        )  # getting rid of seconds
+                    )
+                else:
+                    embed.description = _(
+                        "This stream was scheduled for {min} minutes ago"
+                    ).format(min=round((start_in.total_seconds() * -1) // 60))
                 embed.timestamp = start_time
                 is_schedule = True
             else:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

* If a stream was scheduled for less than 60 minutes ago, the bot will display a message "This stream was scheduled for X minutes ago" (instead of "This stream will start in ")
* Streams scheduled for more than 60 minutes ago are skipped, channel is considered offline