### PR TITLE
Update ambiguous oid parsing to detect candidates on Git 2.31+

### DIFF
--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -476,11 +476,20 @@ class Repo(RepoJSONMixin):
 
         if p.returncode != 0:
             stderr = p.stderr.decode(**DECODE_PARAMS).strip()
-            ambiguous_error = f"error: short SHA1 {rev} is ambiguous\nhint: The candidates are:\n"
-            if not stderr.startswith(ambiguous_error):
+            ambiguous_errors = (
+                # Git 2.31.0-rc0 and newer
+                f"error: short object ID {rev} is ambiguous\nhint: The candidates are:\n",
+                # Git 2.11.0-rc0 and newer
+                f"error: short SHA1 {rev} is ambiguous\nhint: The candidates are:\n",
+            )
+            for substring in ambiguous_errors:
+                if stderr.startswith(substring):
+                    pos = len(substring)
+                    break
+            else:
                 raise errors.UnknownRevision(f"Revision {rev} cannot be found.", git_command)
             candidates = []
-            for match in self.AMBIGUOUS_ERROR_REGEX.finditer(stderr, len(ambiguous_error)):
+            for match in self.AMBIGUOUS_ERROR_REGEX.finditer(stderr, pos):
                 candidates.append(Candidate(match["rev"], match["type"], match["desc"]))
             if candidates:
                 raise errors.AmbiguousRevision(

--- a/redbot/pytest/downloader.py
+++ b/redbot/pytest/downloader.py
@@ -10,6 +10,7 @@ from redbot.cogs.downloader.repo_manager import RepoManager, Repo, ProcessFormat
 from redbot.cogs.downloader.installable import Installable, InstalledModule
 
 __all__ = [
+    "GIT_VERSION",
     "repo_manager",
     "repo",
     "bot_repo",
@@ -25,6 +26,17 @@ __all__ = [
     "cloned_git_repo",
     "git_repo_with_remote",
 ]
+
+
+def _get_git_version():
+    """Returns version tuple in format: (major, minor)"""
+    raw_version = sp.check_output(("git", "version"), text=True)[12:]
+    # we're only interested in major and minor version if we will ever need micro
+    # there's more handling needed for versions like `2.25.0-rc1` and `2.25.0.windows.1`
+    return tuple(int(n) for n in raw_version.split(".", maxsplit=3)[:2])
+
+
+GIT_VERSION = _get_git_version()
 
 
 async def fake_run_noprint(*args, **kwargs):


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
On Git 2.31, the returned error with candidate hints has been changed (https://github.com/git/git/commit/1ffa26c4614720f8bb6c04703c7b65b34bd93fe3) and this PR updates Downloader to be able to parse the updated message.

To be clear here, this is not something that can raise an error on Git 2.31+ without this PR as this logic was written so that it just doesn't show candidates if it can't parse the message from Git.