### PR TITLE
Fix changing default state for a cog as enabled/disabled

### DIFF
--- a/redbot/core/settings_caches.py
+++ b/redbot/core/settings_caches.py
@@ -437,7 +437,7 @@ class DisabledCogCache:
             This should be the cog's qualified name, not necessarily the classname
         """
         await self._config.custom("COG_DISABLE_SETTINGS", cog_name, 0).disabled.set(True)
-        del self._disable_map[cog_name]
+        self._disable_map.pop(cog_name)
 
     async def default_enable(self, cog_name: str):
         """
@@ -449,7 +449,7 @@ class DisabledCogCache:
             This should be the cog's qualified name, not necessarily the classname
         """
         await self._config.custom("COG_DISABLE_SETTINGS", cog_name, 0).disabled.clear()
-        del self._disable_map[cog_name]
+        self._disable_map.pop(cog_name)
 
     async def disable_cog_in_guild(self, cog_name: str, guild_id: int) -> bool:
         """

--- a/redbot/core/settings_caches.py
+++ b/redbot/core/settings_caches.py
@@ -437,7 +437,7 @@ class DisabledCogCache:
             This should be the cog's qualified name, not necessarily the classname
         """
         await self._config.custom("COG_DISABLE_SETTINGS", cog_name, 0).disabled.set(True)
-        self._disable_map.pop(cog_name)
+        self._disable_map.pop(cog_name, None)
 
     async def default_enable(self, cog_name: str):
         """
@@ -449,7 +449,7 @@ class DisabledCogCache:
             This should be the cog's qualified name, not necessarily the classname
         """
         await self._config.custom("COG_DISABLE_SETTINGS", cog_name, 0).disabled.clear()
-        self._disable_map.pop(cog_name)
+        self._disable_map.pop(cog_name, None)
 
     async def disable_cog_in_guild(self, cog_name: str, guild_id: int) -> bool:
         """


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fixes #4767 

The cog disabling cache caches the state of the cog based on the value of default state *and* guild setting, so when the default is changed the whole cache is cleared. Because of this issue, it was failing when the cache for a certain cog was not yet created (as the state wasn't needed yet).
