### PR TITLE
Fix logging and handle NotFound exception in Case.edit()

### DIFF
--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -312,8 +312,19 @@ class Case:
         except discord.Forbidden:
             log.info(
                 "Modlog failed to edit the Discord message for"
-                " the case #%s from guild with ID due to missing permissions."
+                " the case #%s from guild with ID %s due to missing permissions.",
+                self.case_number,
+                self.guild.id,
             )
+        except discord.NotFound:
+            log.info(
+                "Modlog failed to edit the Discord message for"
+                " the case #%s from guild with ID %s as it no longer exists."
+                " Clearing the message ID from case data...",
+                self.case_number,
+                self.guild.id,
+            )
+            await self.edit({"message": None})
         except Exception:  # `finally` with `return` suppresses unexpected exceptions
             log.exception(
                 "Modlog failed to edit the Discord message for"


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
The logging call was missing the format fields used in the log message.
I also added handling for `discord.NotFound` as there's no reason to continue trying to edit the modlog message in the future if we are being told that it no longer exists.