### PR TITLE
[Audio] Fix local track documentation.

### DIFF
--- a/redbot/cogs/audio/core/commands/localtracks.py
+++ b/redbot/cogs/audio/core/commands/localtracks.py
@@ -29,12 +29,12 @@ class LocalTrackCommands(MixinMeta, metaclass=CompositeMetaClass):
     async def command_local_folder(self, ctx: commands.Context, *, folder: str = None):
         """Play all songs in a localtracks folder.
 
-        Examples:
-            [p]local folder
-            Open a menu to pick a folder to queue.
+        **Usage**:
+        ​ ​ ​ ​ `[p]local folder`
+        ​ ​ ​ ​ ​ ​ ​ ​ Open a menu to pick a folder to queue.
 
-            [p]local folder folder_name
-            Queues all of the tracks inside the folder_name folder.
+        ​ ​ `[p]local folder [folder_name]`
+        ​ ​ ​ ​ ​ ​ ​ ​ Queues all of the tracks inside the folder_name folder.
         """
         if not await self.localtracks_folder_exists(ctx):
             return
@@ -61,18 +61,16 @@ class LocalTrackCommands(MixinMeta, metaclass=CompositeMetaClass):
     async def command_local_play(self, ctx: commands.Context):
         """Play a local track.
 
-        To play a local track, either use the menu to choose a track or enter in the
-        localtracks path directly with the play command.
-        To play an entire local folder, use [p]help local folder for instructions.
+        To play a local track, either use the menu to choose a track or enter in the track path directly with the play command.
+        To play an entire folder, use `[p]help local folder` for instructions.
 
-        Examples:
-        [p]local play
-        Open a menu to pick a file.
+        **Usage**:
+        ​ ​ ​ ​ `[p]local play`
+        ​ ​ ​ ​ ​ ​ ​ ​ Open a menu to pick a track.
 
-        [p]play localtracks\album_folder\song_name.mp3
-        OR
-        [p]play album_folder\song_name.mp3
-        Use a direct link relative to the localtracks folder.
+        ​ ​ ​ ​ `[p]play localtracks\\album_folder\\song_name.mp3`
+        ​ ​ ​ ​ `[p]play album_folder\\song_name.mp3`
+        ​ ​ ​ ​ ​ ​ ​ ​ Use a direct link relative to the localtracks folder.
         """
         if not await self.localtracks_folder_exists(ctx):
             return

--- a/redbot/cogs/audio/core/commands/localtracks.py
+++ b/redbot/cogs/audio/core/commands/localtracks.py
@@ -51,7 +51,11 @@ class LocalTrackCommands(MixinMeta, metaclass=CompositeMetaClass):
 
     @command_local.command(name="play")
     async def command_local_play(self, ctx: commands.Context):
-        """Play a local track."""
+        """Play a local track.
+
+        If there's no album folders, and instead a regular .mp3 file, use the play command instead of
+        local play. For more help, check the help documentation for the play command.
+        """
         if not await self.localtracks_folder_exists(ctx):
             return
         localtracks_folders = await self.get_localtracks_folders(ctx, search_subfolders=True)

--- a/redbot/cogs/audio/core/commands/localtracks.py
+++ b/redbot/cogs/audio/core/commands/localtracks.py
@@ -27,7 +27,17 @@ class LocalTrackCommands(MixinMeta, metaclass=CompositeMetaClass):
 
     @command_local.command(name="folder", aliases=["start"])
     async def command_local_folder(self, ctx: commands.Context, *, folder: str = None):
-        """Play all songs in a localtracks folder."""
+        """Play all songs in a localtracks folder.
+
+        To set up your localtracks folders, please see the documentation at: `placeholder`
+
+        Examples:
+            [p]local folder
+            Open a menu to pick a folder to queue.
+
+            [p]local folder folder_name
+            Queues all of the tracks inside the folder_name folder.
+        """
         if not await self.localtracks_folder_exists(ctx):
             return
 
@@ -47,14 +57,25 @@ class LocalTrackCommands(MixinMeta, metaclass=CompositeMetaClass):
             query = Query.process_input(
                 _dir, self.local_folder_current_path, search_subfolders=True
             )
-            await self._local_play_all(ctx, query, from_search=False if not folder else True)
+            await self._local_play_all(ctx, query, from_search=bool(folder))
 
     @command_local.command(name="play")
     async def command_local_play(self, ctx: commands.Context):
         """Play a local track.
 
-        If there's no album folders, and instead a regular .mp3 file, use the play command instead of
-        local play. For more help, check the help documentation for the play command.
+        To set up your localtracks folders, please see the documentation at: `placeholder`
+        To play a local track, either use the menu to choose a track or enter in the
+        localtracks path directly with the play command.
+        To play an entire local folder, use [p]help local folder for instructions.
+
+        Examples:
+        [p]local play
+        Open a menu to pick a file.
+
+        [p]play localtracks/album_folder/song_name.mp3
+        OR
+        [p]play album_folder/song_name.mp3
+        Use a direct link relative to the localtracks folder.
         """
         if not await self.localtracks_folder_exists(ctx):
             return

--- a/redbot/cogs/audio/core/commands/localtracks.py
+++ b/redbot/cogs/audio/core/commands/localtracks.py
@@ -33,7 +33,7 @@ class LocalTrackCommands(MixinMeta, metaclass=CompositeMetaClass):
         ​ ​ ​ ​ `[p]local folder`
         ​ ​ ​ ​ ​ ​ ​ ​ Open a menu to pick a folder to queue.
 
-        ​ ​ `[p]local folder [folder_name]`
+        ​ ​ `[p]local folder folder_name`
         ​ ​ ​ ​ ​ ​ ​ ​ Queues all of the tracks inside the folder_name folder.
         """
         if not await self.localtracks_folder_exists(ctx):

--- a/redbot/cogs/audio/core/commands/localtracks.py
+++ b/redbot/cogs/audio/core/commands/localtracks.py
@@ -29,8 +29,6 @@ class LocalTrackCommands(MixinMeta, metaclass=CompositeMetaClass):
     async def command_local_folder(self, ctx: commands.Context, *, folder: str = None):
         """Play all songs in a localtracks folder.
 
-        To set up your localtracks folders, please see the documentation at: `placeholder`
-
         Examples:
             [p]local folder
             Open a menu to pick a folder to queue.
@@ -63,7 +61,6 @@ class LocalTrackCommands(MixinMeta, metaclass=CompositeMetaClass):
     async def command_local_play(self, ctx: commands.Context):
         """Play a local track.
 
-        To set up your localtracks folders, please see the documentation at: `placeholder`
         To play a local track, either use the menu to choose a track or enter in the
         localtracks path directly with the play command.
         To play an entire local folder, use [p]help local folder for instructions.
@@ -72,9 +69,9 @@ class LocalTrackCommands(MixinMeta, metaclass=CompositeMetaClass):
         [p]local play
         Open a menu to pick a file.
 
-        [p]play localtracks/album_folder/song_name.mp3
+        [p]play localtracks\album_folder\song_name.mp3
         OR
-        [p]play album_folder/song_name.mp3
+        [p]play album_folder\song_name.mp3
         Use a direct link relative to the localtracks folder.
         """
         if not await self.localtracks_folder_exists(ctx):

--- a/redbot/cogs/audio/core/commands/player.py
+++ b/redbot/cogs/audio/core/commands/player.py
@@ -39,8 +39,8 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
     async def command_play(self, ctx: commands.Context, *, query: str):
         """Play a URL or search for a track.
 
-        To play a local track/file, the query should be (your localtrack folder)/(mp3 file).
-        To check what your localtrack folder is, check your audio settings using the audioset command..
+        To play a local track/file, the query should be <parentfolder>/<filename>.
+        If you are the bot owner, use [p]audioset info to display your localtracks path.
         """
         query = Query.process_input(query, self.local_folder_current_path)
         guild_data = await self.config.guild(ctx.guild).all()
@@ -66,7 +66,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
             )
         if not self._player_check(ctx):
             if self.lavalink_connection_aborted:
-                msg = _("Connection to Lavalink has failed")
+                msg = _("Connection to Lavalink has failed.")
                 desc = EmptyEmbed
                 if await self.bot.is_owner(ctx.author):
                     desc = _("Please check your console or logs for details.")

--- a/redbot/cogs/audio/core/commands/player.py
+++ b/redbot/cogs/audio/core/commands/player.py
@@ -40,6 +40,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
         """Play the specified track or search for a close match.
 
         To play a local track, the query should be `<parentfolder>\\<filename>`.
+        If you are the bot owner, use `[p]audioset info` to display your localtracks path.
         """
         query = Query.process_input(query, self.local_folder_current_path)
         guild_data = await self.config.guild(ctx.guild).all()

--- a/redbot/cogs/audio/core/commands/player.py
+++ b/redbot/cogs/audio/core/commands/player.py
@@ -39,7 +39,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
     async def command_play(self, ctx: commands.Context, *, query: str):
         """Play a URL or search for a track.
 
-        To play a local track\file, the query should be <parentfolder>\<filename>.
+        To play a local track/file, the query should be <parentfolder>\<filename>.
         """
         query = Query.process_input(query, self.local_folder_current_path)
         guild_data = await self.config.guild(ctx.guild).all()

--- a/redbot/cogs/audio/core/commands/player.py
+++ b/redbot/cogs/audio/core/commands/player.py
@@ -39,8 +39,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
     async def command_play(self, ctx: commands.Context, *, query: str):
         """Play a URL or search for a track.
 
-        To play a local track/file, the query should be <parentfolder>/<filename>.
-        If you are the bot owner, use [p]audioset info to display your localtracks path.
+        To play a local track\file, the query should be <parentfolder>\<filename>.
         """
         query = Query.process_input(query, self.local_folder_current_path)
         guild_data = await self.config.guild(ctx.guild).all()

--- a/redbot/cogs/audio/core/commands/player.py
+++ b/redbot/cogs/audio/core/commands/player.py
@@ -37,7 +37,11 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
     @commands.guild_only()
     @commands.bot_has_permissions(embed_links=True)
     async def command_play(self, ctx: commands.Context, *, query: str):
-        """Play a URL or search for a track."""
+        """Play a URL or search for a track.
+
+        To play a local track/file, the query should be (your localtrack folder)/(mp3 file).
+        To check what your localtrack folder is, check your audio settings using the audioset command..
+        """
         query = Query.process_input(query, self.local_folder_current_path)
         guild_data = await self.config.guild(ctx.guild).all()
         restrict = await self.config.restrict()

--- a/redbot/cogs/audio/core/commands/player.py
+++ b/redbot/cogs/audio/core/commands/player.py
@@ -37,9 +37,9 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
     @commands.guild_only()
     @commands.bot_has_permissions(embed_links=True)
     async def command_play(self, ctx: commands.Context, *, query: str):
-        """Play a URL or search for a track.
+        """Play the specified track or search for a close match.
 
-        To play a local track/file, the query should be <parentfolder>\<filename>.
+        To play a local track, the query should be `<parentfolder>\\<filename>`.
         """
         query = Query.process_input(query, self.local_folder_current_path)
         guild_data = await self.config.guild(ctx.guild).all()

--- a/redbot/cogs/audio/core/commands/player.py
+++ b/redbot/cogs/audio/core/commands/player.py
@@ -65,7 +65,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
             )
         if not self._player_check(ctx):
             if self.lavalink_connection_aborted:
-                msg = _("Connection to Lavalink has failed.")
+                msg = _("Connection to Lavalink has failed")
                 desc = EmptyEmbed
                 if await self.bot.is_owner(ctx.author):
                     desc = _("Please check your console or logs for details.")

--- a/redbot/cogs/audio/core/utilities/formatting.py
+++ b/redbot/cogs/audio/core/utilities/formatting.py
@@ -93,7 +93,7 @@ class FormattingUtilities(MixinMeta, metaclass=CompositeMetaClass):
     ):
         if not self._player_check(ctx):
             if self.lavalink_connection_aborted:
-                msg = _("Connection to Lavalink has failed.")
+                msg = _("Connection to Lavalink has failed")
                 description = EmptyEmbed
                 if await self.bot.is_owner(ctx.author):
                     description = _("Please check your console or logs for details.")


### PR DESCRIPTION
## Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

This is a workaround to #4777. In particular, this rewrites the help documentation to be more useful to queue local tracks.

- While using `[p]`help local play, this denotes that to play a local track file, and not necessarily by album, to redirect them to `[p]` play.
- While using `[p]` help play, this denotes both regular play usage (URL, search query) and local track files query, whilst also referencing the issue's usage of correctly playing them.
