### PR TITLE
Audio Update - RLL 0.8.1

### DIFF
--- a/redbot/cogs/audio/apis/global_db.py
+++ b/redbot/cogs/audio/apis/global_db.py
@@ -78,14 +78,16 @@ class GlobalCacheWrapper:
                     search_response = await r.json(loads=json.loads)
                     if IS_DEBUG and "x-process-time" in r.headers:
                         log.debug(
-                            f"GET || Ping {r.headers.get('x-process-time')} || "
-                            f"Status code {r.status} || {query}"
+                            "GET || Ping %s || " "Status code %d || %s",
+                            r.headers.get("x-process-time"),
+                            r.status,
+                            query,
                         )
             if "tracks" not in search_response:
                 return {}
             return search_response
         except Exception as err:
-            debug_exc_log(log, err, f"Failed to Get query: {api_url}/{query}")
+            debug_exc_log(log, err, "Failed to Get query: %s/%s", api_url, query)
         return {}
 
     async def get_spotify(self, title: str, author: Optional[str]) -> dict:
@@ -108,14 +110,16 @@ class GlobalCacheWrapper:
                     search_response = await r.json(loads=json.loads)
                     if IS_DEBUG and "x-process-time" in r.headers:
                         log.debug(
-                            f"GET/spotify || Ping {r.headers.get('x-process-time')} || "
-                            f"Status code {r.status} || {title} - {author}"
+                            "GET/spotify || Ping %s || " "Status code %d || %s - %s",
+                            r.headers.get("x-process-time"),
+                            r.status,
+                            title.author,
                         )
             if "tracks" not in search_response:
                 return {}
             return search_response
         except Exception as err:
-            debug_exc_log(log, err, f"Failed to Get query: {api_url}")
+            debug_exc_log(log, err, "Failed to Get query: %s", api_url)
         return {}
 
     async def post_call(self, llresponse: LoadResult, query: Optional[Query]) -> None:
@@ -142,11 +146,13 @@ class GlobalCacheWrapper:
                 await r.read()
                 if IS_DEBUG and "x-process-time" in r.headers:
                     log.debug(
-                        f"POST || Ping {r.headers.get('x-process-time')} ||"
-                        f" Status code {r.status} || {query}"
+                        "GET || Ping %s || " "Status code %d || %s",
+                        r.headers.get("x-process-time"),
+                        r.status,
+                        query,
                     )
         except Exception as err:
-            debug_exc_log(log, err, f"Failed to post query: {query}")
+            debug_exc_log(log, err, "Failed to post query: %s", query)
         await asyncio.sleep(0)
 
     async def update_global(self, llresponse: LoadResult, query: Optional[Query] = None):

--- a/redbot/cogs/audio/apis/interface.py
+++ b/redbot/cogs/audio/apis/interface.py
@@ -932,7 +932,7 @@ class AudioAPIInterface:
         autoplaylist = await self.config.guild(player.channel.guild).autoplaylist()
         current_cache_level = CacheLevel(await self.config.cache_level())
         cache_enabled = CacheLevel.set_lavalink().is_subset(current_cache_level)
-        notify_channel_id = player.fetch("channel")
+        notify_channel_id = player.fetch("notify_channel")
         playlist = None
         tracks = None
         if autoplaylist["enabled"]:

--- a/redbot/cogs/audio/apis/interface.py
+++ b/redbot/cogs/audio/apis/interface.py
@@ -644,7 +644,7 @@ class AudioAPIInterface:
                             player.add(ctx.author, single_track)
                             self.bot.dispatch(
                                 "red_audio_track_enqueue",
-                                player.channel.guild,
+                                player.guild,
                                 single_track,
                                 ctx.author,
                             )
@@ -660,7 +660,7 @@ class AudioAPIInterface:
                         player.add(ctx.author, single_track)
                         self.bot.dispatch(
                             "red_audio_track_enqueue",
-                            player.channel.guild,
+                            player.guild,
                             single_track,
                             ctx.author,
                         )
@@ -934,7 +934,7 @@ class AudioAPIInterface:
 
     async def autoplay(self, player: lavalink.Player, playlist_api: PlaylistWrapper):
         """Enqueue a random track."""
-        autoplaylist = await self.config.guild(player.channel.guild).autoplaylist()
+        autoplaylist = await self.config.guild(player.guild).autoplaylist()
         current_cache_level = CacheLevel(await self.config.cache_level())
         cache_enabled = CacheLevel.set_lavalink().is_subset(current_cache_level)
         notify_channel_id = player.fetch("notify_channel")
@@ -947,8 +947,8 @@ class AudioAPIInterface:
                     autoplaylist["scope"],
                     self.bot,
                     playlist_api,
-                    player.channel.guild,
-                    player.channel.guild.me,
+                    player.guild,
+                    player.guild.me,
                 )
                 tracks = playlist.tracks_obj
             except Exception as exc:
@@ -961,9 +961,7 @@ class AudioAPIInterface:
             if not tracks:
                 ctx = namedtuple("Context", "message guild cog")
                 (results, called_api) = await self.fetch_track(
-                    cast(
-                        commands.Context, ctx(player.channel.guild, player.channel.guild, self.cog)
-                    ),
+                    cast(commands.Context, ctx(player.guild, player.guild, self.cog)),
                     player,
                     Query.process_input(_TOP_100_US, self.cog.local_folder_current_path),
                 )
@@ -1010,18 +1008,18 @@ class AudioAPIInterface:
             player.add(player.guild.me, track)
             self.bot.dispatch(
                 "red_audio_track_auto_play",
-                player.channel.guild,
+                player.guild,
                 track,
-                player.channel.guild.me,
+                player.guild.me,
                 player,
             )
             if notify_channel_id:
                 await self.config.guild_from_id(
-                    guild_id=player.channel.guild.id
+                    guild_id=player.guild.id
                 ).currently_auto_playing_in.set([notify_channel_id, player.channel.id])
             else:
                 await self.config.guild_from_id(
-                    guild_id=player.channel.guild.id
+                    guild_id=player.guild.id
                 ).currently_auto_playing_in.set([])
             if not player.current:
                 await player.play()

--- a/redbot/cogs/audio/apis/interface.py
+++ b/redbot/cogs/audio/apis/interface.py
@@ -149,7 +149,7 @@ class AudioAPIInterface:
         async with self._lock:
             if lock_id in self._tasks:
                 if IS_DEBUG:
-                    log.debug(f"Running database writes for {lock_id} ({lock_author})")
+                    log.debug("Running database writes for %d (%s)", lock_id, lock_author)
                 try:
                     tasks = self._tasks[lock_id]
                     tasks = [self.route_tasks(a, tasks[a]) for a in tasks]
@@ -157,11 +157,11 @@ class AudioAPIInterface:
                     del self._tasks[lock_id]
                 except Exception as exc:
                     debug_exc_log(
-                        log, exc, f"Failed database writes for {lock_id} ({lock_author})"
+                        log, exc, "Running database writes for %d (%s)", lock_id, lock_author
                     )
                 else:
                     if IS_DEBUG:
-                        log.debug(f"Completed database writes for {lock_id} ({lock_author})")
+                        log.debug("Running database writes for %d (%s)", lock_id, lock_author)
 
     async def run_all_pending_tasks(self) -> None:
         """Run all pending tasks left in the cache, called on cog_unload."""
@@ -248,7 +248,9 @@ class AudioAPIInterface:
                             {"track": track_info}
                         )
                     except Exception as exc:
-                        debug_exc_log(log, exc, f"Failed to fetch {track_info} from YouTube table")
+                        debug_exc_log(
+                            log, exc, "Failed to fetch %s from YouTube table", track_info
+                        )
 
                 if val is None:
                     try:
@@ -386,7 +388,7 @@ class AudioAPIInterface:
                 )
             except Exception as exc:
                 debug_exc_log(
-                    log, exc, f"Failed to fetch 'spotify:track:{uri}' from Spotify table"
+                    log, exc, "Failed to fetch 'spotify:track:%s' from Spotify table", uri
                 )
                 val = None
         else:
@@ -513,7 +515,9 @@ class AudioAPIInterface:
                             {"track": track_info}
                         )
                     except Exception as exc:
-                        debug_exc_log(log, exc, f"Failed to fetch {track_info} from YouTube table")
+                        debug_exc_log(
+                            log, exc, "Failed to fetch %s from YouTube table", track_info
+                        )
                 should_query_global = globaldb_toggle and query_global and val is None
                 if should_query_global:
                     llresponse = await self.global_cache_api.get_spotify(track_name, artist_name)
@@ -621,7 +625,7 @@ class AudioAPIInterface:
                 ):
                     has_not_allowed = True
                     if IS_DEBUG:
-                        log.debug(f"Query is not allowed in {ctx.guild} ({ctx.guild.id})")
+                        log.debug("Query is not allowed in %s (%d)", ctx.guild, ctx.guild.id)
                     continue
                 track_list.append(single_track)
                 if enqueue:
@@ -748,7 +752,7 @@ class AudioAPIInterface:
             try:
                 (val, update) = await self.local_cache_api.youtube.fetch_one({"track": track_info})
             except Exception as exc:
-                debug_exc_log(log, exc, f"Failed to fetch {track_info} from YouTube table")
+                debug_exc_log(log, exc, "Failed to fetch %s from YouTube table", track_info)
         if val is None:
             try:
                 youtube_url = await self.fetch_youtube_query(
@@ -813,11 +817,11 @@ class AudioAPIInterface:
                     {"query": query_string}
                 )
             except Exception as exc:
-                debug_exc_log(log, exc, f"Failed to fetch '{query_string}' from Lavalink table")
+                debug_exc_log(log, exc, "Failed to fetch '%s' from Lavalink table", query_string)
 
             if val and isinstance(val, dict):
                 if IS_DEBUG:
-                    log.debug(f"Updating Local Database with {query_string}")
+                    log.debug("Updating Local Database with %s", query_string)
                 task = ("update", ("lavalink", {"query": query_string}))
                 self.append_task(ctx, *task)
             else:
@@ -851,7 +855,7 @@ class AudioAPIInterface:
                     valid_global_entry = True
                 if valid_global_entry:
                     if IS_DEBUG:
-                        log.debug(f"Querying Global DB api for {query}")
+                        log.debug("Querying Global DB api for %s", query)
                     results, called_api = results, False
         if valid_global_entry:
             pass
@@ -870,7 +874,7 @@ class AudioAPIInterface:
             valid_global_entry = False
         else:
             if IS_DEBUG:
-                log.debug(f"Querying Lavalink api for {query_string}")
+                log.debug("Querying Lavalink api for %s", query_string)
             called_api = True
             try:
                 results = await player.load_tracks(query_string)
@@ -923,7 +927,8 @@ class AudioAPIInterface:
                 debug_exc_log(
                     log,
                     exc,
-                    f"Failed to enqueue write task for '{query_string}' to Lavalink table",
+                    "Failed to enqueue write task for '%s' to Lavalink table",
+                    query_string,
                 )
         return results, called_api
 
@@ -990,8 +995,7 @@ class AudioAPIInterface:
                 ):
                     if IS_DEBUG:
                         log.debug(
-                            "Query is not allowed in "
-                            f"{player.channel.guild} ({player.channel.guild.id})"
+                            "Query is not allowed in " "%s (%d)", player.guild, player.guild.id
                         )
                     continue
                 valid = True
@@ -1000,10 +1004,10 @@ class AudioAPIInterface:
                     "autoplay": True,
                     "enqueue_time": int(time.time()),
                     "vc": player.channel.id,
-                    "requester": player.channel.guild.me.id,
+                    "requester": player.guild.me.id,
                 }
             )
-            player.add(player.channel.guild.me, track)
+            player.add(player.guild.me, track)
             self.bot.dispatch(
                 "red_audio_track_auto_play",
                 player.channel.guild,

--- a/redbot/cogs/audio/apis/spotify.py
+++ b/redbot/cogs/audio/apis/spotify.py
@@ -102,7 +102,7 @@ class SpotifyWrapper:
         async with self.session.request("GET", url, params=params, headers=headers) as r:
             data = await r.json(loads=json.loads)
             if r.status != 200:
-                log.debug(f"Issue making GET request to {url}: [{r.status}] {data}")
+                log.debug("Issue making GET request to %s: [%d] %s", url, r.status, data)
             return data
 
     async def update_token(self, new_token: Mapping[str, str]):
@@ -146,7 +146,7 @@ class SpotifyWrapper:
         except KeyError:
             return None
         self.spotify_token = token
-        log.debug(f"Created a new access token for Spotify: {token}")
+        log.debug("Created a new access token for Spotify: %s", token)
         return self.spotify_token["access_token"]
 
     async def post(
@@ -156,7 +156,7 @@ class SpotifyWrapper:
         async with self.session.post(url, data=payload, headers=headers) as r:
             data = await r.json(loads=json.loads)
             if r.status != 200:
-                log.debug(f"Issue making POST request to {url}: [{r.status}] {data}")
+                log.debug("Issue making POST request to %s: [%d] %s", url, r.status, data)
             return data
 
     async def make_get_call(self, url: str, params: MutableMapping) -> MutableMapping:

--- a/redbot/cogs/audio/audio_logging.py
+++ b/redbot/cogs/audio/audio_logging.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 
-from typing import Final
+from typing import Final, Any, Tuple
 
 IS_DEBUG: Final[bool] = "--debug" in sys.argv
 
@@ -10,9 +10,9 @@ def is_debug() -> bool:
     return IS_DEBUG
 
 
-def debug_exc_log(lg: logging.Logger, exc: Exception, msg: str = None) -> None:
+def debug_exc_log(lg: logging.Logger, exc: Exception, msg: str = None, *args: Tuple[Any]) -> None:
     """Logs an exception if logging is set to DEBUG level"""
     if lg.getEffectiveLevel() <= logging.DEBUG:
         if msg is None:
             msg = f"{exc}"
-        lg.exception(msg, exc_info=exc)
+        lg.exception(msg, *args, exc_info=exc)

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -883,7 +883,6 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Unable To Bump Track"),
                 description=_("Song number must be greater than 1 and within the queue limit."),
             )
-
         player.store("notify_channel", ctx.channel.id)
         bump_index = index - 1
         bump_song = player.queue[bump_index]

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -95,8 +95,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
         }
         expected = tuple(emoji.values())
         player = lavalink.get_player(ctx.guild.id)
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         if player.current:
             arrow = await self.draw_time(ctx)
             pos = self.format_time(player.position)
@@ -218,8 +217,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Unable To Manage Tracks"),
                 description=_("You need the DJ role to pause or resume tracks."),
             )
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         if not player.current:
             return await self.send_embed_msg(ctx, title=_("Nothing playing."))
         description = await self.get_track_description(
@@ -273,8 +271,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     "to enqueue the previous song tracks."
                 ),
             )
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         if player.fetch("prev_song") is None:
             return await self.send_embed_msg(
                 ctx, title=_("Unable To Play Tracks"), description=_("No previous track.")
@@ -340,8 +337,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Unable To Seek Tracks"),
                 description=_("You need the DJ role or be the track requester to use seek."),
             )
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         if player.current:
             if player.current.is_stream:
                 return await self.send_embed_msg(
@@ -414,8 +410,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                         title=_("Unable To Toggle Shuffle"),
                         description=_("You must be in the voice channel to toggle shuffle."),
                     )
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
+                player.store("notify_channel", ctx.channel.id)
 
             shuffle = await self.config.guild(ctx.guild).shuffle()
             await self.config.guild(ctx.guild).shuffle.set(not shuffle)
@@ -459,8 +454,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     title=_("Unable To Toggle Shuffle"),
                     description=_("You must be in the voice channel to toggle shuffle."),
                 )
-            player.store("channel", ctx.channel.id)
-            player.store("guild", ctx.guild.id)
+            player.store("notify_channel", ctx.channel.id)
 
         bumped = await self.config.guild(ctx.guild).shuffle_bumped()
         await self.config.guild(ctx.guild).shuffle_bumped.set(not bumped)
@@ -517,8 +511,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     title=_("Unable To Skip Tracks"),
                     description=_("You can only skip the current track."),
                 )
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         if vote_enabled:
             if not can_skip:
                 if skip_to_track is not None:
@@ -597,8 +590,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Unable To Stop Player"),
                 description=_("You need the DJ role to stop the music."),
             )
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         if (
             player.is_playing
             or (not player.is_playing and player.paused)
@@ -662,18 +654,14 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     description=_("I don't have permission to connect to your channel."),
                 )
             if not self._player_check(ctx):
-                await lavalink.connect(
+                player = await lavalink.connect(
                     ctx.author.voice.channel,
                     deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
-                player = lavalink.get_player(ctx.guild.id)
-                player.store("connect", datetime.datetime.utcnow())
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
+                player.store("notify_channel", ctx.channel.id)
             else:
                 player = lavalink.get_player(ctx.guild.id)
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
+                player.store("notify_channel", ctx.channel.id)
                 if (
                     ctx.author.voice.channel == player.channel
                     and ctx.guild.me in ctx.author.voice.channel.members
@@ -710,7 +698,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
         can_skip = await self._can_instaskip(ctx, ctx.author)
         if not vol:
             vol = await self.config.guild(ctx.guild).volume()
-            embed = discord.Embed(title=_("Current Volume:"), description=str(vol) + "%")
+            embed = discord.Embed(title=_("Current Volume:"), description=f"{vol}%")
             if not self._player_check(ctx):
                 embed.set_footer(text=_("Nothing playing."))
             return await self.send_embed_msg(ctx, embed=embed)
@@ -724,8 +712,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     title=_("Unable To Change Volume"),
                     description=_("You must be in the voice channel to change the volume."),
                 )
-            player.store("channel", ctx.channel.id)
-            player.store("guild", ctx.guild.id)
+            player.store("notify_channel", ctx.channel.id)
         if dj_enabled and not can_skip and not await self._has_dj_role(ctx, ctx.author):
             return await self.send_embed_msg(
                 ctx,
@@ -733,25 +720,14 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 description=_("You need the DJ role to change the volume."),
             )
 
-        if vol < 0:
-            vol = 0
-        if vol > 150:
-            vol = 150
-            await self.config.guild(ctx.guild).volume.set(vol)
-            if self._player_check(ctx):
-                player = lavalink.get_player(ctx.guild.id)
-                await player.set_volume(vol)
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
-        else:
-            await self.config.guild(ctx.guild).volume.set(vol)
-            if self._player_check(ctx):
-                player = lavalink.get_player(ctx.guild.id)
-                await player.set_volume(vol)
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
+        vol = max(0, min(150, vol))
+        await self.config.guild(ctx.guild).volume.set(vol)
+        if self._player_check(ctx):
+            player = lavalink.get_player(ctx.guild.id)
+            await player.set_volume(vol)
+            player.store("notify_channel", ctx.channel.id)
 
-        embed = discord.Embed(title=_("Volume:"), description=str(vol) + "%")
+        embed = discord.Embed(title=_("Volume:"), description=f"{vol}%")
         if not self._player_check(ctx):
             embed.set_footer(text=_("Nothing playing."))
         await self.send_embed_msg(ctx, embed=embed)
@@ -782,8 +758,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     title=_("Unable To Toggle Repeat"),
                     description=_("You must be in the voice channel to toggle repeat."),
                 )
-            player.store("channel", ctx.channel.id)
-            player.store("guild", ctx.guild.id)
+            player.store("notify_channel", ctx.channel.id)
 
         autoplay = await self.config.guild(ctx.guild).auto_play()
         repeat = await self.config.guild(ctx.guild).repeat()
@@ -827,8 +802,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Unable To Modify Queue"),
                 description=_("You must be in the voice channel to manage the queue."),
             )
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         if isinstance(index_or_url, int):
             if index_or_url > len(player.queue) or index_or_url < 1:
                 return await self.send_embed_msg(
@@ -909,8 +883,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Unable To Bump Track"),
                 description=_("Song number must be greater than 1 and within the queue limit."),
             )
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         bump_index = index - 1
         bump_song = player.queue[bump_index]
         bump_song.extras["bumped"] = True

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -286,7 +286,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 }
             )
             player.add(player.fetch("prev_requester"), track)
-            self.bot.dispatch("red_audio_track_enqueue", player.channel.guild, track, ctx.author)
+            self.bot.dispatch("red_audio_track_enqueue", player.guild, track, ctx.author)
             queue_len = len(player.queue)
             bump_song = player.queue[-1]
             player.queue.insert(0, bump_song)

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -883,6 +883,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Unable To Bump Track"),
                 description=_("Song number must be greater than 1 and within the queue limit."),
             )
+
         player.store("notify_channel", ctx.channel.id)
         bump_index = index - 1
         bump_song = player.queue[bump_index]

--- a/redbot/cogs/audio/core/commands/equalizer.py
+++ b/redbot/cogs/audio/core/commands/equalizer.py
@@ -173,8 +173,7 @@ class EqualizerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Unable To Load Preset"),
                 description=_("You need the DJ role to load equalizer presets."),
             )
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         await self.config.custom("EQUALIZER", ctx.guild.id).eq_bands.set(eq_values)
         await self._eq_check(ctx, player)
         eq = player.fetch("eq", Equalizer())
@@ -203,8 +202,7 @@ class EqualizerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 description=_("You need the DJ role to reset the equalizer."),
             )
         player = lavalink.get_player(ctx.guild.id)
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         eq = player.fetch("eq", Equalizer())
 
         for band in range(eq.band_count):
@@ -287,8 +285,7 @@ class EqualizerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 return await eq_exists_msg.edit(embed=embed2)
 
         player = lavalink.get_player(ctx.guild.id)
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         eq = player.fetch("eq", Equalizer())
         to_append = {eq_preset: {"author": ctx.author.id, "bands": eq.bands}}
         new_eq_presets = {**eq_presets, **to_append}
@@ -330,8 +327,7 @@ class EqualizerCommands(MixinMeta, metaclass=CompositeMetaClass):
             )
 
         player = lavalink.get_player(ctx.guild.id)
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         band_names = [
             "25",
             "40",

--- a/redbot/cogs/audio/core/commands/miscellaneous.py
+++ b/redbot/cogs/audio/core/commands/miscellaneous.py
@@ -59,10 +59,10 @@ class MiscellaneousCommands(MixinMeta, metaclass=CompositeMetaClass):
                 current_title = await self.get_track_description(
                     p.current, self.local_folder_current_path
                 )
-                msg += "{} [`{}`]: {}\n".format(p.channel.guild.name, connect_dur, current_title)
+                msg += "{} [`{}`]: {}\n".format(p.guild.name, connect_dur, current_title)
             except AttributeError:
                 msg += "{} [`{}`]: **{}**\n".format(
-                    p.channel.guild.name, connect_dur, _("Nothing playing.")
+                    p.guild.name, connect_dur, _("Nothing playing.")
                 )
 
         if total_num == 0:

--- a/redbot/cogs/audio/core/commands/miscellaneous.py
+++ b/redbot/cogs/audio/core/commands/miscellaneous.py
@@ -44,13 +44,14 @@ class MiscellaneousCommands(MixinMeta, metaclass=CompositeMetaClass):
     async def command_audiostats(self, ctx: commands.Context):
         """Audio stats."""
         server_num = len(lavalink.active_players())
-        total_num = len(lavalink.all_players())
+        total_num = len(lavalink.all_live_players())
 
         msg = ""
-        async for p in AsyncIter(lavalink.all_players()):
-            connect_start = p.fetch("connect")
+        async for p in AsyncIter(lavalink.all_live_players()):
             connect_dur = self.get_time_string(
-                int((datetime.datetime.utcnow() - connect_start).total_seconds())
+                int(
+                    (datetime.datetime.now(datetime.timezone.utc) - p.connected_at).total_seconds()
+                )
             )
             try:
                 if not p.current:

--- a/redbot/cogs/audio/core/commands/player.py
+++ b/redbot/cogs/audio/core/commands/player.py
@@ -82,10 +82,6 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     ctx.author.voice.channel,
                     deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
-                player = lavalink.get_player(ctx.guild.id)
-                player.store("connect", datetime.datetime.utcnow())
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
             except AttributeError:
                 return await self.send_embed_msg(
                     ctx,
@@ -99,8 +95,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     description=_("Connection to Lavalink has not yet been established."),
                 )
         player = lavalink.get_player(ctx.guild.id)
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         await self._eq_check(ctx, player)
         await self.set_player_settings(ctx)
         if (not ctx.author.voice or ctx.author.voice.channel != player.channel) and not can_skip:
@@ -193,10 +188,6 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     ctx.author.voice.channel,
                     deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
-                player = lavalink.get_player(ctx.guild.id)
-                player.store("connect", datetime.datetime.utcnow())
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
             except AttributeError:
                 return await self.send_embed_msg(
                     ctx,
@@ -210,8 +201,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     description=_("Connection to Lavalink has not yet been established."),
                 )
         player = lavalink.get_player(ctx.guild.id)
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         await self._eq_check(ctx, player)
         await self.set_player_settings(ctx)
         if (not ctx.author.voice or ctx.author.voice.channel != player.channel) and not can_skip:
@@ -462,10 +452,6 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     ctx.author.voice.channel,
                     deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
-                player = lavalink.get_player(ctx.guild.id)
-                player.store("connect", datetime.datetime.utcnow())
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
             except AttributeError:
                 return await self.send_embed_msg(
                     ctx,
@@ -479,9 +465,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     description=_("Connection to Lavalink has not yet been established."),
                 )
         player = lavalink.get_player(ctx.guild.id)
-
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         await self._eq_check(ctx, player)
         await self.set_player_settings(ctx)
         if (
@@ -582,10 +566,6 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     ctx.author.voice.channel,
                     deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
-                player = lavalink.get_player(ctx.guild.id)
-                player.store("connect", datetime.datetime.utcnow())
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
             except AttributeError:
                 return await self.send_embed_msg(
                     ctx,
@@ -599,9 +579,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     description=_("Connection to Lavalink has not yet been established."),
                 )
         player = lavalink.get_player(ctx.guild.id)
-
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         await self._eq_check(ctx, player)
         await self.set_player_settings(ctx)
         if (
@@ -621,7 +599,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
         try:
             await self.api_interface.autoplay(player, self.playlist_api)
         except DatabaseError:
-            notify_channel = player.fetch("channel")
+            notify_channel = player.fetch("notify_channel")
             if notify_channel:
                 notify_channel = self.bot.get_channel(notify_channel)
                 await self.send_embed_msg(notify_channel, title=_("Couldn't get a valid track."))
@@ -710,10 +688,6 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     ctx.author.voice.channel,
                     deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
-                player = lavalink.get_player(ctx.guild.id)
-                player.store("connect", datetime.datetime.utcnow())
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
             except AttributeError:
                 return await self.send_embed_msg(
                     ctx,
@@ -728,8 +702,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 )
         player = lavalink.get_player(ctx.guild.id)
         guild_data = await self.config.guild(ctx.guild).all()
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         can_skip = await self._can_instaskip(ctx, ctx.author)
         if (not ctx.author.voice or ctx.author.voice.channel != player.channel) and not can_skip:
             return await self.send_embed_msg(

--- a/redbot/cogs/audio/core/commands/player.py
+++ b/redbot/cogs/audio/core/commands/player.py
@@ -300,7 +300,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 player.queue.insert(0, single_track)
                 player.maybe_shuffle()
                 self.bot.dispatch(
-                    "red_audio_track_enqueue", player.channel.guild, single_track, ctx.author
+                    "red_audio_track_enqueue", player.guild, single_track, ctx.author
                 )
             else:
                 self.update_player_lock(ctx, False)
@@ -322,9 +322,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
             )
             player.queue.insert(0, single_track)
             player.maybe_shuffle()
-            self.bot.dispatch(
-                "red_audio_track_enqueue", player.channel.guild, single_track, ctx.author
-            )
+            self.bot.dispatch("red_audio_track_enqueue", player.guild, single_track, ctx.author)
         description = await self.get_track_description(
             single_track, self.local_folder_current_path
         )
@@ -821,7 +819,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                             )
                             player.add(ctx.author, track)
                             self.bot.dispatch(
-                                "red_audio_track_enqueue", player.channel.guild, track, ctx.author
+                                "red_audio_track_enqueue", player.guild, track, ctx.author
                             )
                     else:
                         track_len += 1
@@ -834,7 +832,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                         )
                         player.add(ctx.author, track)
                         self.bot.dispatch(
-                            "red_audio_track_enqueue", player.channel.guild, track, ctx.author
+                            "red_audio_track_enqueue", player.guild, track, ctx.author
                         )
                     if not player.current:
                         await player.play()

--- a/redbot/cogs/audio/core/commands/player.py
+++ b/redbot/cogs/audio/core/commands/player.py
@@ -280,7 +280,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
             query_obj=query,
         ):
             if IS_DEBUG:
-                log.debug(f"Query is not allowed in {ctx.guild} ({ctx.guild.id})")
+                log.debug("Query is not allowed in %s (%d)", ctx.guild, ctx.guild.id)
             self.update_player_lock(ctx, False)
             return await self.send_embed_msg(
                 ctx,
@@ -807,7 +807,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                         query_obj=query,
                     ):
                         if IS_DEBUG:
-                            log.debug(f"Query is not allowed in {ctx.guild} ({ctx.guild.id})")
+                            log.debug("Query is not allowed in %s (%d)", ctx.guild, ctx.guild.id)
                         continue
                     elif guild_data["maxlength"] > 0:
                         if self.is_track_length_allowed(track, guild_data["maxlength"]):

--- a/redbot/cogs/audio/core/commands/playlists.py
+++ b/redbot/cogs/audio/core/commands/playlists.py
@@ -1544,9 +1544,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                         }
                     )
                     player.add(author_obj, track)
-                    self.bot.dispatch(
-                        "red_audio_track_enqueue", player.channel.guild, track, ctx.author
-                    )
+                    self.bot.dispatch("red_audio_track_enqueue", player.guild, track, ctx.author)
                     track_len += 1
                 player.maybe_shuffle(0 if empty_queue else 1)
                 if len(tracks) > track_len:

--- a/redbot/cogs/audio/core/commands/playlists.py
+++ b/redbot/cogs/audio/core/commands/playlists.py
@@ -1525,7 +1525,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                         query_obj=query,
                     ):
                         if IS_DEBUG:
-                            log.debug(f"Query is not allowed in {ctx.guild} ({ctx.guild.id})")
+                            log.debug("Query is not allowed in %s (%d)", ctx.guild, ctx.guild.id)
                         continue
                     query = Query.process_input(track.uri, self.local_folder_current_path)
                     if query.is_local:

--- a/redbot/cogs/audio/core/commands/queue.py
+++ b/redbot/cogs/audio/core/commands/queue.py
@@ -338,14 +338,11 @@ class QueueCommands(MixinMeta, metaclass=CompositeMetaClass):
                     title=_("Unable To Shuffle Queue"),
                     description=_("I don't have permission to connect to your channel."),
                 )
-            await lavalink.connect(
+            player = await lavalink.connect(
                 ctx.author.voice.channel,
                 deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
             )
-            player = lavalink.get_player(ctx.guild.id)
-            player.store("connect", datetime.datetime.utcnow())
-            player.store("channel", ctx.channel.id)
-            player.store("guild", ctx.guild.id)
+            player.store("notify_channel", ctx.channel.id)
         except AttributeError:
             ctx.command.reset_cooldown(ctx)
             return await self.send_embed_msg(

--- a/redbot/cogs/audio/core/events/cog.py
+++ b/redbot/cogs/audio/core/events/cog.py
@@ -194,12 +194,13 @@ class AudioEvents(MixinMeta, metaclass=CompositeMetaClass):
         requester: discord.Member,
         player: lavalink.Player,
     ):
-        notify_channel = self.bot.get_channel(player.fetch("channel"))
+        notify_channel = self.bot.get_channel(player.fetch("notify_channel"))
         tries = 0
         while not player._is_playing:
             await asyncio.sleep(0.1)
             if tries > 1000:
                 return
+            tries += 1
 
         if notify_channel and not player.fetch("autoplay_notified", False):
             if (

--- a/redbot/cogs/audio/core/events/cog.py
+++ b/redbot/cogs/audio/core/events/cog.py
@@ -124,7 +124,7 @@ class AudioEvents(MixinMeta, metaclass=CompositeMetaClass):
                     bot=self.bot,
                 )
             except Exception as err:
-                debug_exc_log(log, err, f"Failed to delete daily playlist ID: {too_old_id}")
+                debug_exc_log(log, err, "Failed to delete daily playlist ID: %d", too_old_id)
             try:
                 await delete_playlist(
                     scope=PlaylistScope.GLOBAL.value,
@@ -135,7 +135,9 @@ class AudioEvents(MixinMeta, metaclass=CompositeMetaClass):
                     bot=self.bot,
                 )
             except Exception as err:
-                debug_exc_log(log, err, f"Failed to delete global daily playlist ID: {too_old_id}")
+                debug_exc_log(
+                    log, err, "Failed to delete global daily playlist ID: %d", too_old_id
+                )
         persist_cache = self._persist_queue_cache.setdefault(
             guild.id, await self.config.guild(guild).persist_queue()
         )

--- a/redbot/cogs/audio/core/events/dpy.py
+++ b/redbot/cogs/audio/core/events/dpy.py
@@ -90,9 +90,9 @@ class DpyEvents(MixinMeta, metaclass=CompositeMetaClass):
 
         with contextlib.suppress(Exception):
             player = lavalink.get_player(ctx.guild.id)
-            notify_channel = player.fetch("channel")
+            notify_channel = player.fetch("notify_channel")
             if not notify_channel:
-                player.store("channel", ctx.channel.id)
+                player.store("notify_channel", ctx.channel.id)
 
         self._daily_global_playlist_cache.setdefault(
             self.bot.user.id, await self.config.daily_playlists()
@@ -262,20 +262,6 @@ class DpyEvents(MixinMeta, metaclass=CompositeMetaClass):
                 self.skip_votes[before.channel.guild.id].discard(member.id)
             except (ValueError, KeyError, AttributeError):
                 pass
-
-        # if (
-        #     member == member.guild.me
-        #     and before.channel
-        #     and after.channel
-        #     and after.channel.id != before.channel.id
-        # ):
-        #     try:
-        #         player = lavalink.get_player(member.guild.id)
-        #         if player.is_playing:
-        #             await player.resume(player.current, start=player.position, replace=False)
-        #             log.debug("Bot changed channel - Resume playback")
-        #     except:
-        #         log.debug("Bot changed channel - Unable to resume playback")
 
         channel = self.rgetattr(member, "voice.channel", None)
         bot_voice_state = self.rgetattr(member, "guild.me.voice.self_deaf", None)

--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -17,7 +17,6 @@ from ..cog_utils import CompositeMetaClass
 
 log = logging.getLogger("red.cogs.Audio.cog.Events.lavalink")
 ws_audio_log = logging.getLogger("red.Audio.WS.Audio")
-ws_audio_log.setLevel(logging.WARNING)
 
 _ = Translator("Audio", Path(__file__))
 

--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -111,7 +111,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                 await self.api_interface.persistent_queue_api.played(
                     guild_id=guild_id, track_id=current_track.track_identifier
                 )
-            notify_channel = player.fetch("channel")
+            notify_channel = player.fetch("notify_channel")
             if notify_channel and autoplay:
                 await self.config.guild_from_id(guild_id=guild_id).currently_auto_playing_in.set(
                     [notify_channel, player.channel.id]
@@ -136,7 +136,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                 and self.playlist_api is not None
                 and self.api_interface is not None
             ):
-                notify_channel = player.fetch("channel")
+                notify_channel = player.fetch("notify_channel")
                 try:
                     await self.api_interface.autoplay(player, self.playlist_api)
                 except DatabaseError:
@@ -159,7 +159,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                         )
                     return
         if event_type == lavalink.LavalinkEvents.TRACK_START and notify:
-            notify_channel = player.fetch("channel")
+            notify_channel = player.fetch("notify_channel")
             if notify_channel:
                 notify_channel = self.bot.get_channel(notify_channel)
                 if player.fetch("notify_message") is not None:
@@ -198,7 +198,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
 
         if event_type == lavalink.LavalinkEvents.QUEUE_END:
             if not autoplay:
-                notify_channel = player.fetch("channel")
+                notify_channel = player.fetch("notify_channel")
                 if notify_channel and notify:
                     notify_channel = self.bot.get_channel(notify_channel)
                     await self.send_embed_msg(notify_channel, title=_("Queue ended."))
@@ -217,7 +217,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
             lavalink.LavalinkEvents.TRACK_EXCEPTION,
             lavalink.LavalinkEvents.TRACK_STUCK,
         ]:
-            message_channel = player.fetch("channel")
+            message_channel = player.fetch("notify_channel")
             while True:
                 if current_track in player.queue:
                     player.queue.remove(current_track)

--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -320,8 +320,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
             if event_channel_id != channel_id:
                 ws_audio_log.info(
                     f"Received an op code for a channel that is no longer valid; {event_channel_id} "
-                    f"in guild: {guild_id}  - Active channel {channel_id} | "
-                    f"Reason: Error code {code} & {reason}."
+                    f"Reason: Error code {code} & {reason}, {player}"
                 )
                 self._ws_op_codes[guild_id]._init(self._ws_op_codes[guild_id]._maxsize)
                 return
@@ -333,10 +332,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
             if code in (1000,) and has_perm and player.current and player.is_playing:
                 player.store("resumes", player.fetch("resumes", 0) + 1)
                 await player.resume(player.current, start=player.position, replace=True)
-                ws_audio_log.info(
-                    f"Player resumed in channel {channel_id} in guild: {guild_id} | "
-                    f"Reason: Error code {code} & {reason}."
-                )
+                ws_audio_log.info(f"Player resumed Reason: Error code {code} & {reason}, {player}")
                 self._ws_op_codes[guild_id]._init(self._ws_op_codes[guild_id]._maxsize)
                 return
 
@@ -350,7 +346,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     "YOU CAN IGNORE THIS UNLESS IT'S CONSISTENTLY REPEATING FOR THE SAME GUILD - "
                     f"Voice websocket closed for guild {guild_id} -> "
                     f"Socket Closed {voice_ws.socket._closing or voice_ws.socket.closed}.  "
-                    f"Code: {code} -- Remote: {by_remote} -- {reason}"
+                    f"Code: {code} -- Remote: {by_remote} -- {reason}, {player}"
                 )
                 ws_audio_log.debug(
                     f"Reconnecting to channel {channel_id} in guild: {guild_id} | {delay:.2f}s"
@@ -366,8 +362,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     await player.resume(player.current, start=player.position, replace=True)
                     ws_audio_log.info(
                         "Voice websocket reconnected "
-                        f"to channel {channel_id} in guild: {guild_id} | "
-                        f"Reason: Error code {code} & Currently playing."
+                        f"Reason: Error code {code} & Currently playing, {player}"
                     )
                 elif has_perm and player.paused and player.current:
                     player.store("resumes", player.fetch("resumes", 0) + 1)
@@ -377,24 +372,21 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     )
                     ws_audio_log.info(
                         "Voice websocket reconnected "
-                        f"to channel {channel_id} in guild: {guild_id} | "
-                        f"Reason: Error code {code} & Currently Paused."
+                        f"Reason: Error code {code} & Currently Paused, {player}"
                     )
                 elif has_perm and (not disconnect) and (not player.is_playing):
                     player.store("resumes", player.fetch("resumes", 0) + 1)
                     await player.connect(deafen=deafen)
                     ws_audio_log.info(
                         "Voice websocket reconnected "
-                        f"to channel {channel_id} in guild: {guild_id} | "
-                        f"Reason: Error code {code} & Not playing, but auto disconnect disabled."
+                        f"Reason: Error code {code} & Not playing, but auto disconnect disabled, {player}"
                     )
                     self._ll_guild_updates.discard(guild_id)
                 elif not has_perm:
                     self.bot.dispatch("red_audio_audio_disconnect", guild)
                     ws_audio_log.info(
                         "Voice websocket disconnected "
-                        f"from channel {channel_id} in guild: {guild_id} | "
-                        f"Reason: Error code {code} & Missing permissions."
+                        f"Reason: Error code {code} & Missing permissions, {player}"
                     )
                     self._ll_guild_updates.discard(guild_id)
                     player.store("autoplay_notified", False)
@@ -407,8 +399,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     self.bot.dispatch("red_audio_audio_disconnect", guild)
                     ws_audio_log.info(
                         "Voice websocket disconnected "
-                        f"from channel {channel_id} in guild: {guild_id} | "
-                        f"Reason: Error code {code} & Unknown."
+                        f"Reason: Error code {code} & Unknown, {player}"
                     )
                     self._ll_guild_updates.discard(guild_id)
                     player.store("autoplay_notified", False)
@@ -422,8 +413,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                 await player.connect(deafen=deafen)
                 await player.resume(player.current, start=player.position, replace=True)
                 ws_audio_log.info(
-                    f"Player resumed in channel {channel_id} in guild: {guild_id} | "
-                    f"Reason: Error code {code} & {reason}."
+                    f"Player resumed - Reason: Error code {code} & {reason}, {player}"
                 )
             elif code in (4015, 4009, 4006, 4000, 1006):
                 if player._con_delay:
@@ -440,8 +430,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     await player.resume(player.current, start=player.position, replace=True)
                     ws_audio_log.info(
                         "Voice websocket reconnected "
-                        f"to channel {channel_id} in guild: {guild_id} | "
-                        f"Reason: Error code {code} & Player is active."
+                        f"Reason: Error code {code} & Player is active, {player}"
                     )
                 elif has_perm and player.paused and player.current:
                     player.store("resumes", player.fetch("resumes", 0) + 1)
@@ -451,8 +440,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     )
                     ws_audio_log.info(
                         "Voice websocket reconnected "
-                        f"to channel {channel_id} in guild: {guild_id} | "
-                        f"Reason: Error code {code} & Player is paused."
+                        f"Reason: Error code {code} & Player is paused, {player}"
                     )
                 elif has_perm and (not disconnect) and (not player.is_playing):
                     player.store("resumes", player.fetch("resumes", 0) + 1)
@@ -467,8 +455,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     self.bot.dispatch("red_audio_audio_disconnect", guild)
                     ws_audio_log.info(
                         "Voice websocket disconnected "
-                        f"from channel {channel_id} in guild: {guild_id} | "
-                        f"Reason: Error code {code} & Missing permissions."
+                        f"Reason: Error code {code} & Missing permissions, {player}"
                     )
                     self._ll_guild_updates.discard(guild_id)
                     player.store("autoplay_notified", False)
@@ -483,8 +470,8 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     await player.resume(player.current, start=player.position, replace=False)
                 ws_audio_log.info(
                     "WS EVENT - IGNORED (Healthy Socket) | "
-                    f"Voice websocket closed event for guild {guild_id} -> "
-                    f"Code: {code} -- Remote: {by_remote} -- {reason}"
+                    f"Voice websocket closed event "
+                    f"Code: {code} -- Remote: {by_remote} -- {reason}, {player}"
                 )
         except Exception:
             log.exception("Error in task")

--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -94,7 +94,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
             current_track, self.local_folder_current_path
         )
         status = await self.config.status()
-        log.debug(f"Received a new lavalink event for {guild_id}: {event_type}: {extra}")
+        log.debug("Received a new lavalink event for %d: %s: %s", guild_id, event_type, extra)
         prev_song: lavalink.Track = player.fetch("prev_song")
         await self.maybe_reset_error_counter(player)
 
@@ -319,8 +319,12 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     code = 4014
             if event_channel_id != channel_id:
                 ws_audio_log.info(
-                    f"Received an op code for a channel that is no longer valid; {event_channel_id} "
-                    f"Reason: Error code {code} & {reason}, {player}"
+                    "Received an op code for a channel that is no longer valid; %d "
+                    "Reason: Error code %d & %s, %r",
+                    event_channel_id,
+                    code,
+                    reason,
+                    player,
                 )
                 self._ws_op_codes[guild_id]._init(self._ws_op_codes[guild_id]._maxsize)
                 return
@@ -332,7 +336,9 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
             if code in (1000,) and has_perm and player.current and player.is_playing:
                 player.store("resumes", player.fetch("resumes", 0) + 1)
                 await player.resume(player.current, start=player.position, replace=True)
-                ws_audio_log.info(f"Player resumed Reason: Error code {code} & {reason}, {player}")
+                ws_audio_log.info(
+                    "Player resumed Reason: Error code %d & %s, %r", code, reason, player
+                )
                 self._ws_op_codes[guild_id]._init(self._ws_op_codes[guild_id]._maxsize)
                 return
 
@@ -344,12 +350,21 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     delay = player._con_delay.delay()
                 ws_audio_log.warning(
                     "YOU CAN IGNORE THIS UNLESS IT'S CONSISTENTLY REPEATING FOR THE SAME GUILD - "
-                    f"Voice websocket closed for guild {guild_id} -> "
-                    f"Socket Closed {voice_ws.socket._closing or voice_ws.socket.closed}.  "
-                    f"Code: {code} -- Remote: {by_remote} -- {reason}, {player}"
+                    "Voice websocket closed for guild %d -> "
+                    "Socket Closed %s.  "
+                    "Code: %d -- Remote: %s -- %s, %r",
+                    guild_id,
+                    voice_ws.socket._closing or voice_ws.socket.closed,
+                    code,
+                    by_remote,
+                    reason,
+                    player,
                 )
                 ws_audio_log.debug(
-                    f"Reconnecting to channel {channel_id} in guild: {guild_id} | {delay:.2f}s"
+                    "Reconnecting to channel %d in guild: %d | %d:.2fs",
+                    channel_id,
+                    guild_id,
+                    delay,
                 )
                 await asyncio.sleep(delay)
                 while voice_ws.socket._closing or voice_ws.socket.closed or not voice_ws.open:
@@ -362,7 +377,9 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     await player.resume(player.current, start=player.position, replace=True)
                     ws_audio_log.info(
                         "Voice websocket reconnected "
-                        f"Reason: Error code {code} & Currently playing, {player}"
+                        "Reason: Error code %d & Currently playing, %r",
+                        code,
+                        player,
                     )
                 elif has_perm and player.paused and player.current:
                     player.store("resumes", player.fetch("resumes", 0) + 1)
@@ -372,21 +389,27 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     )
                     ws_audio_log.info(
                         "Voice websocket reconnected "
-                        f"Reason: Error code {code} & Currently Paused, {player}"
+                        "Reason: Error code %d & Currently Paused, %r",
+                        code,
+                        player,
                     )
                 elif has_perm and (not disconnect) and (not player.is_playing):
                     player.store("resumes", player.fetch("resumes", 0) + 1)
                     await player.connect(deafen=deafen)
                     ws_audio_log.info(
                         "Voice websocket reconnected "
-                        f"Reason: Error code {code} & Not playing, but auto disconnect disabled, {player}"
+                        "Reason: Error code %d & Not playing, but auto disconnect disabled, %r",
+                        code,
+                        player,
                     )
                     self._ll_guild_updates.discard(guild_id)
                 elif not has_perm:
                     self.bot.dispatch("red_audio_audio_disconnect", guild)
                     ws_audio_log.info(
                         "Voice websocket disconnected "
-                        f"Reason: Error code {code} & Missing permissions, {player}"
+                        "Reason: Error code %d & Missing permissions, %r",
+                        code,
+                        player,
                     )
                     self._ll_guild_updates.discard(guild_id)
                     player.store("autoplay_notified", False)
@@ -398,8 +421,9 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                 else:
                     self.bot.dispatch("red_audio_audio_disconnect", guild)
                     ws_audio_log.info(
-                        "Voice websocket disconnected "
-                        f"Reason: Error code {code} & Unknown, {player}"
+                        "Voice websocket disconnected " "Reason: Error code %d & Unknown, %r",
+                        code,
+                        player,
                     )
                     self._ll_guild_updates.discard(guild_id)
                     player.store("autoplay_notified", False)
@@ -413,7 +437,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                 await player.connect(deafen=deafen)
                 await player.resume(player.current, start=player.position, replace=True)
                 ws_audio_log.info(
-                    f"Player resumed - Reason: Error code {code} & {reason}, {player}"
+                    "Player resumed - Reason: Error code %d & %s, %r", code, reason, player
                 )
             elif code in (4015, 4009, 4006, 4000, 1006):
                 if player._con_delay:
@@ -422,7 +446,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     player._con_delay = ExponentialBackoff(base=1)
                     delay = player._con_delay.delay()
                 ws_audio_log.debug(
-                    f"Reconnecting to channel {channel_id} in guild: {guild_id} | {delay:.2f}s"
+                    "Reconnecting to channel %d in guild: %d | %d.2fs", channel_id, guild_id, delay
                 )
                 await asyncio.sleep(delay)
                 if has_perm and player.current and player.is_playing:
@@ -430,7 +454,9 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     await player.resume(player.current, start=player.position, replace=True)
                     ws_audio_log.info(
                         "Voice websocket reconnected "
-                        f"Reason: Error code {code} & Player is active, {player}"
+                        "Reason: Error code %d & Player is active, %r",
+                        code,
+                        player,
                     )
                 elif has_perm and player.paused and player.current:
                     player.store("resumes", player.fetch("resumes", 0) + 1)
@@ -440,22 +466,29 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     )
                     ws_audio_log.info(
                         "Voice websocket reconnected "
-                        f"Reason: Error code {code} & Player is paused, {player}"
+                        "Reason: Error code %d & Player is paused, %r",
+                        code,
+                        player,
                     )
                 elif has_perm and (not disconnect) and (not player.is_playing):
                     player.store("resumes", player.fetch("resumes", 0) + 1)
                     await player.connect(deafen=deafen)
                     ws_audio_log.info(
                         "Voice websocket reconnected "
-                        f"to channel {channel_id} in guild: {guild_id} | "
-                        f"Reason: Error code {code} & Not playing."
+                        "to channel %d in guild: %d | "
+                        "Reason: Error code %d & Not playing.",
+                        channel_id,
+                        guild_id,
+                        code,
                     )
                     self._ll_guild_updates.discard(guild_id)
                 elif not has_perm:
                     self.bot.dispatch("red_audio_audio_disconnect", guild)
                     ws_audio_log.info(
                         "Voice websocket disconnected "
-                        f"Reason: Error code {code} & Missing permissions, {player}"
+                        "Reason: Error code %d & Missing permissions, %r",
+                        code,
+                        player,
                     )
                     self._ll_guild_updates.discard(guild_id)
                     player.store("autoplay_notified", False)
@@ -471,7 +504,11 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                 ws_audio_log.info(
                     "WS EVENT - IGNORED (Healthy Socket) | "
                     "Voice websocket closed event "
-                    f"Code: {code} -- Remote: {by_remote} -- {reason}, {player}"
+                    "Code: %d -- Remote: %s -- %s, %r",
+                    code,
+                    by_remote,
+                    reason,
+                    player,
                 )
         except Exception:
             log.exception("Error in task")

--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -470,7 +470,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     await player.resume(player.current, start=player.position, replace=False)
                 ws_audio_log.info(
                     "WS EVENT - IGNORED (Healthy Socket) | "
-                    f"Voice websocket closed event "
+                    "Voice websocket closed event "
                     f"Code: {code} -- Remote: {by_remote} -- {reason}, {player}"
                 )
         except Exception:

--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -75,9 +75,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     guild=guild, player=player, extra=extra, deafen=deafen, disconnect=disconnect
                 )
             except Exception:
-                log.exception(
-                    f"Error in WEBSOCKET_CLOSED handling for guild: {player.channel.guild.id}"
-                )
+                log.exception("Error in WEBSOCKET_CLOSED handling for guild: %s", player.guild.id)
             return
 
         await set_contextual_locales_from_guild(self.bot, guild)

--- a/redbot/cogs/audio/core/tasks/player.py
+++ b/redbot/cogs/audio/core/tasks/player.py
@@ -40,7 +40,7 @@ class PlayerTasks(MixinMeta, metaclass=CompositeMetaClass):
                             debug_exc_log(
                                 log,
                                 err,
-                                f"Exception raised in Audio's unpausing player for {server.id}.",
+                                f"Exception raised in Audio's unpausing {p}.",
                             )
                     pause_times.pop(server.id, None)
             servers = stop_times.copy()

--- a/redbot/cogs/audio/core/tasks/player.py
+++ b/redbot/cogs/audio/core/tasks/player.py
@@ -37,11 +37,7 @@ class PlayerTasks(MixinMeta, metaclass=CompositeMetaClass):
                         try:
                             await p.pause(False)
                         except Exception as err:
-                            debug_exc_log(
-                                log,
-                                err,
-                                f"Exception raised in Audio's unpausing {p}.",
-                            )
+                            debug_exc_log(log, err, "Exception raised in Audio's unpausing %r.", p)
                     pause_times.pop(server.id, None)
             servers = stop_times.copy()
             servers.update(pause_times)
@@ -61,7 +57,7 @@ class PlayerTasks(MixinMeta, metaclass=CompositeMetaClass):
                         ).currently_auto_playing_in.set([])
                     except Exception as err:
                         debug_exc_log(
-                            log, err, f"Exception raised in Audio's emptydc_timer for {sid}."
+                            log, err, "Exception raised in Audio's emptydc_timer for %s.", sid
                         )
 
                 elif sid in stop_times and await self.config.guild(server_obj).emptydc_enabled():
@@ -81,7 +77,7 @@ class PlayerTasks(MixinMeta, metaclass=CompositeMetaClass):
                             if "No such player for that guild" in str(err):
                                 stop_times.pop(sid, None)
                             debug_exc_log(
-                                log, err, f"Exception raised in Audio's emptydc_timer for {sid}."
+                                log, err, "Exception raised in Audio's emptydc_timer for %s.", sid
                             )
                 elif (
                     sid in pause_times and await self.config.guild(server_obj).emptypause_enabled()
@@ -94,6 +90,6 @@ class PlayerTasks(MixinMeta, metaclass=CompositeMetaClass):
                             if "No such player for that guild" in str(err):
                                 pause_times.pop(sid, None)
                             debug_exc_log(
-                                log, err, f"Exception raised in Audio's pausing for {sid}."
+                                log, err, "Exception raised in Audio's pausing for %s.", sid
                             )
             await asyncio.sleep(5)

--- a/redbot/cogs/audio/core/tasks/player.py
+++ b/redbot/cogs/audio/core/tasks/player.py
@@ -24,7 +24,7 @@ class PlayerTasks(MixinMeta, metaclass=CompositeMetaClass):
         pause_times: Dict = {}
         while True:
             async for p in AsyncIter(lavalink.all_players()):
-                server = p.channel.guild
+                server = p.guild
                 if await self.bot.cog_disabled_in_guild(self, server):
                     continue
 

--- a/redbot/cogs/audio/core/tasks/startup.py
+++ b/redbot/cogs/audio/core/tasks/startup.py
@@ -138,7 +138,7 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
                         except Exception as exc:
                             tries += 1
                             debug_exc_log(
-                                log, exc, f"Failed to restore music voice channel {vc_id}"
+                                log, exc, "Failed to restore music voice channel %s", vc_id
                             )
                             if vc is None:
                                 break
@@ -160,9 +160,9 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
                 player.maybe_shuffle()
                 if not player.is_playing:
                     await player.play()
-                log.info(f"Restored {player}")
+                log.info("Restored %r", player)
             except Exception as err:
-                debug_exc_log(log, err, f"Error restoring player in {guild_id}")
+                debug_exc_log(log, err, "Error restoring player in %d", guild_id)
                 await self.api_interface.persistent_queue_api.drop(guild_id)
 
         for guild_id, (notify_channel_id, vc_id) in metadata.items():
@@ -206,7 +206,9 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
                         tries += 1
                     except Exception as exc:
                         tries += 1
-                        debug_exc_log(log, exc, f"Failed to restore music voice channel ({vc_id})")
+                        debug_exc_log(
+                            log, exc, "Failed to restore music voice channel (%s)", vc_id
+                        )
                         if vc is None:
                             break
                         else:
@@ -220,7 +222,7 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
                 if player.volume != volume:
                     await player.set_volume(volume)
                 player.maybe_shuffle()
-                log.info(f"Restored {player}")
+                log.info("Restored %s", player)
                 if not player.is_playing:
                     notify_channel = player.fetch("notify_channel")
                     try:

--- a/redbot/cogs/audio/core/tasks/startup.py
+++ b/redbot/cogs/audio/core/tasks/startup.py
@@ -129,11 +129,8 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
                             if not (perms.connect and perms.speak):
                                 vc = None
                                 break
-                            await lavalink.connect(vc, deafen=auto_deafen)
-                            player = lavalink.get_player(guild.id)
-                            player.store("connect", datetime.datetime.utcnow())
-                            player.store("guild", guild_id)
-                            player.store("channel", notify_channel_id)
+                            player = await lavalink.connect(vc, deafen=auto_deafen)
+                            player.store("notify_channel", notify_channel_id)
                             break
                         except IndexError:
                             await asyncio.sleep(5)
@@ -201,11 +198,8 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
                         if not (perms.connect and perms.speak):
                             vc = None
                             break
-                        await lavalink.connect(vc, deafen=auto_deafen)
-                        player = lavalink.get_player(guild.id)
-                        player.store("connect", datetime.datetime.utcnow())
-                        player.store("guild", guild_id)
-                        player.store("channel", notify_channel_id)
+                        player = await lavalink.connect(vc, deafen=auto_deafen)
+                        player.store("notify_channel", notify_channel_id)
                         break
                     except IndexError:
                         await asyncio.sleep(5)
@@ -228,7 +222,7 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
                 player.maybe_shuffle()
                 log.info(f"Restored {player}")
                 if not player.is_playing:
-                    notify_channel = player.fetch("channel")
+                    notify_channel = player.fetch("notify_channel")
                     try:
                         await self.api_interface.autoplay(player, self.playlist_api)
                     except DatabaseError:

--- a/redbot/cogs/audio/core/tasks/startup.py
+++ b/redbot/cogs/audio/core/tasks/startup.py
@@ -31,6 +31,7 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
         # There has to be a task since this requires the bot to be ready
         # If it waits for ready in startup, we cause a deadlock during initial load
         # as initial load happens before the bot can ever be ready.
+        lavalink.set_logging_level(self.bot._cli_flags.debug)
         self.cog_init_task = self.bot.loop.create_task(self.initialize())
         self.cog_init_task.add_done_callback(task_callback)
 

--- a/redbot/cogs/audio/core/tasks/startup.py
+++ b/redbot/cogs/audio/core/tasks/startup.py
@@ -140,7 +140,9 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
                             tries += 1
                         except Exception as exc:
                             tries += 1
-                            debug_exc_log(log, exc, "Failed to restore music voice channel")
+                            debug_exc_log(
+                                log, exc, f"Failed to restore music voice channel {vc_id}"
+                            )
                             if vc is None:
                                 break
                             else:
@@ -161,6 +163,7 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
                 player.maybe_shuffle()
                 if not player.is_playing:
                     await player.play()
+                log.info(f"Restored {player}")
             except Exception as err:
                 debug_exc_log(log, err, f"Error restoring player in {guild_id}")
                 await self.api_interface.persistent_queue_api.drop(guild_id)
@@ -209,7 +212,7 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
                         tries += 1
                     except Exception as exc:
                         tries += 1
-                        debug_exc_log(log, exc, "Failed to restore music voice channel")
+                        debug_exc_log(log, exc, f"Failed to restore music voice channel ({vc_id})")
                         if vc is None:
                             break
                         else:
@@ -223,6 +226,7 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
                 if player.volume != volume:
                     await player.set_volume(volume)
                 player.maybe_shuffle()
+                log.info(f"Restored {player}")
                 if not player.is_playing:
                     notify_channel = player.fetch("channel")
                     try:

--- a/redbot/cogs/audio/core/tasks/startup.py
+++ b/redbot/cogs/audio/core/tasks/startup.py
@@ -31,7 +31,7 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
         # There has to be a task since this requires the bot to be ready
         # If it waits for ready in startup, we cause a deadlock during initial load
         # as initial load happens before the bot can ever be ready.
-        lavalink.set_logging_level(self.bot._cli_flags.debug)
+        lavalink.set_logging_level(self.bot._cli_flags.logging_level)
         self.cog_init_task = self.bot.loop.create_task(self.initialize())
         self.cog_init_task.add_done_callback(task_callback)
 

--- a/redbot/cogs/audio/core/utilities/formatting.py
+++ b/redbot/cogs/audio/core/utilities/formatting.py
@@ -103,10 +103,6 @@ class FormattingUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     ctx.author.voice.channel,
                     deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
-                player = lavalink.get_player(ctx.guild.id)
-                player.store("connect", datetime.datetime.utcnow())
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
             except AttributeError:
                 return await self.send_embed_msg(ctx, title=_("Connect to a voice channel first."))
             except IndexError:
@@ -114,6 +110,7 @@ class FormattingUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     ctx, title=_("Connection to Lavalink has not yet been established.")
                 )
         player = lavalink.get_player(ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         guild_data = await self.config.guild(ctx.guild).all()
         if len(player.queue) >= 10000:
             return await self.send_embed_msg(

--- a/redbot/cogs/audio/core/utilities/formatting.py
+++ b/redbot/cogs/audio/core/utilities/formatting.py
@@ -182,7 +182,7 @@ class FormattingUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 player.add(ctx.author, search_choice)
                 player.maybe_shuffle()
                 self.bot.dispatch(
-                    "red_audio_track_enqueue", player.channel.guild, search_choice, ctx.author
+                    "red_audio_track_enqueue", player.guild, search_choice, ctx.author
                 )
             else:
                 return await self.send_embed_msg(ctx, title=_("Track exceeds maximum length."))
@@ -196,9 +196,7 @@ class FormattingUtilities(MixinMeta, metaclass=CompositeMetaClass):
             )
             player.add(ctx.author, search_choice)
             player.maybe_shuffle()
-            self.bot.dispatch(
-                "red_audio_track_enqueue", player.channel.guild, search_choice, ctx.author
-            )
+            self.bot.dispatch("red_audio_track_enqueue", player.guild, search_choice, ctx.author)
 
         if not guild_data["shuffle"] and queue_dur > 0:
             songembed.set_footer(

--- a/redbot/cogs/audio/core/utilities/formatting.py
+++ b/redbot/cogs/audio/core/utilities/formatting.py
@@ -164,7 +164,7 @@ class FormattingUtilities(MixinMeta, metaclass=CompositeMetaClass):
             query_obj=query,
         ):
             if IS_DEBUG:
-                log.debug(f"Query is not allowed in {ctx.guild} ({ctx.guild.id})")
+                log.debug("Query is not allowed in %s (%d)", ctx.guild, ctx.guild.id)
             self.update_player_lock(ctx, False)
             return await self.send_embed_msg(
                 ctx, title=_("This track is not allowed in this server.")

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -128,7 +128,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
 
     async def _skip_action(self, ctx: commands.Context, skip_to_track: int = None) -> None:
         player = lavalink.get_player(ctx.guild.id)
-        autoplay = await self.config.guild(player.channel.guild).auto_play()
+        autoplay = await self.config.guild(player.guild).auto_play()
         if not player.current or (not player.queue and not autoplay):
             try:
                 pos, dur = player.position, player.current.length
@@ -193,7 +193,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 ),
             )
             await self.send_embed_msg(ctx, embed=embed)
-        self.bot.dispatch("red_audio_skip_track", player.channel.guild, player.current, ctx.author)
+        self.bot.dispatch("red_audio_skip_track", player.guild, player.current, ctx.author)
         await player.play()
         player.queue += queue_to_append
 
@@ -218,7 +218,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             return
         if not await self.config.guild_from_id(guild_id).auto_deafen():
             return
-        await player.channel.guild.change_voice_state(channel=player.channel, self_deaf=True)
+        await player.guild.change_voice_state(channel=player.channel, self_deaf=True)
 
     async def _get_spotify_tracks(
         self, ctx: commands.Context, query: Query, forced: bool = False
@@ -466,7 +466,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                         )
                         player.add(ctx.author, track)
                         self.bot.dispatch(
-                            "red_audio_track_enqueue", player.channel.guild, track, ctx.author
+                            "red_audio_track_enqueue", player.guild, track, ctx.author
                         )
 
                 else:
@@ -479,9 +479,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                         }
                     )
                     player.add(ctx.author, track)
-                    self.bot.dispatch(
-                        "red_audio_track_enqueue", player.channel.guild, track, ctx.author
-                    )
+                    self.bot.dispatch("red_audio_track_enqueue", player.guild, track, ctx.author)
             player.maybe_shuffle(0 if empty_queue else 1)
 
             if len(tracks) > track_len:
@@ -562,7 +560,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                         player.maybe_shuffle()
                         self.bot.dispatch(
                             "red_audio_track_enqueue",
-                            player.channel.guild,
+                            player.guild,
                             single_track,
                             ctx.author,
                         )
@@ -583,7 +581,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     player.add(ctx.author, single_track)
                     player.maybe_shuffle()
                     self.bot.dispatch(
-                        "red_audio_track_enqueue", player.channel.guild, single_track, ctx.author
+                        "red_audio_track_enqueue", player.guild, single_track, ctx.author
                     )
             except IndexError:
                 self.update_player_lock(ctx, False)

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -120,7 +120,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
     async def is_requester(self, ctx: commands.Context, member: discord.Member) -> bool:
         try:
             player = lavalink.get_player(ctx.guild.id)
-            log.debug(f"Current requester is {player.current.requester}")
+            log.debug("Current requester is %s", player.current.requester)
             return player.current.requester.id == member.id
         except Exception as err:
             debug_exc_log(log, err, "Caught error in `is_requester`")
@@ -452,7 +452,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     query_obj=query,
                 ):
                     if IS_DEBUG:
-                        log.debug(f"Query is not allowed in {ctx.guild} ({ctx.guild.id})")
+                        log.debug("Query is not allowed in %s (%d)", ctx.guild, ctx.guild.id)
                     continue
                 elif guild_data["maxlength"] > 0:
                     if self.is_track_length_allowed(track, guild_data["maxlength"]):
@@ -544,7 +544,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     query_obj=query,
                 ):
                     if IS_DEBUG:
-                        log.debug(f"Query is not allowed in {ctx.guild} ({ctx.guild.id})")
+                        log.debug("Query is not allowed in %s (%d)", ctx.guild, ctx.guild.id)
                     self.update_player_lock(ctx, False)
                     return await self.send_embed_msg(
                         ctx, title=_("This track is not allowed in this server.")

--- a/redbot/cogs/audio/core/utilities/playlists.py
+++ b/redbot/cogs/audio/core/utilities/playlists.py
@@ -539,10 +539,6 @@ class PlaylistUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     ctx.author.voice.channel,
                     deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
-                player = lavalink.get_player(ctx.guild.id)
-                player.store("connect", datetime.datetime.utcnow())
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
             except IndexError:
                 await self.send_embed_msg(
                     ctx,
@@ -557,10 +553,8 @@ class PlaylistUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     description=_("Connect to a voice channel first."),
                 )
                 return False
-
         player = lavalink.get_player(ctx.guild.id)
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         if (
             not ctx.author.voice or ctx.author.voice.channel != player.channel
         ) and not await self._can_instaskip(ctx, ctx.author):

--- a/redbot/cogs/audio/core/utilities/playlists.py
+++ b/redbot/cogs/audio/core/utilities/playlists.py
@@ -428,14 +428,14 @@ class PlaylistUtilities(MixinMeta, metaclass=CompositeMetaClass):
 
                 track = result.tracks[0]
             except Exception as err:
-                debug_exc_log(log, err, f"Failed to get track for {song_url}")
+                debug_exc_log(log, err, "Failed to get track for %s", song_url)
                 continue
             try:
                 track_obj = self.get_track_json(player, other_track=track)
                 track_list.append(track_obj)
                 successful_count += 1
             except Exception as err:
-                debug_exc_log(log, err, f"Failed to create track for {track}")
+                debug_exc_log(log, err, "Failed to create track for %s", track)
                 continue
             if (track_count % 2 == 0) or (track_count == len(uploaded_track_list)):
                 await notifier.notify_user(

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ install_requires =
     python-Levenshtein-wheels==0.13.2
     pytz==2021.1
     PyYAML==5.4.1
-    Red-Lavalink==0.8.0
+    Red-Lavalink==0.8.1
     rich==9.9.0
     schema==0.7.4
     six==1.15.0


### PR DESCRIPTION
Control RLL logs verbosity with `--debug` flag
Bump RLL dep to 0.8.1
Make certain audio logs more verbose to improve debuggability 
LOOOADS of cleanup
just internal stuff, 
ensure the error fixed in #5042 can never happen
Improve logging audio.
