### PR TITLE
Work around `actions/labeler`'s upstream issue with label sync setting

### DIFF
--- a/.github/workflows/auto_labeler_pr.yml
+++ b/.github/workflows/auto_labeler_pr.yml
@@ -10,4 +10,4 @@ jobs:
         uses: actions/labeler@v3
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          sync-labels: ""
+          sync-labels: ""  # this is a temporary workaround, see #4844

--- a/.github/workflows/auto_labeler_pr.yml
+++ b/.github/workflows/auto_labeler_pr.yml
@@ -10,3 +10,4 @@ jobs:
         uses: actions/labeler@v3
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: ""


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Works around https://github.com/actions/labeler/issues/104 which causes `sync-labels: false` (which is the default) to not work as actual `false`.

