### PR TITLE
[Cleanup] Fix error when providing message snowflake above the maximum (9223372036854775807)

### DIFF
--- a/redbot/cogs/cleanup/converters.py
+++ b/redbot/cogs/cleanup/converters.py
@@ -6,6 +6,7 @@ from redbot.core.utils.chat_formatting import inline
 
 _ = Translator("Cleanup", __file__)
 
+
 SNOWFLAKE_THRESHOLD = 2 ** 63
 
 class RawMessageIds(Converter):

--- a/redbot/cogs/cleanup/converters.py
+++ b/redbot/cogs/cleanup/converters.py
@@ -6,8 +6,8 @@ from redbot.core.utils.chat_formatting import inline
 
 _ = Translator("Cleanup", __file__)
 
-
 SNOWFLAKE_THRESHOLD = 2 ** 63
+
 
 class RawMessageIds(Converter):
     async def convert(self, ctx: Context, argument: str) -> int:

--- a/redbot/cogs/cleanup/converters.py
+++ b/redbot/cogs/cleanup/converters.py
@@ -9,7 +9,7 @@ _ = Translator("Cleanup", __file__)
 
 class RawMessageIds(Converter):
     async def convert(self, ctx: Context, argument: str) -> int:
-        if argument.isnumeric() and len(argument) >= 17 and int(argument) < 9223372036854775808:
+        if argument.isnumeric() and len(argument) >= 17 and int(argument) < 2 ** 63:
             return int(argument)
 
         raise BadArgument(_("{} doesn't look like a valid message ID.").format(argument))

--- a/redbot/cogs/cleanup/converters.py
+++ b/redbot/cogs/cleanup/converters.py
@@ -9,7 +9,7 @@ _ = Translator("Cleanup", __file__)
 
 class RawMessageIds(Converter):
     async def convert(self, ctx: Context, argument: str) -> int:
-        if argument.isnumeric() and len(argument) >= 17:
+        if argument.isnumeric() and len(argument) >= 17 and argument < 9223372036854775808:
             return int(argument)
 
         raise BadArgument(_("{} doesn't look like a valid message ID.").format(argument))

--- a/redbot/cogs/cleanup/converters.py
+++ b/redbot/cogs/cleanup/converters.py
@@ -6,10 +6,11 @@ from redbot.core.utils.chat_formatting import inline
 
 _ = Translator("Cleanup", __file__)
 
+SNOWFLAKE_THRESHOLD = 2 ** 63
 
 class RawMessageIds(Converter):
     async def convert(self, ctx: Context, argument: str) -> int:
-        if argument.isnumeric() and len(argument) >= 17 and int(argument) < 2 ** 63:
+        if argument.isnumeric() and len(argument) >= 17 and int(argument) < SNOWFLAKE_THRESHOLD:
             return int(argument)
 
         raise BadArgument(_("{} doesn't look like a valid message ID.").format(argument))

--- a/redbot/cogs/cleanup/converters.py
+++ b/redbot/cogs/cleanup/converters.py
@@ -9,7 +9,7 @@ _ = Translator("Cleanup", __file__)
 
 class RawMessageIds(Converter):
     async def convert(self, ctx: Context, argument: str) -> int:
-        if argument.isnumeric() and len(argument) >= 17 and argument < 9223372036854775808:
+        if argument.isnumeric() and len(argument) >= 17 and int(argument) < 9223372036854775808:
             return int(argument)
 
         raise BadArgument(_("{} doesn't look like a valid message ID.").format(argument))


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
~~I needed my traditional per-version credit in the documentation~~

Fixes big angry error when you try to delete before, after or between a message that cannot be a snowflake.

Note: untested, but should work tm.