### PR TITLE
[Utils] Additional features for chat_formatting

### DIFF
--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -144,6 +144,92 @@ def italics(text: str, escape_formatting: bool = True) -> str:
     text = escape(text, formatting=escape_formatting)
     return "*{}*".format(text)
 
+def spoiler(text: str, escape_formatting: bool = True) -> str:
+    """Get the given text as a spoiler.
+
+    Note: By default, this function will escape ``text`` prior to making the text a spoiler.
+
+    Parameters
+    ----------
+    text : str
+        The text to be marked up.
+    escape_formatting : `bool`, optional
+        Set to :code:`False` to not escape markdown formatting in the text.
+
+    Returns
+    -------
+    str
+        The marked up text.
+
+    """
+    text = escape(text, formatting=escape_formatting)
+    return "||{}||".format(text)
+
+def strikethrough(text: str, escape_formatting: bool = True) -> str:
+    """Get the given text striked through.
+
+    Note: By default, this function will escape ``text`` prior to striking through.
+
+    Parameters
+    ----------
+    text : str
+        The text to be marked up.
+    escape_formatting : `bool`, optional
+        Set to :code:`False` to not escape markdown formatting in the text.
+
+    Returns
+    -------
+    str
+        The marked up text.
+
+    """
+    text = escape(text, formatting=escape_formatting)
+    return "~~{}~~".format(text)
+
+def snake(text: str, escape_formatting: bool = True) -> str:
+    """Get the given text with snake spaces.
+
+    Note: By default, this function will escape ``text`` prior to replacing spaces with underscores.
+
+    Parameters
+    ----------
+    text : str
+        The text to be marked up.
+    escape_formatting : `bool`, optional
+        Set to :code:`False` to not escape markdown formatting in the text.
+
+    Returns
+    -------
+    str
+        The marked up text.
+
+    """
+    text = escape(text, formatting=escape_formatting)
+    return text.replace(' ', '_')
+
+def alternatingcase(text: str, escape_formatting: bool = True) -> str:
+    """Get the given text with alternating cases.
+
+    Note: By default, this function will escape ``text`` prior to changing cases.
+
+    Parameters
+    ----------
+    text : str
+        The text to be marked up.
+    escape_formatting : `bool`, optional
+        Set to :code:`False` to not escape markdown formatting in the text.
+
+    Returns
+    -------
+    str
+        The marked up text.
+
+    """
+    text = escape(text, formatting=escape_formatting)
+    text = list(text)
+    text[0::2] = map(str.upper, text[0::2])
+    text[1::2] = map(str.lower, text[1::2])
+    return "".join(text)
 
 def bordered(*columns: Sequence[str], ascii_border: bool = False) -> str:
     """Get two blocks of text in a borders.

--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -165,27 +165,6 @@ def spoiler(text: str, escape_formatting: bool = True) -> str:
     text = escape(text, formatting=escape_formatting)
     return "||{}||".format(text)
 
-def strikethrough(text: str, escape_formatting: bool = True) -> str:
-    """Get the given text striked through.
-
-    Note: By default, this function will escape ``text`` prior to striking through.
-
-    Parameters
-    ----------
-    text : str
-        The text to be marked up.
-    escape_formatting : `bool`, optional
-        Set to :code:`False` to not escape markdown formatting in the text.
-
-    Returns
-    -------
-    str
-        The marked up text.
-
-    """
-    text = escape(text, formatting=escape_formatting)
-    return "~~{}~~".format(text)
-
 def snake(text: str, escape_formatting: bool = True) -> str:
     """Get the given text with snake spaces.
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes

Added some additional features for chat_formatting which I would like to see and eventually use. These features include returning the text as a spoiler, ~~with a strikethrough~~, with snake_spaces (just_like_this) and with alternating cases (JuSt LiKe ThIs). Please let me know of your thoughts, I used modified docstrings from previous utils, and kept the escape formatting for each of them.

++ Did not realize that strikethrough was already available, so I removed it.
