### PR TITLE
[Audio] Disallow all users from modifying Playlist 42069.

### DIFF
--- a/redbot/cogs/audio/core/abc.py
+++ b/redbot/cogs/audio/core/abc.py
@@ -322,7 +322,13 @@ class MixinMeta(ABC):
 
     @abstractmethod
     async def can_manage_playlist(
-        self, scope: str, playlist: "Playlist", ctx: commands.Context, user, guild
+        self,
+        scope: str,
+        playlist: "Playlist",
+        ctx: commands.Context,
+        user,
+        guild,
+        bypass: bool = False,
     ) -> bool:
         raise NotImplementedError()
 

--- a/redbot/cogs/audio/core/commands/playlists.py
+++ b/redbot/cogs/audio/core/commands/playlists.py
@@ -125,7 +125,9 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                         arg=playlist_arg
                     ),
                 )
-            if not await self.can_manage_playlist(scope, playlist, ctx, author, guild):
+            if not await self.can_manage_playlist(
+                scope, playlist, ctx, author, guild, bypass=False
+            ):
                 return
             player = lavalink.get_player(ctx.guild.id)
             to_append = await self.fetch_playlist_tracks(
@@ -312,7 +314,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
 
             temp_playlist = cast(Playlist, FakePlaylist(to_author.id, to_scope))
             if not await self.can_manage_playlist(
-                to_scope, temp_playlist, ctx, to_author, to_guild
+                to_scope, temp_playlist, ctx, to_author, to_guild, bypass=False
             ):
                 ctx.command.reset_cooldown(ctx)
                 return
@@ -407,7 +409,9 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
             scope, ctx=guild if scope == PlaylistScope.GUILD.value else author
         )
         async with ctx.typing():
-            if not await self.can_manage_playlist(scope, temp_playlist, ctx, author, guild):
+            if not await self.can_manage_playlist(
+                scope, temp_playlist, ctx, author, guild, bypass=False
+            ):
                 return
             playlist_name = playlist_name.split(" ")[0].strip('"')[:32]
             if playlist_name.isnumeric():
@@ -495,7 +499,9 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                         arg=playlist_arg
                     ),
                 )
-            if not await self.can_manage_playlist(scope, playlist, ctx, author, guild):
+            if not await self.can_manage_playlist(
+                scope, playlist, ctx, author, guild, bypass=False
+            ):
                 return
             scope_name = self.humanize_scope(
                 scope, ctx=guild if scope == PlaylistScope.GUILD.value else author
@@ -591,7 +597,9 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                         arg=playlist_arg
                     ),
                 )
-            if not await self.can_manage_playlist(scope, playlist, ctx, author, guild):
+            if not await self.can_manage_playlist(
+                scope, playlist, ctx, author, guild, bypass=False
+            ):
                 ctx.command.reset_cooldown(ctx)
                 return
 
@@ -1123,7 +1131,9 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                 scope, ctx=guild if scope == PlaylistScope.GUILD.value else author
             )
             temp_playlist = cast(Playlist, FakePlaylist(author.id, scope))
-            if not await self.can_manage_playlist(scope, temp_playlist, ctx, author, guild):
+            if not await self.can_manage_playlist(
+                scope, temp_playlist, ctx, author, guild, bypass=False
+            ):
                 ctx.command.reset_cooldown(ctx)
                 return
             playlist_name = playlist_name.split(" ")[0].strip('"')[:32]
@@ -1245,7 +1255,9 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                         arg=playlist_arg
                     ),
                 )
-            if not await self.can_manage_playlist(scope, playlist, ctx, author, guild):
+            if not await self.can_manage_playlist(
+                scope, playlist, ctx, author, guild, bypass=False
+            ):
                 return
 
             track_list = playlist.tracks
@@ -1351,7 +1363,9 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
         )
         async with ctx.typing():
             temp_playlist = cast(Playlist, FakePlaylist(author.id, scope))
-            if not await self.can_manage_playlist(scope, temp_playlist, ctx, author, guild):
+            if not await self.can_manage_playlist(
+                scope, temp_playlist, ctx, author, guild, bypass=False
+            ):
                 return ctx.command.reset_cooldown(ctx)
             playlist_name = playlist_name.split(" ")[0].strip('"')[:32]
             if playlist_name.isnumeric():
@@ -1676,7 +1690,9 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                 ctx.command.reset_cooldown(ctx)
                 return
             try:
-                if not await self.can_manage_playlist(scope, playlist, ctx, author, guild):
+                if not await self.can_manage_playlist(
+                    scope, playlist, ctx, author, guild, bypass=True
+                ):
                     return
                 if playlist.url or playlist.id == 42069:
                     player = lavalink.get_player(ctx.guild.id)
@@ -1824,7 +1840,9 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
         scope = scope or PlaylistScope.GUILD.value
         temp_playlist = cast(Playlist, FakePlaylist(author.id, scope))
         async with ctx.typing():
-            if not await self.can_manage_playlist(scope, temp_playlist, ctx, author, guild):
+            if not await self.can_manage_playlist(
+                scope, temp_playlist, ctx, author, guild, bypass=False
+            ):
                 return
             if not await self._playlist_check(ctx):
                 return
@@ -2015,7 +2033,9 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                         arg=playlist_arg
                     ),
                 )
-            if not await self.can_manage_playlist(scope, playlist, ctx, author, guild):
+            if not await self.can_manage_playlist(
+                scope, playlist, ctx, author, guild, bypass=False
+            ):
                 ctx.command.reset_cooldown(ctx)
                 return
             scope_name = self.humanize_scope(

--- a/redbot/cogs/audio/core/commands/playlists.py
+++ b/redbot/cogs/audio/core/commands/playlists.py
@@ -1694,7 +1694,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                     scope, playlist, ctx, author, guild, bypass=True
                 ):
                     return
-                if playlist.url or playlist.id == 42069:
+                if playlist.url or getattr(playlist, "id", 0) == 42069:
                     player = lavalink.get_player(ctx.guild.id)
                     added, removed, playlist = await self._maybe_update_playlist(
                         ctx, player, playlist

--- a/redbot/cogs/audio/core/commands/playlists.py
+++ b/redbot/cogs/audio/core/commands/playlists.py
@@ -125,9 +125,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                         arg=playlist_arg
                     ),
                 )
-            if not await self.can_manage_playlist(
-                scope, playlist, ctx, author, guild, bypass=False
-            ):
+            if not await self.can_manage_playlist(scope, playlist, ctx, author, guild):
                 return
             player = lavalink.get_player(ctx.guild.id)
             to_append = await self.fetch_playlist_tracks(
@@ -314,7 +312,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
 
             temp_playlist = cast(Playlist, FakePlaylist(to_author.id, to_scope))
             if not await self.can_manage_playlist(
-                to_scope, temp_playlist, ctx, to_author, to_guild, bypass=False
+                to_scope, temp_playlist, ctx, to_author, to_guild
             ):
                 ctx.command.reset_cooldown(ctx)
                 return
@@ -409,9 +407,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
             scope, ctx=guild if scope == PlaylistScope.GUILD.value else author
         )
         async with ctx.typing():
-            if not await self.can_manage_playlist(
-                scope, temp_playlist, ctx, author, guild, bypass=False
-            ):
+            if not await self.can_manage_playlist(scope, temp_playlist, ctx, author, guild):
                 return
             playlist_name = playlist_name.split(" ")[0].strip('"')[:32]
             if playlist_name.isnumeric():
@@ -499,9 +495,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                         arg=playlist_arg
                     ),
                 )
-            if not await self.can_manage_playlist(
-                scope, playlist, ctx, author, guild, bypass=False
-            ):
+            if not await self.can_manage_playlist(scope, playlist, ctx, author, guild):
                 return
             scope_name = self.humanize_scope(
                 scope, ctx=guild if scope == PlaylistScope.GUILD.value else author
@@ -597,9 +591,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                         arg=playlist_arg
                     ),
                 )
-            if not await self.can_manage_playlist(
-                scope, playlist, ctx, author, guild, bypass=False
-            ):
+            if not await self.can_manage_playlist(scope, playlist, ctx, author, guild):
                 ctx.command.reset_cooldown(ctx)
                 return
 
@@ -1131,9 +1123,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                 scope, ctx=guild if scope == PlaylistScope.GUILD.value else author
             )
             temp_playlist = cast(Playlist, FakePlaylist(author.id, scope))
-            if not await self.can_manage_playlist(
-                scope, temp_playlist, ctx, author, guild, bypass=False
-            ):
+            if not await self.can_manage_playlist(scope, temp_playlist, ctx, author, guild):
                 ctx.command.reset_cooldown(ctx)
                 return
             playlist_name = playlist_name.split(" ")[0].strip('"')[:32]
@@ -1255,9 +1245,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                         arg=playlist_arg
                     ),
                 )
-            if not await self.can_manage_playlist(
-                scope, playlist, ctx, author, guild, bypass=False
-            ):
+            if not await self.can_manage_playlist(scope, playlist, ctx, author, guild):
                 return
 
             track_list = playlist.tracks
@@ -1363,9 +1351,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
         )
         async with ctx.typing():
             temp_playlist = cast(Playlist, FakePlaylist(author.id, scope))
-            if not await self.can_manage_playlist(
-                scope, temp_playlist, ctx, author, guild, bypass=False
-            ):
+            if not await self.can_manage_playlist(scope, temp_playlist, ctx, author, guild):
                 return ctx.command.reset_cooldown(ctx)
             playlist_name = playlist_name.split(" ")[0].strip('"')[:32]
             if playlist_name.isnumeric():
@@ -1840,9 +1826,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
         scope = scope or PlaylistScope.GUILD.value
         temp_playlist = cast(Playlist, FakePlaylist(author.id, scope))
         async with ctx.typing():
-            if not await self.can_manage_playlist(
-                scope, temp_playlist, ctx, author, guild, bypass=False
-            ):
+            if not await self.can_manage_playlist(scope, temp_playlist, ctx, author, guild):
                 return
             if not await self._playlist_check(ctx):
                 return
@@ -2033,9 +2017,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                         arg=playlist_arg
                     ),
                 )
-            if not await self.can_manage_playlist(
-                scope, playlist, ctx, author, guild, bypass=False
-            ):
+            if not await self.can_manage_playlist(scope, playlist, ctx, author, guild):
                 ctx.command.reset_cooldown(ctx)
                 return
             scope_name = self.humanize_scope(

--- a/redbot/cogs/audio/core/utilities/playlists.py
+++ b/redbot/cogs/audio/core/utilities/playlists.py
@@ -54,7 +54,8 @@ class PlaylistUtilities(MixinMeta, metaclass=CompositeMetaClass):
 
         is_different_user = len({playlist.author, user_to_query.id, ctx.author.id}) != 1
         is_different_guild = True if guild_to_query is None else ctx.guild.id != guild_to_query.id
-
+        if playlist.id == 42069:
+            has_perms = False
         if is_owner:
             has_perms = True
         elif playlist.scope == PlaylistScope.USER.value:

--- a/redbot/cogs/audio/core/utilities/playlists.py
+++ b/redbot/cogs/audio/core/utilities/playlists.py
@@ -39,7 +39,13 @@ CURRATED_DATA = (
 
 class PlaylistUtilities(MixinMeta, metaclass=CompositeMetaClass):
     async def can_manage_playlist(
-        self, scope: str, playlist: Playlist, ctx: commands.Context, user, guild
+        self,
+        scope: str,
+        playlist: Playlist,
+        ctx: commands.Context,
+        user,
+        guild,
+        bypass: bool = False,
     ) -> bool:
         is_owner = await self.bot.is_owner(ctx.author)
         has_perms = False
@@ -55,8 +61,8 @@ class PlaylistUtilities(MixinMeta, metaclass=CompositeMetaClass):
         is_different_user = len({playlist.author, user_to_query.id, ctx.author.id}) != 1
         is_different_guild = True if guild_to_query is None else ctx.guild.id != guild_to_query.id
         if playlist.id == 42069:
-            has_perms = False
-        if is_owner:
+            has_perms = bypass
+        elif is_owner:
             has_perms = True
         elif playlist.scope == PlaylistScope.USER.value:
             if not is_different_user:

--- a/redbot/cogs/audio/core/utilities/playlists.py
+++ b/redbot/cogs/audio/core/utilities/playlists.py
@@ -60,7 +60,7 @@ class PlaylistUtilities(MixinMeta, metaclass=CompositeMetaClass):
 
         is_different_user = len({playlist.author, user_to_query.id, ctx.author.id}) != 1
         is_different_guild = True if guild_to_query is None else ctx.guild.id != guild_to_query.id
-        if playlist.id == 42069:
+        if getattr(playlist, "id", 0) == 42069:
             has_perms = bypass
         elif is_owner:
             has_perms = True
@@ -483,7 +483,7 @@ class PlaylistUtilities(MixinMeta, metaclass=CompositeMetaClass):
     async def _maybe_update_playlist(
         self, ctx: commands.Context, player: lavalink.player_manager.Player, playlist: Playlist
     ) -> Tuple[List[lavalink.Track], List[lavalink.Track], Playlist]:
-        if playlist.id == 42069:
+        if getattr(playlist, "id", 0) == 42069:
             _, updated_tracks = await self._get_bundled_playlist_tracks()
             results = {}
             old_tracks = playlist.tracks_obj


### PR DESCRIPTION
As the title states, users should not manually edit this playlist, specially delete it, even though it comes back on next cog reload/bot restart it may leave the bot in a unsupported state as the presence of this playlist is mandatory, if autoplay is expected to work.