### PR TITLE
Use ctx.send_interactive for SyntaxErrors in Dev cog

### DIFF
--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -15,7 +15,7 @@ import discord
 from . import checks, commands
 from .commands import NoParseOptional as Optional
 from .i18n import Translator, cog_i18n
-from .utils.chat_formatting import box, pagify
+from .utils.chat_formatting import pagify
 from .utils.predicates import MessagePredicate
 
 """
@@ -71,16 +71,16 @@ class Dev(commands.Cog):
         # remove `foo`
         return content.strip("` \n")
 
-    @staticmethod
-    def get_syntax_error(e):
+    @classmethod
+    def get_syntax_error(cls, e):
         """Format a syntax error to send to the user.
 
         Returns a string representation of the error formatted as a codeblock.
         """
         if e.text is None:
-            return box("{0.__class__.__name__}: {0}".format(e), lang="py")
-        return box(
-            "{0.text}\n{1:>{0.offset}}\n{2}: {0}".format(e, "^", type(e).__name__), lang="py"
+            return cls.get_pages("{0.__class__.__name__}: {0}".format(e))
+        return cls.get_pages(
+            "{0.text}\n{1:>{0.offset}}\n{2}: {0}".format(e, "^", type(e).__name__)
         )
 
     @staticmethod
@@ -147,10 +147,12 @@ class Dev(commands.Cog):
             compiled = self.async_compile(code, "<string>", "eval")
             result = await self.maybe_await(eval(compiled, env))
         except SyntaxError as e:
-            await ctx.send(self.get_syntax_error(e))
+            await ctx.send_interactive(self.get_syntax_error(e), box_lang="py")
             return
         except Exception as e:
-            await ctx.send(box("{}: {!s}".format(type(e).__name__, e), lang="py"))
+            await ctx.send_interactive(
+                self.get_pages("{}: {!s}".format(type(e).__name__, e), box_lang="py")
+            )
             return
 
         self._last_result = result
@@ -190,7 +192,7 @@ class Dev(commands.Cog):
             compiled = self.async_compile(to_compile, "<string>", "exec")
             exec(compiled, env)
         except SyntaxError as e:
-            return await ctx.send(self.get_syntax_error(e))
+            return await ctx.send_interactive(self.get_syntax_error(e), box_lang="py")
 
         func = env["func"]
         result = None
@@ -271,7 +273,7 @@ class Dev(commands.Cog):
                 try:
                     code = self.async_compile(cleaned, "<repl session>", "exec")
                 except SyntaxError as e:
-                    await ctx.send(self.get_syntax_error(e))
+                    await ctx.send_interactive(self.get_syntax_error(e), box_lang="py")
                     continue
 
             env["message"] = response

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -151,7 +151,7 @@ class Dev(commands.Cog):
             return
         except Exception as e:
             await ctx.send_interactive(
-                self.get_pages("{}: {!s}".format(type(e).__name__, e), box_lang="py")
+                self.get_pages("{}: {!s}".format(type(e).__name__, e)), box_lang="py"
             )
             return
 


### PR DESCRIPTION
# Bugfix request

#### Describe the bug being fixed

Fixes an issue where the SyntaxErrors (and any exceptions in case of `[p]debug`) were not sent interactively causing the command to error when the content is over 2k chars.
