### PR TITLE
[Cleanup] Pre-set the variable to `None` in `[p]cleanup before`

### DIFF
--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -357,7 +357,7 @@ class Cleanup(commands.Cog):
                 return await ctx.send(_("Message not found."))
         elif ref := ctx.message.reference:
             before = await self.get_message_from_reference(channel, ref)
-        
+
         if before is None:
             raise commands.BadArgument
 

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -303,7 +303,8 @@ class Cleanup(commands.Cog):
                 return await ctx.send(_("Message not found."))
         elif ref := ctx.message.reference:
             after = await self.get_message_from_reference(channel, ref)
-        else:
+
+        if after is None:
             raise commands.BadArgument
 
         to_delete = await self.get_messages_for_deletion(
@@ -347,6 +348,7 @@ class Cleanup(commands.Cog):
 
         channel = ctx.channel
         author = ctx.author
+        before = None
 
         if message_id:
             try:
@@ -355,7 +357,8 @@ class Cleanup(commands.Cog):
                 return await ctx.send(_("Message not found."))
         elif ref := ctx.message.reference:
             before = await self.get_message_from_reference(channel, ref)
-        else:
+        
+        if before is None:
             raise commands.BadArgument
 
         to_delete = await self.get_messages_for_deletion(

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -303,8 +303,7 @@ class Cleanup(commands.Cog):
                 return await ctx.send(_("Message not found."))
         elif ref := ctx.message.reference:
             after = await self.get_message_from_reference(channel, ref)
-
-        if after is None:
+        else:
             raise commands.BadArgument
 
         to_delete = await self.get_messages_for_deletion(
@@ -356,8 +355,7 @@ class Cleanup(commands.Cog):
                 return await ctx.send(_("Message not found."))
         elif ref := ctx.message.reference:
             before = await self.get_message_from_reference(channel, ref)
-
-        if before is None:
+        else:
             raise commands.BadArgument
 
         to_delete = await self.get_messages_for_deletion(


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

```python
Exception in command 'cleanup before'
Traceback (most recent call last):
  File "/home/ubuntu/reddev/.venv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/ubuntu/reddev/redbot/cogs/cleanup/cleanup.py", line 360, in before
    if before is None:
UnboundLocalError: local variable 'before' referenced before assignment

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ubuntu/reddev/.venv/lib/python3.8/site-packages/discord/ext/commands/bot.py", line 939, in invoke
    await ctx.command.invoke(ctx)
  File "/home/ubuntu/reddev/redbot/core/commands/commands.py", line 832, in invoke
    await super().invoke(ctx)
  File "/home/ubuntu/reddev/.venv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 1348, in invoke
    await ctx.invoked_subcommand.invoke(ctx)
  File "/home/ubuntu/reddev/.venv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 863, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/home/ubuntu/reddev/.venv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 94, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: UnboundLocalError: local variable 'before' referenced before assignment
```

Not tested.