### PR TITLE
[Docs] Raspian Installation Directs to 404

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -277,7 +277,7 @@ If you want to do it, follow these steps.
   you're a beginner, we recommend **Ubuntu 20.04 LTS**.
 
   For Raspberry Pi users, just install `Raspbian
-  <https://www.raspberrypi.org/downloads/raspbian/>`_ on a micro-SD card.
+  <https://www.raspberrypi.org/software/>`_ on a micro-SD card.
 
 2.1. **Log in**
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Raspian Installation URL in the documentation brings you straight to a 404. I replaced the URL with a valid one. [Here is the link I proposed.](https://www.raspberrypi.org/software/) 
