### PR TITLE
Fix crash in [p]audiostats by using the new connected_at attr

### DIFF
--- a/redbot/cogs/audio/apis/interface.py
+++ b/redbot/cogs/audio/apis/interface.py
@@ -937,7 +937,7 @@ class AudioAPIInterface:
         autoplaylist = await self.config.guild(player.guild).autoplaylist()
         current_cache_level = CacheLevel(await self.config.cache_level())
         cache_enabled = CacheLevel.set_lavalink().is_subset(current_cache_level)
-        notify_channel_id = player.fetch("channel")
+        notify_channel_id = player.fetch("notify_channel")
         playlist = None
         tracks = None
         if autoplaylist["enabled"]:

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -725,8 +725,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
         if self._player_check(ctx):
             player = lavalink.get_player(ctx.guild.id)
             await player.set_volume(vol)
-            player.store("channel", ctx.channel.id)
-            player.store("guild", ctx.guild.id)
+            player.store("notify_channel", ctx.channel.id)
 
         embed = discord.Embed(title=_("Volume:"), description=f"{vol}%")
         if not self._player_check(ctx):

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -95,8 +95,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
         }
         expected = tuple(emoji.values())
         player = lavalink.get_player(ctx.guild.id)
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         if player.current:
             arrow = await self.draw_time(ctx)
             pos = self.format_time(player.position)
@@ -218,8 +217,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Unable To Manage Tracks"),
                 description=_("You need the DJ role to pause or resume tracks."),
             )
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         if not player.current:
             return await self.send_embed_msg(ctx, title=_("Nothing playing."))
         description = await self.get_track_description(
@@ -273,8 +271,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     "to enqueue the previous song tracks."
                 ),
             )
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         if player.fetch("prev_song") is None:
             return await self.send_embed_msg(
                 ctx, title=_("Unable To Play Tracks"), description=_("No previous track.")
@@ -340,8 +337,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Unable To Seek Tracks"),
                 description=_("You need the DJ role or be the track requester to use seek."),
             )
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         if player.current:
             if player.current.is_stream:
                 return await self.send_embed_msg(
@@ -414,8 +410,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                         title=_("Unable To Toggle Shuffle"),
                         description=_("You must be in the voice channel to toggle shuffle."),
                     )
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
+                player.store("notify_channel", ctx.channel.id)
 
             shuffle = await self.config.guild(ctx.guild).shuffle()
             await self.config.guild(ctx.guild).shuffle.set(not shuffle)
@@ -459,8 +454,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     title=_("Unable To Toggle Shuffle"),
                     description=_("You must be in the voice channel to toggle shuffle."),
                 )
-            player.store("channel", ctx.channel.id)
-            player.store("guild", ctx.guild.id)
+            player.store("notify_channel", ctx.channel.id)
 
         bumped = await self.config.guild(ctx.guild).shuffle_bumped()
         await self.config.guild(ctx.guild).shuffle_bumped.set(not bumped)
@@ -517,8 +511,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     title=_("Unable To Skip Tracks"),
                     description=_("You can only skip the current track."),
                 )
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         if vote_enabled:
             if not can_skip:
                 if skip_to_track is not None:
@@ -597,8 +590,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Unable To Stop Player"),
                 description=_("You need the DJ role to stop the music."),
             )
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         if (
             player.is_playing
             or (not player.is_playing and player.paused)
@@ -662,18 +654,14 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     description=_("I don't have permission to connect to your channel."),
                 )
             if not self._player_check(ctx):
-                await lavalink.connect(
+                player = await lavalink.connect(
                     ctx.author.voice.channel,
                     deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
-                player = lavalink.get_player(ctx.guild.id)
-                player.store("connect", datetime.datetime.utcnow())
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
+                player.store("notify_channel", ctx.channel.id)
             else:
                 player = lavalink.get_player(ctx.guild.id)
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
+                player.store("notify_channel", ctx.channel.id)
                 if (
                     ctx.author.voice.channel == player.channel
                     and ctx.guild.me in ctx.author.voice.channel.members
@@ -724,8 +712,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     title=_("Unable To Change Volume"),
                     description=_("You must be in the voice channel to change the volume."),
                 )
-            player.store("channel", ctx.channel.id)
-            player.store("guild", ctx.guild.id)
+            player.store("notify_channel", ctx.channel.id)
         if dj_enabled and not can_skip and not await self._has_dj_role(ctx, ctx.author):
             return await self.send_embed_msg(
                 ctx,
@@ -772,8 +759,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     title=_("Unable To Toggle Repeat"),
                     description=_("You must be in the voice channel to toggle repeat."),
                 )
-            player.store("channel", ctx.channel.id)
-            player.store("guild", ctx.guild.id)
+            player.store("notify_channel", ctx.channel.id)
 
         autoplay = await self.config.guild(ctx.guild).auto_play()
         repeat = await self.config.guild(ctx.guild).repeat()
@@ -817,8 +803,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Unable To Modify Queue"),
                 description=_("You must be in the voice channel to manage the queue."),
             )
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         if isinstance(index_or_url, int):
             if index_or_url > len(player.queue) or index_or_url < 1:
                 return await self.send_embed_msg(
@@ -899,8 +884,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Unable To Bump Track"),
                 description=_("Song number must be greater than 1 and within the queue limit."),
             )
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         bump_index = index - 1
         bump_song = player.queue[bump_index]
         bump_song.extras["bumped"] = True

--- a/redbot/cogs/audio/core/commands/equalizer.py
+++ b/redbot/cogs/audio/core/commands/equalizer.py
@@ -173,8 +173,7 @@ class EqualizerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Unable To Load Preset"),
                 description=_("You need the DJ role to load equalizer presets."),
             )
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         await self.config.custom("EQUALIZER", ctx.guild.id).eq_bands.set(eq_values)
         await self._eq_check(ctx, player)
         eq = player.fetch("eq", Equalizer())
@@ -203,8 +202,7 @@ class EqualizerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 description=_("You need the DJ role to reset the equalizer."),
             )
         player = lavalink.get_player(ctx.guild.id)
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         eq = player.fetch("eq", Equalizer())
 
         for band in range(eq.band_count):
@@ -287,8 +285,7 @@ class EqualizerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 return await eq_exists_msg.edit(embed=embed2)
 
         player = lavalink.get_player(ctx.guild.id)
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         eq = player.fetch("eq", Equalizer())
         to_append = {eq_preset: {"author": ctx.author.id, "bands": eq.bands}}
         new_eq_presets = {**eq_presets, **to_append}
@@ -330,8 +327,7 @@ class EqualizerCommands(MixinMeta, metaclass=CompositeMetaClass):
             )
 
         player = lavalink.get_player(ctx.guild.id)
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         band_names = [
             "25",
             "40",

--- a/redbot/cogs/audio/core/commands/miscellaneous.py
+++ b/redbot/cogs/audio/core/commands/miscellaneous.py
@@ -53,7 +53,7 @@ class MiscellaneousCommands(MixinMeta, metaclass=CompositeMetaClass):
                 int(
                     (datetime.datetime.now(datetime.timezone.utc) - p.connected_at).total_seconds()
                 )
-            )
+            ) or "0s"
             try:
                 if not p.current:
                     raise AttributeError

--- a/redbot/cogs/audio/core/commands/miscellaneous.py
+++ b/redbot/cogs/audio/core/commands/miscellaneous.py
@@ -45,13 +45,14 @@ class MiscellaneousCommands(MixinMeta, metaclass=CompositeMetaClass):
     async def command_audiostats(self, ctx: commands.Context):
         """Audio stats."""
         server_num = len(lavalink.active_players())
-        total_num = len(lavalink.all_players())
+        total_num = len(lavalink.all_connected_players())
 
         msg = ""
-        async for p in AsyncIter(lavalink.all_players()):
-            connect_start = p.fetch("connect")
+        async for p in AsyncIter(lavalink.all_connected_players()):
             connect_dur = self.get_time_string(
-                int((datetime.datetime.utcnow() - connect_start).total_seconds())
+                int(
+                    (datetime.datetime.now(datetime.timezone.utc) - p.connected_at).total_seconds()
+                )
             )
             try:
                 if not p.current:
@@ -59,7 +60,7 @@ class MiscellaneousCommands(MixinMeta, metaclass=CompositeMetaClass):
                 current_title = await self.get_track_description(
                     p.current, self.local_folder_current_path
                 )
-                msg += "{} [`{}`]: {}\n".format(p.guild.name, connect_dur, current_title)
+                msg += f"{p.guild.name} [`{connect_dur}`]: {current_title}\n"
             except AttributeError:
                 msg += "{} [`{}`]: **{}**\n".format(
                     p.guild.name, connect_dur, _("Nothing playing.")

--- a/redbot/cogs/audio/core/commands/miscellaneous.py
+++ b/redbot/cogs/audio/core/commands/miscellaneous.py
@@ -49,11 +49,16 @@ class MiscellaneousCommands(MixinMeta, metaclass=CompositeMetaClass):
 
         msg = ""
         async for p in AsyncIter(lavalink.all_connected_players()):
-            connect_dur = self.get_time_string(
-                int(
-                    (datetime.datetime.now(datetime.timezone.utc) - p.connected_at).total_seconds()
+            connect_dur = (
+                self.get_time_string(
+                    int(
+                        (
+                            datetime.datetime.now(datetime.timezone.utc) - p.connected_at
+                        ).total_seconds()
+                    )
                 )
-            ) or "0s"
+                or "0s"
+            )
             try:
                 if not p.current:
                     raise AttributeError

--- a/redbot/cogs/audio/core/commands/player.py
+++ b/redbot/cogs/audio/core/commands/player.py
@@ -86,10 +86,6 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     ctx.author.voice.channel,
                     deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
-                player = lavalink.get_player(ctx.guild.id)
-                player.store("connect", datetime.datetime.utcnow())
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
             except AttributeError:
                 return await self.send_embed_msg(
                     ctx,
@@ -103,8 +99,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     description=_("Connection to Lavalink has not yet been established."),
                 )
         player = lavalink.get_player(ctx.guild.id)
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         await self._eq_check(ctx, player)
         await self.set_player_settings(ctx)
         if (not ctx.author.voice or ctx.author.voice.channel != player.channel) and not can_skip:
@@ -197,10 +192,6 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     ctx.author.voice.channel,
                     deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
-                player = lavalink.get_player(ctx.guild.id)
-                player.store("connect", datetime.datetime.utcnow())
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
             except AttributeError:
                 return await self.send_embed_msg(
                     ctx,
@@ -214,8 +205,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     description=_("Connection to Lavalink has not yet been established."),
                 )
         player = lavalink.get_player(ctx.guild.id)
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         await self._eq_check(ctx, player)
         await self.set_player_settings(ctx)
         if (not ctx.author.voice or ctx.author.voice.channel != player.channel) and not can_skip:
@@ -464,10 +454,6 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     ctx.author.voice.channel,
                     deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
-                player = lavalink.get_player(ctx.guild.id)
-                player.store("connect", datetime.datetime.utcnow())
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
             except AttributeError:
                 return await self.send_embed_msg(
                     ctx,
@@ -481,9 +467,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     description=_("Connection to Lavalink has not yet been established."),
                 )
         player = lavalink.get_player(ctx.guild.id)
-
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         await self._eq_check(ctx, player)
         await self.set_player_settings(ctx)
         if (
@@ -584,10 +568,6 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     ctx.author.voice.channel,
                     deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
-                player = lavalink.get_player(ctx.guild.id)
-                player.store("connect", datetime.datetime.utcnow())
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
             except AttributeError:
                 return await self.send_embed_msg(
                     ctx,
@@ -601,9 +581,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     description=_("Connection to Lavalink has not yet been established."),
                 )
         player = lavalink.get_player(ctx.guild.id)
-
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         await self._eq_check(ctx, player)
         await self.set_player_settings(ctx)
         if (
@@ -623,7 +601,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
         try:
             await self.api_interface.autoplay(player, self.playlist_api)
         except DatabaseError:
-            notify_channel = player.fetch("channel")
+            notify_channel = player.fetch("notify_channel")
             if notify_channel:
                 notify_channel = self.bot.get_channel(notify_channel)
                 await self.send_embed_msg(notify_channel, title=_("Couldn't get a valid track."))
@@ -712,10 +690,6 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     ctx.author.voice.channel,
                     deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
-                player = lavalink.get_player(ctx.guild.id)
-                player.store("connect", datetime.datetime.utcnow())
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
             except AttributeError:
                 return await self.send_embed_msg(
                     ctx,
@@ -730,8 +704,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 )
         player = lavalink.get_player(ctx.guild.id)
         guild_data = await self.config.guild(ctx.guild).all()
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         can_skip = await self._can_instaskip(ctx, ctx.author)
         if (not ctx.author.voice or ctx.author.voice.channel != player.channel) and not can_skip:
             return await self.send_embed_msg(

--- a/redbot/cogs/audio/core/commands/queue.py
+++ b/redbot/cogs/audio/core/commands/queue.py
@@ -338,14 +338,11 @@ class QueueCommands(MixinMeta, metaclass=CompositeMetaClass):
                     title=_("Unable To Shuffle Queue"),
                     description=_("I don't have permission to connect to your channel."),
                 )
-            await lavalink.connect(
+            player = await lavalink.connect(
                 ctx.author.voice.channel,
                 deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
             )
-            player = lavalink.get_player(ctx.guild.id)
-            player.store("connect", datetime.datetime.utcnow())
-            player.store("channel", ctx.channel.id)
-            player.store("guild", ctx.guild.id)
+            player.store("notify_channel", ctx.channel.id)
         except AttributeError:
             ctx.command.reset_cooldown(ctx)
             return await self.send_embed_msg(

--- a/redbot/cogs/audio/core/events/cog.py
+++ b/redbot/cogs/audio/core/events/cog.py
@@ -196,7 +196,7 @@ class AudioEvents(MixinMeta, metaclass=CompositeMetaClass):
         requester: discord.Member,
         player: lavalink.Player,
     ):
-        notify_channel = self.bot.get_channel(player.fetch("channel"))
+        notify_channel = self.bot.get_channel(player.fetch("notify_channel"))
         has_perms = self._has_notify_perms(notify_channel)
         tries = 0
         while not player._is_playing:

--- a/redbot/cogs/audio/core/events/dpy.py
+++ b/redbot/cogs/audio/core/events/dpy.py
@@ -90,9 +90,9 @@ class DpyEvents(MixinMeta, metaclass=CompositeMetaClass):
 
         with contextlib.suppress(Exception):
             player = lavalink.get_player(ctx.guild.id)
-            notify_channel = player.fetch("channel")
+            notify_channel = player.fetch("notify_channel")
             if not notify_channel:
-                player.store("channel", ctx.channel.id)
+                player.store("notify_channel", ctx.channel.id)
 
         self._daily_global_playlist_cache.setdefault(
             self.bot.user.id, await self.config.daily_playlists()

--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -109,7 +109,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                 await self.api_interface.persistent_queue_api.played(
                     guild_id=guild_id, track_id=current_track.track_identifier
                 )
-            notify_channel = player.fetch("channel")
+            notify_channel = player.fetch("notify_channel")
             if notify_channel and autoplay:
                 await self.config.guild_from_id(guild_id=guild_id).currently_auto_playing_in.set(
                     [notify_channel, player.channel.id]
@@ -134,7 +134,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                 and self.playlist_api is not None
                 and self.api_interface is not None
             ):
-                notify_channel_id = player.fetch("channel")
+                notify_channel_id = player.fetch("notify_channel")
                 try:
                     await self.api_interface.autoplay(player, self.playlist_api)
                 except DatabaseError:
@@ -157,7 +157,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                         )
                     return
         if event_type == lavalink.LavalinkEvents.TRACK_START and notify:
-            notify_channel_id = player.fetch("channel")
+            notify_channel_id = player.fetch("notify_channel")
             notify_channel = self.bot.get_channel(notify_channel_id)
             if notify_channel and self._has_notify_perms(notify_channel):
                 if player.fetch("notify_message") is not None:
@@ -196,7 +196,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
 
         if event_type == lavalink.LavalinkEvents.QUEUE_END:
             if not autoplay:
-                notify_channel_id = player.fetch("channel")
+                notify_channel_id = player.fetch("notify_channel")
                 notify_channel = self.bot.get_channel(notify_channel_id)
                 if notify_channel and notify and self._has_notify_perms(notify_channel):
                     await self.send_embed_msg(notify_channel, title=_("Queue ended."))
@@ -215,7 +215,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
             lavalink.LavalinkEvents.TRACK_EXCEPTION,
             lavalink.LavalinkEvents.TRACK_STUCK,
         ]:
-            message_channel = player.fetch("channel")
+            message_channel = player.fetch("notify_channel")
             while True:
                 if current_track in player.queue:
                     player.queue.remove(current_track)

--- a/redbot/cogs/audio/core/tasks/startup.py
+++ b/redbot/cogs/audio/core/tasks/startup.py
@@ -129,11 +129,8 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
                             if not (perms.connect and perms.speak):
                                 vc = None
                                 break
-                            await lavalink.connect(vc, deafen=auto_deafen)
-                            player = lavalink.get_player(guild.id)
-                            player.store("connect", datetime.datetime.utcnow())
-                            player.store("guild", guild_id)
-                            player.store("channel", notify_channel_id)
+                            player = await lavalink.connect(vc, deafen=auto_deafen)
+                            player.store("notify_channel", notify_channel_id)
                             break
                         except IndexError:
                             await asyncio.sleep(5)
@@ -201,11 +198,8 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
                         if not (perms.connect and perms.speak):
                             vc = None
                             break
-                        await lavalink.connect(vc, deafen=auto_deafen)
-                        player = lavalink.get_player(guild.id)
-                        player.store("connect", datetime.datetime.utcnow())
-                        player.store("guild", guild_id)
-                        player.store("channel", notify_channel_id)
+                        player = await lavalink.connect(vc, deafen=auto_deafen)
+                        player.store("notify_channel", notify_channel_id)
                         break
                     except IndexError:
                         await asyncio.sleep(5)
@@ -228,7 +222,7 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
                 player.maybe_shuffle()
                 log.info("Restored %r", player)
                 if not player.is_playing:
-                    notify_channel = player.fetch("channel")
+                    notify_channel = player.fetch("notify_channel")
                     try:
                         await self.api_interface.autoplay(player, self.playlist_api)
                     except DatabaseError:

--- a/redbot/cogs/audio/core/utilities/formatting.py
+++ b/redbot/cogs/audio/core/utilities/formatting.py
@@ -103,10 +103,6 @@ class FormattingUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     ctx.author.voice.channel,
                     deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
-                player = lavalink.get_player(ctx.guild.id)
-                player.store("connect", datetime.datetime.utcnow())
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
             except AttributeError:
                 return await self.send_embed_msg(ctx, title=_("Connect to a voice channel first."))
             except IndexError:
@@ -114,6 +110,7 @@ class FormattingUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     ctx, title=_("Connection to Lavalink has not yet been established.")
                 )
         player = lavalink.get_player(ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         guild_data = await self.config.guild(ctx.guild).all()
         if len(player.queue) >= 10000:
             return await self.send_embed_msg(

--- a/redbot/cogs/audio/core/utilities/playlists.py
+++ b/redbot/cogs/audio/core/utilities/playlists.py
@@ -539,10 +539,6 @@ class PlaylistUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     ctx.author.voice.channel,
                     deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
-                player = lavalink.get_player(ctx.guild.id)
-                player.store("connect", datetime.datetime.utcnow())
-                player.store("channel", ctx.channel.id)
-                player.store("guild", ctx.guild.id)
             except IndexError:
                 await self.send_embed_msg(
                     ctx,
@@ -557,10 +553,8 @@ class PlaylistUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     description=_("Connect to a voice channel first."),
                 )
                 return False
-
         player = lavalink.get_player(ctx.guild.id)
-        player.store("channel", ctx.channel.id)
-        player.store("guild", ctx.guild.id)
+        player.store("notify_channel", ctx.channel.id)
         if (
             not ctx.author.voice or ctx.author.voice.channel != player.channel
         ) and not await self._can_instaskip(ctx, ctx.author):


### PR DESCRIPTION
This PR depends on bump from Part 1 + the new `Player.guild` attribute

- [player.store] channel -> notify_channel
- [player.store] removed guild
- [player.store] removed connect
- changes in [p]audiostats

Co-authored-by: alec <50505980+aleclol@users.noreply.github.com>



What to test:
 - `[p]audiostats` shows the correct join time.
 - `[p]audiostats` doesn't crash
 - `[p]audiostats` show the correct join time for a player that that wasnt created by audio (sfx cog/eval)