### PR TITLE
Stop fetching the messages when getting the cases in Modlog

### DIFF
--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -286,8 +286,11 @@ class Case:
     modified_at: Optional[float]
         The UNIX time of the last change to the case.
         `None` if the case was never edited.
-    message: Optional[discord.Message]
+    message: Optional[Union[discord.PartialMessage, discord.Message]]
         The message created by Modlog for this case.
+        Instance of `discord.Message` *if* the Case object was returned from
+        `modlog.create_case()`, otherwise `discord.PartialMessage`.
+
         `None` if we know that the message no longer exists
         (note: it might not exist regardless of whether this attribute is `None`)
         or if it has never been created.

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -311,7 +311,7 @@ class Case:
         channel: Optional[Union[discord.abc.GuildChannel, int]] = None,
         amended_by: Optional[Union[discord.Object, discord.abc.User, int]] = None,
         modified_at: Optional[float] = None,
-        message: Optional[discord.Message] = None,
+        message: Optional[Union[discord.PartialMessage, discord.Message]] = None,
         last_known_username: Optional[str] = None,
     ):
         self.bot = bot
@@ -617,14 +617,7 @@ class Case:
         if message is None:
             message_id = data.get("message")
             if message_id is not None:
-                message = discord.utils.get(bot.cached_messages, id=message_id)
-                if message is None:
-                    try:
-                        message = await mod_channel.fetch_message(message_id)
-                    except discord.HTTPException:
-                        message = None
-            else:
-                message = None
+                message = mod_channel.get_partial_message(message_id)
 
         user_objects = {"user": None, "moderator": None, "amended_by": None}
         for user_key in tuple(user_objects):


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
This gives us an enormous performance improvement (in the case of my test bot that had 500 cases, it went down from 7:33 minutes to ~0.06s) with the very small cost of API users now having to *manually* fetch the message *if* they actually need its content for some reason.
From looking at various cog repositories, it does not seem to be something that people do at all, which is not really surprising and fetching the message with `PartialMessage` object is a matter of calling `partial_message.fetch()`. Also, `Case.message` will continue to be `discord.Message` for object returned from `modlog.create_case()` as I didn't see much reason to require the API users to fetch the message object that we already got from the API. I did not, however, make it update the `Case.message` with full `discord.Message` when doing any edits on the `Case` object as I think it's just an unnecessary complication.

Depends on #4975 (needed because this is more likely to occur with PartialMessage objects) and #4979 (this PR should update the documentation added by #4979 though it doesn't yet as I want to wait with that until #4979 gets merged)