### PR TITLE
[Streams] Use timezone-aware time

### DIFF
--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -178,7 +178,7 @@ class YoutubeStream(Stream):
         if vid_data["liveStreamingDetails"].get("scheduledStartTime", None) is not None:
             if "actualStartTime" not in vid_data["liveStreamingDetails"]:
                 start_time = parse_time(vid_data["liveStreamingDetails"]["scheduledStartTime"])
-                start_in = start_time.replace(tzinfo=None) - datetime.now()
+                start_in = start_time.replace() - datetime.now()
                 if start_in.total_seconds() > 0:
                     embed.description = _("This stream will start in {time}").format(
                         time=humanize_timedelta(

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -138,9 +138,7 @@ class YoutubeStream(Stream):
                         scheduled = stream_data.get("scheduledStartTime", None)
                         if scheduled is not None and actual_start_time is None:
                             scheduled = parse_time(scheduled)
-                            if (
-                                scheduled - datetime.now(timezone.utc)
-                            ).total_seconds() < -3600:
+                            if (scheduled - datetime.now(timezone.utc)).total_seconds() < -3600:
                                 continue
                         elif actual_start_time is None:
                             continue

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -4,7 +4,7 @@ import logging
 from dateutil.parser import parse as parse_time
 from random import choice
 from string import ascii_letters
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import xml.etree.ElementTree as ET
 from typing import ClassVar, Optional, List, Tuple
 
@@ -139,7 +139,7 @@ class YoutubeStream(Stream):
                         if scheduled is not None and actual_start_time is None:
                             scheduled = parse_time(scheduled)
                             if (
-                                scheduled.replace(tzinfo=None) - datetime.now()
+                                scheduled - datetime.now(timezone.utc)
                             ).total_seconds() < -3600:
                                 continue
                         elif actual_start_time is None:
@@ -178,7 +178,7 @@ class YoutubeStream(Stream):
         if vid_data["liveStreamingDetails"].get("scheduledStartTime", None) is not None:
             if "actualStartTime" not in vid_data["liveStreamingDetails"]:
                 start_time = parse_time(vid_data["liveStreamingDetails"]["scheduledStartTime"])
-                start_in = start_time.replace() - datetime.now()
+                start_in = start_time - datetime.now(timezone.utc)
                 if start_in.total_seconds() > 0:
                     embed.description = _("This stream will start in {time}").format(
                         time=humanize_timedelta(


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This PR fixes #4693 by converting the naive `.now()` time into a timezone-aware time (such as UTC, but any timezone will work) instead of vice-versa, so that the timedelta difference is relatively correct in the scheduled YouTube embed description.

Screenshots below:
![image](https://user-images.githubusercontent.com/6710854/103114694-833c7600-4614-11eb-801f-4a0ad296e414.png)
![image](https://user-images.githubusercontent.com/6710854/103384753-6092dd00-4aac-11eb-8676-7bef2cc63000.png)