### PR TITLE
Remove unnecessary escape from Cog Manager UI cog guide

### DIFF
--- a/docs/cog_guides/cog_manager_ui.rst
+++ b/docs/cog_guides/cog_manager_ui.rst
@@ -193,7 +193,7 @@ reorderpath
 
 .. code-block:: none
 
-    [p]reorderpath <from\_> <to>
+    [p]reorderpath <from_> <to>
 
 **Description**
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
There's a `\` rendered in the "Syntax" section of the `[p]reorderpath` which was probably meant to be an escape. The escape is not required here so this PR removes it so that this gets rendered properly.