### PR TITLE
Nuke PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,0 @@
-### Type
-
-- [ ] Bugfix
-- [ ] Enhancement
-- [ ] New feature
-
-### Description of the changes

--- a/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,0 @@
-### Type
-
-- [ ] Bugfix
-- [ ] Enhancement
-- [ ] New feature
-
-### Description of the changes


### PR DESCRIPTION
We could also nuke the whole `.github/PULL_REQUEST_TEMPLATE` directory but those templates aren't really that bad so if someone creates it from a program that supports it, why not have these I guess...