### PR TITLE
Fix KeyError for cached messages from deleted channels in Streams

### DIFF
--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -80,8 +80,10 @@ class Stream:
                 channel = guild and guild.get_channel(msg_data["channel"])
             else:
                 channel = self._bot.get_channel(msg_data["channel"])
-            if channel is not None:
-                data["partial_message"] = channel.get_partial_message(data["message"])
+
+            data["partial_message"] = (
+                channel.get_partial_message(data["message"]) if channel is not None else None
+            )
             yield data
 
     def export(self):


### PR DESCRIPTION
# Bugfix request

#### Describe the bug being fixed
Fixes #5032 

If the channel is deleted (or perhaps just not in cache), the cog was raising a KeyError for `partial_message` key. This fixes that issue.

#### Anything we need to know about this fix?
Untested