### PR TITLE
Fix auto labeler error from invalid yaml -> json

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,7 +4,7 @@
   - redbot/cogs/alias/*
 "Category: Audio Cog":
   - redbot/cogs/audio/**/*
-  - !redbot/cogs/audio/**/locales/*
+  - "!redbot/cogs/audio/**/locales/*"
 "Category: Bank API":
   - redbot/core/bank.py
 "Category: Bank Cog":
@@ -29,7 +29,7 @@
   - redbot/cogs/cleanup/*
 "Category: Command Module":
   - redbot/core/commands/*
-  - !redbot/core/commands/help.py
+  - "!redbot/core/commands/help.py"
 "Category: Config":
   - redbot/core/drivers/*
   - redbot/core/config.py


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Without quotes, it converts as `null`. Adding quotes allows it to properly convert as a string.