### PR TITLE
Raise `StreamNotFound` for 404 errors in YouTube RSS feed

### DIFF
--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -724,6 +724,7 @@ class Streams(commands.Cog):
         stream._messages_cache.append(m)
 
     async def check_streams(self):
+        to_remove = []
         for stream in self.streams:
             try:
                 try:
@@ -738,6 +739,10 @@ class Streams(commands.Cog):
 
                     else:
                         embed = await stream.is_online()
+                except StreamNotFound:
+                    log.info("Stream with name %s no longer exists. Removing...", stream.name)
+                    to_remove.append(stream)
+                    continue
                 except OfflineStream:
                     if not stream._messages_cache:
                         continue
@@ -817,6 +822,11 @@ class Streams(commands.Cog):
                         await self.save_streams()
             except Exception as e:
                 log.error("An error has occured with Streams. Please report it.", exc_info=e)
+
+        if to_remove:
+            for stream in to_remove:
+                self.streams.remove(stream)
+            await self.save_streams()
 
     async def _get_mention_str(
         self, guild: discord.Guild, channel: discord.TextChannel

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -106,6 +106,8 @@ class YoutubeStream(Stream):
 
         async with aiohttp.ClientSession() as session:
             async with session.get(YOUTUBE_CHANNEL_RSS.format(channel_id=self.id)) as r:
+                if r.status == 404:
+                    raise StreamNotFound()
                 rssdata = await r.text()
 
         if self.not_livestreams:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #4735 
Here's an example Streams config for a no longer existing YouTube channel:
```py
        {
          "id": "UCxp3CLeYRoPOlqkpPHtdsKg",
          "not_livestreams": [],
          "livestreams": [],
          "name": "Brad Chadford",
          "channels": [
            549642722953396225
          ],
          "type": "YoutubeStream",
          "messages": [
            {
              "channel": 549642722953396225,
              "message": 678772046997487626
            }
          ]
        },
```

Note: I have NOT tested this PR.