### PR TITLE
Pre-fetch app owners and fail early on no owners

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -28,7 +28,7 @@ from redbot import _early_init, __version__
 _early_init()
 
 import redbot.logging
-from redbot.core.bot import Red, ExitCodes
+from redbot.core.bot import Red, ExitCodes, _NoOwnerSet
 from redbot.core.cli import interactive_config, confirm, parse_cli_flags
 from redbot.setup import get_data_dir, get_name, save_config
 from redbot.core import data_manager, drivers
@@ -401,6 +401,24 @@ async def run_bot(red: Red, cli_flags: Namespace) -> None:
             "You can find out how to enable Privileged Intents with this guide:\n"
             "https://docs.discord.red/en/stable/bot_application_guide.html#enabling-privileged-intents",
             style="red",
+        )
+        sys.exit(1)
+    except _NoOwnerSet:
+        print(
+            "Bot doesn't have any owner set!\n"
+            "This can happen when your bot's application is owned by team"
+            " as team members are NOT owners by default.\n\n"
+            "Remember:\n"
+            "ONLY the person who is hosting Red should be owner."
+            " This has SERIOUS security implications."
+            " The owner can access any data that is present on the host system.\n"
+            "With that out of the way, depending on who you want to be considered as owner,"
+            " you can:\n"
+            "a) pass --team-members-are-owners when launching Red"
+            " - in this case Red will treat all members of the bot application's team as owners\n"
+            "b) set owner manually with redbot --edit <instance_name>\n"
+            "c) pass owner ID(s) when launching Red with --owner"
+            " (and --co-owner if you need more than one) flag\n"
         )
         sys.exit(1)
 

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -416,7 +416,7 @@ async def run_bot(red: Red, cli_flags: Namespace) -> None:
             " you can:\n"
             "a) pass --team-members-are-owners when launching Red"
             " - in this case Red will treat all members of the bot application's team as owners\n"
-            "b) set owner manually with redbot --edit <instance_name>\n"
+            f"b) set owner manually with `redbot --edit {cli_flags.instance_name}`\n"
             "c) pass owner ID(s) when launching Red with --owner"
             " (and --co-owner if you need more than one) flag\n"
         )

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -384,7 +384,7 @@ async def run_bot(red: Red, cli_flags: Namespace) -> None:
         await red.http.close()
         sys.exit(0)
     try:
-        await red.start(token, bot=True, cli_flags=cli_flags)
+        await red.start(token, bot=True)
     except discord.LoginFailure:
         log.critical("This token doesn't seem to be valid.")
         db_token = await red._config.token()

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -70,19 +70,7 @@ def init_events(bot, cli_flags):
         guilds = len(bot.guilds)
         users = len(set([m for m in bot.get_all_members()]))
 
-        app_info = await bot.application_info()
-
-        if app_info.team:
-            if bot._use_team_features:
-                bot.owner_ids.update(m.id for m in app_info.team.members)
-        elif bot._owner_id_overwrite is None:
-            bot.owner_ids.add(app_info.owner.id)
-        bot._app_owners_fetched = True
-
-        try:
-            invite_url = discord.utils.oauth_url(app_info.id)
-        except:
-            invite_url = "Could not fetch invite url"
+        invite_url = discord.utils.oauth_url(bot._app_info.id)
 
         prefixes = cli_flags.prefix or (await bot._config.prefix())
         lang = await bot._config.locale()
@@ -199,10 +187,6 @@ def init_events(bot, cli_flags):
             )
         if rich_outdated_message:
             rich_console.print(rich_outdated_message)
-
-        if not bot.owner_ids:
-            # we could possibly exit here in future
-            log.warning("Bot doesn't have any owner set!")
 
         bot._color = discord.Colour(await bot._config.color())
         bot._red_ready.set()


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
There's really no reason to allow users to run the bot without having an owner set and this is a point of confusion for users that are trying to set up Red using a team application.

Marked as Breaking Change as this will affect anyone who runs Red without having any owner set for some strange reason...