### PR TITLE
Red 3.4.7 - Changelog

### DIFF
--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -3,7 +3,7 @@
 Redbot 3.4.7 (2021-02-26)
 =========================
 | Thanks to all these amazing people that contributed to this release:
-| 
+| :ghuser:`elijabesu`, :ghuser:`Flame442`, :ghuser:`flaree`, :ghuser:`jack1142`, :ghuser:`Kowlin`, :ghuser:`kreusada`, :ghuser:`palmtree5`, :ghuser:`TrustyJAID`
 
 End-user changelog
 ------------------

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -1,5 +1,24 @@
 .. 3.4.x Changelogs
 
+Redbot 3.4.7 (2021-02-26)
+=========================
+| Thanks to all these amazing people that contributed to this release:
+| 
+
+End-user changelog
+------------------
+
+- Added proper permission checks to ``[p]muteset senddm`` and ``[p]muteset showmoderator`` (:issue:`4849`)
+- Updated the ``[p]lmgtfy`` command to use the new domain (:issue:`4840`)
+- Fixed minor issues with error messages in Mutes cog (:issue:`4847`, :issue:`4850`)
+
+Documentation changes
+---------------------
+
+- Added `cog guide for General cog <cog_guides/trivia>` (:issue:`4797`)
+- Added `cog guide for Trivia cog <cog_guides/trivia>` (:issue:`4566`)
+
+
 Redbot 3.4.6 (2021-02-16)
 =========================
 | Thanks to all these amazing people that contributed to this release:

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -10,7 +10,7 @@ End-user changelog
 
 - Added proper permission checks to ``[p]muteset senddm`` and ``[p]muteset showmoderator`` (:issue:`4849`)
 - Updated the ``[p]lmgtfy`` command to use the new domain (:issue:`4840`)
-- Fixed minor issues with error messages in Mutes cog (:issue:`4847`, :issue:`4850`)
+- Fixed minor issues with error messages in Mutes cog (:issue:`4847`, :issue:`4850`, :issue:`4853`)
 
 Documentation changes
 ---------------------

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -10,6 +10,7 @@ End-user changelog
 
 - Added proper permission checks to ``[p]muteset senddm`` and ``[p]muteset showmoderator`` (:issue:`4849`)
 - Updated the ``[p]lmgtfy`` command to use the new domain (:issue:`4840`)
+- Updated the ``[p]info`` command to more clearly indicate that the instance is owned by a team (:issue:`4851`)
 - Fixed minor issues with error messages in Mutes cog (:issue:`4847`, :issue:`4850`, :issue:`4853`)
 
 Documentation changes


### PR DESCRIPTION
Draft PR for Red 3.4.7 changelog.

The rendered changelog can be seen here: https://red-discordbot--4851.org.readthedocs.build/en/4851/changelog_3_4_0.html#redbot-3-4-7-2021-02-26