### PR TITLE
Update `actions/labeler` to use `v3` version

### DIFF
--- a/.github/workflows/auto_labeler_pr.yml
+++ b/.github/workflows/auto_labeler_pr.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply Type Label
-        uses: actions/labeler@v2
+        uses: actions/labeler@v3
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
The more advanced rules that we were trying to use are available since `actions/labeler@v3`, but *someone* thought it's a good idea to use an outdated version of the labeler...

