### PR TITLE
Red 3.4.4 - Changelog

### DIFF
--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -93,7 +93,7 @@ Documentation changes
 - Added `cog guide for Downloader cog <streams>` (:issue:`4511`)
 - Added `cog guide for Economy cog <streams>` (:issue:`4519`)
 - Added `cog guide for Streams cog <streams>` (:issue:`4521`)
-- Added `guide_cog_creators` (:issue:`4637`)
+- Added `guide_cog_creators` document (:issue:`4637`)
 - Removed install instructions for Ubuntu 16.04 (:issue:`4650`)
 
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -26,7 +26,7 @@ Core Bot
 
 - Red's logging will now shine in your terminal more than ever (:issue:`4577`)
 - Improved consistency of command usage in the help messages within all commands in Core Red (:issue:`4589`)
-- Added friendly error when the duration provided to the command is out of maximum bounds allowed by Python interpreter (:issue:`4019`, :issue:`4628`,:issue:`4630`)
+- Added friendly error when the duration provided to the command is out of maximum bounds allowed by Python interpreter (:issue:`4019`, :issue:`4628`, :issue:`4630`)
 - Fixed an error when removing path from other operating system with ``[p]removepath`` (:issue:`2609`, :issue:`4662`, :issue:`4466`)
 
 Audio
@@ -84,7 +84,7 @@ Developer changelog
 -------------------
 
 - `get_audit_reason()` can now be passed ``shorten`` keyword argument which will automatically shorten the returned audit reason to fit the max length allowed by Discord audit logs (:issue:`4189`)
-- ``bot.remove_command()`` now returns the command object of the removed command as does `discord.ext.commands.Bot.remove_command()` method (:issue:`4636`)
+- ``bot.remove_command()`` now returns the command object of the removed command as does the equivalent method from `discord.ext.commands.Bot` class (:issue:`4636`)
 
 
 Documentation changes

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -15,7 +15,7 @@ Read before updating
 
 2. Ubuntu 16.04 is no longer supported as it will soon reach its end of life and it is no longer viable for us to maintain support for it.
 
-    While you might still be able to run Red on it, we will no longer put any resources into supporting it. If you're using Ubuntu 16.04, we highly recommend that you upgrade to latest LTS version of Ubuntu.
+    While you might still be able to run Red on it, we will no longer put any resources into supporting it. If you're using Ubuntu 16.04, we highly recommend that you upgrade to the latest LTS version of Ubuntu.
 
 
 End-user changelog
@@ -26,8 +26,8 @@ Core Bot
 
 - Red's logging will now shine in your terminal more than ever (:issue:`4577`)
 - Improved consistency of command usage in the help messages within all commands in Core Red (:issue:`4589`)
-- Added friendly error when the duration provided to the command is out of maximum bounds allowed by Python interpreter (:issue:`4019`, :issue:`4628`, :issue:`4630`)
-- Fixed an error when removing path from other operating system with ``[p]removepath`` (:issue:`2609`, :issue:`4662`, :issue:`4466`)
+- Added a friendly error when the duration provided to commands that use the ``commands.TimedeltaConverter`` converter is out of the maximum bounds allowed by Python interpreter (:issue:`4019`, :issue:`4628`, :issue:`4630`)
+- Fixed an error when removing path from a different operating system than the bot is currently running on with ``[p]removepath`` (:issue:`2609`, :issue:`4662`, :issue:`4466`)
 
 Audio
 *****
@@ -35,7 +35,7 @@ Audio
 - Fixed ``[p]llset java`` failing to set the Java executable path (:issue:`4621`, :issue:`4624`)
 - Fixed Soundcloud playback (:issue:`4683`)
 - Fixed YouTube age-restricted track playback (:issue:`4683`)
-- Added more friendly message for 429 errors to let users know they have been temporarily banned from accessing the service instead of a generic Lavalink error (:issue:`4683`)
+- Added more friendly messages for 429 errors to let users know they have been temporarily banned from accessing the service instead of a generic Lavalink error (:issue:`4683`)
 - Environment information will now be appended to Lavalink tracebacks in the spring.log (:issue:`4683`)
 
 Cleanup
@@ -76,14 +76,14 @@ Streams
 Trivia Lists
 ************
 
-- Added ``whosthatpokemon5`` trivia containing Pokémons from 5th generation (:issue:`4646`)
+- Added ``whosthatpokemon5`` trivia list containing Pokémon from the 5th generation (:issue:`4646`)
 - Added ``geography`` trivia list (:issue:`4618`)
 
 
 Developer changelog
 -------------------
 
-- `get_audit_reason()` can now be passed ``shorten`` keyword argument which will automatically shorten the returned audit reason to fit the max length allowed by Discord audit logs (:issue:`4189`)
+- `get_audit_reason()` can now be passed a ``shorten`` keyword argument which will automatically shorten the returned audit reason to fit the max length allowed by Discord audit logs (:issue:`4189`)
 - ``bot.remove_command()`` now returns the command object of the removed command as does the equivalent method from `discord.ext.commands.Bot` class (:issue:`4636`)
 
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -4,7 +4,7 @@ Redbot 3.4.4 (2020-12-24)
 =========================
 
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`aikaterna`, :ghuser:`bobloy`, :ghuser:`flaree`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`kreus7`, :ghuser:`NeuroAssassin`, :ghuser:`npc203`, :ghuser:`palmtree5`, :ghuser:`phenom4n4n`, :ghuser:`Predeactor`, :ghuser:`retke`, :ghuser:`siu3334`, :ghuser:`Vexed01`, :ghuser:`yamikaitou`
+| :ghuser:`aikaterna`, :ghuser:`bobloy`, :ghuser:`Flame442`, :ghuser:`flaree`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`kreus7`, :ghuser:`NeuroAssassin`, :ghuser:`npc203`, :ghuser:`palmtree5`, :ghuser:`phenom4n4n`, :ghuser:`Predeactor`, :ghuser:`retke`, :ghuser:`siu3334`, :ghuser:`Vexed01`, :ghuser:`yamikaitou`
 
 Read before updating
 --------------------

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -1,5 +1,102 @@
 .. 3.4.x Changelogs
 
+Redbot 3.4.4 (2020-12-24)
+=========================
+
+| Thanks to all these amazing people that contributed to this release:
+| :ghuser:`aikaterna`, :ghuser:`bobloy`, :ghuser:`flaree`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`kreus7`, :ghuser:`NeuroAssassin`, :ghuser:`npc203`, :ghuser:`palmtree5`, :ghuser:`phenom4n4n`, :ghuser:`Predeactor`, :ghuser:`retke`, :ghuser:`siu3334`, :ghuser:`Vexed01`, :ghuser:`yamikaitou`
+
+Read before updating
+--------------------
+
+1. Information for Audio users that are using an external Lavalink instance (if you don't know what that is, you should skip this point):
+
+    Red 3.4.4 uses a new Lavalink jar that you will need to manually update from `our GitHub <https://github.com/Cog-Creators/Lavalink-Jars/releases/tag/3.3.2.2_1170>`__.
+
+2. Ubuntu 16.04 is no longer supported as it will soon reach its end of life and it is no longer viable for us to maintain support for it.
+
+    While you might still be able to run Red on it, we will no longer put any resources into supporting it. If you're using Ubuntu 16.04, we highly recommend that you upgrade to latest LTS version of Ubuntu.
+
+
+End-user changelog
+------------------
+
+Core Bot
+********
+
+- Red's logging will now shine in your terminal more than ever (:issue:`4577`)
+- Improved consistency of command usage in the help messages within all commands in Core Red (:issue:`4589`)
+- Added friendly error when the duration provided to the command is out of maximum bounds allowed by Python interpreter (:issue:`4019`, :issue:`4628`,:issue:`4630`)
+- Fixed an error when removing path from other operating system with ``[p]removepath`` (:issue:`2609`, :issue:`4662`, :issue:`4466`)
+
+Audio
+*****
+
+- Fixed ``[p]llset java`` failing to set the Java executable path (:issue:`4621`, :issue:`4624`)
+- Fixed Soundcloud playback (:issue:`4683`)
+- Fixed YouTube age-restricted track playback (:issue:`4683`)
+- Added more friendly message for 429 errors to let users know they have been temporarily banned from accessing the service instead of a generic Lavalink error (:issue:`4683`)
+- Environment information will now be appended to Lavalink tracebacks in the spring.log (:issue:`4683`)
+
+Cleanup
+*******
+
+- ``[p]cleanup self`` will now delete the command message when the bot has permissions to do so (:issue:`4640`)
+
+Dev
+***
+
+- Added new ``[p]bypasscooldown`` command that allows owners to bypass command cooldowns (:issue:`4440`)
+
+Economy
+*******
+
+- ``[p]economyset slotmin`` and ``[p]economyset slotmax`` now warn when the new value will cause the slots command to not work (:issue:`4583`)
+
+General
+*******
+
+- Updated features list in ``[p]serverinfo`` with the latest changes from Discord (:issue:`4678`)
+
+Mod
+***
+
+- ``[p]ban`` command will no longer error out when the given reason is too long (:issue:`4187`, :issue:`4189`)
+
+Streams
+*******
+
+- Scheduled YouTube streams now work properly with the cog (:issue:`3691`, :issue:`4615`)
+- YouTube stream schedules are now announced before the stream (:issue:`4615`)
+
+    - Alerts about YouTube stream schedules can be disabled with a new ``[p]streamset ignoreschedule`` command (:issue:`4615`)
+
+- Improved error logging (:issue:`4680`)
+
+Trivia Lists
+************
+
+- Added ``whosthatpokemon5`` trivia containing Pokémons from 5th generation (:issue:`4646`)
+- Added ``geography`` trivia list (:issue:`4618`)
+
+
+Developer changelog
+-------------------
+
+- `get_audit_reason()` can now be passed ``shorten`` keyword argument which will automatically shorten the returned audit reason to fit the max length allowed by Discord audit logs (:issue:`4189`)
+- ``bot.remove_command()`` now returns the command object of the removed command as does `discord.ext.commands.Bot.remove_command()` method (:issue:`4636`)
+
+
+Documentation changes
+---------------------
+
+- Added `cog guide for Downloader cog <streams>` (:issue:`4511`)
+- Added `cog guide for Economy cog <streams>` (:issue:`4519`)
+- Added `cog guide for Streams cog <streams>` (:issue:`4521`)
+- Added `guide_cog_creators` (:issue:`4637`)
+- Removed install instructions for Ubuntu 16.04 (:issue:`4650`)
+
+
 Redbot 3.4.3 (2020-11-16)
 =========================
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature
- [x] Docs

### Description of the changes
Changelog for Red version 3.4.4.

Rendered documentation can be seen at https://red-discordbot--4684.org.readthedocs.build/en/4684/changelog_3_4_0.html#redbot-3-4-4-2020-12-24