### PR TITLE
Ensure no role hierarchy bypassing in Mutes

### DIFF
--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -687,6 +687,11 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
             # removed the mute role
             await ctx.send(_("Channel overwrites will be used for mutes instead."))
         else:
+            if role >= ctx.author.top_role:
+                await ctx.send(
+                    _("You can't set this role as it is not lower than you in the role hierarchy.")
+                )
+                return
             await self.config.guild(ctx.guild).mute_role.set(role.id)
             self.mute_role_cache[ctx.guild.id] = role.id
             await ctx.send(_("Mute role set to {role}").format(role=role.name))

--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -28,6 +28,9 @@ MUTE_UNMUTE_ISSUES = {
     "hierarchy_problem": _(
         "I cannot let you do that. You are not higher than the user in the role hierarchy."
     ),
+    "assigned_role_hierarchy_problem": _(
+        "I cannot let you do that. You are not higher than the mute role in the role hierarchy."
+    ),
     "is_admin": _("That user cannot be muted, as they have the Administrator permission."),
     "permissions_issue_role": _(
         "Failed to mute or unmute user. I need the Manage Roles "
@@ -1330,6 +1333,9 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
             role = guild.get_role(mute_role)
             if not role:
                 ret["reason"] = _(MUTE_UNMUTE_ISSUES["role_missing"])
+                return ret
+            if author != guild.owner and role >= author.top_role:
+                ret["reason"] = _(MUTE_UNMUTE_ISSUES["assigned_role_hierarchy_problem"])
                 return ret
             if not guild.me.guild_permissions.manage_roles or role >= guild.me.top_role:
                 ret["reason"] = _(MUTE_UNMUTE_ISSUES["permissions_issue_role"])


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Before this, it was possible for the admin to set a role higher or equal to their own top role as mute role.
It was also possible for the moderator to assign roles higher or equal to their own top role if admin set such role as a mute role.