### PR TITLE
[Mod] Make tempban not fail if no vanity url is set up

### DIFF
--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -46,7 +46,7 @@ class KickBanMixin(MixinMeta):
                     # but does not have it set up,
                     # this prevents the command from failing
                     # and defaults back to another regular invite.
-                    pass 
+                    pass
             invites = await guild.invites()
         else:
             invites = []

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -39,7 +39,14 @@ class KickBanMixin(MixinMeta):
         if my_perms.manage_guild or my_perms.administrator:
             if "VANITY_URL" in guild.features:
                 # guild has a vanity url so use it as the one to send
-                return await guild.vanity_invite()
+                try:
+                    return await guild.vanity_invite()
+                except discord.NotFound:
+                    # If a guild has the vanity url feature,
+                    # but does not have it set up,
+                    # this prevents the command from failing
+                    # and defaults back to another regular invite.
+                    pass 
             invites = await guild.invites()
         else:
             invites = []


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

If a guild has the VANITY_URL feature but doesn't actually have a value set for their vanity url, ``guild.vanity_invite()`` fails and breaks ``[p]tempban``. This PR fixes that.