### PR TITLE
[Alias] Alter `call_alias()` to prevent stripping of newlines

### DIFF
--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -173,6 +173,15 @@ class Alias(commands.Cog):
         raise ValueError("No prefix found.")
 
     async def call_alias(self, message: discord.Message, prefix: str, alias: AliasEntry):
+        new_message = translate_alias_message(message, prefix, alias)
+        await self.bot.process_commands(new_message)
+
+    def translate_alias_message(self, message: discord.Message, prefix: str, alias: AliasEntry):
+        """
+        Translates a discord message using an alias
+        for a command to a discord message using the
+        alias' base command.
+        """
         new_message = copy(message)
         try:
             args = alias.get_extra_args_from_alias(message, prefix)
@@ -187,7 +196,7 @@ class Alias(commands.Cog):
 
         # noinspection PyDunderSlots
         new_message.content = "{}{} {}".format(prefix, command, arg_string)
-        await self.bot.process_commands(new_message)
+        return new_message
 
     async def paginate_alias_list(
         self, ctx: commands.Context, alias_list: List[AliasEntry]

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -173,7 +173,7 @@ class Alias(commands.Cog):
         raise ValueError("No prefix found.")
 
     async def call_alias(self, message: discord.Message, prefix: str, alias: AliasEntry):
-        new_message = translate_alias_message(message, prefix, alias)
+        new_message = self.translate_alias_message(message, prefix, alias)
         await self.bot.process_commands(new_message)
 
     def translate_alias_message(self, message: discord.Message, prefix: str, alias: AliasEntry):

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -188,14 +188,12 @@ class Alias(commands.Cog):
         except commands.BadArgument:
             return
 
-        # Valid argument, now get it as a single string
-        arg_string = alias.get_args_as_single_string(message, prefix)
-
         trackform = _TrackingFormatter()
         command = trackform.format(alias.command, *args)
 
         # noinspection PyDunderSlots
-        new_message.content = "{}{} {}".format(prefix, command, arg_string)
+        new_message.content = "{}{} {}".format(prefix, command, "".join(args[trackform.max + 1 :]))
+
         return new_message
 
     async def paginate_alias_list(

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -174,18 +174,20 @@ class Alias(commands.Cog):
 
     async def call_alias(self, message: discord.Message, prefix: str, alias: AliasEntry):
         new_message = copy(message)
+        print("Original message: " + new_message.content + "\n")
         try:
             args = alias.get_extra_args_from_alias(message, prefix)
         except commands.BadArgument:
             return
 
+        # Valid argument, now get it as a single string
+        arg_string = alias.get_args_as_single_string(message, prefix)
+
         trackform = _TrackingFormatter()
         command = trackform.format(alias.command, *args)
 
         # noinspection PyDunderSlots
-        new_message.content = "{}{} {}".format(
-            prefix, command, " ".join(args[trackform.max + 1 :])
-        )
+        new_message.content = "{}{} {}".format(prefix, command, arg_string)
         await self.bot.process_commands(new_message)
 
     async def paginate_alias_list(

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -174,7 +174,6 @@ class Alias(commands.Cog):
 
     async def call_alias(self, message: discord.Message, prefix: str, alias: AliasEntry):
         new_message = copy(message)
-        print("Original message: " + new_message.content + "\n")
         try:
             args = alias.get_extra_args_from_alias(message, prefix)
         except commands.BadArgument:

--- a/redbot/cogs/alias/alias_entry.py
+++ b/redbot/cogs/alias/alias_entry.py
@@ -66,6 +66,22 @@ class AliasEntry:
             view.skip_ws()
         return extra
 
+    def get_args_as_single_string(self, message: discord.Message, prefix: str) -> str:
+        """
+        When an alias is executed by a user in chat this function tries
+            to get all arguments that follow the prefix and command,
+            as one single string.
+            Whitespace will be trimmed from both ends.
+        :param message:
+        :param prefix:
+        :param alias:
+        :return:
+        """
+        known_content_length = len(prefix) + len(self.name)
+        arg_string = message.content[known_content_length:]
+        arg_string.strip()
+        return arg_string
+
     def to_json(self) -> dict:
 
         return {

--- a/redbot/cogs/alias/alias_entry.py
+++ b/redbot/cogs/alias/alias_entry.py
@@ -63,8 +63,6 @@ class AliasEntry:
             if len(word) < view.index - prev:
                 word = "".join((view.buffer[prev], word, view.buffer[view.index - 1]))
             extra.append(word)
-            # view.skip_ws()
-        print("extra: " + str(extra))
         return extra
 
     def to_json(self) -> dict:

--- a/redbot/cogs/alias/alias_entry.py
+++ b/redbot/cogs/alias/alias_entry.py
@@ -63,24 +63,9 @@ class AliasEntry:
             if len(word) < view.index - prev:
                 word = "".join((view.buffer[prev], word, view.buffer[view.index - 1]))
             extra.append(word)
-            view.skip_ws()
+            # view.skip_ws()
+        print("extra: " + str(extra))
         return extra
-
-    def get_args_as_single_string(self, message: discord.Message, prefix: str) -> str:
-        """
-        When an alias is executed by a user in chat this function tries
-            to get all arguments that follow the prefix and command,
-            as one single string.
-            Whitespace will be trimmed from both ends.
-        :param message:
-        :param prefix:
-        :param alias:
-        :return:
-        """
-        known_content_length = len(prefix) + len(self.name)
-        arg_string = message.content[known_content_length:]
-        arg_string = arg_string.strip()
-        return arg_string
 
     def to_json(self) -> dict:
 

--- a/redbot/cogs/alias/alias_entry.py
+++ b/redbot/cogs/alias/alias_entry.py
@@ -79,7 +79,7 @@ class AliasEntry:
         """
         known_content_length = len(prefix) + len(self.name)
         arg_string = message.content[known_content_length:]
-        arg_string.strip()
+        arg_string = arg_string.strip()
         return arg_string
 
     def to_json(self) -> dict:

--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -203,7 +203,7 @@ def _decode_time(time: int) -> datetime:
     return datetime.utcfromtimestamp(time)
 
 
-async def get_balance(member: discord.Member) -> int:
+async def get_balance(member: Union[discord.Member, discord.User, discord.Object]) -> int:
     """Get the current balance of a member.
 
     Parameters
@@ -599,7 +599,7 @@ async def get_leaderboard_position(
             return pos[0]
 
 
-async def get_account(member: Union[discord.Member, discord.User]) -> Account:
+async def get_account(member: Union[discord.Member, discord.User, discord.Object]) -> Account:
     """Get the appropriate account for the given user or member.
 
     A member is required if the bank is currently guild specific.

--- a/redbot/pytest/core.py
+++ b/redbot/pytest/core.py
@@ -23,7 +23,9 @@ __all__ = [
     "empty_role",
     "empty_user",
     "member_factory",
+    "newline_message",
     "user_factory",
+    "prefix",
     "ctx",
 ]
 
@@ -140,6 +142,18 @@ def empty_user(user_factory):
 def empty_message():
     mock_msg = namedtuple("Message", "content")
     return mock_msg("No content.")
+
+
+@pytest.fixture(scope="module")
+def newline_message():
+    mock_msg = type("", (), {})()
+    mock_msg.content = "!test a\nb\nc\n"
+    return mock_msg
+
+
+@pytest.fixture(scope="module")
+def prefix():
+    return "!"
 
 
 @pytest.fixture()

--- a/redbot/pytest/core.py
+++ b/redbot/pytest/core.py
@@ -22,6 +22,7 @@ __all__ = [
     "empty_message",
     "empty_role",
     "empty_user",
+    "object_as_member_factory",
     "member_factory",
     "newline_message",
     "user_factory",
@@ -136,6 +137,16 @@ def user_factory():
 @pytest.fixture()
 def empty_user(user_factory):
     return user_factory.get()
+
+@pytest.fixture()
+def object_as_member_factory(guild_factory):
+    mock_member = namedtuple("Object", "id guild display_name")
+
+    class ObjectAsMemberFactory:
+        def get(self):
+            return mock_member(random.randint(1, 999999999), guild_factory.get(), "Testing_Name")
+
+    return ObjectAsMemberFactory()
 
 
 @pytest.fixture(scope="module")

--- a/tests/cogs/test_alias.py
+++ b/tests/cogs/test_alias.py
@@ -34,6 +34,18 @@ async def test_add_guild_alias(alias, ctx):
 
 
 @pytest.mark.asyncio
+async def test_translate_alias_message(alias, ctx, newline_message, prefix):
+    await create_test_guild_alias(alias, ctx)
+    alias_obj = await alias._aliases.get_alias(ctx.guild, "test")
+
+    translated_message = alias.translate_alias_message(newline_message, prefix, alias_obj)
+
+    new_arg_string = alias_obj.get_args_as_single_string(translated_message, prefix)
+    original_arg_string = alias_obj.get_args_as_single_string(newline_message, prefix)
+    assert new_arg_string == original_arg_string
+
+
+@pytest.mark.asyncio
 async def test_delete_guild_alias(alias, ctx):
     await create_test_guild_alias(alias, ctx)
     alias_obj = await alias._aliases.get_alias(ctx.guild, "test")

--- a/tests/cogs/test_alias.py
+++ b/tests/cogs/test_alias.py
@@ -40,9 +40,10 @@ async def test_translate_alias_message(alias, ctx, newline_message, prefix):
 
     translated_message = alias.translate_alias_message(newline_message, prefix, alias_obj)
 
-    new_arg_string = alias_obj.get_args_as_single_string(translated_message, prefix)
-    original_arg_string = alias_obj.get_args_as_single_string(newline_message, prefix)
-    assert new_arg_string == original_arg_string
+    original_content = newline_message.content.split(" ", 1)[1]
+    new_content = translated_message.content.split(" ", 1)[1]
+
+    assert new_content == original_content
 
 
 @pytest.mark.asyncio

--- a/tests/cogs/test_economy.py
+++ b/tests/cogs/test_economy.py
@@ -27,6 +27,12 @@ async def test_bank_transfer(bank, member_factory):
     assert bal1 - 50 == newbal1
     assert bal2 + 50 == newbal2
 
+@pytest.mark.asyncio
+async def test_bank_get_from_object(bank, object_as_member_factory):
+    mbr = object_as_member_factory.get()
+    await bank.set_balance(mbr, 250)
+    acc = await bank.get_account(mbr)
+    assert acc.balance == 250
 
 @pytest.mark.asyncio
 async def test_bank_set(bank, member_factory):


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
As detailed in issue #2704 when an alias for a command is created, and this alias is passed input, any newlines in the input are stripped. This is reproducible with the [p]say command (an example can be seen in the issue documentation).

To fix this, I altered the method get_extra_args_from_alias() in redbot/cogs/alias/alias_entry.py to not skip whitespace in between arguments, maintaining newlines if they exist. When these arguments are then formatted into the content of the message that is passed along to the bot, whitespace is not added back in. This should have the effect of better maintaining the passed message, while still allowing customized parameters to be inserted into the input.
 
I also added a test case for this issue to tests/cogs/test_alias.py. This required the splitting up of the call_alias in redbot/cogs/alias/alias.py into two functions, in order to return a value that could be tested. It also required the creation of two new fixtures in redbot/pytest/core.py, newline_message and prefix. In the case that more tests are eventually added to test_alias, these might prove useful.
