### PR TITLE
[Docs] Update GC free credit period

### DIFF
--- a/docs/host-list.rst
+++ b/docs/host-list.rst
@@ -83,9 +83,9 @@ Free hosting
   `Oracle Cloud Compute <https://oracle.com/cloud/free/#always-free>`_ and
   `AWS EC2 <https://aws.amazon.com/free/>`_ have free tier VPSes suitable for small bots.
 
-| **Note:** AWS EC2's free tier does not last forever - it's a 3 month trial.
+| **Note:** AWS EC2's free tier does not last forever - it's a 12 month trial.
 | Additionally, new Google Cloud customers get a $300 credit which is valid
-  for 12 months.
+  for 3 months.
 
 Other than that... no. There is no good free VPS hoster, outside of
 persuading somebody to host for you, which is incredibly unlikely.

--- a/docs/host-list.rst
+++ b/docs/host-list.rst
@@ -83,7 +83,7 @@ Free hosting
   `Oracle Cloud Compute <https://oracle.com/cloud/free/#always-free>`_ and
   `AWS EC2 <https://aws.amazon.com/free/>`_ have free tier VPSes suitable for small bots.
 
-| **Note:** AWS EC2's free tier does not last forever - it's a 12 month trial.
+| **Note:** AWS EC2's free tier does not last forever - it's a 3 month trial.
 | Additionally, new Google Cloud customers get a $300 credit which is valid
   for 12 months.
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Google's $300 credit now lasts for 3 months, not 12 as it was previously.
See https://cloud.google.com/free/docs/gcp-free-tier