### PR TITLE
Update issue templates with new key name for description

### DIFF
--- a/.github/ISSUE_TEMPLATE/command_bug.yml
+++ b/.github/ISSUE_TEMPLATE/command_bug.yml
@@ -1,5 +1,5 @@
 name: Bug reports for commands
-about: For bugs that involve commands found within Red.
+description: For bugs that involve commands found within Red.
 title: ''
 labels: 'Type: Bug'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/enhancements.yml
+++ b/.github/ISSUE_TEMPLATE/enhancements.yml
@@ -1,5 +1,5 @@
 name: Enhancement proposal
-about: For feature requests and improvements related to already existing functionality.
+description: For feature requests and improvements related to already existing functionality.
 title: ''
 labels: 'Type: Enhancement'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-about: For feature requests regarding Red itself.
+description: For feature requests regarding Red itself.
 title: ''
 labels: 'Type: Feature'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/other_bugs.yml
+++ b/.github/ISSUE_TEMPLATE/other_bugs.yml
@@ -1,5 +1,5 @@
 name: Bug report
-about: "For bugs that don't involve a command."
+description: "For bugs that don't involve a command."
 title: ''
 labels: 'Type: Bug'
 assignees: ''


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Update the top-level key `about` to `description`, as `about` will be deprecated in favor of `description` (see attached screenshot).

![Image](https://user-images.githubusercontent.com/67752638/113770816-87e7ee80-971a-11eb-8115-e687fc7ec0f0.png)
