### PR TITLE
Make files - fallback to python(3.8) from PATH if `.venv` doesn't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,12 @@ PYTHON ?= python3.8
 
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+ifneq ($(wildcard $(ROOT_DIR)/.venv/.),)
+	VENV_PYTHON = $(ROOT_DIR)/.venv/bin/python
+else
+	VENV_PYTHON = $(PYTHON)
+endif
+
 define HELP_BODY
 Usage:
   make <command>
@@ -25,11 +31,11 @@ export HELP_BODY
 
 # Python Code Style
 reformat:
-	$(PYTHON) -m black $(ROOT_DIR)
+	$(VENV_PYTHON) -m black $(ROOT_DIR)
 stylecheck:
-	$(PYTHON) -m black --check $(ROOT_DIR)
+	$(VENV_PYTHON) -m black --check $(ROOT_DIR)
 stylediff:
-	$(PYTHON) -m black --check --diff $(ROOT_DIR)
+	$(VENV_PYTHON) -m black --check --diff $(ROOT_DIR)
 
 # Translations
 gettext:

--- a/make.bat
+++ b/make.bat
@@ -2,18 +2,24 @@
 
 if [%1] == [] goto help
 
+if exist "%~dp0.venv\" (
+    set "VENV_PYTHON=%~dp0.venv\Scripts\python"
+) else (
+    set VENV_PYTHON=python
+)
+
 goto %1
 
 :reformat
-"%~dp0.venv\Scripts\black" "%~dp0."
+"%VENV_PYTHON%" -m black "%~dp0."
 goto:eof
 
 :stylecheck
-"%~dp0.venv\Scripts\black" --check "%~dp0."
+"%VENV_PYTHON%" -m black --check "%~dp0."
 goto:eof
 
 :stylediff
-"%~dp0.venv\Scripts\black" --check --diff "%~dp0."
+"%VENV_PYTHON%" -m black --check --diff "%~dp0."
 goto:eof
 
 :newenv

--- a/make.ps1
+++ b/make.ps1
@@ -41,32 +41,38 @@ param (
 )
 
 function reformat() {
-    black $PSScriptRoot
+    & $script:venvPython -m black $PSScriptRoot
 }
 
 function stylecheck() {
-    black --check $PSScriptRoot
+    & $script:venvPython -m black --check $PSScriptRoot
 }
 
 function stylediff() {
-    black --check --diff $PSScriptRoot
+    & $script:venvPython -m black --check --diff $PSScriptRoot
 }
 
 function newenv() {
     py -3.8 -m venv --clear .venv
-    .\.venv\Scripts\python.exe -m pip install -U pip setuptools
+    & $PSScriptRoot\.venv\Scripts\python.exe -m pip install -U pip setuptools
     syncenv
 }
 
 function syncenv() {
-    .\.venv\Scripts\python.exe -m pip install -Ur .\tools\dev-requirements.txt
+    & $PSScriptRoot\.venv\Scripts\python.exe -m pip install -Ur .\tools\dev-requirements.txt
 }
 
 function activateenv() {
-    .\.venv\Scripts\Activate.ps1
+    & $PSScriptRoot\.venv\Scripts\Activate.ps1
 }
 
 $script:availableCommands = @("reformat", "stylecheck", "stylediff", "newenv", "syncenv", "activateenv")
+
+if (Test-Path -LiteralPath "$PSScriptRoot\.venv" -PathType Container) {
+    $script:venvPython = "$PSScriptRoot\.venv\Scripts\python.exe"
+} else {
+    $script:venvPython = "python"
+}
 
 if ($help -or !$command) {
     Get-Help $MyInvocation.InvocationName


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
And also improve the consistency of this behavior within different make files.
@Drapersniper does this work for you?