### PR TITLE
[Docs] updates to the Linux and Mac auto-restart docs

### DIFF
--- a/docs/autostart_mac.rst
+++ b/docs/autostart_mac.rst
@@ -75,7 +75,7 @@ Save and exit :code:`ctrl + O; enter; ctrl + x`
 Starting and loading the plist
 -------------------------------
 
-To start the bot and enable auto-restart, run the following:
+To start the bot and set it to start on boot, you must run the following command:
 
 .. prompt:: bash
 
@@ -94,7 +94,7 @@ To start the bot again after a shutdown, run the following:
 
     sudo launchctl start red
 
-To disable auto-restart and stop the bot, run the following:
+To stop the bot and set it to not start on boot anymore, run the following:
 
 .. prompt:: bash
 

--- a/docs/autostart_mac.rst
+++ b/docs/autostart_mac.rst
@@ -66,21 +66,44 @@ Paste the following and replace the following:
 
 .. note::
 
-    Should you need to view the output from Red (for example: to find error messages that 
-    are output to the console to help with support), you can run :code:`nano /tmp/red_out.log` 
-    and :code:`nano /tmp/red_err.log` to do so
+    Should you need to set up auto-restart for additional bots, create a :code:`.plist` file for
+    each bot under a different file name, and use the respective file names for the commands below.
 
 Save and exit :code:`ctrl + O; enter; ctrl + x`
 
------------------
-Loading the plist
------------------
+-------------------------------
+Starting and loading the plist
+-------------------------------
 
-Run the following:
+To start the bot and enable auto-restart, run the following:
 
-:code:`sudo launchctl load /Library/LaunchDaemons/red.plist`
+.. prompt:: bash
+
+    sudo launchctl load -w /Library/LaunchDaemons/red.plist
 
 If you need to shutdown the bot, you can use the ``[p]shutdown`` command or
 type the following command in the terminal:
 
-:code:`sudo launchctl stop red`
+.. prompt:: bash
+
+    sudo launchctl stop red
+
+To start the bot again after a shutdown, run the following:
+
+.. prompt:: bash
+
+    sudo launchctl start red
+
+To disable auto-restart and stop the bot, run the following:
+
+.. prompt:: bash
+
+    sudo launchctl unload -w /Library/LaunchDaemons/red.plist
+
+To view Red's log, run the following (:code:`red_out.log` is for the console output, and
+:code:`red_err.log` for the error logs):
+
+.. prompt:: bash
+
+    nano /tmp/red_out.log
+    nano /tmp/red_err.log

--- a/docs/autostart_systemd.rst
+++ b/docs/autostart_systemd.rst
@@ -89,7 +89,7 @@ type the following command in the terminal, still by adding the instance name af
 .. warning:: If the service doesn't stop in the next 10 seconds, the process is killed.
     Check your logs to know the cause of the error that prevents the shutdown.
 
-To disable the service, run the following, adding the instance name after the **@**:
+To set the bot to not start on boot anymore, you must disable the service by running the following command, adding the instance name after the **@**:
 
 .. prompt:: bash
 

--- a/docs/autostart_systemd.rst
+++ b/docs/autostart_systemd.rst
@@ -95,7 +95,7 @@ To disable the service, run the following, adding the instance name after the **
 
     sudo systemctl disable red@instancename
 
-To view Red’s log, you can acccess through journalctl:
+To view Red’s log, you can access through journalctl:
 
 .. prompt:: bash
 

--- a/docs/autostart_systemd.rst
+++ b/docs/autostart_systemd.rst
@@ -89,6 +89,12 @@ type the following command in the terminal, still by adding the instance name af
 .. warning:: If the service doesn't stop in the next 10 seconds, the process is killed.
     Check your logs to know the cause of the error that prevents the shutdown.
 
+To disable the service, run the following, adding the instance name after the **@**:
+
+.. prompt:: bash
+
+    sudo systemctl disable red@instancename
+
 To view Red’s log, you can acccess through journalctl:
 
 .. prompt:: bash

--- a/docs/autostart_systemd.rst
+++ b/docs/autostart_systemd.rst
@@ -95,7 +95,7 @@ To set the bot to not start on boot anymore, you must disable the service by run
 
     sudo systemctl disable red@instancename
 
-To view Red’s log, you can access through journalctl:
+You can access Red's log through journalctl:
 
 .. prompt:: bash
 


### PR DESCRIPTION
Updates include:
- add `sudo systemctl disable` command to Linux auto-restart docs
- specify the purposes of each of the two `.log` files for Mac auto-restart
- add a note on what users should do for multiple bots in Mac auto-restart docs
- more commands (that more or less correspond to Linux's) for the loading/starting the `.plist` in Mac auto-restart docs

The Linux update has been tested on a Ubuntu 20.04 VPS, and Mac updates on MacOS Big Sur (non-M1). Anyone with a different MacOS version and/or M1 architecture is welcome to test these command as well, but I don't expect there to be issues.