### PR TITLE
Add support for pip 20.3 (a.k.a. use old dependency resolver) and disallow pip 21

### DIFF
--- a/redbot/pytest/downloader.py
+++ b/redbot/pytest/downloader.py
@@ -49,6 +49,8 @@ def repo(tmp_path):
     repo_folder = tmp_path / "repos" / "squid"
     repo_folder.mkdir(parents=True, exist_ok=True)
 
+    Repo.PIP_VERSION_INFO = (20, 3, 0)
+
     return Repo(
         url="https://github.com/tekulvw/Squid-Plugins",
         name="squid",


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This makes use of `-use-deprecated=legacy-resolver` for pip 20.3.x to avoid using the new dependency resolver in Downloader until we ensure proper support for how it works. Until then, Red will forbid using pip 21 to avoid problems that may occur because of it.