### PR TITLE
Wrap `Red-DiscordBot[postgres]` in quotes in Unix install docs

### DIFF
--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -446,6 +446,7 @@ Or, to install with PostgreSQL support:
     python -m pip install -U pip setuptools wheel
     python -m pip install -U "Red-DiscordBot[postgres]"
 
+
 .. note::
 
     These commands are also used for updating Red

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -449,7 +449,7 @@ Or, to install with PostgreSQL support:
 
 .. attention:: 
 
-    Depending on your system brackets may need to be escaped. A common escape sequence would look like this: ``\[``
+    Depending on your system, brackets may need to be escaped. A common escape sequence would look like this: ``\[``
 
 .. note::
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -444,12 +444,7 @@ Or, to install with PostgreSQL support:
 .. code-block:: none
 
     python -m pip install -U pip setuptools wheel
-    python -m pip install -U Red-DiscordBot[postgres]
-
-
-.. attention:: 
-
-    Depending on your system, brackets may need to be escaped. A common escape sequence would look like this: ``\[``
+    python -m pip install -U "Red-DiscordBot[postgres]"
 
 .. note::
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -447,6 +447,10 @@ Or, to install with PostgreSQL support:
     python -m pip install -U Red-DiscordBot[postgres]
 
 
+.. attention:: 
+
+    Depending on your system brackets may need to be escaped. A common escape sequence would look like this: ``\[``
+
 .. note::
 
     These commands are also used for updating Red


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

Just added an "attention" block inside of the Linux/macOS bot installation documention which highlights the necessity of escaping brackets in terminals.
