### PR TITLE
[Core] Fix commands using plural with the same user

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2985,9 +2985,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         await self.bot._whiteblacklist_cache.remove_from_whitelist(ctx.guild, uids)
 
         if len(uids) > 1:
-            await ctx.send(_("Users and/or roles have been removed from the server allowlist.")))
+            await ctx.send(_("Users and/or roles have been removed from the server allowlist."))
         else:
-            await ctx.send(_("User or role has been removed from the server allowlist.")))
+            await ctx.send(_("User or role has been removed from the server allowlist."))
 
     @localallowlist.command(name="clear")
     async def localallowlist_clear(self, ctx: commands.Context):
@@ -3030,9 +3030,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         
         if len(uids) > 1:
-            await ctx.send(_("Users and/or roles have been added from the server blocklist.")))
+            await ctx.send(_("Users and/or roles have been added from the server blocklist."))
         else:
-            await ctx.send(_("User or role has been added from the server blocklist.")))
+            await ctx.send(_("User or role has been added from the server blocklist."))
 
     @localblocklist.command(name="list")
     async def localblocklist_list(self, ctx: commands.Context):
@@ -3067,9 +3067,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         
         if len(uids) > 1:
-            await ctx.send(_("Users and/or roles have been removed from the server blocklist.")))
+            await ctx.send(_("Users and/or roles have been removed from the server blocklist."))
         else:
-            await ctx.send(_("User or role has been removed from the server blocklist.")))
+            await ctx.send(_("User or role has been removed from the server blocklist."))
 
     @localblocklist.command(name="clear")
     async def localblocklist_clear(self, ctx: commands.Context):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -47,7 +47,6 @@ from .utils.chat_formatting import (
 )
 from .commands.requires import PrivilegeLevel
 
-
 _entities = {
     "*": "&midast;",
     "\\": "&bsol;",
@@ -91,7 +90,6 @@ if TYPE_CHECKING:
 __all__ = ["Core"]
 
 log = logging.getLogger("red")
-
 
 _ = i18n.Translator("Core", __file__)
 
@@ -3028,7 +3026,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         uids = {getattr(u_or_r, "id", u_or_r) for u_or_r in users_or_roles}
         await self.bot._whiteblacklist_cache.add_to_blacklist(ctx.guild, uids)
 
-        
         if len(uids) > 1:
             await ctx.send(_("Users and/or roles have been added from the server blocklist."))
         else:
@@ -3065,7 +3062,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         uids = {getattr(u_or_r, "id", u_or_r) for u_or_r in users_or_roles}
         await self.bot._whiteblacklist_cache.remove_from_blacklist(ctx.guild, uids)
 
-        
         if len(uids) > 1:
             await ctx.send(_("Users and/or roles have been removed from the server blocklist."))
         else:

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2791,7 +2791,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """
         uids = {getattr(user, "id", user) for user in users}
         await self.bot._whiteblacklist_cache.add_to_whitelist(None, uids)
-        if len(users) > 1:
+        if len(uids) > 1:
             await ctx.send(_("Users have been added to the allowlist."))
         else:
             await ctx.send(_("User has been added to the allowlist."))
@@ -2823,7 +2823,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """
         uids = {getattr(user, "id", user) for user in users}
         await self.bot._whiteblacklist_cache.remove_from_whitelist(None, uids)
-        if len(users) > 1:
+        if len(uids) > 1:
             await ctx.send(_("Users have been removed from the allowlist."))
         else:
             await ctx.send(_("User has been removed from the allowlist."))
@@ -2860,7 +2860,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         uids = {getattr(user, "id", user) for user in users}
         await self.bot._whiteblacklist_cache.add_to_blacklist(None, uids)
-        if len(users) > 1:
+        if len(uids) > 1:
             await ctx.send(_("Users have been added to the blocklist."))
         else:
             await ctx.send(_("User has been added to the blocklist."))
@@ -2892,7 +2892,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """
         uids = {getattr(user, "id", user) for user in users}
         await self.bot._whiteblacklist_cache.remove_from_blacklist(None, uids)
-        if len(users) > 1:
+        if len(uids) > 1:
             await ctx.send(_("Users have been removed from the blocklist."))
         else:
             await ctx.send(_("User has been removed from the blocklist."))
@@ -2937,7 +2937,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 )
         await self.bot._whiteblacklist_cache.add_to_whitelist(ctx.guild, uids)
 
-        await ctx.send(_("{names} added to allowlist.").format(names=humanize_list(names)))
+        if len(uids) > 1:
+            await ctx.send(_("Users and/or roles have been added to allowlist."))
+        else:
+            await ctx.send(_("User or role has been added to allowlist."))
 
     @localallowlist.command(name="list")
     async def localallowlist_list(self, ctx: commands.Context):
@@ -2981,9 +2984,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 )
         await self.bot._whiteblacklist_cache.remove_from_whitelist(ctx.guild, uids)
 
-        await ctx.send(
-            _("{names} removed from the server allowlist.").format(names=humanize_list(names))
-        )
+        if len(uids) > 1:
+            await ctx.send(_("Users and/or roles have been removed from the server allowlist.")))
+        else:
+            await ctx.send(_("User or role has been removed from the server allowlist.")))
 
     @localallowlist.command(name="clear")
     async def localallowlist_clear(self, ctx: commands.Context):
@@ -3024,9 +3028,11 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         uids = {getattr(u_or_r, "id", u_or_r) for u_or_r in users_or_roles}
         await self.bot._whiteblacklist_cache.add_to_blacklist(ctx.guild, uids)
 
-        await ctx.send(
-            _("{names} added to the server blocklist.").format(names=humanize_list(names))
-        )
+        
+        if len(uids) > 1:
+            await ctx.send(_("Users and/or roles have been added from the server blocklist.")))
+        else:
+            await ctx.send(_("User or role has been added from the server blocklist.")))
 
     @localblocklist.command(name="list")
     async def localblocklist_list(self, ctx: commands.Context):
@@ -3059,9 +3065,11 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         uids = {getattr(u_or_r, "id", u_or_r) for u_or_r in users_or_roles}
         await self.bot._whiteblacklist_cache.remove_from_blacklist(ctx.guild, uids)
 
-        await ctx.send(
-            _("{names} removed from the server blocklist.").format(names=humanize_list(names))
-        )
+        
+        if len(uids) > 1:
+            await ctx.send(_("Users and/or roles have been removed from the server blocklist.")))
+        else:
+            await ctx.send(_("User or role has been removed from the server blocklist.")))
 
     @localblocklist.command(name="clear")
     async def localblocklist_clear(self, ctx: commands.Context):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2936,9 +2936,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         await self.bot._whiteblacklist_cache.add_to_whitelist(ctx.guild, uids)
 
         if len(uids) > 1:
-            await ctx.send(_("Users and/or roles have been added to allowlist."))
+            await ctx.send(_("Users and/or roles have been added to the allowlist."))
         else:
-            await ctx.send(_("User or role has been added to allowlist."))
+            await ctx.send(_("User or role has been added to the allowlist."))
 
     @localallowlist.command(name="list")
     async def localallowlist_list(self, ctx: commands.Context):


### PR DESCRIPTION
Some plural checking have also been added to the local blocklist/allowlist and the wording has been revised.

### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

This PR fix an user Draper reported to me, https://canary.discord.com/channels/133049272517001216/171665724262055936/802571672137105448
This also add some plural checking to the local blocklist/allowlist and the wording has been revised.