### PR TITLE
Use explicit name of the python packages for openSUSE Tumbleweed, add warning for Arch instructions

### DIFF
--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -210,7 +210,7 @@ with zypper:
 
 .. code-block:: none
 
-    sudo zypper -n install python3-base python3-pip git-core java-11-openjdk-headless
+    sudo zypper -n install python38-base python38-pip git-core java-11-openjdk-headless
     sudo zypper -n install -t pattern devel_basis
 
 Continue by `creating-venv-linux`.

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -41,6 +41,11 @@ Operating systems
 Arch Linux
 ~~~~~~~~~~
 
+.. warning::
+
+    Latest Python packages for Arch Linux provide Python 3.9 which Red does not currently support.
+    To use Red on Arch Linux, you will need to install latest version of Python 3.8 on your own.
+
 .. code-block:: none
 
     sudo pacman -Syu python python-pip git jre11-openjdk-headless base-devel


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This PR replaces `python3-base` and `python3-pip` packages that get automatically resolved to `python38-base` and `python3-pip` by `zypper` with the explicit package names to avoid future Tumbleweed updates from preventing the commands from working.
Additionally, I also added a warning for Arch Linux due to #4655.