### PR TITLE
Cleanup `[p]volume` and fix infinite retrying in autoplay

### DIFF
--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -703,7 +703,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
     @commands.guild_only()
     @commands.bot_has_permissions(embed_links=True)
     async def command_volume(self, ctx: commands.Context, vol: int = None):
-        """Set the volume in percentages greater or equal to 0%."""
+        """Set the volume, 1% - 150%."""
         dj_enabled = self._dj_status_cache.setdefault(
             ctx.guild.id, await self.config.guild(ctx.guild).dj_enabled()
         )

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -710,7 +710,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
         can_skip = await self._can_instaskip(ctx, ctx.author)
         if not vol:
             vol = await self.config.guild(ctx.guild).volume()
-            embed = discord.Embed(title=_("Current Volume:"), description=str(vol) + "%")
+            embed = discord.Embed(title=_("Current Volume:"), description=f"{vol}%")
             if not self._player_check(ctx):
                 embed.set_footer(text=_("Nothing playing."))
             return await self.send_embed_msg(ctx, embed=embed)
@@ -733,25 +733,14 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 description=_("You need the DJ role to change the volume."),
             )
 
-        if vol < 0:
-            vol = 0
-        if vol > 150:
-            vol = 150
-            await self.config.guild(ctx.guild).volume.set(vol)
-            if self._player_check(ctx):
-                player = lavalink.get_player(ctx.guild.id)
-                await player.set_volume(vol)
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
-        else:
-            await self.config.guild(ctx.guild).volume.set(vol)
-            if self._player_check(ctx):
-                player = lavalink.get_player(ctx.guild.id)
-                await player.set_volume(vol)
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
+        vol = max(0, vol)
+        await self.config.guild(ctx.guild).volume.set(vol)
+        if self._player_check(ctx):
+            player = lavalink.get_player(ctx.guild.id)
+            await player.set_volume(vol)
+            player.store("notify_channel", ctx.channel.id)
 
-        embed = discord.Embed(title=_("Volume:"), description=str(vol) + "%")
+        embed = discord.Embed(title=_("Volume:"), description=f"{vol}%")
         if not self._player_check(ctx):
             embed.set_footer(text=_("Nothing playing."))
         await self.send_embed_msg(ctx, embed=embed)

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -733,7 +733,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 description=_("You need the DJ role to change the volume."),
             )
 
-        vol = max(0, vol)
+        vol = max(0, min(vol, 150))
         await self.config.guild(ctx.guild).volume.set(vol)
         if self._player_check(ctx):
             player = lavalink.get_player(ctx.guild.id)

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -703,7 +703,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
     @commands.guild_only()
     @commands.bot_has_permissions(embed_links=True)
     async def command_volume(self, ctx: commands.Context, vol: int = None):
-        """Set the volume, 1% - 150%."""
+        """Set the volume in percentages greater or equal to 0%."""
         dj_enabled = self._dj_status_cache.setdefault(
             ctx.guild.id, await self.config.guild(ctx.guild).dj_enabled()
         )

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -738,7 +738,8 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
         if self._player_check(ctx):
             player = lavalink.get_player(ctx.guild.id)
             await player.set_volume(vol)
-            player.store("notify_channel", ctx.channel.id)
+            player.store("channel", ctx.channel.id)
+            player.store("guild", ctx.guild.id)
 
         embed = discord.Embed(title=_("Volume:"), description=f"{vol}%")
         if not self._player_check(ctx):

--- a/redbot/cogs/audio/core/events/cog.py
+++ b/redbot/cogs/audio/core/events/cog.py
@@ -200,6 +200,7 @@ class AudioEvents(MixinMeta, metaclass=CompositeMetaClass):
             await asyncio.sleep(0.1)
             if tries > 1000:
                 return
+            tries += 1
 
         if notify_channel and not player.fetch("autoplay_notified", False):
             if (


### PR DESCRIPTION
- cleanup of [p]volume
- a fix for infinite retrying

What to test:
 - `[p]volume` shows the correct percentage when being set
 - `[p]volume` allows volumes >= 0
 - `[p]volume` correctly persist on a new song / cog reload