### PR TITLE
Add note about updating cogs to update message and docs

### DIFF
--- a/docs/update_red.rst
+++ b/docs/update_red.rst
@@ -53,6 +53,8 @@ If you have Red 3.2.0 or newer, you can upgrade by following these 4 easy steps:
 
 4. Start your bot.
 
+5. If you've installed some cogs, we highly recommend you update them with this command: ``[p]cog update``
+
 Linux & Mac
 -----------
 
@@ -85,6 +87,8 @@ If you have Red 3.2.0 or newer, you can upgrade by following these 4 easy steps:
     If you're using PostgreSQL data backend, replace ``Red-DiscordBot`` in the second command with ``Red-DiscordBot[postgres]``
 
 4. Start your bot.
+
+5. If you've installed some cogs, we highly recommend you update them with this command: ``[p]cog update``
 
 Red 3.1.X
 *********

--- a/docs/update_red.rst
+++ b/docs/update_red.rst
@@ -53,7 +53,7 @@ If you have Red 3.2.0 or newer, you can upgrade by following these 4 easy steps:
 
 4. Start your bot.
 
-5. If you've installed some cogs, we highly recommend you update them with this command in Discord: ``[p]cog update``
+5. If you have any 3rd-party cogs installed, we highly recommend you update them with this command in Discord: ``[p]cog update`` (``[p]`` is considered as your prefix)
 
 Linux & Mac
 -----------
@@ -88,7 +88,7 @@ If you have Red 3.2.0 or newer, you can upgrade by following these 4 easy steps:
 
 4. Start your bot.
 
-5. If you've installed some cogs, we highly recommend you update them with this command in Discord: ``[p]cog update``
+5. If you have any 3rd-party cogs installed, we highly recommend you update them with this command in Discord: ``[p]cog update`` (``[p]`` is considered as your prefix)
 
 Red 3.1.X
 *********

--- a/docs/update_red.rst
+++ b/docs/update_red.rst
@@ -53,7 +53,7 @@ If you have Red 3.2.0 or newer, you can upgrade by following these 4 easy steps:
 
 4. Start your bot.
 
-5. If you've installed some cogs, we highly recommend you update them with this command: ``[p]cog update``
+5. If you've installed some cogs, we highly recommend you update them with this command in Discord: ``[p]cog update``
 
 Linux & Mac
 -----------
@@ -88,7 +88,7 @@ If you have Red 3.2.0 or newer, you can upgrade by following these 4 easy steps:
 
 4. Start your bot.
 
-5. If you've installed some cogs, we highly recommend you update them with this command: ``[p]cog update``
+5. If you've installed some cogs, we highly recommend you update them with this command in Discord: ``[p]cog update``
 
 Red 3.1.X
 *********

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -158,7 +158,7 @@ def init_events(bot, cli_flags):
                     )
                     extra_update += _(
                         "\nOnce you've started up your bot again, if you've installed some cogs "
-                        "we then highly recommend you update them with this command: "
+                        "we then highly recommend you update them with this command in Discord: "
                         "`[p]cog update`"
                     )
 

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -158,7 +158,7 @@ def init_events(bot, cli_flags):
                     )
                     extra_update += _(
                         "\nOnce you've started up your bot again, if you've installed some cogs "
-                        "we then highly recommend you update your cogs with this command: "
+                        "we then highly recommend you update them with this command: "
                         "`[p]cog update`"
                     )
 

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -156,6 +156,11 @@ def init_events(bot, cli_flags):
                             python=sys.executable, package_extras=package_extras
                         )
                     )
+                    extra_update += _(
+                        "\nOnce you've started up your bot again, if you've installed some cogs "
+                        "we then highly recommend you update your cogs with this command: "
+                        "`[p]cog update`"
+                    )
 
                 else:
                     extra_update += _(

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -29,6 +29,7 @@ from .utils._internal_utils import (
     format_fuzzy_results,
     expected_version,
     fetch_latest_red_version_info,
+    send_to_owners_with_prefix_replaced,
 )
 from .utils.chat_formatting import inline, bordered, format_perms_list, humanize_timedelta
 
@@ -157,9 +158,9 @@ def init_events(bot, cli_flags):
                         )
                     )
                     extra_update += _(
-                        "\nOnce you've started up your bot again, if you've installed some cogs "
-                        "we then highly recommend you update them with this command in Discord: "
-                        "`[p]cog update`"
+                        "\nOnce you've started up your bot again, if you have any 3rd-party cogs"
+                        " installed we then highly recommend you update them with this command"
+                        " in Discord: `[p]cog update`"
                     )
 
                 else:
@@ -206,7 +207,7 @@ def init_events(bot, cli_flags):
         bot._color = discord.Colour(await bot._config.color())
         bot._red_ready.set()
         if outdated_red_message:
-            await bot.send_to_owners(outdated_red_message)
+            await send_to_owners_with_prefix_replaced(bot, outdated_red_message)
 
     @bot.event
     async def on_command_completion(ctx: commands.Context):


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Add a note to the DM for when Red's out of date to update cogs and the Updating Red docs.

Because I have zero trust in myself I set the version to 3.4.6 to test this, and it worked. Surprise.