### PR TITLE
[Economy] Make top parameter optional in leaderboard

### DIFF
--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -4,7 +4,7 @@ import random
 from collections import defaultdict, deque, namedtuple
 from enum import Enum
 from math import ceil
-from typing import cast, Iterable, Union, Literal
+from typing import cast, Iterable, Union, Literal, Optional
 
 import discord
 
@@ -555,7 +555,7 @@ class Economy(commands.Cog):
 
     @commands.command()
     @guild_only_check()
-    async def leaderboard(self, ctx: commands.Context, top: int = 10, show_global: bool = False):
+    async def leaderboard(self, ctx: commands.Context, top: Optioonal[int] = 10, show_global: bool = False):
         """Print the leaderboard.
 
         Defaults to top 10.

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -556,7 +556,7 @@ class Economy(commands.Cog):
     @commands.command()
     @guild_only_check()
     async def leaderboard(
-        self, ctx: commands.Context, top: Optioonal[int] = 10, show_global: bool = False
+        self, ctx: commands.Context, top: Optional[int] = 10, show_global: bool = False
     ):
         """Print the leaderboard.
 

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -555,7 +555,9 @@ class Economy(commands.Cog):
 
     @commands.command()
     @guild_only_check()
-    async def leaderboard(self, ctx: commands.Context, top: Optioonal[int] = 10, show_global: bool = False):
+    async def leaderboard(
+        self, ctx: commands.Context, top: Optioonal[int] = 10, show_global: bool = False
+    ):
         """Print the leaderboard.
 
         Defaults to top 10.


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes

The docstring says the top argument can be omited to show the global leaderboard, however, doing so will say `Converting to "int" failed for parameter "top".`
I prefered to fix this by making top an optional parameter.