### PR TITLE
[Mutes] Add guild ID to mutes data

### DIFF
--- a/redbot/cogs/mutes/__init__.py
+++ b/redbot/cogs/mutes/__init__.py
@@ -2,7 +2,6 @@ from redbot.core.bot import Red
 from .mutes import Mutes
 
 
-async def setup(bot: Red):
+def setup(bot: Red):
     cog = Mutes(bot)
     bot.add_cog(cog)
-    await cog.initialize()

--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -81,7 +81,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
             "dm": False,
             "show_mod": False,
         }
-        self.config.register_global(force_role_mutes=True, version=0)
+        self.config.register_global(force_role_mutes=True, schema_version=0)
         # Tbh I would rather force everyone to use role mutes.
         # I also honestly think everyone would agree they're the
         # way to go. If for whatever reason someone wants to

--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -323,7 +323,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
                 ):
                     continue
                 guild = self.bot.get_guild(self._channel_mutes[c_id][u_id]["guild"])
-                if guild is None or await self.bot.cog_disabled_in_guild(guild):
+                if guild is None or await self.bot.cog_disabled_in_guild(self, guild):
                     continue
                 time_to_unmute = (
                     self._channel_mutes[c_id][u_id]["until"]


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
The reason of this change is because the `bot.get_channel` in `_handle_channel_unmutes` was too much intensive on bot runtime, even more since this runs every 30s.

It includes a converter for the data that runs on `initialize`, once bot fired red_ready.