### PR TITLE
Update d.py to 1.6.0, aiohttp to 3.7.3, Red-Lavalink to 0.7.2

### DIFF
--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -204,12 +204,3 @@ if "--debug" not in _sys.argv:
     # Individual warnings - tracked in https://github.com/Cog-Creators/Red-DiscordBot/issues/3529
     # DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
     _warnings.filterwarnings("ignore", category=DeprecationWarning, module="importlib", lineno=219)
-    # DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
-    #   def noop(*args, **kwargs):  # type: ignore
-    _warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=107)
-    # DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
-    #   hosts = await asyncio.shield(self._resolve_host(..
-    _warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=964)
-    # DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
-    #   self._event = asyncio.Event(loop=loop)
-    _warnings.filterwarnings("ignore", category=DeprecationWarning, module="aiohttp", lineno=21)

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -188,7 +188,7 @@ class Context(DPYContext):
                 else:
                     try:
                         await self.channel.delete_messages((query, resp))
-                    except (discord.HTTPException, AttributeError):
+                    except discord.HTTPException:
                         # In case the bot can't delete other users' messages,
                         # or is not a bot account
                         # or channel is a DM

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -546,15 +546,11 @@ class Case:
         if message is None:
             message_id = data.get("message")
             if message_id is not None:
-                try:
-                    message = discord.utils.get(bot.cached_messages, id=message_id)
-                except AttributeError:
-                    # bot.cached_messages didn't exist prior to discord.py 1.1.0
-                    message = None
+                message = discord.utils.get(bot.cached_messages, id=message_id)
                 if message is None:
                     try:
                         message = await mod_channel.fetch_message(message_id)
-                    except (discord.HTTPException, AttributeError):
+                    except discord.HTTPException:
                         message = None
             else:
                 message = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ classifiers =
 packages = find_namespace:
 python_requires = >=3.8.1,<3.9
 install_requires =
-    aiohttp==3.6.2
+    aiohttp==3.7.3
     aiohttp-json-rpc==0.13.2
     aiosqlite==0.15.0
     appdirs==1.4.4
@@ -45,7 +45,7 @@ install_requires =
     colorama==0.4.3
     commonmark==0.9.1
     contextlib2==0.6.0.post1
-    discord.py==1.5.1
+    discord.py==1.6.0
     distro==1.5.0; sys_platform == "linux"
     fuzzywuzzy==0.18.0
     idna==2.10
@@ -56,7 +56,7 @@ install_requires =
     python-Levenshtein-wheels==0.13.1
     pytz==2020.1
     PyYAML==5.3.1
-    Red-Lavalink==0.7.1
+    Red-Lavalink==0.7.2
     rich==9.5.1
     schema==0.7.2
     six==1.15.0


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature
- [x] Dependency update

### Description of the changes
- Update d.py to 1.6.0, aiohttp to 3.7.3, Red-Lavalink to 0.7.2 (the last one because of the dependency conflict with aiohttp 3.7+)
- Remove suppression of deprecation warnings that are no longer relevant with the update of aiohttp
- Change things that require changing after bumping d.py 1.6
    - in this update, it's only some max concurrency things in `Command.prepare()`
- Remove two random `AttributeError` exception catching that doesn't make sense at least since d.py 1.1...

After this PR gets merged, #3529 should be updated appropriately.