### PR TITLE
Humanize number fix

### DIFF
--- a/redbot/cogs/audio/core/commands/audioset.py
+++ b/redbot/cogs/audio/core/commands/audioset.py
@@ -754,9 +754,17 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
         """Set a price for queueing tracks for non-mods, 0 to disable."""
         if price < 0:
             return await self.send_embed_msg(
-                ctx, title=_("Invalid Price"), description=_("Price can't be less than zero.")
+                ctx,
+                title=_("Invalid Price"),
+                description=_("Price can't be less than zero."),
             )
-        if price == 0:
+        elif price > 2 ** 63 - 1:
+            return await self.send_embed_msg(
+                ctx,
+                title=_("Invalid Price"),
+                description=_("Price can't be greater than 2^63 - 1."),
+            )
+        elif price == 0:
             jukebox = False
             await self.send_embed_msg(
                 ctx, title=_("Setting Changed"), description=_("Jukebox mode disabled.")

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -50,6 +50,9 @@ class Cleanup(commands.Cog):
         if ctx.assume_yes:
             return True
 
+        if number > 2 ** 63 - 1:
+            return await ctx.send(_("Try a smaller number instead."))
+
         prompt = await ctx.send(
             _("Are you sure you want to delete {number} messages? (y/n)").format(
                 number=humanize_number(number)

--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -39,7 +39,7 @@ class RPSParser:
             self.choice = None
 
 
-MAX_ROLL: Final[int] = 2 ** 64 - 1
+MAX_ROLL: Final[int] = 2 ** 63 - 1
 
 
 @cog_i18n(_)

--- a/redbot/cogs/trivia/converters.py
+++ b/redbot/cogs/trivia/converters.py
@@ -8,6 +8,9 @@ __all__ = ("finite_float",)
 _ = Translator("Trivia", __file__)
 
 
+MAX_VALUE = 2 ** 63 - 1
+
+
 def finite_float(arg: str) -> float:
     try:
         ret = float(arg)

--- a/redbot/cogs/trivia/session.py
+++ b/redbot/cogs/trivia/session.py
@@ -8,6 +8,7 @@ from redbot.core import bank, errors
 from redbot.core.i18n import Translator
 from redbot.core.utils.chat_formatting import box, bold, humanize_list, humanize_number
 from redbot.core.utils.common_filters import normalize_smartquotes
+from .converters import MAX_VALUE
 from .log import LOG
 
 __all__ = ["TriviaSession"]
@@ -301,6 +302,7 @@ class TriviaSession:
                 contestants.remove(me_)
             if len(contestants) >= 3:
                 amount = int(multiplier * score)
+                amount = MAX_VALUE if amount > MAX_VALUE else amount
                 if amount > 0:
                     LOG.debug("Paying trivia winner: %d credits --> %s", amount, str(winner))
                     try:

--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -519,7 +519,7 @@ def humanize_timedelta(
 
 def humanize_number(val: Union[int, float], override_locale=None) -> str:
     """
-    Convert an int or float to a str with digit separators based on bot locale
+    Convert an int or float to a str with digit separators based on bot locale.
 
     Parameters
     ----------
@@ -528,10 +528,15 @@ def humanize_number(val: Union[int, float], override_locale=None) -> str:
     override_locale: Optional[str]
         A value to override bot's regional format.
 
+    Raises
+    ------
+    decimals.InvalidOperation
+        If val is greater than 10 x 10^21 for some locales, 10 x 10^24 in others.
+
     Returns
     -------
     str
-        locale aware formatted number.
+        Locale-aware formatted number.
     """
     return format_decimal(val, locale=get_babel_regional_format(override_locale))
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
humanize_number has the capability to error out with very large values, in some cases over 10 quintillion (9,999,999,999,999,999,999,999), in other locales over 1,000 quintillion (9,999,999,999,999,999,999,999,999). 

This PR:
Closes #4619 and fixes the instance of this in cleanup that started this PR (prompts the user to provide a more sane number value)
Addresses this issue in audioset jukebox (prompts the user to provide a more sane number value)
Addresses this issue in trivia's payout (caps payout at 2 ** 63 - 1)
Changes the [p]roll max value to 2 ** 63 - 1 to help standardize max value across the bot
Adds to humanize_number's docstring to explain the possible limit on some systems
These should be all the places in Red where this number value for a limit could be enforced/used.

This PR does not:
Add a possible limit for triviaset payout (it's an uncapped float at the moment)
Cap anything that's passed to humanize_number via the function itself