### PR TITLE
Include more files in distributions

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -19,13 +19,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
+          pip install build twine
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.pypi_token }}
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
           twine upload dist/*
 
   pr_dev_bump:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,27 @@
+# include license files
+include LICENSE
+recursive-include redbot *.LICENSE
+
+# include locale files
+recursive-include redbot locales/*.po
+
+# include data folders for cogs
+recursive-include redbot/**/data *
+
+# include *.export files from the test fixtures
+recursive-include redbot *.export
+
+# include the py.typed file informing about Red being typed
+recursive-include redbot py.typed
+
+# include *.sql files from postgres driver
+recursive-include redbot/core/drivers/postgres *.sql
+
+# include tests
+graft tests
+
+# include tox configuration
+include tox.ini
+
+# exclude files containing byte-code and compiled libs
+global-exclude *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+    requires = ["setuptools", "wheel"]
+    build-backend = "setuptools.build_meta"
+
 [tool.black]
     line-length = 99
     target-version = ['py38']

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,10 +27,14 @@ classifiers =
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3.8
     Topic :: Communications :: Chat
+license_files =
+    LICENSE
+    redbot/**/*.LICENSE
 
 [options]
 packages = find_namespace:
 python_requires = >=3.8.1,<3.9
+include_package_data = True
 install_requires =
     aiohttp==3.7.3
     aiohttp-json-rpc==0.13.3
@@ -134,14 +138,3 @@ pytest11 =
 include =
     redbot
     redbot.*
-
-[options.package_data]
-* =
-    locales/*.po
-    **/locales/*.po
-    data/*
-    data/**/*
-    *.export
-    py.typed
-redbot.core.drivers.postgres =
-    *.sql


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
The main `LICENSE` file was already included in dist-info, now it's also included in the root of the source dist.
In addition to that, now we *actually* include `discord-ext-menus.LICENSE` file as part of the wheel and source distribution.
I also added `tests` folder and `tox.ini` to sdist so that people downloading sdist can do a full tox run from the sdist, similarly to what we do when building.

I've ensured that the only difference between the files that were included before and the files that are included now is the inclusion of LICENSE files (+ tests folder and tox.ini file in case of sdist).

Since I've also updated our build system to use PEP 517 isolated builds and the new `build` package from PyPA, I've also ensured that the `python -m build` command works properly to avoid issue during release.