### PR TITLE
checks if the channel history has < 100 msgs

### DIFF
--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -49,6 +49,9 @@ class Cleanup(commands.Cog):
 
         if ctx.assume_yes:
             return True
+        
+        if len(await ctx.channel.history(limit=101)) < 100: #checks if the history doesn't even have 100 messages
+            return True
 
         prompt = await ctx.send(
             _("Are you sure you want to delete {number} messages? (y/n)").format(


### PR DESCRIPTION
basically for the check_100_plus if the channel history has less than 100 messages it returns True instead of asking.

### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
