### PR TITLE
Send the DM to a user before applying the warn action.

### DIFF
--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -430,13 +430,7 @@ class Warnings(commands.Cog):
                 "mod": ctx.author.id,
             }
         }
-        async with member_settings.warnings() as user_warnings:
-            user_warnings.update(warning_to_add)
-        current_point_count += reason_type["points"]
-        await member_settings.total_points.set(current_point_count)
-
-        await warning_points_add_check(self.config, ctx, user, current_point_count)
-        dm = guild_settings["toggle_dm"]
+		dm = guild_settings["toggle_dm"]
         showmod = guild_settings["show_mod"]
         dm_failed = False
         if dm:
@@ -465,6 +459,12 @@ class Warnings(commands.Cog):
                     " but I wasn't able to send them a warn message."
                 ).format(user=user.mention)
             )
+        async with member_settings.warnings() as user_warnings:
+            user_warnings.update(warning_to_add)
+        current_point_count += reason_type["points"]
+        await member_settings.total_points.set(current_point_count)
+
+        await warning_points_add_check(self.config, ctx, user, current_point_count)
 
         toggle_channel = guild_settings["toggle_channel"]
         if toggle_channel:

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -430,7 +430,7 @@ class Warnings(commands.Cog):
                 "mod": ctx.author.id,
             }
         }
-		dm = guild_settings["toggle_dm"]
+        dm = guild_settings["toggle_dm"]
         showmod = guild_settings["show_mod"]
         dm_failed = False
         if dm:
@@ -463,7 +463,6 @@ class Warnings(commands.Cog):
             user_warnings.update(warning_to_add)
         current_point_count += reason_type["points"]
         await member_settings.total_points.set(current_point_count)
-
         await warning_points_add_check(self.config, ctx, user, current_point_count)
 
         toggle_channel = guild_settings["toggle_channel"]


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature

### Description of Changes
When a warn action is enforced, it can sometimes prevent the actual warning being sent via DM too - the most reliable example I can get to trigger is setting a softban as a warn action. This PR aims to prevent that simply Moving the warn action handling to after the DM itself is sent. Thats It, really.

This technically fixes #4713 But considering the way I worded that rivals Topical English Football Controversy in how stupid it is, I'm half tempted to call the association accidental

 

-- Dan