### PR TITLE
Add `RelativedeltaConverter` and `parse_relativedelta`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -218,6 +218,7 @@ intersphinx_mapping = {
     "dpy": (f"https://discordpy.readthedocs.io/en/v{dpy_version}/", None),
     "motor": ("https://motor.readthedocs.io/en/stable/", None),
     "babel": ("http://babel.pocoo.org/en/stable/", None),
+    "dateutil": ("https://dateutil.readthedocs.io/en/stable/", None),
 }
 
 # Extlinks

--- a/redbot/core/commands/__init__.py
+++ b/redbot/core/commands/__init__.py
@@ -21,9 +21,11 @@ from .commands import (
 from .context import Context as Context, GuildContext as GuildContext, DMContext as DMContext
 from .converter import (
     DictConverter as DictConverter,
+    RelativedeltaConverter as RelativedeltaConverter,
     TimedeltaConverter as TimedeltaConverter,
     get_dict_converter as get_dict_converter,
     get_timedelta_converter as get_timedelta_converter,
+    parse_relativedelta as parse_relativedelta,
     parse_timedelta as parse_timedelta,
     NoParseOptional as NoParseOptional,
     UserInputOptional as UserInputOptional,

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -154,9 +154,7 @@ def parse_timedelta(
 
 
 def parse_relativedelta(
-    argument: str,
-    *,
-    allowed_units: Optional[List[str]] = None,
+    argument: str, *, allowed_units: Optional[List[str]] = None
 ) -> Optional[relativedelta]:
     """
     This converts a user provided string into a datetime with offset from NOW

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -454,10 +454,7 @@ else:
             if self.default_unit and argument.isdecimal():
                 argument = argument + self.default_unit
 
-            delta = parse_relativedelta(
-                argument,
-                allowed_units=self.allowed_units,
-            )
+            delta = parse_relativedelta(argument, allowed_units=self.allowed_units)
 
             if delta is not None:
                 return delta

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -420,10 +420,10 @@ else:
 
 
 if TYPE_CHECKING:
-    RelativeDeltaConverter = relativedelta
+    RelativedeltaConverter = relativedelta
 else:
 
-    class RelativeDeltaConverter(dpy_commands.Converter):
+    class RelativedeltaConverter(dpy_commands.Converter):
         """
         This is a converter for relative deltas.
         The units should be in order from largest to smallest.
@@ -500,7 +500,7 @@ else:
         Returns
         -------
         type
-            The converter class, which will be a subclass of `RelativeDeltaConverter`
+            The converter class, which will be a subclass of `RelativedeltaConverter`
         """
 
         class PartialMeta(type):
@@ -510,7 +510,7 @@ else:
                 default_unit=default_unit,
             )
 
-        class ValidatedConverter(RelativeDeltaConverter, metaclass=PartialMeta):
+        class ValidatedConverter(RelativedeltaConverter, metaclass=PartialMeta):
             pass
 
         return ValidatedConverter

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -441,7 +441,7 @@ if TYPE_CHECKING:
     RelativeDeltaConverter = relativedelta
 else:
 
-    class RelativeDeltaConveter(dpy_commands.Converter):
+    class RelativeDeltaConverter(dpy_commands.Converter):
         """
         This is a converter for relative deltas.
         The units should be in order from largest to smallest.

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -38,9 +38,12 @@ __all__ = [
     "DictConverter",
     "UserInputOptional",
     "NoParseOptional",
+    "RelativedeltaConverter",
     "TimedeltaConverter",
     "get_dict_converter",
+    "get_relativedelta_converter",
     "get_timedelta_converter",
+    "parse_relativedelta",
     "parse_timedelta",
     "Literal",
 ]

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -100,9 +100,9 @@ def parse_timedelta(
     ----------
     argument : str
         The user provided input
-    maximum : Optional[timedelta]
+    maximum : Optional[datetime.timedelta]
         If provided, any parsed value higher than this will raise an exception
-    minimum : Optional[timedelta]
+    minimum : Optional[datetime.timedelta]
         If provided, any parsed value lower than this will raise an exception
     allowed_units : Optional[List[str]]
         If provided, you can constrain a user to expressing the amount of time
@@ -111,7 +111,7 @@ def parse_timedelta(
 
     Returns
     -------
-    Optional[timedelta]
+    Optional[datetime.timedelta]
         If matched, the timedelta which was parsed. This can return `None`
 
     Raises
@@ -173,7 +173,7 @@ def parse_relativedelta(
 
     Returns
     -------
-    Optional[relativedelta]
+    Optional[dateutil.relativedelta.relativedelta]
         If matched, the relativedelta which was parsed. This can return `None`
 
     Raises
@@ -320,9 +320,9 @@ else:
 
         Attributes
         ----------
-        maximum : Optional[timedelta]
+        maximum : Optional[datetime.timedelta]
             If provided, any parsed value higher than this will raise an exception
-        minimum : Optional[timedelta]
+        minimum : Optional[datetime.timedelta]
             If provided, any parsed value lower than this will raise an exception
         allowed_units : Optional[List[str]]
             If provided, you can constrain a user to expressing the amount of time
@@ -385,9 +385,9 @@ else:
 
         Parameters
         ----------
-        maximum : Optional[timedelta]
+        maximum : Optional[datetime.timedelta]
             If provided, any parsed value higher than this will raise an exception
-        minimum : Optional[timedelta]
+        minimum : Optional[datetime.timedelta]
             If provided, any parsed value lower than this will raise an exception
         allowed_units : Optional[List[str]]
             If provided, you can constrain a user to expressing the amount of time

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -7,7 +7,7 @@ Some of the converters within are included provisionally and are marked as such.
 """
 import functools
 import re
-import datetime as dt
+import datetime
 from dateutil import relativedelta
 from typing import (
     TYPE_CHECKING,
@@ -86,10 +86,10 @@ def _parse_and_match(string_to_match: str, allowed_units: List[str]) -> Optional
 def parse_timedelta(
     argument: str,
     *,
-    maximum: Optional[dt.timedelta] = None,
-    minimum: Optional[dt.timedelta] = None,
+    maximum: Optional[datetime.timedelta] = None,
+    minimum: Optional[datetime.timedelta] = None,
     allowed_units: Optional[List[str]] = None,
-) -> Optional[dt.timedelta]:
+) -> Optional[datetime.timedelta]:
     """
     This converts a user provided string into a timedelta
 
@@ -130,7 +130,7 @@ def parse_timedelta(
     params = _parse_and_match(argument, allowed_units)
     if params:
         try:
-            delta = dt.timedelta(**params)
+            delta = datetime.timedelta(**params)
         except OverflowError:
             raise BadArgument(
                 _("The time set is way too high, consider setting something reasonable.")
@@ -154,10 +154,10 @@ def parse_timedelta(
 def parse_datetimedelta(
     argument: str,
     *,
-    maximum: Optional[dt.datetime] = None,
-    minimum: Optional[dt.datetime] = None,
+    maximum: Optional[datetime.datetime] = None,
+    minimum: Optional[datetime.datetime] = None,
     allowed_units: Optional[List[str]] = None,
-) -> Optional[dt.datetime]:
+) -> Optional[datetime.datetime]:
     """
     This converts a user provided string into a datetime with offset from NOW
 
@@ -201,7 +201,7 @@ def parse_datetimedelta(
     if params:
         try:
             delta = relativedelta.relativedelta(**params)
-            new_timestamp = dt.datetime.now() + delta
+            new_timestamp = datetime.datetime.now() + delta
         except OverflowError:
             raise BadArgument(
                 _("The time set is way too high, consider setting something reasonable.")
@@ -326,7 +326,7 @@ else:
 
 
 if TYPE_CHECKING:
-    TimedeltaConverter = dt.timedelta
+    TimedeltaConverter = datetime.timedelta
 else:
 
     class TimedeltaConverter(dpy_commands.Converter):
@@ -359,7 +359,7 @@ else:
             self.minimum = minimum
             self.maximum = maximum
 
-        async def convert(self, ctx: "Context", argument: str) -> dt.timedelta:
+        async def convert(self, ctx: "Context", argument: str) -> datetime.timedelta:
             if self.default_unit and argument.isdecimal():
                 argument = argument + self.default_unit
 
@@ -380,10 +380,10 @@ if TYPE_CHECKING:
     def get_timedelta_converter(
         *,
         default_unit: Optional[str] = None,
-        maximum: Optional[dt.timedelta] = None,
-        minimum: Optional[dt.timedelta] = None,
+        maximum: Optional[datetime.timedelta] = None,
+        minimum: Optional[datetime.timedelta] = None,
         allowed_units: Optional[List[str]] = None,
-    ) -> Type[dt.timedelta]:
+    ) -> Type[datetime.timedelta]:
         ...
 
 
@@ -392,10 +392,10 @@ else:
     def get_timedelta_converter(
         *,
         default_unit: Optional[str] = None,
-        maximum: Optional[dt.timedelta] = None,
-        minimum: Optional[dt.timedelta] = None,
+        maximum: Optional[datetime.timedelta] = None,
+        minimum: Optional[datetime.timedelta] = None,
         allowed_units: Optional[List[str]] = None,
-    ) -> Type[dt.timedelta]:
+    ) -> Type[datetime.timedelta]:
         """
         This creates a type suitable for typechecking which works with discord.py's
         commands.
@@ -439,7 +439,7 @@ else:
 
 
 if TYPE_CHECKING:
-    DatetimeDeltaConverter = dt.datetime
+    DatetimeDeltaConverter = datetime.datetime
 else:
 
     class DatetimeDeltaConverter(dpy_commands.Converter):
@@ -472,7 +472,7 @@ else:
             self.minimum = minimum
             self.maximum = maximum
 
-        async def convert(self, ctx: "Context", argument: str) -> dt.datetime:
+        async def convert(self, ctx: "Context", argument: str) -> datetime.datetime:
             if self.default_unit and argument.isdecimal():
                 argument = argument + self.default_unit
 
@@ -493,10 +493,10 @@ if TYPE_CHECKING:
     def get_datetimedelta_converter(
         *,
         default_unit: Optional[str] = None,
-        maximum: Optional[dt.datetime] = None,
-        minimum: Optional[dt.datetime] = None,
+        maximum: Optional[datetime.datetime] = None,
+        minimum: Optional[datetime.datetime] = None,
         allowed_units: Optional[List[str]] = None,
-    ) -> Type[dt.datetime]:
+    ) -> Type[datetime.datetime]:
         ...
 
 
@@ -505,10 +505,10 @@ else:
     def get_datetimedelta_converter(
         *,
         default_unit: Optional[str] = None,
-        maximum: Optional[dt.datetime] = None,
-        minimum: Optional[dt.datetime] = None,
+        maximum: Optional[datetime.datetime] = None,
+        minimum: Optional[datetime.datetime] = None,
         allowed_units: Optional[List[str]] = None,
-    ) -> Type[dt.datetime]:
+    ) -> Type[datetime.datetime]:
         """
         This creates a type suitable for typechecking which works with discord.py's
         commands.

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -154,8 +154,6 @@ def parse_timedelta(
 def parse_relativedelta(
     argument: str,
     *,
-    maximum: Optional[relativedelta] = None,
-    minimum: Optional[relativedelta] = None,
     allowed_units: Optional[List[str]] = None,
 ) -> Optional[relativedelta]:
     """
@@ -168,10 +166,6 @@ def parse_relativedelta(
     ----------
     argument : str
         The user provided input
-    maximum : Optional[relativedelta]
-        If provided, any parsed value higher than this will raise an exception
-    minimum : Optional[relativedelta]
-        If provided, any parsed value lower than this will raise an exception
     allowed_units : Optional[List[str]]
         If provided, you can constrain a user to expressing the amount of time
         in specific units. The units you can chose to provide are the same as the
@@ -204,18 +198,6 @@ def parse_relativedelta(
         except OverflowError:
             raise BadArgument(
                 _("The time set is way too high, consider setting something reasonable.")
-            )
-        if maximum and maximum < delta:
-            raise BadArgument(
-                _(
-                    "This amount of time is too large for this command. (Maximum: {maximum})"
-                ).format(maximum=humanize_timedelta(timedelta=maximum))
-            )
-        if minimum and delta < minimum:
-            raise BadArgument(
-                _(
-                    "This amount of time is too small for this command. (Minimum: {minimum})"
-                ).format(minimum=humanize_timedelta(timedelta=minimum))
             )
         return delta
     return None
@@ -451,10 +433,6 @@ else:
 
         Attributes
         ----------
-        maximum : Optional[relativedelta]
-            If provided, any parsed value higher than this will raise an exception
-        minimum : Optional[relativedelta]
-            If provided, any parsed value lower than this will raise an exception
         allowed_units : Optional[List[str]]
             If provided, you can constrain a user to expressing the amount of time
             in specific units. The units you can choose to provide are the same as the
@@ -465,11 +443,9 @@ else:
             apply.
         """
 
-        def __init__(self, *, minimum=None, maximum=None, allowed_units=None, default_unit=None):
+        def __init__(self, *, allowed_units=None, default_unit=None):
             self.allowed_units = allowed_units
             self.default_unit = default_unit
-            self.minimum = minimum
-            self.maximum = maximum
 
         async def convert(self, ctx: "Context", argument: str) -> relativedelta:
             if self.default_unit and argument.isdecimal():
@@ -477,8 +453,6 @@ else:
 
             delta = parse_relativedelta(
                 argument,
-                minimum=self.minimum,
-                maximum=self.maximum,
                 allowed_units=self.allowed_units,
             )
 
@@ -504,8 +478,6 @@ else:
     def get_relativedelta_converter(
         *,
         default_unit: Optional[str] = None,
-        maximum: Optional[relativedelta] = None,
-        minimum: Optional[relativedelta] = None,
         allowed_units: Optional[List[str]] = None,
     ) -> Type[relativedelta]:
         """
@@ -516,10 +488,6 @@ else:
 
         Parameters
         ----------
-        maximum : Optional[relativedelta]
-            If provided, any parsed value higher than this will raise an exception
-        minimum : Optional[relativedelta]
-            If provided, any parsed value lower than this will raise an exception
         allowed_units : Optional[List[str]]
             If provided, you can constrain a user to expressing the amount of time
             in specific units. The units you can choose to provide are the same as the
@@ -540,8 +508,6 @@ else:
                 type(DictConverter).__call__,
                 allowed_units=allowed_units,
                 default_unit=default_unit,
-                minimum=minimum,
-                maximum=maximum,
             )
 
         class ValidatedConverter(RelativeDeltaConverter, metaclass=PartialMeta):

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -41,7 +41,6 @@ __all__ = [
     "RelativedeltaConverter",
     "TimedeltaConverter",
     "get_dict_converter",
-    "get_relativedelta_converter",
     "get_timedelta_converter",
     "parse_relativedelta",
     "parse_timedelta",
@@ -429,6 +428,7 @@ else:
     class RelativedeltaConverter(dpy_commands.Converter):
         """
         This is a converter for relative deltas.
+
         The units should be in order from largest to smallest.
         This works with or without whitespace.
 
@@ -462,61 +462,6 @@ else:
             if delta is not None:
                 return delta
             raise BadArgument()  # This allows this to be a required argument.
-
-
-if TYPE_CHECKING:
-
-    def get_relativedelta_converter(
-        *,
-        default_unit: Optional[str] = None,
-        maximum: Optional[relativedelta] = None,
-        minimum: Optional[relativedelta] = None,
-        allowed_units: Optional[List[str]] = None,
-    ) -> Type[relativedelta]:
-        ...
-
-
-else:
-
-    def get_relativedelta_converter(
-        *,
-        default_unit: Optional[str] = None,
-        allowed_units: Optional[List[str]] = None,
-    ) -> Type[relativedelta]:
-        """
-        This creates a type suitable for typechecking which works with discord.py's
-        commands.
-
-        See `parse_relativedelta` for more information about how this functions.
-
-        Parameters
-        ----------
-        allowed_units : Optional[List[str]]
-            If provided, you can constrain a user to expressing the amount of time
-            in specific units. The units you can choose to provide are the same as the
-            parser understands: (``years`, ``months``, ``weeks``, ``days``, ``hours``, ``minutes``, ``seconds``)
-        default_unit : Optional[str]
-            If provided, it will additionally try to match integer-only input into
-            a timedelta, using the unit specified. Same units as in ``allowed_units``
-            apply.
-
-        Returns
-        -------
-        type
-            The converter class, which will be a subclass of `RelativedeltaConverter`
-        """
-
-        class PartialMeta(type):
-            __call__ = functools.partialmethod(
-                type(DictConverter).__call__,
-                allowed_units=allowed_units,
-                default_unit=default_unit,
-            )
-
-        class ValidatedConverter(RelativedeltaConverter, metaclass=PartialMeta):
-            pass
-
-        return ValidatedConverter
 
 
 if not TYPE_CHECKING:

--- a/tests/core/test_commands.py
+++ b/tests/core/test_commands.py
@@ -60,7 +60,7 @@ def test_converter_timedelta():
     assert converter.parse_timedelta("13 days 5 minutes") == datetime.timedelta(days=13, minutes=5)
 
 
-def test_converter_datetimedelta():
+def test_converter_relativedelta():
     assert converter.parse_relativedelta("1 year") == relativedelta(years=1)
     assert converter.parse_relativedelta("1 year 10 days 3 seconds") == relativedelta(
         years=1, days=10, seconds=3

--- a/tests/core/test_commands.py
+++ b/tests/core/test_commands.py
@@ -1,4 +1,5 @@
 import inspect
+import datetime as dt
 
 import pytest
 from discord.ext import commands as dpy_commands
@@ -53,6 +54,17 @@ def test_dpy_commands_reexports():
 
 
 def test_converter_timedelta():
-    assert converter.parse_timedelta("1 year") == converter.parse_timedelta("365 days")
-    assert converter.parse_timedelta("1 month") == converter.parse_timedelta("30 days")
-    assert converter.parse_timedelta("1 month 10 days") == converter.parse_timedelta("40 days")
+    assert converter.parse_timedelta("1 day") == dt.timedelta(days=1)
+    assert converter.parse_timedelta("1 minute") == dt.timedelta(minutes=1)
+    assert converter.parse_timedelta("13 days 5 minutes") == dt.timedelta(days=13, minutes=5)
+
+
+def test_converter_datetimedelta():
+    assert (
+        converter.parse_datetimedelta("1 year") - (dt.datetime.now() + dt.timedelta(days=365))
+    ) < dt.timedelta(seconds=1)
+
+    assert (
+        converter.parse_datetimedelta("1 year 10 days 3 seconds")
+        - (dt.datetime.now() + dt.timedelta(days=375, seconds=3))
+    ) < dt.timedelta(seconds=1)

--- a/tests/core/test_commands.py
+++ b/tests/core/test_commands.py
@@ -1,5 +1,6 @@
 import inspect
-import datetime as dt
+import datetime
+from dateutil.relativedelta import relativedelta
 
 import pytest
 from discord.ext import commands as dpy_commands
@@ -54,17 +55,13 @@ def test_dpy_commands_reexports():
 
 
 def test_converter_timedelta():
-    assert converter.parse_timedelta("1 day") == dt.timedelta(days=1)
-    assert converter.parse_timedelta("1 minute") == dt.timedelta(minutes=1)
-    assert converter.parse_timedelta("13 days 5 minutes") == dt.timedelta(days=13, minutes=5)
+    assert converter.parse_timedelta("1 day") == datetime.timedelta(days=1)
+    assert converter.parse_timedelta("1 minute") == datetime.timedelta(minutes=1)
+    assert converter.parse_timedelta("13 days 5 minutes") == datetime.timedelta(days=13, minutes=5)
 
 
 def test_converter_datetimedelta():
-    assert (
-        converter.parse_datetimedelta("1 year") - (dt.datetime.now() + dt.timedelta(days=365))
-    ) < dt.timedelta(seconds=1)
-
-    assert (
-        converter.parse_datetimedelta("1 year 10 days 3 seconds")
-        - (dt.datetime.now() + dt.timedelta(days=375, seconds=3))
-    ) < dt.timedelta(seconds=1)
+    assert converter.parse_relativedelta("1 year") == relativedelta(years=1)
+    assert converter.parse_relativedelta("1 year 10 days 3 seconds") == relativedelta(
+        years=1, days=10, seconds=3
+    )

--- a/tests/core/test_commands.py
+++ b/tests/core/test_commands.py
@@ -4,6 +4,7 @@ import pytest
 from discord.ext import commands as dpy_commands
 
 from redbot.core import commands
+from redbot.core.commands import converter
 
 
 @pytest.fixture(scope="session")
@@ -49,3 +50,9 @@ def test_dpy_commands_reexports():
     missing_attrs = dpy_attrs - set(commands.__dict__.keys())
 
     assert not missing_attrs
+
+
+def test_converter_timedelta():
+    assert converter.parse_timedelta("1 year") == converter.parse_timedelta("365 days")
+    assert converter.parse_timedelta("1 month") == converter.parse_timedelta("30 days")
+    assert converter.parse_timedelta("1 month 10 days") == converter.parse_timedelta("40 days")


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes

~~I've added `months` and `years` to `redbot.core.commands.converter.parse_timedelta`. These parameters are not natively supported by `datetime.timedelta` so I've essentially aliased them for 30d and 365d respectively.~~

Adds `RelativeDeltaConverter` and `parse_relativedelta`, which accept `months` and `years` and returns a dateutil.relativedelta.relativedelta object.

I've also added a few simple tests in `tests.core.test_commands.py`

Fixes #4140 