### PR TITLE
Make `[p]mockmsg` include the attachments in the mocked message

### DIFF
--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -336,18 +336,12 @@ class Dev(commands.Cog):
 
     @commands.command(name="mockmsg")
     @checks.is_owner()
-    async def mock_msg(self, ctx, user: Union[discord.Member, discord.User, int], *, content: str):
+    async def mock_msg(self, ctx, user: discord.Member, *, content: str):
         """Dispatch a message event as if it were sent by a different user.
 
-        Only reads the raw content of the message. Attachments, embeds etc. are
-        ignored.
+        Embeds are ignored. Attachments are accepted
         """
-        if isinstance(user, int):
-            try:
-                user = await self.bot.fetch_user(user)
-            except discord.NotFound:
-                raise Exception("User not found") #change this to some other Exception
-                
+       
         old_author = ctx.author
         old_content = ctx.message.content
         ctx.message.author = user

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -352,11 +352,10 @@ class Dev(commands.Cog):
         if ctx.message.attachments:
             attachment = ctx.message.attachments[0]
             image = attachment.proxy_url
+            name = attachment.filename
+            type = name.split()[1]
         
         if image:
-            imgname = image.split(".")
-            type = imgname[1]
-            name = imgname[0]
             image = discord.File(image, filename=f"{name}.{type}")
             ctx.message.attachments = []
             ctx.message.attachments.append(image)

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -336,17 +336,33 @@ class Dev(commands.Cog):
 
     @commands.command(name="mockmsg")
     @checks.is_owner()
-    async def mock_msg(self, ctx, user: discord.Member, *, content: str):
+    async def mock_msg(self, ctx, user: Union[discord.Member, discord.User, int], *, content: str):
         """Dispatch a message event as if it were sent by a different user.
 
         Only reads the raw content of the message. Attachments, embeds etc. are
         ignored.
         """
+        if isinstance(user, int):
+            try:
+                user = await self.bot.fetch_user(user)
+            except discord.NotFound:
+                raise Exception("User not found") #change this to some other Exception
+                
         old_author = ctx.author
         old_content = ctx.message.content
         ctx.message.author = user
         ctx.message.content = content
-
+        
+        image = False 
+        
+        if ctx.message.attachments:
+            attachment = ctx.message.attachments[0]
+            image = attachment.proxy_url
+        
+        if image:
+            image = discord.File(image, filename="previousattachments.png")
+        ctx.message.attachments = image
+        
         ctx.bot.dispatch("message", ctx.message)
 
         # If we change the author and content back too quickly,

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -347,7 +347,7 @@ class Dev(commands.Cog):
         ctx.message.author = user
         ctx.message.content = content
         
-        image = False 
+        image = None
         
         if ctx.message.attachments:
             attachment = ctx.message.attachments[0]
@@ -355,7 +355,10 @@ class Dev(commands.Cog):
         
         if image:
             image = discord.File(image, filename="previousattachments.png")
-        ctx.message.attachments = image
+            ctx.message.attachments = []
+            ctx.message.attachments.append(image)
+        
+
         
         ctx.bot.dispatch("message", ctx.message)
 

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -354,7 +354,10 @@ class Dev(commands.Cog):
             image = attachment.proxy_url
         
         if image:
-            image = discord.File(image, filename="previousattachments.png")
+            imgname = image.split(".")
+            type = imgname[1]
+            name = imgname[0]
+            image = discord.File(image, filename=f"{name}.{type}")
             ctx.message.attachments = []
             ctx.message.attachments.append(image)
         

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -358,8 +358,6 @@ class Dev(commands.Cog):
             ctx.message.attachments = []
             ctx.message.attachments.append(image)
         
-
-        
         ctx.bot.dispatch("message", ctx.message)
 
         # If we change the author and content back too quickly,


### PR DESCRIPTION
### Type
- [x] Enhancement

### Description of the changes
Updated mockmsg to allow images and also to allow discord.User for those cases where you need it. Change the raise Exception to an exception you like.