### PR TITLE
Add user/role names to `[p](local)allow/blocklist list`

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2977,7 +2977,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         for obj in curr_list:
             get_user_or_role = self.bot.get_user(obj) or ctx.guild.get_role(obj)
             if not get_user_or_role:
-                get_user_or_role = _("Unknown or Deleted User")
+                get_user_or_role = _("Unknown or Deleted User/Role")
             msg += "\n\t- {} ({})".format(obj, get_user_or_role)
 
         for page in pagify(msg):
@@ -3071,7 +3071,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         for obj in curr_list:
             get_user_or_role = self.bot.get_user(obj) or ctx.guild.get_role(obj)
             if not get_user_or_role:
-                get_user_or_role = _("Unknown or Deleted User")
+                get_user_or_role = _("Unknown or Deleted User/Role")
             msg += "\n\t- {} ({})".format(obj, get_user_or_role)
 
         for page in pagify(msg):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3071,7 +3071,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         for obj in curr_list:
             get_user = self.bot.get_user(obj)
             if not get_user:
-                get_user = _("Unknown or Deleted User")
+                get_user = _("[Unknown or Deleted User]")
             msg += "\n\t- {} ({})".format(get_user, obj)
 
         for page in pagify(msg):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2823,7 +2823,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             msg = _("User on the allowlist:")
         for user in curr_list:
-            msg += "\n\t- {}".format(user)
+            msg += "\n\t- {} ({})".format(self.bot.get_user(user), user)
 
         for page in pagify(msg):
             await ctx.send(box(page))
@@ -2892,7 +2892,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             msg = _("User on the blocklist:")
         for user in curr_list:
-            msg += "\n\t- {}".format(user) 
+            msg += "\n\t- {} ({})".format(self.bot.get_user(user), user) 
 
         for page in pagify(msg):
             await ctx.send(box(page))
@@ -2969,7 +2969,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             msg = _("Allowed user or role:")
         for obj in curr_list:
-            msg += "\n\t- {}".format(obj)
+            msg += "\n\t- {} ({})".format(self.bot.get_user(obj), obj)
 
         for page in pagify(msg):
             await ctx.send(box(page))
@@ -3060,7 +3060,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             msg = _("Blocked user or role:")
         for obj in curr_list:
-            msg += "\n\t- {}".format(obj)
+            msg += "\n\t- {} ({})".format(self.bot.get_user(obj), obj)
 
         for page in pagify(msg):
             await ctx.send(box(page))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2892,7 +2892,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             msg = _("User on the blocklist:")
         for user in curr_list:
-            msg += "\n\t- {}".format(user)
+            msg += "\n\t- {}".format(user) 
 
         for page in pagify(msg):
             await ctx.send(box(page))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2825,7 +2825,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         for user in curr_list:
             get_user = self.bot.get_user(user)
             if not get_user:
-                get_user = _("Unknown or Deleted User")
+                get_user = _("[Unknown or Deleted User]")
             msg += "\n\t- {} ({})".format(get_user, user)
 
         for page in pagify(msg):
@@ -2897,7 +2897,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         for user in curr_list:
             get_user = self.bot.get_user(user)
             if not get_user:
-                get_user = _("Unknown or Deleted User")
+                get_user = _("[Unknown or Deleted User]")
             msg += "\n\t- {} ({})".format(get_user, user)
 
         for page in pagify(msg):
@@ -2977,7 +2977,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         for obj in curr_list:
             get_user = self.bot.get_user(obj)
             if not get_user:
-                get_user = _("Unknown or Deleted User")
+                get_user = _("[Unknown or Deleted User]")
             msg += "\n\t- {} ({})".format(get_user, obj)
 
         for page in pagify(msg):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2975,10 +2975,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             msg = _("Allowed user or role:")
         for obj in curr_list:
-            get_user = self.bot.get_user(obj)
-            if not get_user:
-                get_user = _("Unknown or Deleted User")
-            msg += "\n\t- {} ({})".format(obj, get_user)
+            get_user_or_role = self.bot.get_user(obj) or ctx.guild.get_role(obj)
+            if not get_user_or_role:
+                get_user_or_role = _("Unknown or Deleted User")
+            msg += "\n\t- {} ({})".format(obj, get_user_or_role)
 
         for page in pagify(msg):
             await ctx.send(box(page))
@@ -3069,10 +3069,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             msg = _("Blocked user or role:")
         for obj in curr_list:
-            get_user = self.bot.get_user(obj)
-            if not get_user:
-                get_user = _("Unknown or Deleted User")
-            msg += "\n\t- {} ({})".format(obj, get_user)
+            get_user_or_role = self.bot.get_user(obj) or ctx.guild.get_role(obj)
+            if not get_user_or_role:
+                get_user_or_role = _("Unknown or Deleted User")
+            msg += "\n\t- {} ({})".format(obj, get_user_or_role)
 
         for page in pagify(msg):
             await ctx.send(box(page))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2825,8 +2825,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         for user in curr_list:
             get_user = self.bot.get_user(user)
             if not get_user:
-                get_user = _("[Unknown or Deleted User]")
-            msg += "\n\t- {} ({})".format(get_user, user)
+                get_user = _("Unknown or Deleted User")
+            msg += "\n\t- {} ({})".format(user, get_user)
 
         for page in pagify(msg):
             await ctx.send(box(page))
@@ -2897,8 +2897,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         for user in curr_list:
             get_user = self.bot.get_user(user)
             if not get_user:
-                get_user = _("[Unknown or Deleted User]")
-            msg += "\n\t- {} ({})".format(get_user, user)
+                get_user = _("Unknown or Deleted User")
+            msg += "\n\t- {} ({})".format(user, get_user)
 
         for page in pagify(msg):
             await ctx.send(box(page))
@@ -2977,8 +2977,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         for obj in curr_list:
             get_user = self.bot.get_user(obj)
             if not get_user:
-                get_user = _("[Unknown or Deleted User]")
-            msg += "\n\t- {} ({})".format(get_user, obj)
+                get_user = _("Unknown or Deleted User")
+            msg += "\n\t- {} ({})".format(obj, get_user)
 
         for page in pagify(msg):
             await ctx.send(box(page))
@@ -3071,8 +3071,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         for obj in curr_list:
             get_user = self.bot.get_user(obj)
             if not get_user:
-                get_user = _("[Unknown or Deleted User]")
-            msg += "\n\t- {} ({})".format(get_user, obj)
+                get_user = _("Unknown or Deleted User")
+            msg += "\n\t- {} ({})".format(obj, get_user)
 
         for page in pagify(msg):
             await ctx.send(box(page))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2823,7 +2823,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             msg = _("User on the allowlist:")
         for user in curr_list:
-            msg += "\n\t- {} ({})".format(self.bot.get_user(user), user)
+            get_user = self.bot.get_user(user)
+            if not get_user:
+                get_user = _("Unknown or Deleted User")
+            msg += "\n\t- {} ({})".format(get_user, user)
 
         for page in pagify(msg):
             await ctx.send(box(page))
@@ -2892,7 +2895,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             msg = _("User on the blocklist:")
         for user in curr_list:
-            msg += "\n\t- {} ({})".format(self.bot.get_user(user), user) 
+            get_user = self.bot.get_user(user)
+            if not get_user:
+                get_user = _("Unknown or Deleted User")
+            msg += "\n\t- {} ({})".format(get_user, user)
 
         for page in pagify(msg):
             await ctx.send(box(page))
@@ -2969,7 +2975,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             msg = _("Allowed user or role:")
         for obj in curr_list:
-            msg += "\n\t- {} ({})".format(self.bot.get_user(obj), obj)
+            get_user = self.bot.get_user(obj)
+            if not get_user:
+                get_user = _("Unknown or Deleted User")
+            msg += "\n\t- {} ({})".format(get_user, obj)
 
         for page in pagify(msg):
             await ctx.send(box(page))
@@ -3060,7 +3069,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             msg = _("Blocked user or role:")
         for obj in curr_list:
-            msg += "\n\t- {} ({})".format(self.bot.get_user(obj), obj)
+            get_user = self.bot.get_user(obj)
+            if not get_user:
+                get_user = _("Unknown or Deleted User")
+            msg += "\n\t- {} ({})".format(get_user, obj)
 
         for page in pagify(msg):
             await ctx.send(box(page))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2822,11 +2822,11 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             msg = _("Users on the allowlist:")
         else:
             msg = _("User on the allowlist:")
-        for user in curr_list:
-            get_user = self.bot.get_user(user)
-            if not get_user:
-                get_user = _("Unknown or Deleted User")
-            msg += "\n\t- {} ({})".format(user, get_user)
+        for user_id in curr_list:
+            user = self.bot.get_user(user_id)
+            if not user:
+                user = _("Unknown or Deleted User")
+            msg += f"\n\t- {user_id} ({user})"
 
         for page in pagify(msg):
             await ctx.send(box(page))
@@ -2894,11 +2894,11 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             msg = _("Users on the blocklist:")
         else:
             msg = _("User on the blocklist:")
-        for user in curr_list:
-            get_user = self.bot.get_user(user)
-            if not get_user:
-                get_user = _("Unknown or Deleted User")
-            msg += "\n\t- {} ({})".format(user, get_user)
+        for user_id in curr_list:
+            user = self.bot.get_user(user_id)
+            if not user:
+                user = _("Unknown or Deleted User")
+            msg += f"\n\t- {user_id} ({user})"
 
         for page in pagify(msg):
             await ctx.send(box(page))
@@ -2974,11 +2974,11 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             msg = _("Allowed users and/or roles:")
         else:
             msg = _("Allowed user or role:")
-        for obj in curr_list:
-            get_user_or_role = self.bot.get_user(obj) or ctx.guild.get_role(obj)
-            if not get_user_or_role:
-                get_user_or_role = _("Unknown or Deleted User/Role")
-            msg += "\n\t- {} ({})".format(obj, get_user_or_role)
+        for obj_id in curr_list:
+            user_or_role = self.bot.get_user(obj_id) or ctx.guild.get_role(obj_id)
+            if not user_or_role:
+                user_or_role = _("Unknown or Deleted User/Role")
+            msg += f"\n\t- {obj_id} ({user_or_role})"
 
         for page in pagify(msg):
             await ctx.send(box(page))
@@ -3068,11 +3068,11 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             msg = _("Blocked users and/or roles:")
         else:
             msg = _("Blocked user or role:")
-        for obj in curr_list:
-            get_user_or_role = self.bot.get_user(obj) or ctx.guild.get_role(obj)
-            if not get_user_or_role:
-                get_user_or_role = _("Unknown or Deleted User/Role")
-            msg += "\n\t- {} ({})".format(obj, get_user_or_role)
+        for obj_id in curr_list:
+            user_or_role = self.bot.get_user(obj_id) or ctx.guild.get_role(obj_id)
+            if not user_or_role:
+                user_or_role = _("Unknown or Deleted User/Role")
+            msg += f"\n\t- {obj_id} ({user_or_role})"
 
         for page in pagify(msg):
             await ctx.send(box(page))


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

Feature Request: Allow for the bot to get the user in each allowlist/blocklist in the format:

```yaml
- user#1234 (1234567890)
```

I feel this feature would help these lists to be more expansive in the information they provide, because sometimes, especially on a large redbot, there will be lots of users on the blocklist/allowlist, and to sift through the IDs may not be so convenient, but also I can't think of a reason against why this couldn't be implemented.

If a user could not be found, I check against a variable getting the user and change the variable content to `Unknown or Deleted User` if that were to be the case.

I've tested these changes on my fork of Red and they appear to work just fine. I attempted to provide an image below. Please let me know if there are any changes required.

![Example Image](https://user-images.githubusercontent.com/67752638/108606375-b2235e00-73b1-11eb-9d88-f6849131927b.png)

~~Edit: 'Unknown or Deleted User' has been edited to have squares brackets around it inside the string.~~

Further edits:

A few more additional edits were made to the original UI to make it look slightly neater, seeing as usernames can vary drastically in length, but IDs cannot. The layout has been changed to look something like this:

```yaml
- 123456789012345 (user#1234)
- 543210987654321 (Unknown or Deleted User)
```
