### PR TITLE
[Mod] Add default bot color to kick & ban DM

### DIFF
--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -153,7 +153,8 @@ class KickBanMixin(MixinMeta):
             if toggle:
                 with contextlib.suppress(discord.HTTPException):
                     em = discord.Embed(
-                        title=bold(_("You have been banned from {guild}.").format(guild=guild))
+                        title=bold(_("You have been banned from {guild}.").format(guild=guild)),
+                        color=await self.bot.get_embed_color(user),
                     )
                     em.add_field(
                         name=_("**Reason**"),
@@ -309,7 +310,8 @@ class KickBanMixin(MixinMeta):
         if toggle:
             with contextlib.suppress(discord.HTTPException):
                 em = discord.Embed(
-                    title=bold(_("You have been kicked from {guild}.").format(guild=guild))
+                    title=bold(_("You have been kicked from {guild}.").format(guild=guild)),
+                    color=await self.bot.get_embed_color(user),
                 )
                 em.add_field(
                     name=_("**Reason**"),


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This just adds the bot color to the DM sent to a user on ban or kick if it's enabled, instead of the ugly default grey/black color.