### PR TITLE
[Events] Handle NSFWChannelRequired error

### DIFF
--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -294,6 +294,8 @@ def init_events(bot, cli_flags):
             await ctx.send(_("That command is not available in DMs."))
         elif isinstance(error, commands.PrivateMessageOnly):
             await ctx.send(_("That command is only available in DMs."))
+        elif isinstance(error, commands.NSFWChannelRequired):
+            await ctx.send(_("That command is only available in NSFW channels."))
         elif isinstance(error, commands.CheckFailure):
             pass
         elif isinstance(error, commands.CommandOnCooldown):


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This PR adds handling of `NSFWChannelRequired` error, which has been added at [discord.py 1.1](https://discordpy.readthedocs.io/en/latest/ext/commands/api.html?highlight=is_nsfw#discord.ext.commands.is_nsfw).