### PR TITLE
Use `brew install --cask` instead of `brew cask install`

### DIFF
--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -153,7 +153,7 @@ one-by-one:
     echo 'export PATH="/usr/local/opt/python@3.8/bin:$PATH"' >> ~/.profile
     source ~/.profile
     brew install git
-    brew cask install adoptopenjdk/openjdk/adoptopenjdk11
+    brew install --cask adoptopenjdk/openjdk/adoptopenjdk11
 
 Continue by `creating-venv-linux`.
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
`brew cask install` has been removed in Brew 3.0.0: https://github.com/Homebrew/brew/pull/10397

You can see the error when running our current install instructions here:
https://github.com/jack1142/Red-Install-Tests/runs/1998480687?check_suite_focus=true

@aikaterna because this affects Mac, I would appreciate it if you could verify this works