### PR TITLE
[Downloader] Fix `[p]cog uninstall` examples

### DIFF
--- a/docs/cog_guides/downloader.rst
+++ b/docs/cog_guides/downloader.rst
@@ -235,8 +235,8 @@ You may only uninstall cogs which were previously installed
 by Downloader.
 
 Examples:
-    - ``[p]cog uninstall 26-Cogs defender``
-    - ``[p]cog uninstall Laggrons-Dumb-Cogs say roleinvite``
+    - ``[p]cog uninstall defender``
+    - ``[p]cog uninstall say roleinvite``
 
 **Arguments**
 

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -904,8 +904,8 @@ class Downloader(commands.Cog):
         by Downloader.
 
         Examples:
-            - `[p]cog uninstall 26-Cogs defender`
-            - `[p]cog uninstall Laggrons-Dumb-Cogs say roleinvite`
+            - `[p]cog uninstall defender`
+            - `[p]cog uninstall say roleinvite`
 
         **Arguments**
 


### PR DESCRIPTION
Previously, the examples in the help command for `[p]cog uninstall` showed that the repository name was to be inputted, inconsistent with the actual parameters for the command. They have been fixed so users will not be confused when following the examples.