### PR TITLE
[Warnings] fix raw namedtuple output

### DIFF
--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -552,7 +552,9 @@ class Warnings(commands.Cog):
                     )
                 await ctx.send_interactive(
                     pagify(msg, shorten_by=58),
-                    box_lang=_("Warnings for {user}").format(user=user),
+                    box_lang=_("Warnings for {user}").format(
+                        user=user if isinstance(user, discord.Member) else user.id
+                    ),
                 )
 
     @commands.command()


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Updated the `[p]warnings` command to display the user's ID instead of the raw namedtuple if the member has left the server.

resolves #4900