### PR TITLE
[Downloader] Check author attribute as a fallback for `[p]findcog` author(s)

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1724,14 +1724,12 @@ class Downloader(commands.Cog):
                 made_by = _("Unknown")
                 repo_url = _("None - this cog wasn't installed via downloader")
                 cog_name = cog.__class__.__name__
-
             author_attr = getattr(cog.__class__, "__author__", None)
             if author_attr:
                 if isinstance(author_attr, (list, tuple)):
                     made_by = humanize_list(author_attr)
                 elif isinstance(author_attr, str):
                     made_by = author_attr
-                    
         else:
             msg = _("This command is not provided by a cog.")
             await ctx.send(msg)

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1724,12 +1724,14 @@ class Downloader(commands.Cog):
                 made_by = _("Unknown")
                 repo_url = _("None - this cog wasn't installed via downloader")
                 cog_name = cog.__class__.__name__
+
             author_attr = getattr(cog.__class__, "__author__", None)
             if author_attr:
                 if isinstance(author_attr, (list, tuple)):
                     made_by = humanize_list(author_attr)
-                else:
+                elif isinstance(author_attr, str):
                     made_by = author_attr
+                    
         else:
             msg = _("This command is not provided by a cog.")
             await ctx.send(msg)

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1722,14 +1722,14 @@ class Downloader(commands.Cog):
                 cog_name = cog.__class__.__name__
             else:  # assume not installed via downloader
                 made_by = _("Unknown")
+                author_attr = getattr(cog.__class__, "__author__", None)
+                if author_attr:
+                    if isinstance(author_attr, (list, tuple)):
+                        made_by = humanize_list(author_attr)
+                    elif isinstance(author_attr, str):
+                        made_by = author_attr
                 repo_url = _("None - this cog wasn't installed via downloader")
                 cog_name = cog.__class__.__name__
-            author_attr = getattr(cog.__class__, "__author__", None)
-            if author_attr:
-                if isinstance(author_attr, (list, tuple)):
-                    made_by = humanize_list(author_attr)
-                elif isinstance(author_attr, str):
-                    made_by = author_attr
         else:
             msg = _("This command is not provided by a cog.")
             await ctx.send(msg)

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1727,7 +1727,7 @@ class Downloader(commands.Cog):
             author_attr = getattr(cog.__class__, "__author__", None)
             if author_attr:
                 if isinstance(author_attr, (list, tuple)):
-                    made_by = humanize_list(author_attr, style="and")
+                    made_by = humanize_list(author_attr)
                 else:
                     made_by = author_attr
         else:

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1,4 +1,4 @@
-import asyncio
+import asyncio #
 import contextlib
 import os
 import re

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1,4 +1,4 @@
-import asyncio #
+import asyncio
 import contextlib
 import os
 import re
@@ -1724,6 +1724,12 @@ class Downloader(commands.Cog):
                 made_by = _("Unknown")
                 repo_url = _("None - this cog wasn't installed via downloader")
                 cog_name = cog.__class__.__name__
+            author_attr = getattr(cog.__class__, "__author__", None)
+            if author_attr:
+                if isinstance(author_attr, (list, tuple)):
+                    made_by = humanize_list(author_attr, style="and")
+                else:
+                    made_by = author_attr
         else:
             msg = _("This command is not provided by a cog.")
             await ctx.send(msg)


### PR DESCRIPTION
Check if the cog class has an `__author__` attribute as a fallback to when a cog is not installed via downloader.
```py
author_attr = getattr(cog.__class__, "__author__", None)
if author_attr:
    if isinstance(author_attr, (list, tuple)):
        made_by = humanize_list(author_attr)
    elif isinstance(author_attr, str):
        made_by = author_attr
```
IMO it's worth having in there, especially for private cog owners who would still like to display their name in the `[p]findcog` command.

This **has** been tested, can confirm that it works™️. If the attribute is not a list, tuple or str, or if the attribute does not exist, it is ignored and falls back to "Unknown".

From the following cog, `[p]findcog` will show the author's in a list, humanized.

```py
from redbot.core import commands

class Test(commands.Cog):

    __author__ = ["Kreusada", "Red"]

    @commands.command()
    async def test(self, ctx):
        await ctx.send("Hello world!")
```

![list](https://user-images.githubusercontent.com/67752638/116897652-6c92d500-ac2d-11eb-8da7-26f8df5a314d.png)
The same applies if the attribute was a string (see files changed). 
Now, if we change this attribute to an unsupported type, it will still show Unknown.

```py
__author__ = 123
```

![unsupported](https://user-images.githubusercontent.com/67752638/116897746-8cc29400-ac2d-11eb-8c43-4bf4a81897cf.png)

It's only going to show if the type is a tuple, string or list. Anyhow, I'm not sure why i'm explaining this so much 😄 