### PR TITLE
Fix the negation rules in labeler configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,8 +3,10 @@
 "Category: Alias":
   - redbot/cogs/alias/*
 "Category: Audio Cog":
-  - redbot/cogs/audio/**/*
-  - "!redbot/cogs/audio/**/locales/*"
+  - any:
+      - redbot/cogs/audio/**/*
+    all:
+      - "!redbot/cogs/audio/**/locales/*"
 "Category: Bank API":
   - redbot/core/bank.py
 "Category: Bank Cog":
@@ -28,8 +30,10 @@
 "Category: Cleanup Cog":
   - redbot/cogs/cleanup/*
 "Category: Command Module":
-  - redbot/core/commands/*
-  - "!redbot/core/commands/help.py"
+  - any:
+      - redbot/core/commands/*
+  - all:
+      - "!redbot/core/commands/help.py"
 "Category: Config":
   - redbot/core/drivers/*
   - redbot/core/config.py


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
By default *any* rule must match, so negation rules cause all files except the ones specified in the rule to match. This fixes it by properly requiring the negation rule to match **in addition to** the other rules.