### PR TITLE
Fix `AttributeError` in `Context.delete_messages()`

### DIFF
--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -188,7 +188,7 @@ class Context(DPYContext):
                 else:
                     try:
                         await self.channel.delete_messages((query, resp))
-                    except discord.HTTPException:
+                    except (discord.HTTPException, AttributeError):
                         # In case the bot can't delete other users' messages,
                         # or is not a bot account
                         # or channel is a DM


### PR DESCRIPTION
### Type

- [x] Bugfix

### Description of the changes
delete_messages() isn't an attribute of DMChannels which causes an error when sending interactives in DM channels

Regression was introduced in #4728