### PR TITLE
Prefer home directory even for system users if it exists

### DIFF
--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -36,13 +36,21 @@ basic_config_default: Dict[str, Any] = {
     "CORE_PATH_APPEND": "core",
 }
 
-config_dir = None
 appdir = appdirs.AppDirs("Red-DiscordBot")
-if sys.platform == "linux":
-    if 0 < os.getuid() < 1000:  # pylint: disable=no-member
+config_dir = Path(appdir.user_config_dir)
+_system_user = sys.platform == "linux" and 0 < os.getuid() < 1000
+if _system_user:
+    if Path.home().exists():
+        # We don't want to break someone just because they created home dir
+        # but were already using the site_data_dir.
+        #
+        # But otherwise, we do want Red to use user_config_dir if home dir exists.
+        _maybe_config_file = Path(appdir.site_data_dir) / "config.json"
+        if _maybe_config_file.exists():
+            config_dir = _maybe_config_file.parent
+    else:
         config_dir = Path(appdir.site_data_dir)
-if not config_dir:
-    config_dir = Path(appdir.user_config_dir)
+
 config_file = config_dir / "config.json"
 
 

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -6,14 +6,12 @@ _early_init()
 import asyncio
 import json
 import logging
-import os
 import sys
 import re
 from copy import deepcopy
 from pathlib import Path
 from typing import Dict, Any, Optional, Union
 
-import appdirs
 import click
 
 from redbot.core.cli import confirm
@@ -23,23 +21,16 @@ from redbot.core.utils._internal_utils import (
     cli_level_to_log_level,
 )
 from redbot.core import config, data_manager, drivers
+from redbot.core.data_manager import appdir, config_dir, config_file
 from redbot.core.drivers import BackendType, IdentifierData
 
 conversion_log = logging.getLogger("red.converter")
 
-config_dir = None
-appdir = appdirs.AppDirs("Red-DiscordBot")
-if sys.platform == "linux":
-    if 0 < os.getuid() < 1000:  # pylint: disable=no-member  # Non-exist on win
-        config_dir = Path(appdir.site_data_dir)
-if not config_dir:
-    config_dir = Path(appdir.user_config_dir)
 try:
     config_dir.mkdir(parents=True, exist_ok=True)
 except PermissionError:
     print("You don't have permission to write to '{}'\nExiting...".format(config_dir))
     sys.exit(1)
-config_file = config_dir / "config.json"
 
 instance_data = data_manager.load_existing_config()
 if instance_data is None:


### PR DESCRIPTION
Useful especially when you create system users with a home directory (`useradd -rm`) so that you don't have to use the shared directory for configuration. Might also benefit people on systems like CentOS that I believe start assigning the non-system UIDs from 500 rather than 1000.

This is written in a way that prefers the home directory (if it exists) *unless* the shared directory was already used before by Red (which can be easily detected by checking whether `config.json` file exists.