### PR TITLE
Fix the tracking of nicks that were set just before nick reset

### DIFF
--- a/redbot/cogs/mod/events.py
+++ b/redbot/cogs/mod/events.py
@@ -176,7 +176,7 @@ class Events(MixinMeta):
 
     @commands.Cog.listener()
     async def on_member_update(self, before: discord.Member, after: discord.Member):
-        if before.nick != after.nick and after.nick is not None:
+        if before.nick != after.nick and before.nick is not None:
             guild = after.guild
             if (not guild) or await self.bot.cog_disabled_in_guild(self, guild):
                 return


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
This PR fixes tracking of nicknames that were set just before nick reset (i.e. XYZ not getting saved when the user has nickname XYZ and then the nickname is reset rather than changed to something else) and stops adding `None`s to the list when the nickname wasn't set *before* the nickname change.

This issue was introduced by #4131.
