### PR TITLE
[Downloader] Fix spacing in `[p]cog install` response

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -870,7 +870,7 @@ class Downloader(commands.Cog):
                     (
                         _("Successfully installed cogs: ")
                         if len(installed_cogs) > 1
-                        else _("Successfully installed the cog:")
+                        else _("Successfully installed the cog: ")
                     )
                     + humanize_list(cognames)
                     + (


### PR DESCRIPTION
Adds a space after the colon in the cog install message so that it's format matches the response when multiple arguments are provided.