### PR TITLE
Add `on_red_before_identify` dispatch

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -381,7 +381,7 @@ class RedBase(
     async def before_identify_hook(self, shard_id, *, initial=False):
         """A hook that is called before IDENTIFYing a session.
         Same as in discord.py, but also dispatches "on_red_identify" bot event."""
-        self.dispatch("red_identify", shard_id, initial)
+        self.dispatch("red_before_identify", shard_id, initial)
         return await super().before_identify_hook(shard_id, initial=initial)
 
     @property

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -378,6 +378,12 @@ class RedBase(
         self._red_before_invoke_objs.add(coro)
         return coro
 
+    async def before_identify_hook(self, shard_id, *, initial=False):
+        """A hook that is called before IDENTIFYing a session.
+        Same as in discord.py, but also dispatches "on_identify" bot event."""
+        self.dispatch("identify", shard_id, initial)
+        return await super().before_identify_hook(shard_id, initial=initial)
+
     @property
     def cog_mgr(self) -> NoReturn:
         raise AttributeError("Please don't mess with the cog manager internals.")
@@ -1544,12 +1550,6 @@ class RedBase(
 
         await asyncio.sleep(delay)
         await _delete_helper(message)
-
-    async def before_identify_hook(self, shard_id, *, initial=False):
-        """A hook that is called before IDENTIFYing a session.
-        Dispatches "on_identify" bot event."""
-        self.dispatch("identify", shard_id, initial)
-        return await super().before_identify_hook(shard_id, initial=initial)
 
     async def logout(self):
         """Logs out of Discord and closes all connections."""

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -380,8 +380,8 @@ class RedBase(
 
     async def before_identify_hook(self, shard_id, *, initial=False):
         """A hook that is called before IDENTIFYing a session.
-        Same as in discord.py, but also dispatches "on_identify" bot event."""
-        self.dispatch("identify", shard_id, initial)
+        Same as in discord.py, but also dispatches "on_red_identify" bot event."""
+        self.dispatch("red_identify", shard_id, initial)
         return await super().before_identify_hook(shard_id, initial=initial)
 
     @property

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1545,6 +1545,12 @@ class RedBase(
         await asyncio.sleep(delay)
         await _delete_helper(message)
 
+    async def before_identify_hook(self, shard_id, *, initial=False):
+        """A hook that is called before IDENTIFYing a session.
+        Dispatches "on_identify" bot event."""
+        self.dispatch("identify", shard_id, initial)
+        return await super().before_identify_hook(shard_id, initial=initial)
+
     async def logout(self):
         """Logs out of Discord and closes all connections."""
         await super().logout()


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes

Adds a dispatch of `on_red_before_identify` event in `before_identify_hook`

Allows detecting `IDENTIFY` without editing core