### PR TITLE
[Streams] Remove stream alert if stream not found

### DIFF
--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -778,6 +778,10 @@ class Streams(commands.Cog):
 
                     stream.messages.clear()
                     await self.save_streams()
+                except StreamNotFound:
+                    self.streams.remove(stream)
+                    await self.save_streams()
+                    continue
                 else:
                     if stream.messages:
                         continue

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -779,8 +779,7 @@ class Streams(commands.Cog):
                     stream.messages.clear()
                     await self.save_streams()
                 except StreamNotFound:
-                    self.streams.remove(stream)
-                    await self.save_streams()
+                    to_remove.append(stream)
                     continue
                 else:
                     if stream.messages:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
It removes a stream from `self.streams` and there streams config value if it is not found.

This PR depends off #4938.