### PR TITLE
Make customcoms convert-parameters a core util

### DIFF
--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -1,16 +1,31 @@
+from __future__ import annotations
 import datetime
 import itertools
 import re
 import textwrap
 from io import BytesIO
-from typing import Iterator, List, Optional, Sequence, SupportsInt, Union, Pattern, Dict, Any
+from typing import (
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    SupportsInt,
+    Union,
+    Pattern,
+    Dict,
+    Any,
+    TYPE_CHECKING,
+)
 
 import discord
 from babel.lists import format_list as babel_list
 from babel.numbers import format_decimal
 
-from redbot.core.commands import Context
+
 from redbot.core.i18n import Translator, get_babel_locale, get_babel_regional_format
+
+if TYPE_CHECKING:
+    from redbot.core.commands import Context
 
 _ = Translator("UtilsChatFormatting", __file__)
 


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes
This adds the utility of converting ctx arguments into strings for use by other cogs where this was previously only available in customcommands. This also adds `{p}` for the bots prefix in the channel and `{pp}` for all the bots prefixes for the channel.

This has not been tested using Context but it has been tested using message object.