### PR TITLE
Strip the reason from whitespace in Mutes cog

### DIFF
--- a/redbot/cogs/mutes/converters.py
+++ b/redbot/cogs/mutes/converters.py
@@ -51,5 +51,5 @@ class MuteTime(Converter):
                     time_data[k] = int(v)
         if time_data:
             result["duration"] = timedelta(**time_data)
-        result["reason"] = argument
+        result["reason"] = argument.strip()
         return result


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
When you do ``[p]mute @User 1m Some reason`` the reason ends up being " Some reason" (with space at the beginning). This PR fixes that issue.