### PR TITLE
[Streams] Change streamtypes log name

### DIFF
--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -35,7 +35,7 @@ YOUTUBE_CHANNEL_RSS = "https://www.youtube.com/feeds/videos.xml?channel_id={chan
 
 _ = Translator("Streams", __file__)
 
-log = logging.getLogger("redbot.cogs.Streams")
+log = logging.getLogger("red.core.cogs.Streams")
 
 
 def rnd(url):


### PR DESCRIPTION
### Type
- [x] Bugfix

### Description of the changes
This small PR changes the log name in `streamtypes.py` to match the one in `streams.py`, as I wasn't seeing the debug level log messages after launching the bot with the `--debug` flag.