### PR TITLE
[Bank] Add discord.Object support to bank.get_balance

### DIFF
--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -203,7 +203,7 @@ def _decode_time(time: int) -> datetime:
     return datetime.utcfromtimestamp(time)
 
 
-async def get_balance(member: discord.Member) -> int:
+async def get_balance(member: Union[discord.Member, discord.User, discord.Object]) -> int:
     """Get the current balance of a member.
 
     Parameters
@@ -599,7 +599,7 @@ async def get_leaderboard_position(
             return pos[0]
 
 
-async def get_account(member: Union[discord.Member, discord.User]) -> Account:
+async def get_account(member: Union[discord.Member, discord.User, discord.Object]) -> Account:
     """Get the appropriate account for the given user or member.
 
     A member is required if the bank is currently guild specific.

--- a/redbot/core/bank.py
+++ b/redbot/core/bank.py
@@ -203,7 +203,7 @@ def _decode_time(time: int) -> datetime:
     return datetime.utcfromtimestamp(time)
 
 
-async def get_balance(member: Union[discord.Member, discord.User, discord.Object]) -> int:
+async def get_balance(member: Union[discord.Member, discord.Object]) -> int:
     """Get the current balance of a member.
 
     Parameters

--- a/redbot/pytest/core.py
+++ b/redbot/pytest/core.py
@@ -24,9 +24,7 @@ __all__ = [
     "empty_user",
     "object_as_member_factory",
     "member_factory",
-    "newline_message",
     "user_factory",
-    "prefix",
     "ctx",
 ]
 
@@ -154,18 +152,6 @@ def object_as_member_factory(guild_factory):
 def empty_message():
     mock_msg = namedtuple("Message", "content")
     return mock_msg("No content.")
-
-
-@pytest.fixture(scope="module")
-def newline_message():
-    mock_msg = type("", (), {})()
-    mock_msg.content = "!test a\nb\nc\n"
-    return mock_msg
-
-
-@pytest.fixture(scope="module")
-def prefix():
-    return "!"
 
 
 @pytest.fixture()

--- a/redbot/pytest/core.py
+++ b/redbot/pytest/core.py
@@ -22,8 +22,11 @@ __all__ = [
     "empty_message",
     "empty_role",
     "empty_user",
+    "object_as_member_factory",
     "member_factory",
+    "newline_message",
     "user_factory",
+    "prefix",
     "ctx",
 ]
 
@@ -136,10 +139,33 @@ def empty_user(user_factory):
     return user_factory.get()
 
 
+@pytest.fixture()
+def object_as_member_factory(guild_factory):
+    mock_member = namedtuple("Object", "id guild display_name")
+
+    class ObjectAsMemberFactory:
+        def get(self):
+            return mock_member(random.randint(1, 999999999), guild_factory.get(), "Testing_Name")
+
+    return ObjectAsMemberFactory()
+
+
 @pytest.fixture(scope="module")
 def empty_message():
     mock_msg = namedtuple("Message", "content")
     return mock_msg("No content.")
+
+
+@pytest.fixture(scope="module")
+def newline_message():
+    mock_msg = type("", (), {})()
+    mock_msg.content = "!test a\nb\nc\n"
+    return mock_msg
+
+
+@pytest.fixture(scope="module")
+def prefix():
+    return "!"
 
 
 @pytest.fixture()

--- a/tests/cogs/test_economy.py
+++ b/tests/cogs/test_economy.py
@@ -29,6 +29,14 @@ async def test_bank_transfer(bank, member_factory):
 
 
 @pytest.mark.asyncio
+async def test_bank_get_from_object(bank, object_as_member_factory):
+    mbr = object_as_member_factory.get()
+    await bank.set_balance(mbr, 250)
+    acc = await bank.get_account(mbr)
+    assert acc.balance == 250
+
+
+@pytest.mark.asyncio
 async def test_bank_set(bank, member_factory):
     mbr = member_factory.get()
     await bank.set_balance(mbr, 250)

--- a/tests/cogs/test_economy.py
+++ b/tests/cogs/test_economy.py
@@ -29,6 +29,19 @@ async def test_bank_transfer(bank, member_factory):
 
 
 @pytest.mark.asyncio
+async def test_bank_transfer_from_objects(bank, object_as_member_factory):
+    mbr1 = object_as_member_factory.get()
+    mbr2 = object_as_member_factory.get()
+    bal1 = (await bank.get_account(mbr1)).balance
+    bal2 = (await bank.get_account(mbr2)).balance
+    await bank.transfer_credits(mbr1, mbr2, 50)
+    newbal1 = (await bank.get_account(mbr1)).balance
+    newbal2 = (await bank.get_account(mbr2)).balance
+    assert bal1 - 50 == newbal1
+    assert bal2 + 50 == newbal2
+
+
+@pytest.mark.asyncio
 async def test_bank_get_from_object(bank, object_as_member_factory):
     mbr = object_as_member_factory.get()
     await bank.set_balance(mbr, 250)
@@ -39,6 +52,14 @@ async def test_bank_get_from_object(bank, object_as_member_factory):
 @pytest.mark.asyncio
 async def test_bank_set(bank, member_factory):
     mbr = member_factory.get()
+    await bank.set_balance(mbr, 250)
+    acc = await bank.get_account(mbr)
+    assert acc.balance == 250
+
+
+@pytest.mark.asyncio
+async def test_bank_set_from_object(bank, object_as_member_factory):
+    mbr = object_as_member_factory.get()
     await bank.set_balance(mbr, 250)
     acc = await bank.get_account(mbr)
     assert acc.balance == 250


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
As detailed in #4391, much of the Core Bank API functions only accepted discord.Member or discord.User input types for routine functions such as get_balance(). This is problematic, given the unnecessary and possibly sensitive information that is included with a Member or User object. This can be improved by changing the calls' input types to enable passing it a discord.Object instead, in order to prevent sensitive information being unnecessarily acquired.

I also added test cases to tests/cogs/test_economy.py, in order to test the ability of these API calls to function correctly with a  discord.Object as input, and the necessary infrastructure in pytest/core.py