### PR TITLE
Add meaningful error messages for bad arguments in [p]bank set

### DIFF
--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -100,7 +100,7 @@ def guild_only_check():
 class SetParser:
     def __init__(self, argument):
         allowed = ("+", "-")
-        if(argument.isdigit()):
+        if argument.isdigit():
             self.sum = int(argument)
         if argument and argument[0] in allowed:
             if self.sum < 0:
@@ -112,8 +112,8 @@ class SetParser:
             self.sum = abs(self.sum)
         elif argument.isdigit():
             self.operation = "set"
-        elif (not argument.isdigit()):
-            self.operation ='error'
+        elif not argument.isdigit():
+            self.operation = "error"
         else:
             raise RuntimeError
 
@@ -269,7 +269,7 @@ class Economy(commands.Cog):
                     currency=currency,
                     user=to.display_name,
                 )
-            elif creds.operation =='set':
+            elif creds.operation == "set":
                 await bank.set_balance(to, creds.sum)
                 msg = _("{author} set {user}'s account balance to {num} {currency}.").format(
                     author=author.display_name,
@@ -277,8 +277,10 @@ class Economy(commands.Cog):
                     currency=currency,
                     user=to.display_name,
                 )
-            elif creds.operation =='error':
-                msg="Please enter a valid argument!"
+            elif creds.operation == "error":
+                msg = (
+                    "Can not set bank balance to a non-integer value.Try giving a valid argument!"
+                )
         except (ValueError, errors.BalanceTooHigh) as e:
             await ctx.send(str(e))
         else:

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -278,9 +278,7 @@ class Economy(commands.Cog):
                     user=to.display_name,
                 )
             elif creds.operation == "error":
-                msg = (
-                    "Can not set bank balance to a non-integer value.Try using a valid argument such as...(+1. 1. -1)"
-                )
+                msg = "Can not set bank balance to a non-integer value.Try using a valid argument such as...(+1. 1. -1)"
         except (ValueError, errors.BalanceTooHigh) as e:
             await ctx.send(str(e))
         else:

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -279,7 +279,7 @@ class Economy(commands.Cog):
                 )
             elif creds.operation == "error":
                 msg = (
-                    "Can not set bank balance to a non-integer value.Try giving a valid argument!"
+                    "Can not set bank balance to a non-integer value.Try using a valid argument such as...(+1. 1. -1)"
                 )
         except (ValueError, errors.BalanceTooHigh) as e:
             await ctx.send(str(e))

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -278,7 +278,7 @@ class Economy(commands.Cog):
                     user=to.display_name,
                 )
             elif creds.operation == "error":
-                msg = "Can't set bank balance to a non-integer value.Try using a valid argument,for example: `+100`, `-100`, or `100`"
+                msg = "Can't set bank balance to a non-integer value . Try using a valid argument , for example: `+100` , `-100` , or `100`"
         except (ValueError, errors.BalanceTooHigh) as e:
             await ctx.send(str(e))
         else:

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -100,7 +100,8 @@ def guild_only_check():
 class SetParser:
     def __init__(self, argument):
         allowed = ("+", "-")
-        self.sum = int(argument)
+        if(argument.isdigit()):
+            self.sum = int(argument)
         if argument and argument[0] in allowed:
             if self.sum < 0:
                 self.operation = "withdraw"
@@ -111,6 +112,8 @@ class SetParser:
             self.sum = abs(self.sum)
         elif argument.isdigit():
             self.operation = "set"
+        elif (not argument.isdigit()):
+            self.operation ='error'
         else:
             raise RuntimeError
 
@@ -266,7 +269,7 @@ class Economy(commands.Cog):
                     currency=currency,
                     user=to.display_name,
                 )
-            else:
+            elif creds.operation =='set':
                 await bank.set_balance(to, creds.sum)
                 msg = _("{author} set {user}'s account balance to {num} {currency}.").format(
                     author=author.display_name,
@@ -274,6 +277,8 @@ class Economy(commands.Cog):
                     currency=currency,
                     user=to.display_name,
                 )
+            elif creds.operation =='error':
+                msg="Please enter a valid argument!"
         except (ValueError, errors.BalanceTooHigh) as e:
             await ctx.send(str(e))
         else:

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -278,7 +278,7 @@ class Economy(commands.Cog):
                     user=to.display_name,
                 )
             elif creds.operation == "error":
-                msg = "Can't set bank balance to a non-integer value . Try using a valid argument , for example: `+100` , `-100` , or `100`"
+                msg = "Can't see bank balance to a non-integer value . Try using a valid argument , for example: `+100` , `-100` , or `100` ."
         except (ValueError, errors.BalanceTooHigh) as e:
             await ctx.send(str(e))
         else:

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -278,7 +278,7 @@ class Economy(commands.Cog):
                     user=to.display_name,
                 )
             elif creds.operation == "error":
-                msg = "Can not set bank balance to a non-integer value.Try using a valid argument such as...(+1. 1. -1)"
+                msg = "Can't set bank balance to a non-integer value.Try using a valid argument,for example: `+100`, `-100`, or `100`"
         except (ValueError, errors.BalanceTooHigh) as e:
             await ctx.send(str(e))
         else:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
If the user passes some invalid argument, the bot will now give a meaningful error message in reply.
 
Fixes #4789 

### screenshot
![Screenshot from 2021-02-10 19-25-19](https://user-images.githubusercontent.com/52108435/107519991-ea1eea00-6bd6-11eb-8b48-1090bedad5ad.png)
