### PR TITLE
Make `[p]selfrole` without subcommand "toggle" the selfrole

### DIFF
--- a/docs/cog_guides/admin.rst
+++ b/docs/cog_guides/admin.rst
@@ -99,6 +99,7 @@ by admins using the :ref:`selfroleset command <admin-command-selfroleset>`.
 
 * ``<selfrole>``: The role you want to remove from yourself. |role-input|
 
+
 .. _admin-command-selfrole-list:
 
 """""""""""""

--- a/docs/cog_guides/admin.rst
+++ b/docs/cog_guides/admin.rst
@@ -54,17 +54,17 @@ Add or remove roles to yourself. Those roles must have been configured as user
 settable by admins using the :ref:`selfroleset command
 <admin-command-selfroleset>`.
 
-.. _admin-command-selfrole-add:
+.. _admin-command-selfrole:
 
 """"""""""""
-selfrole register
+selfrole
 """"""""""""
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]selfrole register <selfrole>
+    [p]selfrole <selfrole>
 
 **Description**
 
@@ -75,7 +75,7 @@ by admins using the :ref:`selfroleset command <admin-command-selfroleset>`.
 
 * ``<selfrole>``: The role you want to attribute to yourself. |role-input|
 
-.. _admin-command-selfrole-register:
+.. _admin-command-selfrole-add:
 
 """"""""""""
 selfrole add

--- a/docs/cog_guides/admin.rst
+++ b/docs/cog_guides/admin.rst
@@ -46,34 +46,16 @@ selfrole
 
 .. code-block:: none
 
-    [p]selfrole
-
-**Description**
-
-Add or remove roles to yourself. Those roles must have been configured as user
-settable by admins using the :ref:`selfroleset command
-<admin-command-selfroleset>`.
-
-.. _admin-command-selfrole:
-
-""""""""""""
-selfrole
-""""""""""""
-
-**Syntax**
-
-.. code-block:: none
-
     [p]selfrole <selfrole>
 
 **Description**
 
-Add or remove a role to yourself. It must have been configured as user settable
+Add or remove a role from yourself. It must have been configured as user settable
 by admins using the :ref:`selfroleset command <admin-command-selfroleset>`.
 
 **Arguments**
 
-* ``<selfrole>``: The role you want to attribute to yourself. |role-input|
+* ``<selfrole>``: The role you want to attribute or remove from yourself. |role-input|
 
 .. _admin-command-selfrole-add:
 

--- a/docs/cog_guides/admin.rst
+++ b/docs/cog_guides/admin.rst
@@ -57,6 +57,27 @@ settable by admins using the :ref:`selfroleset command
 .. _admin-command-selfrole-add:
 
 """"""""""""
+selfrole register
+""""""""""""
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]selfrole register <selfrole>
+
+**Description**
+
+Add or remove a role to yourself. It must have been configured as user settable
+by admins using the :ref:`selfroleset command <admin-command-selfroleset>`.
+
+**Arguments**
+
+* ``<selfrole>``: The role you want to attribute to yourself. |role-input|
+
+.. _admin-command-selfrole-register:
+
+""""""""""""
 selfrole add
 """"""""""""
 
@@ -95,7 +116,6 @@ by admins using the :ref:`selfroleset command <admin-command-selfroleset>`.
 **Arguments**
 
 * ``<selfrole>``: The role you want to remove from yourself. |role-input|
-
 
 .. _admin-command-selfrole-list:
 

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -391,12 +391,7 @@ class Admin(commands.Cog):
         return valid_roles
 
     @commands.guild_only()
-    @commands.group()
-    async def selfrole(self, ctx: commands.Context):
-        """Apply selfroles."""
-        pass
-
-    @selfrole.command()
+    @commands.group(invoke_without_command=True)
     async def selfrole(self, ctx: commands.Context, *, selfrole: SelfRole):
         """
         Add or remove a selfrole from yourself.

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -404,8 +404,7 @@ class Admin(commands.Cog):
         else:
             return await self._addrole(ctx, ctx.author, selfrole, check_user=False)
 
-    @selfrole.command(name="add")
-    @commands.command(hidden=True)
+    @selfrole.command(name="add", hidden=True)
     async def selfrole_add(self, ctx: commands.Context, *, selfrole: SelfRole):
         """
         Add a selfrole to yourself.
@@ -416,8 +415,7 @@ class Admin(commands.Cog):
         # noinspection PyTypeChecker
         await self._addrole(ctx, ctx.author, selfrole, check_user=False)
 
-    @selfrole.command(name="remove")
-    @commands.command(hidden=True)
+    @selfrole.command(name="remove", hidden=True)
     async def selfrole_remove(self, ctx: commands.Context, *, selfrole: SelfRole):
         """
         Remove a selfrole from yourself.

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -396,8 +396,8 @@ class Admin(commands.Cog):
         """Apply selfroles."""
         pass
 
-    @selfrole.command(name="register")
-    async def selfrole_register(self, ctx: commands.Context, *, selfrole: SelfRole):
+    @selfrole.command()
+    async def selfrole(self, ctx: commands.Context, *, selfrole: SelfRole):
         """
         Add or remove a selfrole from yourself.
 

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -396,7 +396,21 @@ class Admin(commands.Cog):
         """Apply selfroles."""
         pass
 
+    @selfrole.command(name="register")
+    async def selfrole_register(self, ctx: commands.Context, *, selfrole: SelfRole):
+        """
+        Add or remove a selfrole from yourself.
+
+        Server admins must have configured the role as user settable.
+        NOTE: The role is case sensitive!
+        """
+        if selfrole in ctx.author.roles:
+            return await self._removerole(ctx, ctx.author, selfrole, check_user=False)
+        else:
+            return await self._addrole(ctx, ctx.author, selfrole, check_user=False)
+
     @selfrole.command(name="add")
+    @commands.command(hidden=True)
     async def selfrole_add(self, ctx: commands.Context, *, selfrole: SelfRole):
         """
         Add a selfrole to yourself.
@@ -408,6 +422,7 @@ class Admin(commands.Cog):
         await self._addrole(ctx, ctx.author, selfrole, check_user=False)
 
     @selfrole.command(name="remove")
+    @commands.command(hidden=True)
     async def selfrole_remove(self, ctx: commands.Context, *, selfrole: SelfRole):
         """
         Remove a selfrole from yourself.


### PR DESCRIPTION
Replaces #4660 

Merged Selfrole add/remove commands into a single toggle.

### Type

- [ ] Bugfix
- [X] Enhancement
- [x] New feature

### Description of the changes

Merged Selfrole add/remove commands into a single toggle.