### PR TITLE
[Audio] Update Lavalink.jar build

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -24,7 +24,7 @@ from .utils import task_callback
 _ = Translator("Audio", pathlib.Path(__file__))
 log = logging.getLogger("red.audio.manager")
 JAR_VERSION: Final[str] = "3.3.2.3"
-JAR_BUILD: Final[int] = 1199
+JAR_BUILD: Final[int] = 1212
 LAVALINK_DOWNLOAD_URL: Final[str] = (
     "https://github.com/Cog-Creators/Lavalink-Jars/releases/download/"
     f"{JAR_VERSION}_{JAR_BUILD}/"


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Updates audio's manager to download the new Lavalink.jar.

Changelog:
```
Fixed playlist loading for playlists with over 100 songs
Fixed an issue with alerts causing errors in playlists being loaded
Improved playlist extraction
Fix for consent pages appearing while trying to load songs or playlists
```