### PR TITLE
[Alias] Strip extra whitespace from fake command messages

### DIFF
--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -185,7 +185,7 @@ class Alias(commands.Cog):
         # noinspection PyDunderSlots
         new_message.content = "{}{} {}".format(
             prefix, command, " ".join(args[trackform.max + 1 :])
-        )
+        ).strip()
         await self.bot.process_commands(new_message)
 
     async def paginate_alias_list(


### PR DESCRIPTION
### Type

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Discord messages are unable to have trailing whitespace when created via the client. Alias previously would leave trailing whitespace in fake command messages when the alias had no arguments passed to it. This whitespace broke certain commands that take an arbitrary, but non-zero, number of arguments, such as `[p]load`. This PR removes that trailing space.

Closes #4766