### PR TITLE
[Docs] Use pascal casing for example cog in cog creation guide

### DIFF
--- a/docs/guide_cog_creation.rst
+++ b/docs/guide_cog_creation.rst
@@ -83,7 +83,7 @@ In that file, place the following code:
 
     from redbot.core import commands
 
-    class Mycog(commands.Cog):
+    class MyCog(commands.Cog):
         """My custom cog"""
 
         @commands.command()
@@ -96,11 +96,11 @@ Open :code:`__init__.py`. In that file, place the following:
 
 .. code-block:: python
 
-    from .mycog import Mycog
+    from .mycog import MyCog
 
 
     def setup(bot):
-        bot.add_cog(Mycog())
+        bot.add_cog(MyCog())
 
 Make sure that both files are saved.
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

This area of the docs is referenced by a lot by users trying to create their own cogs - I do think the example cog should use the camel case recommendation provided in the cog creators guide (see below)

![image](https://user-images.githubusercontent.com/67752638/113389863-a51e6500-9388-11eb-8a2f-9cc407af223f.png)
