### PR TITLE
[Context] Fixup docstrings in `react_quietly` function

### DIFF
--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     from ..bot import Red
 
 TICK = "\N{WHITE HEAVY CHECK MARK}"
-CROSS = "\N{CROSS MARK}"
 
 __all__ = ["Context", "GuildContext", "DMContext"]
 

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from ..bot import Red
 
 TICK = "\N{WHITE HEAVY CHECK MARK}"
+CROSS = "\N{CROSS MARK}"
 
 __all__ = ["Context", "GuildContext", "DMContext"]
 
@@ -115,10 +116,26 @@ class Context(DPYContext):
         else:
             return True
 
+    async def cross(self) -> bool:
+        """Add a cross reaction to the command message.
+
+        Returns
+        -------
+        bool
+            :code:`True` if adding the reaction succeeded.
+
+        """
+        try:
+            await self.message.add_reaction(CROSS)
+        except discord.HTTPException:
+            return False
+        else:
+            return True
+
     async def react_quietly(
         self, reaction: Union[discord.Emoji, discord.Reaction, discord.PartialEmoji, str]
     ) -> bool:
-        """Adds a reaction to to the command message.
+        """Adds a reaction to the command message.
 
         Returns
         -------

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -116,22 +116,6 @@ class Context(DPYContext):
         else:
             return True
 
-    async def cross(self) -> bool:
-        """Add a cross reaction to the command message.
-
-        Returns
-        -------
-        bool
-            :code:`True` if adding the reaction succeeded.
-
-        """
-        try:
-            await self.message.add_reaction(CROSS)
-        except discord.HTTPException:
-            return False
-        else:
-            return True
-
     async def react_quietly(
         self, reaction: Union[discord.Emoji, discord.Reaction, discord.PartialEmoji, str]
     ) -> bool:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [x] New feature

### Description of the changes

~~Add a ``cross()`` function in context which is analogous to ``tick()``. Also, a small docstring fix with the ``react_quietly()`` function.
The cross function could be debatable due to the fact that an 'error' should respond with meaningful information, there are a few times where I've wanted to use this, though, and imo it would be better to have it, than to not - up for discussion.~~

Re-opened just to fix the docstring in `react_quietly`.
