### PR TITLE
Red 3.4.6 - Changelog

### DIFF
--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -119,6 +119,7 @@ Documentation changes
 Miscellaneous
 -------------
 
+- Various grammar fixes (:issue:`4705`, :issue:`4748`, :issue:`4750`, :issue:`4788`, :issue:`4810`)
 
 
 Redbot 3.4.5 (2020-12-24)

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -18,6 +18,7 @@ Mutes
 *****
 
 - Fixed the edge case in role hierarchy checks (:issue:`4740`)
+- Added more role hierarchy checks to ensure it can't be bypassed on servers with careless configuration (:issue:`4741`)
 
 Trivia
 ******

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -83,6 +83,7 @@ Core Bot
 ********
 
 - Updated versions of the libraries used in Red: discord.py to 1.6.0, aiohttp to 3.7.3 (:issue:`4728`)
+- Added ``on_red_before_identify`` event that is dispatched before IDENTIFYing a session (:issue:`4647`)
 
 Dev Cog
 *******

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -106,6 +106,7 @@ Documentation changes
 - Added `cog guide for Filter cog <cog_guides/filter>` (:issue:`4579`)
 - Restructured the host list (:issue:`4710`)
 - Clarified how to use pm2 with ``pyenv virtualenv`` (:issue:`4709`)
+- Updated pip command for Red with postgres extra in `install_linux_mac` document to work on zsh shell (:issue:`4697`)
 
 
 Miscellaneous

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -52,6 +52,7 @@ Filter
 ******
 
 - Added ``filterhit`` case type which is used to log filter hits (:issue:`4676`, :issue:`4739`)
+- Added meaningful error messages for incorrect arguments in ``[p]bank set`` command (:issue:`4789`, :issue:`4801`)
 
 Mod
 ***

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -126,6 +126,7 @@ Documentation changes
 ---------------------
 
 - Added `cog guide for Filter cog <cog_guides/filter>` (:issue:`4579`)
+- Added information about the Red Index to `guide_publish_cogs` (:issue:`4778`)
 - Restructured the host list (:issue:`4710`)
 - Clarified how to use pm2 with ``pyenv virtualenv`` (:issue:`4709`)
 - Updated pip command for Red with postgres extra in `install_linux_mac` document to work on zsh shell (:issue:`4697`)

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -101,6 +101,7 @@ Documentation changes
 
 - Added `cog guide for Filter cog <cog_guides/filter>` (:issue:`4579`)
 - Restructured the host list (:issue:`4710`)
+- Clarified how to use pm2 with ``pyenv virtualenv`` (:issue:`4709`)
 
 
 Miscellaneous

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -12,6 +12,12 @@ Mod
 ***
 
 - ``[p]tempban`` command no longer errors out when trying to ban a user in a guild with vanity url feature that doesn't have vanity url set (:issue:`4714`)
+- Fixed the edge case in role hierarchy checks (:issue:`4740`)
+
+Mutes
+*****
+
+- Fixed the edge case in role hierarchy checks (:issue:`4740`)
 
 Trivia
 ******

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -8,6 +8,10 @@ Redbot 3.4.6 (Unreleased)
 End-user changelog
 ------------------
 
+Trivia
+******
+
+- Payout for trivia sessions ending in a tie now gets split between all the players with the highest score (:issue:`3931`, :issue:`4649`)
 
 
 Developer changelog

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -37,6 +37,11 @@ Core Bot
 
 - Removed option to drop the entire PostgreSQL database in ``redbot-setup delete`` due to limitations of PostgreSQL (:issue:`3699`, :issue:`3833`)
 
+Economy
+*******
+
+- ``[p]economyset rolepaydayamount`` can now remove the previously set payday amount (:issue:`4661`, :issue:`4758`)
+
 Filter
 ******
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -14,6 +14,11 @@ Core Bot
 - Fixed rotation of Red's logs that could before result in big disk usage (:issue:`4405`, :issue:`4738`)
 - Fixed command usage in the help messages for few commands in Red (:issue:`4599`, :issue:`4733`)
 
+Filter
+******
+
+- Added ``filterhit`` case type which is used to log filter hits (:issue:`4676`, :issue:`4739`)
+
 Mod
 ***
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -13,6 +13,7 @@ Core Bot
 
 - Fixed rotation of Red's logs that could before result in big disk usage (:issue:`4405`, :issue:`4738`)
 - Fixed command usage in the help messages for few commands in Red (:issue:`4599`, :issue:`4733`)
+- Added a friendly error message to ``[p]load`` that is shown when trying to load a cog with command name that is already taken by a different cog (:issue:`3870`)
 
 Filter
 ******

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -48,7 +48,7 @@ Core Bot
 Admin
 *****
 
-- Added ``[p]selfrole register`` command that adds or removes a selfrole from the user running it (:issue:`4660`)
+- Added the command ``[p]selfrole register`` that adds or removes a selfrole from the user running it (:issue:`4660`)
 
 Audio
 *****

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -3,7 +3,7 @@
 Redbot 3.4.6 (Unreleased)
 =========================
 | Thanks to all these amazing people that contributed to this release:
-| 
+| :ghuser:`aikaterna`, :ghuser:`aleclol`, :ghuser:`Andeeeee`, :ghuser:`bobloy`, :ghuser:`BreezeQS`, :ghuser:`Danstr5544`, :ghuser:`Dav-Git`, :ghuser:`Elysweyr`, :ghuser:`Fabian-Evolved`, :ghuser:`fixator10`, :ghuser:`Flame442`, :ghuser:`Injabie3`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`kreusada`, :ghuser:`leblancg`, :ghuser:`maxbooiii`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`Predeactor`, :ghuser:`retke`, :ghuser:`siu3334`, :ghuser:`Strafee`, :ghuser:`TrustyJAID`, :ghuser:`Vexed01`, :ghuser:`yamikaitou`
 
 End-user changelog
 ------------------

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -91,6 +91,11 @@ Trivia
 
 - Payout for trivia sessions ending in a tie now gets split between all the players with the highest score (:issue:`3931`, :issue:`4649`)
 
+Trivia Lists
+************
+
+- Updated answers regarding some of the hero's health and abilities in ``overwatch`` trivia (:issue:`4805`)
+
 
 Developer changelog
 -------------------

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -14,6 +14,10 @@ Core Bot
 - Fixed rotation of Red's logs that could before result in big disk usage (:issue:`4405`, :issue:`4738`)
 - Fixed command usage in the help messages for few commands in Red (:issue:`4599`, :issue:`4733`)
 - Added a friendly error message to ``[p]load`` that is shown when trying to load a cog with command name that is already taken by a different cog (:issue:`3870`)
+- Help now includes command aliases in the command help (:issue:`3040`)
+
+    - This can be disabled with ``[p]helpset showaliases`` command
+
 - Removed option to drop the entire PostgreSQL database in ``redbot-setup delete`` due to limitations of PostgreSQL (:issue:`3699`, :issue:`3833`)
 
 Filter

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -8,6 +8,11 @@ Redbot 3.4.6 (Unreleased)
 End-user changelog
 ------------------
 
+Core Bot
+********
+
+- Fixed rotation of Red's logs that could before result in big disk usage (:issue:`4405`, :issue:`4738`)
+
 Mod
 ***
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -68,6 +68,7 @@ Streams
 *******
 
 - Streams cog should now load faster on bots that have many stream alerts set up (:issue:`4731`, :issue:`4742`)
+- Fixed incorrect timezone offsets for some YouTube stream schedules (:issue:`4693`, :issue:`4694`)
 - Fixed possible memory leak related to automatic message deletion (:issue:`4731`, :issue:`4742`)
 
 Trivia

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -14,6 +14,7 @@ Core Bot
 - Fixed rotation of Red's logs that could before result in big disk usage (:issue:`4405`, :issue:`4738`)
 - Fixed command usage in the help messages for few commands in Red (:issue:`4599`, :issue:`4733`)
 - Added a friendly error message to ``[p]load`` that is shown when trying to load a cog with command name that is already taken by a different cog (:issue:`3870`)
+- Removed option to drop the entire PostgreSQL database in ``redbot-setup delete`` due to limitations of PostgreSQL (:issue:`3699`, :issue:`3833`)
 
 Filter
 ******

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -107,6 +107,7 @@ Documentation changes
 - Restructured the host list (:issue:`4710`)
 - Clarified how to use pm2 with ``pyenv virtualenv`` (:issue:`4709`)
 - Updated pip command for Red with postgres extra in `install_linux_mac` document to work on zsh shell (:issue:`4697`)
+- Updated Python version in ``pyenv`` and Windows instructions (:issue:`4770`)
 
 
 Miscellaneous

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -19,26 +19,26 @@ End-user changelog
 Core Bot
 ********
 
-- Fixed rotation of Red's logs that could before result in big disk usage (:issue:`4405`, :issue:`4738`)
+- Fixed the rotation of Red's logs that could before result in big disk usage (:issue:`4405`, :issue:`4738`)
 - Fixed command usage in the help messages for few commands in Red (:issue:`4599`, :issue:`4733`)
 - Fixed errors in ``[p]command defaultdisablecog`` and ``[p]command defaultenablecog`` commands (:issue:`4767`, :issue:`4768`)
-- ``[p]command listdisabled guild`` can no longer be ran in DMs (:issue:`4771`, :issue:`4772`)
+- ``[p]command listdisabled guild`` can no longer be run in DMs (:issue:`4771`, :issue:`4772`)
 - Improved and fixed a lot of things about our new (colorful) logging (:issue:`4702`, :issue:`4726`)
 
-    - Used colors have been adjusted to be readable on many more terminal applications
-    - ``NO_COLOR`` environment variable can now be set to forcefully disable all colors in the console output
-    - Tracebacks will now use full width of the terminal again
-    - Tracebacks no longer contain multiple lines per stack level (this can now be changed with ``-rich-traceback-extra-lines`` flag)
+    - The colors used have been adjusted to be readable on many more terminal applications
+    - The ``NO_COLOR`` environment variable can now be set to forcefully disable all colors in the console output
+    - Tracebacks will now use the full width of the terminal again
+    - Tracebacks no longer contain multiple lines per stack level (this can now be changed with the flag ``-rich-traceback-extra-lines``)
     - Disabled syntax highlighting on the log messages
     - Dev cog no longer captures logging output
     - Added some cool features for developers
 
-        - Added ``--rich-traceback-extra-lines`` flag which can be used to set the number of additional lines in tracebacks
-        - Added ``--rich-traceback-show-locals`` flag which enables showing local variables in tracebacks
+        - Added the flag ``--rich-traceback-extra-lines`` which can be used to set the number of additional lines in tracebacks
+        - Added the flag ``--rich-traceback-show-locals`` which enables showing local variables in tracebacks
 
-    - Improved and fixed few other minor things
+    - Improved and fixed a few other minor things
 
-- Added a friendly error message to ``[p]load`` that is shown when trying to load a cog with command name that is already taken by a different cog (:issue:`3870`)
+- Added a friendly error message to ``[p]load`` that is shown when trying to load a cog with a command name that is already taken by a different cog (:issue:`3870`)
 - Help now includes command aliases in the command help (:issue:`3040`)
 
     - This can be disabled with ``[p]helpset showaliases`` command
@@ -55,13 +55,13 @@ Audio
 
 - Improved detection of embed players for fallback on age-restricted YT tracks (:issue:`4818`, :issue:`4819`)
 - Improved MP4/AAC decoding (:issue:`4818`, :issue:`4819`)
-- Requests for YT tracks are now retried if initial request causes connection reset (:issue:`4818`, :issue:`4819`)
+- Requests for YT tracks are now retried if the initial request causes a connection reset (:issue:`4818`, :issue:`4819`)
 
 Cleanup
 *******
 
-- Renamed ``[p]cleanup spam`` command to ``[p]cleanup duplicates`` with the old name kept as an alias for the time being (:issue:`4814`)
-- Fixed too big integer passed as message ID raising an error in ``[p]cleanup after`` and ``[p]cleanup before`` (:issue:`4791`)
+- Renamed the ``[p]cleanup spam`` command to ``[p]cleanup duplicates``, with the old name kept as an alias for the time being (:issue:`4814`)
+- Fixed an error from passing an overly large integer as a message ID to ``[p]cleanup after`` and ``[p]cleanup before`` (:issue:`4791`)
 
 Dev Cog
 *******
@@ -76,17 +76,17 @@ Economy
 Filter
 ******
 
-- Added ``filterhit`` case type which is used to log filter hits (:issue:`4676`, :issue:`4739`)
+- Added a case type ``filterhit`` which is used to log filter hits (:issue:`4676`, :issue:`4739`)
 
 Mod
 ***
 
-- ``[p]tempban`` command no longer errors out when trying to ban a user in a guild with vanity url feature that doesn't have vanity url set (:issue:`4714`)
-- Fixed the edge case in role hierarchy checks (:issue:`4740`)
+- The ``[p]tempban`` command no longer errors out when trying to ban a user in a guild with the vanity url feature that doesn't have a vanity url set (:issue:`4714`)
+- Fixed an edge case in role hierarchy checks (:issue:`4740`)
 - Added two new settings for disabling username and nickname tracking (:issue:`4799`)
 
-    - Added ``[p]modset trackallnames`` command that allows to disable username tracking and override the nickname tracking setting for all guilds
-    - Added ``[p]modset tracknicknames`` command that allows to disable nickname tracking in a specific guild
+    - Added a command ``[p]modset trackallnames`` that disables username tracking and overrides the nickname tracking setting for all guilds
+    - Added a command ``[p]modset tracknicknames`` that disables nickname tracking in a specific guild
 
 - Added usage examples to ``[p]kick``, ``[p]ban``, ``[p]massban``, and ``[p]tempban`` (:issue:`4712`, :issue:`4715`)
 - Updated DM on kick/ban to use bot's default embed color (:issue:`4822`)
@@ -94,32 +94,32 @@ Mod
 Modlog
 ******
 
-- Added ``[p]listcases`` command that allows you to see multiple cases for user at once (:issue:`4426`)
+- Added a command ``[p]listcases`` that allows you to see multiple cases for a user at once (:issue:`4426`)
 - Added typing indicator to ``[p]casesfor`` command (:issue:`4426`)
 
 Mutes
 *****
 
-- Fixed the edge case in role hierarchy checks (:issue:`4740`)
+- Fixed an edge case in role hierarchy checks (:issue:`4740`)
 - Reason no longer contains leading whitespace when it's passed *after* mute time (:issue:`4749`)
-- Mutes cog can now send a DM to the (un)muted user on mute and unmute (:issue:`3752`, :issue:`4563`)
+- A DM can now be sent to the (un)muted user on mute and unmute (:issue:`3752`, :issue:`4563`)
 
     - Added ``[p]muteset senddm`` to set whether the DM should be sent (function disabled by default)
     - Added ``[p]muteset showmoderator`` to set whether the DM sent to the user should include the name of the moderator that muted the user (function disabled by default)
 
-- Added more role hierarchy checks to ensure it can't be bypassed on servers with careless configuration (:issue:`4741`)
+- Added more role hierarchy checks to ensure permission escalations cannot occur on servers with a careless configuration (:issue:`4741`)
 - Help descriptions of the cog and its commands now get translated properly (:issue:`4815`)
 
 Reports
 *******
 
-- Updated the output of Reports cog to use default embed color for the embeds it sends (:issue:`4800`)
+- Reports now use the default embed color of the bot (:issue:`4800`)
 
 Streams
 *******
 
 - Fixed incorrect timezone offsets for some YouTube stream schedules (:issue:`4693`, :issue:`4694`)
-- Fixed meaningless errors happening when YouTube API key becomes invalid or when the YouTube quota is exceeded (:issue:`4745`)
+- Fixed meaningless errors happening when the YouTube API key becomes invalid or when the YouTube quota is exceeded (:issue:`4745`)
 
 Trivia
 ******
@@ -130,7 +130,7 @@ Trivia Lists
 ************
 
 - Added new Who's That Pokémon - Gen. VI trivia list (:issue:`4785`)
-- Updated answers regarding some of the hero's health and abilities in ``overwatch`` trivia (:issue:`4805`)
+- Updated answers regarding some of the hero's health and abilities in the ``overwatch`` trivia list (:issue:`4805`)
 
 
 Developer changelog
@@ -140,12 +140,12 @@ Core Bot
 ********
 
 - Updated versions of the libraries used in Red: discord.py to 1.6.0, aiohttp to 3.7.3 (:issue:`4728`)
-- Added ``on_red_before_identify`` event that is dispatched before IDENTIFYing a session (:issue:`4647`)
+- Added an event ``on_red_before_identify`` that is dispatched before IDENTIFYing a session (:issue:`4647`)
 
 Utility Functions
 *****************
 
-- Added `redbot.core.utils.chat_formatting.spoiler()` function that wraps the given text in a spoiler (:issue:`4754`)
+- Added a function `redbot.core.utils.chat_formatting.spoiler()` that wraps the given text in a spoiler (:issue:`4754`)
 
 Dev Cog
 *******
@@ -165,7 +165,7 @@ Documentation changes
 - Added information about the Red Index to `guide_publish_cogs` (:issue:`4778`)
 - Restructured the host list (:issue:`4710`)
 - Clarified how to use pm2 with ``pyenv virtualenv`` (:issue:`4709`)
-- Updated pip command for Red with postgres extra in `install_linux_mac` document to work on zsh shell (:issue:`4697`)
+- Updated the pip command for Red with the postgres extra in `install_linux_mac` document to work on zsh shell (:issue:`4697`)
 - Updated Python version in ``pyenv`` and Windows instructions (:issue:`4770`)
 
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -159,7 +159,7 @@ Documentation changes
 Miscellaneous
 -------------
 
-- Various grammar fixes (:issue:`4705`, :issue:`4748`, :issue:`4750`, :issue:`4788`, :issue:`4810`)
+- Various grammar fixes (:issue:`4705`, :issue:`4748`, :issue:`4750`, :issue:`4763`, :issue:`4788`, :issue:`4792`, :issue:`4810`)
 - Red's dependencies have been bumped (:issue:`4572`)
 
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -27,6 +27,12 @@ Mod
 - ``[p]tempban`` command no longer errors out when trying to ban a user in a guild with vanity url feature that doesn't have vanity url set (:issue:`4714`)
 - Fixed the edge case in role hierarchy checks (:issue:`4740`)
 
+Modlog
+******
+
+- Added ``[p]listcases`` command that allows you to see multiple cases for user at once (:issue:`4426`)
+- Added typing indicator to ``[p]casesfor`` command (:issue:`4426`)
+
 Mutes
 *****
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -83,11 +83,12 @@ Mod
 
 - The ``[p]tempban`` command no longer errors out when trying to ban a user in a guild with the vanity url feature that doesn't have a vanity url set (:issue:`4714`)
 - Fixed an edge case in role hierarchy checks (:issue:`4740`)
-- Added two new settings for disabling username and nickname tracking (:issue:`4799`)
+- Added two new settings for disabling username and nickname tracking (:issue:`4827`)
 
     - Added a command ``[p]modset trackallnames`` that disables username tracking and overrides the nickname tracking setting for all guilds
     - Added a command ``[p]modset tracknicknames`` that disables nickname tracking in a specific guild
 
+- Added a command ``[p]modset deletenames`` that deletes all stored usernames and nicknames (:issue:`4827`)
 - Added usage examples to ``[p]kick``, ``[p]ban``, ``[p]massban``, and ``[p]tempban`` (:issue:`4712`, :issue:`4715`)
 - Updated DM on kick/ban to use bot's default embed color (:issue:`4822`)
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -78,6 +78,11 @@ Mutes
 
 - Added more role hierarchy checks to ensure it can't be bypassed on servers with careless configuration (:issue:`4741`)
 
+Reports
+*******
+
+- Updated the output of Reports cog to use default embed color for the embeds it sends (:issue:`4800`)
+
 Streams
 *******
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -35,6 +35,7 @@ Core Bot
 
     - This can be disabled with ``[p]helpset showaliases`` command
 
+- Fixed errors appearing when using Ctrl+C to interrupt ``redbot --edit`` (:issue:`3777`, :issue:`4572`)
 - Removed option to drop the entire PostgreSQL database in ``redbot-setup delete`` due to limitations of PostgreSQL (:issue:`3699`, :issue:`3833`)
 
 Economy
@@ -120,6 +121,7 @@ Miscellaneous
 -------------
 
 - Various grammar fixes (:issue:`4705`, :issue:`4748`, :issue:`4750`, :issue:`4788`, :issue:`4810`)
+- Red's dependencies have been bumped (:issue:`4572`)
 
 
 Redbot 3.4.5 (2020-12-24)

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -12,6 +12,7 @@ Core Bot
 ********
 
 - Fixed rotation of Red's logs that could before result in big disk usage (:issue:`4405`, :issue:`4738`)
+- Fixed command usage in the help messages for few commands in Red (:issue:`4599`)
 
 Mod
 ***

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -41,6 +41,7 @@ Core Bot
 Cleanup
 *******
 
+- Renamed ``[p]cleanup spam`` command to ``[p]cleanup duplicates`` with the old name kept as an alias for the time being (:issue:`4814`)
 - Fixed too big integer passed as message ID raising an error in ``[p]cleanup after`` and ``[p]cleanup before`` (:issue:`4791`)
 
 Economy

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -1,5 +1,30 @@
 .. 3.4.x Changelogs
 
+Redbot 3.4.6 (Unreleased)
+=========================
+| Thanks to all these amazing people that contributed to this release:
+| 
+
+End-user changelog
+------------------
+
+
+
+Developer changelog
+-------------------
+
+
+
+Documentation changes
+---------------------
+
+
+
+Miscellaneous
+-------------
+
+
+
 Redbot 3.4.5 (2020-12-24)
 =========================
 | Thanks to all these amazing people that contributed to this release:

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -31,6 +31,12 @@ Mutes
 - Fixed the edge case in role hierarchy checks (:issue:`4740`)
 - Added more role hierarchy checks to ensure it can't be bypassed on servers with careless configuration (:issue:`4741`)
 
+Streams
+*******
+
+- Streams cog should now load faster on bots that have many stream alerts set up (:issue:`4731`, :issue:`4742`)
+- Fixed possible memory leak related to automatic message deletion (:issue:`4731`, :issue:`4742`)
+
 Trivia
 ******
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -12,7 +12,7 @@ Core Bot
 ********
 
 - Fixed rotation of Red's logs that could before result in big disk usage (:issue:`4405`, :issue:`4738`)
-- Fixed command usage in the help messages for few commands in Red (:issue:`4599`)
+- Fixed command usage in the help messages for few commands in Red (:issue:`4599`, :issue:`4733`)
 
 Mod
 ***

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -38,6 +38,13 @@ Core Bot
 - Fixed errors appearing when using Ctrl+C to interrupt ``redbot --edit`` (:issue:`3777`, :issue:`4572`)
 - Removed option to drop the entire PostgreSQL database in ``redbot-setup delete`` due to limitations of PostgreSQL (:issue:`3699`, :issue:`3833`)
 
+Audio
+*****
+
+- Improved detection of embed players for fallback on age-restricted YT tracks (:issue:`4818`, :issue:`4819`)
+- Improved MP4/AAC decoding (:issue:`4818`, :issue:`4819`)
+- Requests for YT tracks are now retried if initial request causes connection reset (:issue:`4818`, :issue:`4819`)
+
 Cleanup
 *******
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -83,7 +83,7 @@ Mod
 
 - The ``[p]tempban`` command no longer errors out when trying to ban a user in a guild with the vanity url feature that doesn't have a vanity url set (:issue:`4714`)
 - Fixed an edge case in role hierarchy checks (:issue:`4740`)
-- Added two new settings for disabling username and nickname tracking (:issue:`4827`)
+- Added two new settings for disabling username and nickname tracking (:issue:`4799`)
 
     - Added a command ``[p]modset trackallnames`` that disables username tracking and overrides the nickname tracking setting for all guilds
     - Added a command ``[p]modset tracknicknames`` that disables nickname tracking in a specific guild

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -69,6 +69,16 @@ Core Bot
 
 - Updated versions of the libraries used in Red: discord.py to 1.6.0, aiohttp to 3.7.3 (:issue:`4728`)
 
+Dev Cog
+*******
+
+- Cogs can now add their own variables to the environment of ``[p]debug``, ``[p]eval``, and ``[p]repl`` commands (:issue:`4667`)
+
+    - Variables can be added and removed from the environment of Dev cog using two new methods:
+
+        - `bot.add_dev_env_value() <RedBase.add_dev_env_value()>`
+        - `bot.remove_dev_env_value() <RedBase.remove_dev_env_value()>`
+
 
 Documentation changes
 ---------------------

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -19,6 +19,7 @@ Documentation changes
 ---------------------
 
 - Added `cog guide for Filter cog <cog_guides/filter>` (:issue:`4579`)
+- Restructured the host list (:issue:`4710`)
 
 
 Miscellaneous

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -13,6 +13,21 @@ Core Bot
 
 - Fixed rotation of Red's logs that could before result in big disk usage (:issue:`4405`, :issue:`4738`)
 - Fixed command usage in the help messages for few commands in Red (:issue:`4599`, :issue:`4733`)
+- Improved and fixed a lot of things about our new (colorful) logging (:issue:`4702`, :issue:`4726`)
+
+    - Used colors have been adjusted to be readable on many more terminal applications
+    - ``NO_COLOR`` environment variable can now be set to forcefully disable all colors in the console output
+    - Tracebacks will now use full width of the terminal again
+    - Tracebacks no longer contain multiple lines per stack level (this can now be changed with ``-rich-traceback-extra-lines`` flag)
+    - Disabled syntax highlighting on the log messages
+    - Dev cog no longer captures logging output
+    - Added some cool features for developers
+
+        - Added ``--rich-traceback-extra-lines`` flag which can be used to set the number of additional lines in tracebacks
+        - Added ``--rich-traceback-show-locals`` flag which enables showing local variables in tracebacks
+
+    - Improved and fixed few other minor things
+
 - Added a friendly error message to ``[p]load`` that is shown when trying to load a cog with command name that is already taken by a different cog (:issue:`3870`)
 - Help now includes command aliases in the command help (:issue:`3040`)
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -3,7 +3,7 @@
 Redbot 3.4.6 (2021-02-16)
 =========================
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`aikaterna`, :ghuser:`aleclol`, :ghuser:`Andeeeee`, :ghuser:`bobloy`, :ghuser:`BreezeQS`, :ghuser:`Danstr5544`, :ghuser:`Dav-Git`, :ghuser:`Elysweyr`, :ghuser:`Fabian-Evolved`, :ghuser:`fixator10`, :ghuser:`Flame442`, :ghuser:`Injabie3`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`kreusada`, :ghuser:`leblancg`, :ghuser:`maxbooiii`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`Predeactor`, :ghuser:`retke`, :ghuser:`siu3334`, :ghuser:`Strafee`, :ghuser:`TrustyJAID`, :ghuser:`Vexed01`, :ghuser:`yamikaitou`
+| :ghuser:`aikaterna`, :ghuser:`aleclol`, :ghuser:`Andeeeee`, :ghuser:`bobloy`, :ghuser:`BreezeQS`, :ghuser:`Danstr5544`, :ghuser:`Dav-Git`, :ghuser:`Elysweyr`, :ghuser:`Fabian-Evolved`, :ghuser:`fixator10`, :ghuser:`Flame442`, :ghuser:`Injabie3`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`kreusada`, :ghuser:`leblancg`, :ghuser:`maxbooiii`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`Predeactor`, :ghuser:`retke`, :ghuser:`siu3334`, :ghuser:`Strafee`, :ghuser:`TheWyn`, :ghuser:`TrustyJAID`, :ghuser:`Vexed01`, :ghuser:`yamikaitou`
 
 Read before updating
 --------------------

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -57,6 +57,7 @@ Mutes
 *****
 
 - Fixed the edge case in role hierarchy checks (:issue:`4740`)
+- Reason no longer contains leading whitespace when it's passed *after* mute time (:issue:`4749`)
 - Mutes cog can now send a DM to the (un)muted user on mute and unmute (:issue:`3752`, :issue:`4563`)
 
     - Added ``[p]muteset senddm`` to set whether the DM should be sent (function disabled by default)

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -22,6 +22,10 @@ Trivia
 Developer changelog
 -------------------
 
+Core Bot
+********
+
+- Updated versions of the libraries used in Red: discord.py to 1.6.0, aiohttp to 3.7.3 (:issue:`4728`)
 
 
 Documentation changes

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -1,6 +1,6 @@
 .. 3.4.x Changelogs
 
-Redbot 3.4.6 (Unreleased)
+Redbot 3.4.6 (2021-02-16)
 =========================
 | Thanks to all these amazing people that contributed to this release:
 | :ghuser:`aikaterna`, :ghuser:`aleclol`, :ghuser:`Andeeeee`, :ghuser:`bobloy`, :ghuser:`BreezeQS`, :ghuser:`Danstr5544`, :ghuser:`Dav-Git`, :ghuser:`Elysweyr`, :ghuser:`Fabian-Evolved`, :ghuser:`fixator10`, :ghuser:`Flame442`, :ghuser:`Injabie3`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`kreusada`, :ghuser:`leblancg`, :ghuser:`maxbooiii`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`Predeactor`, :ghuser:`retke`, :ghuser:`siu3334`, :ghuser:`Strafee`, :ghuser:`TrustyJAID`, :ghuser:`Vexed01`, :ghuser:`yamikaitou`

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -38,6 +38,11 @@ Mutes
 *****
 
 - Fixed the edge case in role hierarchy checks (:issue:`4740`)
+- Mutes cog can now send a DM to the (un)muted user on mute and unmute (:issue:`3752`, :issue:`4563`)
+
+    - Added ``[p]muteset senddm`` to set whether the DM should be sent (function disabled by default)
+    - Added ``[p]muteset showmoderator`` to set whether the DM sent to the user should include the name of the moderator that muted the user (function disabled by default)
+
 - Added more role hierarchy checks to ensure it can't be bypassed on servers with careless configuration (:issue:`4741`)
 
 Streams

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -14,6 +14,7 @@ Core Bot
 - Fixed rotation of Red's logs that could before result in big disk usage (:issue:`4405`, :issue:`4738`)
 - Fixed command usage in the help messages for few commands in Red (:issue:`4599`, :issue:`4733`)
 - Fixed errors in ``[p]command defaultdisablecog`` and ``[p]command defaultenablecog`` commands (:issue:`4767`, :issue:`4768`)
+- ``[p]command listdisabled guild`` can no longer be ran in DMs (:issue:`4771`, :issue:`4772`)
 - Improved and fixed a lot of things about our new (colorful) logging (:issue:`4702`, :issue:`4726`)
 
     - Used colors have been adjusted to be readable on many more terminal applications

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -36,7 +36,6 @@ Core Bot
     - This can be disabled with ``[p]helpset showaliases`` command
 
 - Fixed errors appearing when using Ctrl+C to interrupt ``redbot --edit`` (:issue:`3777`, :issue:`4572`)
-- Removed option to drop the entire PostgreSQL database in ``redbot-setup delete`` due to limitations of PostgreSQL (:issue:`3699`, :issue:`3833`)
 
 Audio
 *****
@@ -65,7 +64,6 @@ Filter
 ******
 
 - Added ``filterhit`` case type which is used to log filter hits (:issue:`4676`, :issue:`4739`)
-- Added meaningful error messages for incorrect arguments in ``[p]bank set`` command (:issue:`4789`, :issue:`4801`)
 
 Mod
 ***
@@ -102,10 +100,8 @@ Reports
 Streams
 *******
 
-- Streams cog should now load faster on bots that have many stream alerts set up (:issue:`4731`, :issue:`4742`)
 - Fixed incorrect timezone offsets for some YouTube stream schedules (:issue:`4693`, :issue:`4694`)
 - Fixed meaningless errors happening when YouTube API key becomes invalid or when the YouTube quota is exceeded (:issue:`4745`)
-- Fixed possible memory leak related to automatic message deletion (:issue:`4731`, :issue:`4742`)
 
 Trivia
 ******

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -45,6 +45,11 @@ Core Bot
 
 - Fixed errors appearing when using Ctrl+C to interrupt ``redbot --edit`` (:issue:`3777`, :issue:`4572`)
 
+Admin
+*****
+
+- Added ``[p]selfrole register`` command that adds or removes a selfrole from the user running it (:issue:`4660`)
+
 Audio
 *****
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -13,6 +13,7 @@ Core Bot
 
 - Fixed rotation of Red's logs that could before result in big disk usage (:issue:`4405`, :issue:`4738`)
 - Fixed command usage in the help messages for few commands in Red (:issue:`4599`, :issue:`4733`)
+- Fixed errors in ``[p]command defaultdisablecog`` and ``[p]command defaultenablecog`` commands (:issue:`4767`, :issue:`4768`)
 - Improved and fixed a lot of things about our new (colorful) logging (:issue:`4702`, :issue:`4726`)
 
     - Used colors have been adjusted to be readable on many more terminal applications

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -3,7 +3,7 @@
 Redbot 3.4.6 (2021-02-16)
 =========================
 | Thanks to all these amazing people that contributed to this release:
-| :ghuser:`aikaterna`, :ghuser:`aleclol`, :ghuser:`Andeeeee`, :ghuser:`bobloy`, :ghuser:`BreezeQS`, :ghuser:`Danstr5544`, :ghuser:`Dav-Git`, :ghuser:`Elysweyr`, :ghuser:`Fabian-Evolved`, :ghuser:`fixator10`, :ghuser:`Flame442`, :ghuser:`Injabie3`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`kreusada`, :ghuser:`leblancg`, :ghuser:`maxbooiii`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`Predeactor`, :ghuser:`retke`, :ghuser:`siu3334`, :ghuser:`Strafee`, :ghuser:`TheWyn`, :ghuser:`TrustyJAID`, :ghuser:`Vexed01`, :ghuser:`yamikaitou`
+| :ghuser:`aikaterna`, :ghuser:`aleclol`, :ghuser:`Andeeeee`, :ghuser:`bobloy`, :ghuser:`BreezeQS`, :ghuser:`Danstr5544`, :ghuser:`Dav-Git`, :ghuser:`Elysweyr`, :ghuser:`Fabian-Evolved`, :ghuser:`fixator10`, :ghuser:`Flame442`, :ghuser:`Injabie3`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`kreusada`, :ghuser:`leblancg`, :ghuser:`maxbooiii`, :ghuser:`NeuroAssassin`, :ghuser:`phenom4n4n`, :ghuser:`PredaaA`, :ghuser:`Predeactor`, :ghuser:`retke`, :ghuser:`siu3334`, :ghuser:`Strafee`, :ghuser:`TheWyn`, :ghuser:`TrustyJAID`, :ghuser:`Vexed01`, :ghuser:`yamikaitou`
 
 Read before updating
 --------------------

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -44,6 +44,11 @@ Cleanup
 - Renamed ``[p]cleanup spam`` command to ``[p]cleanup duplicates`` with the old name kept as an alias for the time being (:issue:`4814`)
 - Fixed too big integer passed as message ID raising an error in ``[p]cleanup after`` and ``[p]cleanup before`` (:issue:`4791`)
 
+Dev Cog
+*******
+
+- Help descriptions of the cog and its commands now get translated properly (:issue:`4815`)
+
 Economy
 *******
 
@@ -79,6 +84,7 @@ Mutes
     - Added ``[p]muteset showmoderator`` to set whether the DM sent to the user should include the name of the moderator that muted the user (function disabled by default)
 
 - Added more role hierarchy checks to ensure it can't be bypassed on servers with careless configuration (:issue:`4741`)
+- Help descriptions of the cog and its commands now get translated properly (:issue:`4815`)
 
 Reports
 *******

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -8,6 +8,11 @@ Redbot 3.4.6 (Unreleased)
 End-user changelog
 ------------------
 
+Mod
+***
+
+- ``[p]tempban`` command no longer errors out when trying to ban a user in a guild with vanity url feature that doesn't have vanity url set (:issue:`4714`)
+
 Trivia
 ******
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -23,7 +23,7 @@ Core Bot
 - Fixed command usage in the help messages for few commands in Red (:issue:`4599`, :issue:`4733`)
 - Fixed errors in ``[p]command defaultdisablecog`` and ``[p]command defaultenablecog`` commands (:issue:`4767`, :issue:`4768`)
 - ``[p]command listdisabled guild`` can no longer be run in DMs (:issue:`4771`, :issue:`4772`)
-- Improved and fixed a lot of things about our new (colorful) logging (:issue:`4702`, :issue:`4726`)
+- Improvements and fixes for our new (colorful) logging (:issue:`4702`, :issue:`4726`)
 
     - The colors used have been adjusted to be readable on many more terminal applications
     - The ``NO_COLOR`` environment variable can now be set to forcefully disable all colors in the console output

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -18,6 +18,7 @@ Developer changelog
 Documentation changes
 ---------------------
 
+- Added `cog guide for Filter cog <cog_guides/filter>` (:issue:`4579`)
 
 
 Miscellaneous

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -48,7 +48,7 @@ Core Bot
 Admin
 *****
 
-- Added the command ``[p]selfrole register`` that adds or removes a selfrole from the user running it (:issue:`4660`)
+- ``[p]selfrole`` can now be used without a subcommand and passed with a selfrole directly to add/remove it from the user running the command (:issue:`4826`)
 
 Audio
 *****

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -73,6 +73,7 @@ Mod
 - ``[p]tempban`` command no longer errors out when trying to ban a user in a guild with vanity url feature that doesn't have vanity url set (:issue:`4714`)
 - Fixed the edge case in role hierarchy checks (:issue:`4740`)
 - Added usage examples to ``[p]kick``, ``[p]ban``, ``[p]massban``, and ``[p]tempban`` (:issue:`4712`, :issue:`4715`)
+- Updated DM on kick/ban to use bot's default embed color (:issue:`4822`)
 
 Modlog
 ******

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -69,6 +69,7 @@ Streams
 
 - Streams cog should now load faster on bots that have many stream alerts set up (:issue:`4731`, :issue:`4742`)
 - Fixed incorrect timezone offsets for some YouTube stream schedules (:issue:`4693`, :issue:`4694`)
+- Fixed meaningless errors happening when YouTube API key becomes invalid or when the YouTube quota is exceeded (:issue:`4745`)
 - Fixed possible memory leak related to automatic message deletion (:issue:`4731`, :issue:`4742`)
 
 Trivia

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -101,6 +101,11 @@ Core Bot
 - Updated versions of the libraries used in Red: discord.py to 1.6.0, aiohttp to 3.7.3 (:issue:`4728`)
 - Added ``on_red_before_identify`` event that is dispatched before IDENTIFYing a session (:issue:`4647`)
 
+Utility Functions
+*****************
+
+- Added `redbot.core.utils.chat_formatting.spoiler()` function that wraps the given text in a spoiler (:issue:`4754`)
+
 Dev Cog
 *******
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -26,6 +26,7 @@ Mod
 
 - ``[p]tempban`` command no longer errors out when trying to ban a user in a guild with vanity url feature that doesn't have vanity url set (:issue:`4714`)
 - Fixed the edge case in role hierarchy checks (:issue:`4740`)
+- Added usage examples to ``[p]kick``, ``[p]ban``, ``[p]massban``, and ``[p]tempban`` (:issue:`4712`, :issue:`4715`)
 
 Modlog
 ******

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -101,7 +101,7 @@ Mutes
 *****
 
 - Fixed an edge case in role hierarchy checks (:issue:`4740`)
-- Reason no longer contains leading whitespace when it's passed *after* mute time (:issue:`4749`)
+- The modlog reason no longer contains leading whitespace when it's passed *after* the mute time (:issue:`4749`)
 - A DM can now be sent to the (un)muted user on mute and unmute (:issue:`3752`, :issue:`4563`)
 
     - Added ``[p]muteset senddm`` to set whether the DM should be sent (function disabled by default)

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -38,6 +38,11 @@ Core Bot
 - Fixed errors appearing when using Ctrl+C to interrupt ``redbot --edit`` (:issue:`3777`, :issue:`4572`)
 - Removed option to drop the entire PostgreSQL database in ``redbot-setup delete`` due to limitations of PostgreSQL (:issue:`3699`, :issue:`3833`)
 
+Cleanup
+*******
+
+- Fixed too big integer passed as message ID raising an error in ``[p]cleanup after`` and ``[p]cleanup before`` (:issue:`4791`)
+
 Economy
 *******
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -111,6 +111,7 @@ Trivia
 Trivia Lists
 ************
 
+- Added new Who's That Pokémon - Gen. VI trivia list (:issue:`4785`)
 - Updated answers regarding some of the hero's health and abilities in ``overwatch`` trivia (:issue:`4805`)
 
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -70,6 +70,11 @@ Mod
 
 - ``[p]tempban`` command no longer errors out when trying to ban a user in a guild with vanity url feature that doesn't have vanity url set (:issue:`4714`)
 - Fixed the edge case in role hierarchy checks (:issue:`4740`)
+- Added two new settings for disabling username and nickname tracking (:issue:`4799`)
+
+    - Added ``[p]modset trackallnames`` command that allows to disable username tracking and override the nickname tracking setting for all guilds
+    - Added ``[p]modset tracknicknames`` command that allows to disable nickname tracking in a specific guild
+
 - Added usage examples to ``[p]kick``, ``[p]ban``, ``[p]massban``, and ``[p]tempban`` (:issue:`4712`, :issue:`4715`)
 - Updated DM on kick/ban to use bot's default embed color (:issue:`4822`)
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -5,6 +5,14 @@ Redbot 3.4.6 (2021-02-16)
 | Thanks to all these amazing people that contributed to this release:
 | :ghuser:`aikaterna`, :ghuser:`aleclol`, :ghuser:`Andeeeee`, :ghuser:`bobloy`, :ghuser:`BreezeQS`, :ghuser:`Danstr5544`, :ghuser:`Dav-Git`, :ghuser:`Elysweyr`, :ghuser:`Fabian-Evolved`, :ghuser:`fixator10`, :ghuser:`Flame442`, :ghuser:`Injabie3`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`kreusada`, :ghuser:`leblancg`, :ghuser:`maxbooiii`, :ghuser:`NeuroAssassin`, :ghuser:`PredaaA`, :ghuser:`Predeactor`, :ghuser:`retke`, :ghuser:`siu3334`, :ghuser:`Strafee`, :ghuser:`TrustyJAID`, :ghuser:`Vexed01`, :ghuser:`yamikaitou`
 
+Read before updating
+--------------------
+
+1. Information for Audio users that are using an external Lavalink instance (if you don't know what that is, you should skip this point):
+
+    Red 3.4.6 uses a new Lavalink jar that you will need to manually update from `our GitHub <https://github.com/Cog-Creators/Lavalink-Jars/releases/tag/3.3.2.3_1199>`__.
+
+
 End-user changelog
 ------------------
 

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -13,6 +13,7 @@ Streams
 
 - Fixed Streams failing to load and work properly (:issue:`4687`, :issue:`4688`)
 
+
 Redbot 3.4.4 (2020-12-24)
 =========================
 
@@ -103,9 +104,9 @@ Developer changelog
 Documentation changes
 ---------------------
 
-- Added `cog guide for Downloader cog <streams>` (:issue:`4511`)
-- Added `cog guide for Economy cog <streams>` (:issue:`4519`)
-- Added `cog guide for Streams cog <streams>` (:issue:`4521`)
+- Added `cog guide for Downloader cog <cog_guides/downloader>` (:issue:`4511`)
+- Added `cog guide for Economy cog <cog_guides/economy>` (:issue:`4519`)
+- Added `cog guide for Streams cog <cog_guides/streams>` (:issue:`4521`)
 - Added `guide_cog_creators` document (:issue:`4637`)
 - Removed install instructions for Ubuntu 16.04 (:issue:`4650`)
 


### PR DESCRIPTION
The good old draft PR for Red 3.4.6 changelog.

This *will* contain changelog entries for most of the PRs that are planned for Red 3.4.6, whether they're merged or not. When making the release, ensure that the changelog entries for PRs that didn't get merged don't get included in the final version of this PR (currently the PRs that are not merged but have changelog entry are: 4799, 4826)

Also, please generate the contributor list for the milestone once all PRs get merged (you can get the list with the command `=getcontributors 3.4.6` in #testing/#advanced-testing) and put it in this PR.

The build erroring is to be expected - some of the PRs add new API functionalities that are cross-referenced in the changelog and will fail to cross-reference until the relevant PRs get merged.

The rendered changelog can be seen here: https://red-discordbot--4743.org.readthedocs.build/en/4743/changelog_3_4_0.html#redbot-3-4-6-unreleased