### PR TITLE
[Cleanup] Delete command message when using `[p]cleanup self`

### DIFF
--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -579,7 +579,8 @@ class Cleanup(commands.Cog):
             before=ctx.message,
             delete_pinned=delete_pinned,
         )
-        to_delete.append(ctx.message)
+        if can_mass_purge:
+            to_delete.append(ctx.message)
 
         if ctx.guild:
             channel_name = "channel " + channel.name

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -579,6 +579,7 @@ class Cleanup(commands.Cog):
             before=ctx.message,
             delete_pinned=delete_pinned,
         )
+        to_delete.append(ctx.message)
 
         if ctx.guild:
             channel_name = "channel " + channel.name


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Fix #4639 
This will make `cleanup self` consistent with the rest of the commands in the cog