### PR TITLE
Update Downloader tests to work with newer git versions

### DIFF
--- a/redbot/pytest/downloader.py
+++ b/redbot/pytest/downloader.py
@@ -139,6 +139,7 @@ def _init_test_repo(destination: Path):
     git_dirparams = ("git", "-C", str(destination))
     init_commands = (
         (*git_dirparams, "init"),
+        (*git_dirparams, "checkout", "-b", "master"),
         (*git_dirparams, "config", "--local", "user.name", "Cog-Creators"),
         (*git_dirparams, "config", "--local", "user.email", "cog-creators@example.org"),
         (*git_dirparams, "config", "--local", "commit.gpgSign", "false"),


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
As of Git 2.28, you can configure the name of the branch created when you init a new repository. If the developer has this setting changed locally, some of the Downloader tests fail which means the tests aren't reproducible.
Git 2.31 also plans to change the default branch name to `main` so this should safe-guard our CI against this once that version is released and deployed to GH Actions images.