### PR TITLE
fix a minor grammar issue

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1271,7 +1271,7 @@ class RedBase(
 
     @staticmethod
     def list_packages():
-        """Lists packages present in the cogs the folder"""
+        """Lists packages present in the cogs folder"""
         return os.listdir("cogs")
 
     async def save_packages_status(self, packages):


### PR DESCRIPTION
### Type

- [ x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
The docstring in the `list_packages` is "cogs the folder" which should be "cogs folder"