### PR TITLE
Allow Cleanup before/after to accept message replies

### DIFF
--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -123,12 +123,14 @@ class Cleanup(commands.Cog):
         return collected
 
     @staticmethod
-    async def get_message_from_reference(channel: discord.TextChannel, reference: discord.MessageReference) -> Optional[discord.Message]:
+    async def get_message_from_reference(
+        channel: discord.TextChannel, reference: discord.MessageReference
+    ) -> Optional[discord.Message]:
         message = None
         resolved = reference.resolved
         if resolved and isinstance(resolved, discord.Message):
             message = resolved
-        elif (message := reference.cached_message):
+        elif (message := reference.cached_message) :
             pass
         else:
             try:

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -257,7 +257,10 @@ class Cleanup(commands.Cog):
     @checks.mod_or_permissions(manage_messages=True)
     @commands.bot_has_permissions(manage_messages=True)
     async def after(
-        self, ctx: commands.Context, message_id: Optional[RawMessageIds], delete_pinned: bool = False
+        self,
+        ctx: commands.Context,
+        message_id: Optional[RawMessageIds],
+        delete_pinned: bool = False,
     ):
         """Delete all messages after a specified message.
 
@@ -285,7 +288,7 @@ class Cleanup(commands.Cog):
             resolved = ref.resolved
             if resolved and isinstance(resolved, discord.Message):
                 after = resolved
-            elif (after := ref.cached_message):
+            elif (after := ref.cached_message) :
                 pass
             else:
                 try:
@@ -308,7 +311,7 @@ class Cleanup(commands.Cog):
         log.info(reason)
 
         await mass_purge(to_delete, channel)
-        
+
     @cleanup.command()
     @commands.guild_only()
     @checks.mod_or_permissions(manage_messages=True)

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -328,7 +328,7 @@ class Cleanup(commands.Cog):
     async def before(
         self,
         ctx: commands.Context,
-        message_id: RawMessageIds,
+        message_id: Optional[RawMessageIds],
         number: positive_int,
         delete_pinned: bool = False,
     ):

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -257,13 +257,14 @@ class Cleanup(commands.Cog):
     @checks.mod_or_permissions(manage_messages=True)
     @commands.bot_has_permissions(manage_messages=True)
     async def after(
-        self, ctx: commands.Context, message_id: RawMessageIds, delete_pinned: bool = False
+        self, ctx: commands.Context, message_id: Optional[RawMessageIds], delete_pinned: bool = False
     ):
         """Delete all messages after a specified message.
 
         To get a message id, enable developer mode in Discord's
         settings, 'appearance' tab. Then right click a message
         and copy its id.
+        Replying to a message will cleanup all messages after it.
 
         **Arguments:**
 
@@ -273,11 +274,26 @@ class Cleanup(commands.Cog):
 
         channel = ctx.channel
         author = ctx.author
+        after = None
 
-        try:
-            after = await channel.fetch_message(message_id)
-        except discord.NotFound:
-            return await ctx.send(_("Message not found."))
+        if message_id:
+            try:
+                after = await channel.fetch_message(message_id)
+            except discord.NotFound:
+                return await ctx.send("Message not found.")
+        elif ref := ctx.message.reference:
+            resolved = ref.resolved
+            if resolved and isinstance(resolved, discord.Message):
+                after = resolved
+            elif (after := ref.cached_message):
+                pass
+            else:
+                try:
+                    after = await channel.fetch_message(ref.message_id)
+                except discord.NotFound:
+                    pass
+        if after is None:
+            raise commands.BadArgument
 
         to_delete = await self.get_messages_for_deletion(
             channel=channel, number=None, after=after, delete_pinned=delete_pinned
@@ -292,54 +308,7 @@ class Cleanup(commands.Cog):
         log.info(reason)
 
         await mass_purge(to_delete, channel)
-
-    @cleanup.command()
-    @commands.guild_only()
-    @checks.mod_or_permissions(manage_messages=True)
-    @commands.bot_has_permissions(manage_messages=True)
-    async def before(
-        self,
-        ctx: commands.Context,
-        message_id: RawMessageIds,
-        number: positive_int,
-        delete_pinned: bool = False,
-    ):
-        """Deletes X messages before the specified message.
-
-        To get a message id, enable developer mode in Discord's
-        settings, 'appearance' tab. Then right click a message
-        and copy its id.
-
-        **Arguments:**
-
-        - `<message_id>` The id of the message to cleanup before. This message won't be deleted.
-        - `<number>` The max number of messages to cleanup. Must be a positive integer.
-        - `<delete_pinned>` Whether to delete pinned messages or not. Defaults to False
-        """
-
-        channel = ctx.channel
-        author = ctx.author
-
-        try:
-            before = await channel.fetch_message(message_id)
-        except discord.NotFound:
-            return await ctx.send(_("Message not found."))
-
-        to_delete = await self.get_messages_for_deletion(
-            channel=channel, number=number, before=before, delete_pinned=delete_pinned
-        )
-        to_delete.append(ctx.message)
-
-        reason = "{}({}) deleted {} messages in channel {}.".format(
-            author.name,
-            author.id,
-            humanize_number(len(to_delete), override_locale="en_US"),
-            channel.name,
-        )
-        log.info(reason)
-
-        await mass_purge(to_delete, channel)
-
+        
     @cleanup.command()
     @commands.guild_only()
     @checks.mod_or_permissions(manage_messages=True)

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -337,6 +337,7 @@ class Cleanup(commands.Cog):
         To get a message id, enable developer mode in Discord's
         settings, 'appearance' tab. Then right click a message
         and copy its id.
+        Replying to a message will cleanup all messages before it.
 
         **Arguments:**
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Allows `[p]cleanup after` to work without message ID's being provided if the invocation message has a reference.