### PR TITLE
[Trivia] Add support for payout to multiple trivia winners

### DIFF
--- a/redbot/cogs/trivia/session.py
+++ b/redbot/cogs/trivia/session.py
@@ -261,7 +261,7 @@ class TriviaSession:
             await self.send_table()
         multiplier = self.settings["payout_multiplier"]
         if multiplier > 0:
-            await self.pay_winner(multiplier)
+            await self.pay_winners(multiplier)
         self.stop()
 
     async def send_table(self):
@@ -281,7 +281,7 @@ class TriviaSession:
         channel = self.ctx.channel
         LOG.debug("Force stopping trivia session; #%s in %s", channel, channel.guild.id)
 
-    async def pay_winner(self, multiplier: float):
+    async def pay_winners(self, multiplier: float):
         """Pay the winner(s) of this trivia session.
 
         Payout only occurs if there are at least 3 human contestants.

--- a/redbot/cogs/trivia/session.py
+++ b/redbot/cogs/trivia/session.py
@@ -324,7 +324,7 @@ class TriviaSession:
                 currency=await bank.get_currency_name(self.ctx.guild),
             )
         else:
-            msg =  _(
+            msg = _(
                 "Congratulations {user}! You have received {num} {currency} for winning!"
             ).format(
                 user=bold(winners[0].display_name),

--- a/redbot/cogs/trivia/session.py
+++ b/redbot/cogs/trivia/session.py
@@ -285,6 +285,7 @@ class TriviaSession:
         """Pay the winner(s) of this trivia session.
 
         Payout only occurs if there are at least 3 human contestants.
+        If a tie occurs the payout is split evenly among the winners.
 
         Parameters
         ----------
@@ -295,17 +296,15 @@ class TriviaSession:
         """
         if not self.scores:
             return
-        sorted_scores = self.scores.most_common()
-        top_score = sorted_scores[0][1]
+        top_score = self.scores.most_common(1)[0][1]
         winners = []
-        for (player, score) in sorted_scores:
-            if score == top_score:
-                winners.append(player)
-            else:
-                break
-        if self.ctx.guild.me in winners:
-            winners.remove(self.ctx.guild.me)
-        if len(winners) == 0:
+        num_humans = 0
+        for (player, score) in self.scores.items():
+            if not player.bot:
+                if score == top_score:
+                    winners.append(player)
+                num_humans += 1
+        if len(winners) == 0 or num_humans < 3:
             return
         payout = int(top_score * multiplier / len(winners))
         if payout <= 0:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

This PR is for issue #3931. These changes allow for more than one winner of the trivia game. Each winner will receive an even split of the payout. This also adds a new message to congratulate the winner(s).