### PR TITLE
[API] add ability to check for disabled command

### DIFF
--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -626,9 +626,7 @@ class Command(CogCommandMixin, DPYCommand):
         """
         disabler = get_command_disabler(guild)
         # If disabler is in self.checks, then command disabled; else the command is enabled
-        if disabler in self.checks:
-            return True
-        return False
+        return disabler in self.checks
 
     def allow_for(self, model_id: Union[int, str], guild_id: int) -> None:
         super().allow_for(model_id, guild_id=guild_id)

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -622,7 +622,6 @@ class Command(CogCommandMixin, DPYCommand):
         -------
         bool
             ``True`` if the command is disabled.
-            ``False`` if the command isn't disabled.
 
         """
         disabler = get_command_disabler(guild)

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -611,7 +611,6 @@ class Command(CogCommandMixin, DPYCommand):
             return True
 
     def is_disabled_in_guild(self, guild: discord.Guild) -> bool:
-
         """Checks if this command is disabled in the given guild.
 
         Parameters

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -610,8 +610,29 @@ class Command(CogCommandMixin, DPYCommand):
         else:
             return True
 
-    def is_disabled_in_guild(self, guild: discord.Guild): 
-        print('just trying with guild ')
+    def is_disabled_in_guild(self, guild: discord.Guild) -> bool: 
+
+        """Checks if this command is disabled in the given guild. 
+
+        Parameters
+        ----------
+        guild : discord.Guild
+            The guild to enable the command in.
+
+        Returns
+        -------
+        bool
+            ``True`` if the command is disabled. 
+            ``False`` if the command isn't disabled.
+
+        """
+
+        disabler = get_command_disabler(guild)
+        # If disabler is in self.checks, then command disabled; else the command is enabled
+        if disabler in self.checks: 
+            return True
+        return False
+
 
     def allow_for(self, model_id: Union[int, str], guild_id: int) -> None:
         super().allow_for(model_id, guild_id=guild_id)

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -610,9 +610,9 @@ class Command(CogCommandMixin, DPYCommand):
         else:
             return True
 
-    def is_disabled_in_guild(self, guild: discord.Guild) -> bool: 
+    def is_disabled_in_guild(self, guild: discord.Guild) -> bool:
 
-        """Checks if this command is disabled in the given guild. 
+        """Checks if this command is disabled in the given guild.
 
         Parameters
         ----------
@@ -622,17 +622,15 @@ class Command(CogCommandMixin, DPYCommand):
         Returns
         -------
         bool
-            ``True`` if the command is disabled. 
+            ``True`` if the command is disabled.
             ``False`` if the command isn't disabled.
 
         """
-
         disabler = get_command_disabler(guild)
         # If disabler is in self.checks, then command disabled; else the command is enabled
-        if disabler in self.checks: 
+        if disabler in self.checks:
             return True
         return False
-
 
     def allow_for(self, model_id: Union[int, str], guild_id: int) -> None:
         super().allow_for(model_id, guild_id=guild_id)

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -610,6 +610,9 @@ class Command(CogCommandMixin, DPYCommand):
         else:
             return True
 
+    def is_disabled_in_guild(self, guild: discord.Guild): 
+        print('just trying with guild ')
+
     def allow_for(self, model_id: Union[int, str], guild_id: int) -> None:
         super().allow_for(model_id, guild_id=guild_id)
         parents = self.parents

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -4225,7 +4225,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         **Arguments:**
             - `<command>` - The command to disable globally.
         """
-        
         command_obj: Optional[commands.Command] = ctx.bot.get_command(command)
         if command_obj is None:
             await ctx.send(
@@ -4270,7 +4269,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                     - `<command>` - The command to disable for the current server.
         """
         command_obj: Optional[commands.Command] = ctx.bot.get_command(command)
-
         if command_obj is None:
             await ctx.send(
                 _("I couldn't find that command. Please note that it is case sensitive.")

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -4225,6 +4225,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         **Arguments:**
             - `<command>` - The command to disable globally.
         """
+        
         command_obj: Optional[commands.Command] = ctx.bot.get_command(command)
         if command_obj is None:
             await ctx.send(
@@ -4269,6 +4270,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                     - `<command>` - The command to disable for the current server.
         """
         command_obj: Optional[commands.Command] = ctx.bot.get_command(command)
+
+        command_obj.is_disabled_in_guild(ctx.guild)
+
         if command_obj is None:
             await ctx.send(
                 _("I couldn't find that command. Please note that it is case sensitive.")

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -4271,8 +4271,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """
         command_obj: Optional[commands.Command] = ctx.bot.get_command(command)
 
-        command_obj.is_disabled_in_guild(ctx.guild)
-
         if command_obj is None:
             await ctx.send(
                 _("I couldn't find that command. Please note that it is case sensitive.")


### PR DESCRIPTION
### Type of Feature Request

- [ ] Cog

- [ ] Command

- [x] API Functionality 

### Description of the changes
Previously, there was already a way to check whether the command is disabled using the command.enabled attribute, however, we needed to implement a way to check whether a command is disabled in a specific guild.

We made a method that checks whether a command is disabled in a specific guild in the Command class with the name is_disabled_in_guild(). This functions accepts a discord.Guild object as a positional-only argument and will return true if the command is disabled in the guild and returns false if the command is enabled in the guild.

Closes [#4130 ](https://github.com/Cog-Creators/Red-DiscordBot/issues/4130)