### PR TITLE
[Core] Add custom image setting to `[p]info`

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -105,6 +105,7 @@ class RedBase(
             color=15158332,
             fuzzy=False,
             custom_info=None,
+            custom_info_image=None,
             help__page_char_limit=1000,
             help__max_pages_in_guild=2,
             help__delete_delay=0,

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -464,13 +464,15 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             if custom_info:
                 embed.add_field(name=_("About this instance"), value=custom_info, inline=False)
             embed.add_field(name=_("About Red"), value=about, inline=False)
-            if custom_info_image:
-                with contextlib.suppress(discord.HTTPException):
-                    embed.set_image(url=custom_info_image)
             embed.set_footer(
                 text=_("Bringing joy since 02 Jan 2016 (over {} days ago!)").format(days_since)
             )
-            await ctx.send(embed=embed)
+            try:
+                if custom_info_image:
+                    embed.set_image(url=custom_info_image)
+                await ctx.send(embed=embed)
+            except discord.HTTPException:
+                await ctx.send(embed=embed)
         else:
             python_version = "{}.{}.{}".format(*sys.version_info[:3])
             dpy_version = "{}".format(discord.__version__)

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -472,6 +472,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                     embed.set_image(url=custom_info_image)
                 await ctx.send(embed=embed)
             except discord.HTTPException:
+                embed.set_image(url=embed.Empty)
                 await ctx.send(embed=embed)
         else:
             python_version = "{}.{}.{}".format(*sys.version_info[:3])
@@ -2877,9 +2878,13 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             )
         )
 
-    @_set.group(invoke_without_command=True)
+    @_set.group()
     @checks.is_owner()
-    async def custominfo(self, ctx: commands.Context, *, text: str = None):
+    async def custominfo(self, ctx: commands.Context):
+        """Customize `[p]info` with text and images."""
+
+    @custominfo.command()
+    async def text(self, ctx: commands.Context, *, text: str = None):
         """Customizes a section of `[p]info`.
 
         The maximum amount of allowed characters is 1024.
@@ -2905,16 +2910,20 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             await ctx.invoke(self.info)
         else:
             await ctx.send(_("Text must be fewer than 1024 characters long."))
+            
 
     @custominfo.command()
     async def image(self, ctx: commands.Context, image_url: str = None):
         """Customizes `[p]info` with an embed image.
 
-        You must provide a valid URL.
+        If an invalid URL is provided, an image will not appear through `[p]info`.
         """
+        url_check = lambda x: x.startswith(("http", "https")) and not " " in x
         if not image_url:
             await ctx.bot._config.custom_info_image.clear()
             await ctx.send(_("The custom image has been cleared."))
+        elif not url_check(image_url):
+            await ctx.send(_("Please provide a valid URL."))
         else:
             await ctx.bot._config.custom_info_image.set(image_url)
             await ctx.send(_("The custom image has been set."))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -423,7 +423,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             owner = app_info.team.name
         else:
             owner = app_info.owner
-            
+
         settings = await self.bot._config.all()
         custom_info = settings["custom_info"]
         custom_info_image = settings["custom_info_image"]

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1,4 +1,4 @@
-import asyncio
+import asyncio#
 import contextlib
 import datetime
 import importlib


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes

Feature Request

Add a new command (`[p]custominfo image`) as a subcommand to `[p]custominfo`, to allow users to customize their info embed with an image. This PR is a draft and therefore isn't ready for review.

It also does not yet apply to plain text info, because personally I don't think it should. Perhaps the URL handling could be revised too.

Edit: I will update docs correspondingly if this is accepted

Side note: This is absolutely not even ready for a quick look yet. I'm probably gonna use aiohttp to validate url, if accepting url as argument.