### PR TITLE
[Reports] Improve usage in the report command's decorator

### DIFF
--- a/redbot/cogs/reports/reports.py
+++ b/redbot/cogs/reports/reports.py
@@ -236,7 +236,7 @@ class Reports(commands.Cog):
         )
         return ticket_number
 
-    @commands.group(name="report", invoke_without_command=True)
+    @commands.group(name="report", usage="<text>", invoke_without_command=True)
     async def report(self, ctx: commands.Context, *, _report: str = ""):
         """Send a report.
 

--- a/redbot/cogs/reports/reports.py
+++ b/redbot/cogs/reports/reports.py
@@ -236,12 +236,12 @@ class Reports(commands.Cog):
         )
         return ticket_number
 
-    @commands.group(name="report", usage="<text>", invoke_without_command=True)
+    @commands.group(name="report", usage="[text]", invoke_without_command=True)
     async def report(self, ctx: commands.Context, *, _report: str = ""):
         """Send a report.
 
         Use without arguments for interactive reporting, or do
-        `[p]report <text>` to use it non-interactively.
+        `[p]report [text]` to use it non-interactively.
         """
         author = ctx.author
         guild = ctx.guild


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

A small enhancement for the end user to improve the UI from the help menu. Given that the docstring already mentions `<text>`, I added this into the command's usage in the decorator.