### PR TITLE
Fix a typo in Track Stuck error

### DIFF
--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -271,7 +271,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                             colour=await self.bot.get_embed_color(message_channel),
                             title=_("Track Stuck"),
                             description=_(
-                                "Playback of the song has stopped due to an unexcepted error.\n{error}"
+                                "Playback of the song has stopped due to an unexpected error.\n{error}"
                             ).format(error=description),
                         )
                     else:


### PR DESCRIPTION
When it came to Track Stuck error I noticed a small typo in word unexpected which I went and wanted to fix in lavalink.py