### PR TITLE
Update `[p]economyset slottime&paydaytime` to use `TimedeltaConverter` and not accept negative integers

### DIFF
--- a/docs/cog_guides/economy.rst
+++ b/docs/cog_guides/economy.rst
@@ -303,9 +303,7 @@ economyset paydaytime
 .. code-block:: none
 
     [p]economyset paydaytime <duration>
-    Duration can take arguments in `seconds`, `minutes`, `days`, and `weeks`. 
-    If the duration type is not specified, it will default to seconds.
-        
+
 **Description**
 
 Set the cooldown for the payday command.
@@ -316,7 +314,8 @@ Example:
 
 **Arguments**
 
-- ``<seconds>`` The new number of seconds to wait in between uses of payday. Default is 300.
+- | ``<seconds>`` The new duration to wait in between uses of payday. Default is 5 minutes.
+  | Accepts: seconds, minutes, hours, days, weeks (if no unit is specified, the duration is assumed to be given in seconds)
 
 .. _economy-command-economyset-registeramount:
 
@@ -422,7 +421,7 @@ economyset slotmin
 
 Set the minimum slot machine bid.
 
-Example:
+Examples:
     - ``[p]economyset slotmin 10``
 
 **Arguments**
@@ -439,21 +438,20 @@ economyset slottime
 
 .. code-block:: none
 
-    [p]economyset paydaytime <duration>
-    Duration can take arguments in `seconds`, `minutes`, `days`, and `weeks`. 
-    If the duration type is not specified, it will default to seconds.
+    [p]economyset slottime <duration>
 
 **Description**
 
 Set the cooldown for the slot machine.
 
-Example:
+Examples:
     - ``[p]economyset slottime 10``
     - ``[p]economyset slottime 10m``
 
 **Arguments**
 
-- ``<seconds>`` The new number of seconds to wait in between uses of the slot machine. Default is 5.
+- | ``<seconds>`` The new duration to wait in between uses of the slot machine. Default is 5 seconds.
+  | Accepts: seconds, minutes, hours, days, weeks (if no unit is specified, the duration is assumed to be given in seconds)
 
 .. _economy-command-leaderboard:
 

--- a/docs/cog_guides/economy.rst
+++ b/docs/cog_guides/economy.rst
@@ -302,14 +302,17 @@ economyset paydaytime
 
 .. code-block:: none
 
-    [p]economyset paydaytime <seconds>
-
+    [p]economyset paydaytime <duration>
+    Duration can take arguments in `seconds`, `minutes`, `days`, and `weeks`. 
+    If the duration type is not specified, it will default to seconds.
+        
 **Description**
 
 Set the cooldown for the payday command.
 
 Example:
-    - ``[p]economyset paydaytime 86400``
+    - ``[p]economyset paydaytime 100``
+    - ``[p]economyset paydaytime 10m``
 
 **Arguments**
 
@@ -436,7 +439,9 @@ economyset slottime
 
 .. code-block:: none
 
-    [p]economyset slottime <seconds>
+    [p]economyset paydaytime <duration>
+    Duration can take arguments in `seconds`, `minutes`, `days`, and `weeks`. 
+    If the duration type is not specified, it will default to seconds.
 
 **Description**
 
@@ -444,6 +449,7 @@ Set the cooldown for the slot machine.
 
 Example:
     - ``[p]economyset slottime 10``
+    - ``[p]economyset slottime 10m``
 
 **Arguments**
 

--- a/docs/cog_guides/economy.rst
+++ b/docs/cog_guides/economy.rst
@@ -308,9 +308,9 @@ economyset paydaytime
 
 Set the cooldown for the payday command.
 
-Example:
-    - ``[p]economyset paydaytime 100``
-    - ``[p]economyset paydaytime 10m``
+Examples:
+    - ``[p]economyset paydaytime 86400``
+    - ``[p]economyset paydaytime 1d``
 
 **Arguments**
 
@@ -421,7 +421,7 @@ economyset slotmin
 
 Set the minimum slot machine bid.
 
-Examples:
+Example:
     - ``[p]economyset slotmin 10``
 
 **Arguments**

--- a/docs/cog_guides/economy.rst
+++ b/docs/cog_guides/economy.rst
@@ -314,7 +314,7 @@ Examples:
 
 **Arguments**
 
-- | ``<seconds>`` The new duration to wait in between uses of payday. Default is 5 minutes.
+- | ``<duration>`` The new duration to wait in between uses of payday. Default is 5 minutes.
   | Accepts: seconds, minutes, hours, days, weeks (if no unit is specified, the duration is assumed to be given in seconds)
 
 .. _economy-command-economyset-registeramount:
@@ -450,7 +450,7 @@ Examples:
 
 **Arguments**
 
-- | ``<seconds>`` The new duration to wait in between uses of the slot machine. Default is 5 seconds.
+- | ``<duration>`` The new duration to wait in between uses of the slot machine. Default is 5 seconds.
   | Accepts: seconds, minutes, hours, days, weeks (if no unit is specified, the duration is assumed to be given in seconds)
 
 .. _economy-command-leaderboard:

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -12,6 +12,7 @@ from redbot.cogs.bank import is_owner_if_bank_global
 from redbot.cogs.mod.converters import RawUserIds
 from redbot.core import Config, bank, commands, errors, checks
 from redbot.core.commands import BadArgument, Converter
+from redbot.core.commands.converter import TimedeltaConverter
 from redbot.core.bot import Red
 from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils import AsyncIter
@@ -115,27 +116,6 @@ class SetParser:
         else:
             raise RuntimeError
             
-class TimeConverter(Converter):
-    async def convert(self, ctx: commands.Context, time: str) -> int:
-        conversions = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800, "mo": 604800*30 }
-        
-        if str(time[-1]) not in conversions:
-            if not str(time).isdigit():
-                raise BadArgument(f"{time} was not able to be converted to a time.")
-            return int(time) 
-        
-        multiplier = conversions[str(time[-1])]
-        
-        time = time[:-1]
-        if not str(time).isdigit():
-            raise BadArgument(f"{time} was not able to be converted to a time.")
-        
-        if int(time) * multiplier < 0:
-            raise BadArgument("This is not a positive integer")
-
-        return int(time) * multiplier
-
-
 @cog_i18n(_)
 class Economy(commands.Cog):
     """Get rich and have fun with imaginary currency!"""
@@ -925,7 +905,7 @@ class Economy(commands.Cog):
         )
 
     @economyset.command()
-    async def slottime(self, ctx: commands.Context, seconds: TimeConverter):
+    async def slottime(self, ctx: commands.Context, seconds: TimedeltaConverter):
         """Set the cooldown for the slot machine.
 
         Example:
@@ -935,6 +915,7 @@ class Economy(commands.Cog):
 
         - `<seconds>` The new number of seconds to wait in between uses of the slot machine. Default is 5.
         """
+        seconds = seconds.total_seconds()
         guild = ctx.guild
         if await bank.is_global():
             await self.config.SLOT_TIME.set(seconds)
@@ -943,7 +924,7 @@ class Economy(commands.Cog):
         await ctx.send(_("Cooldown is now {num} seconds.").format(num=seconds))
 
     @economyset.command()
-    async def paydaytime(self, ctx: commands.Context, seconds: TimeConverter):
+    async def paydaytime(self, ctx: commands.Context, seconds: TimedeltaConverter):
         """Set the cooldown for the payday command.
 
         Example:
@@ -953,6 +934,7 @@ class Economy(commands.Cog):
 
         - `<seconds>` The new number of seconds to wait in between uses of payday. Default is 300.
         """
+        seconds = seconds.total_seconds()
         guild = ctx.guild
         if await bank.is_global():
             await self.config.PAYDAY_TIME.set(seconds)

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -11,7 +11,6 @@ import discord
 from redbot.cogs.bank import is_owner_if_bank_global
 from redbot.cogs.mod.converters import RawUserIds
 from redbot.core import Config, bank, commands, errors, checks
-from redbot.core.commands import BadArgument, Converter
 from redbot.core.commands.converter import TimedeltaConverter
 from redbot.core.bot import Red
 from redbot.core.i18n import Translator, cog_i18n
@@ -115,6 +114,8 @@ class SetParser:
             self.operation = "set"
         else:
             raise RuntimeError
+            
+            
             
 @cog_i18n(_)
 class Economy(commands.Cog):

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -11,6 +11,7 @@ import discord
 from redbot.cogs.bank import is_owner_if_bank_global
 from redbot.cogs.mod.converters import RawUserIds
 from redbot.core import Config, bank, commands, errors, checks
+from redbot.core.commands import BadArgument, Converter
 from redbot.core.bot import Red
 from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils import AsyncIter
@@ -113,6 +114,26 @@ class SetParser:
             self.operation = "set"
         else:
             raise RuntimeError
+            
+class TimeConverter(Converter):
+    async def convert(self, ctx: commands.Context, time: str) -> int:
+        conversions = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800, "mo": 604800*30 }
+        
+        if str(time[-1]) not in conversions:
+            if not str(time).isdigit():
+                raise BadArgument(f"{time} was not able to be converted to a time.")
+            return int(time) 
+        
+        multiplier = conversions[str(time[-1])]
+        
+        time = time[:-1]
+        if not str(time).isdigit():
+            raise BadArgument(f"{time} was not able to be converted to a time.")
+        
+        if int(time) * multiplier < 0:
+            raise BadArgument("This is not a positive integer")
+
+        return int(time) * multiplier
 
 
 @cog_i18n(_)
@@ -904,7 +925,7 @@ class Economy(commands.Cog):
         )
 
     @economyset.command()
-    async def slottime(self, ctx: commands.Context, seconds: int):
+    async def slottime(self, ctx: commands.Context, seconds: TimeConverter):
         """Set the cooldown for the slot machine.
 
         Example:
@@ -922,7 +943,7 @@ class Economy(commands.Cog):
         await ctx.send(_("Cooldown is now {num} seconds.").format(num=seconds))
 
     @economyset.command()
-    async def paydaytime(self, ctx: commands.Context, seconds: int):
+    async def paydaytime(self, ctx: commands.Context, seconds: TimeConverter):
         """Set the cooldown for the payday command.
 
         Example:

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -906,7 +906,7 @@ class Economy(commands.Cog):
 
     @economyset.command()
     async def slottime(
-        self, ctx: commands.Context, duration: TimedeltaConverter(default_unit="seconds")
+        self, ctx: commands.Context, *, duration: TimedeltaConverter(default_unit="seconds")
     ):
         """Set the cooldown for the slot machine.
 
@@ -929,7 +929,7 @@ class Economy(commands.Cog):
 
     @economyset.command()
     async def paydaytime(
-        self, ctx: commands.Context, duration: TimedeltaConverter(default_unit="seconds")
+        self, ctx: commands.Context, *, duration: TimedeltaConverter(default_unit="seconds")
     ):
         """Set the cooldown for the payday command.
 

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -916,7 +916,7 @@ class Economy(commands.Cog):
         **Arguments**
 
         - `<duration>` The new number of seconds to wait in between uses of the slot machine. Default is 5.
-        - It is also a timedeltaconverter so `1d` is converted to 1 day
+        - Accepts: seconds, minutes, hours, days, weeks
         """
         seconds = duration.total_seconds()
         guild = ctx.guild
@@ -937,7 +937,7 @@ class Economy(commands.Cog):
         **Arguments**
 
         - `<duration>` The new number of seconds to wait in between uses of payday. Default is 300.
-        - It is also a timedeltaconverter so `1d` is converted to 1 day
+        - Accepts: seconds, minutes, hours, days, weeks
         """
         seconds = duration.total_seconds()
         guild = ctx.guild

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -906,7 +906,7 @@ class Economy(commands.Cog):
         )
 
     @economyset.command()
-    async def slottime(self, ctx: commands.Context, duration: TimedeltaConverter):
+    async def slottime(self, ctx: commands.Context, duration: TimedeltaConverter(default_unit="seconds")):
         """Set the cooldown for the slot machine.
 
         Example:
@@ -927,7 +927,7 @@ class Economy(commands.Cog):
         await ctx.send(_("Cooldown is now {num} seconds.").format(num=seconds))
 
     @economyset.command()
-    async def paydaytime(self, ctx: commands.Context, duration: TimedeltaConverter):
+    async def paydaytime(self, ctx: commands.Context, duration: TimedeltaConverter(default_unit="seconds")):
         """Set the cooldown for the payday command.
 
         Example:

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -114,9 +114,8 @@ class SetParser:
             self.operation = "set"
         else:
             raise RuntimeError
-            
-            
-            
+
+
 @cog_i18n(_)
 class Economy(commands.Cog):
     """Get rich and have fun with imaginary currency!"""
@@ -906,7 +905,9 @@ class Economy(commands.Cog):
         )
 
     @economyset.command()
-    async def slottime(self, ctx: commands.Context, duration: TimedeltaConverter(default_unit="seconds")):
+    async def slottime(
+        self, ctx: commands.Context, duration: TimedeltaConverter(default_unit="seconds")
+    ):
         """Set the cooldown for the slot machine.
 
         Example:
@@ -927,7 +928,9 @@ class Economy(commands.Cog):
         await ctx.send(_("Cooldown is now {num} seconds.").format(num=seconds))
 
     @economyset.command()
-    async def paydaytime(self, ctx: commands.Context, duration: TimedeltaConverter(default_unit="seconds")):
+    async def paydaytime(
+        self, ctx: commands.Context, duration: TimedeltaConverter(default_unit="seconds")
+    ):
         """Set the cooldown for the payday command.
 
         Example:

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -919,7 +919,7 @@ class Economy(commands.Cog):
         - `<duration>` The new duration to wait in between uses of the slot machine. Default is 5 seconds.
         Accepts: seconds, minutes, hours, days, weeks (if no unit is specified, the duration is assumed to be given in seconds)
         """
-        seconds = duration.total_seconds()
+        seconds = int(duration.total_seconds())
         guild = ctx.guild
         if await bank.is_global():
             await self.config.SLOT_TIME.set(seconds)
@@ -942,7 +942,7 @@ class Economy(commands.Cog):
         - `<duration>` The new duration to wait in between uses of payday. Default is 5 minutes.
         Accepts: seconds, minutes, hours, days, weeks (if no unit is specified, the duration is assumed to be given in seconds)
         """
-        seconds = duration.total_seconds()
+        seconds = int(duration.total_seconds())
         guild = ctx.guild
         if await bank.is_global():
             await self.config.PAYDAY_TIME.set(seconds)

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -906,7 +906,7 @@ class Economy(commands.Cog):
         )
 
     @economyset.command()
-    async def slottime(self, ctx: commands.Context, seconds: TimedeltaConverter):
+    async def slottime(self, ctx: commands.Context, duration: TimedeltaConverter):
         """Set the cooldown for the slot machine.
 
         Example:
@@ -915,10 +915,10 @@ class Economy(commands.Cog):
 
         **Arguments**
 
-        - `<seconds>` The new number of seconds to wait in between uses of the slot machine. Default is 5.
+        - `<duration>` The new number of seconds to wait in between uses of the slot machine. Default is 5.
         - It is also a timedeltaconverter so `1d` is converted to 1 day
         """
-        seconds = seconds.total_seconds()
+        seconds = duration.total_seconds()
         guild = ctx.guild
         if await bank.is_global():
             await self.config.SLOT_TIME.set(seconds)
@@ -927,7 +927,7 @@ class Economy(commands.Cog):
         await ctx.send(_("Cooldown is now {num} seconds.").format(num=seconds))
 
     @economyset.command()
-    async def paydaytime(self, ctx: commands.Context, seconds: TimedeltaConverter):
+    async def paydaytime(self, ctx: commands.Context, duration: TimedeltaConverter):
         """Set the cooldown for the payday command.
 
         Example:
@@ -936,10 +936,10 @@ class Economy(commands.Cog):
 
         **Arguments**
 
-        - `<seconds>` The new number of seconds to wait in between uses of payday. Default is 300.
+        - `<duration>` The new number of seconds to wait in between uses of payday. Default is 300.
         - It is also a timedeltaconverter so `1d` is converted to 1 day
         """
-        seconds = seconds.total_seconds()
+        seconds = duration.total_seconds()
         guild = ctx.guild
         if await bank.is_global():
             await self.config.PAYDAY_TIME.set(seconds)

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -910,14 +910,14 @@ class Economy(commands.Cog):
     ):
         """Set the cooldown for the slot machine.
 
-        Example:
+        Examples:
             - `[p]economyset slottime 10`
             - `[p]economyset slottime 10m`
 
         **Arguments**
 
-        - `<duration>` The new number of seconds to wait in between uses of the slot machine. Default is 5.
-        - Accepts: seconds, minutes, hours, days, weeks
+        - `<duration>` The new duration to wait in between uses of the slot machine. Default is 5 seconds.
+        Accepts: seconds, minutes, hours, days, weeks (if no unit is specified, the duration is assumed to be given in seconds)
         """
         seconds = duration.total_seconds()
         guild = ctx.guild
@@ -933,14 +933,14 @@ class Economy(commands.Cog):
     ):
         """Set the cooldown for the payday command.
 
-        Example:
+        Examples:
             - `[p]economyset paydaytime 86400`
             - `[p]economyset paydaytime 1d`
 
         **Arguments**
 
-        - `<duration>` The new number of seconds to wait in between uses of payday. Default is 300.
-        - Accepts: seconds, minutes, hours, days, weeks
+        - `<duration>` The new duration to wait in between uses of payday. Default is 5 minutes.
+        Accepts: seconds, minutes, hours, days, weeks (if no unit is specified, the duration is assumed to be given in seconds)
         """
         seconds = duration.total_seconds()
         guild = ctx.guild

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -911,10 +911,12 @@ class Economy(commands.Cog):
 
         Example:
             - `[p]economyset slottime 10`
+            - `[p]economyset slottime 10m`
 
         **Arguments**
 
         - `<seconds>` The new number of seconds to wait in between uses of the slot machine. Default is 5.
+        - It is also a timedeltaconverter so `1d` is converted to 1 day
         """
         seconds = seconds.total_seconds()
         guild = ctx.guild
@@ -930,10 +932,12 @@ class Economy(commands.Cog):
 
         Example:
             - `[p]economyset paydaytime 86400`
+            - `[p]economyset paydaytime 1d`
 
         **Arguments**
 
         - `<seconds>` The new number of seconds to wait in between uses of payday. Default is 300.
+        - It is also a timedeltaconverter so `1d` is converted to 1 day
         """
         seconds = seconds.total_seconds()
         guild = ctx.guild


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Paydaytime and Slottime command seconds param now only takes a positive integer, but accepts 0
Paydaytime and Slottime seconds param has a converter so `1d` would be 86400 seconds, along with seconds, minutes, etc.
