### PR TITLE
[Docs] Add explanation for multiple arguments

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -92,11 +92,11 @@ parameters.
     Sometimes (especially for the last argument) these double quotes are not
     required.
 
-    Arguments followed by ``=value`` means that, if not specified,
-    the argument will be equal to ``value``.
-    
     Arguments followed by an ellipsis ``...`` means that you may provide
     multiple arguments for the command.
+
+    Arguments followed by ``=value`` means that, if not specified,
+    the argument will be equal to ``value``.
 
     For example, the command ``[p]cleanup messages`` in the cleanup cog has
     the syntax ``cleanup messages <number> [delete_pinned=False]``, which means

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -97,7 +97,7 @@ parameters.
 
     For example, the command ``[p]cog install`` in the downloader cog has
     the syntax ``cog install <repo> <cogs...>``, meaning that you can provide
-    1 or more cogs to install from the ``<repo>``.
+    1 or more ``cogs`` to install from the ``repo``.
 
     Arguments followed by ``=value`` means that, if not specified,
     the argument will be equal to ``value``.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -94,6 +94,9 @@ parameters.
 
     Arguments followed by ``=value`` means that, if not specified,
     the argument will be equal to ``value``.
+    
+    Arguments followed by an ellipsis ``...`` means that you may provide
+    multiple arguments for the command.
 
     For example, the command ``[p]cleanup messages`` in the cleanup cog has
     the syntax ``cleanup messages <number> [delete_pinned=False]``, which means

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -95,6 +95,10 @@ parameters.
     Arguments followed by an ellipsis ``...`` means that you may provide
     multiple arguments for the command.
 
+    For example, the command ``[p]cog install`` in the downloader cog has
+    the syntax ``cog install <repo> <cogs...>``, meaning that you can provide
+    1 or more cogs to install from the ``<repo>``.
+
     Arguments followed by ``=value`` means that, if not specified,
     the argument will be equal to ``value``.
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

Closes #4888. Adds a description for when multiple arguments can be passed in a command.