### PR TITLE
[Docs] Update alias userdoc to reflect updated help menu layout

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -343,9 +343,11 @@ The cog guides are formatted the same. They're divided into 3 sections:
 
     A line that will show how the command must be invoked, with the arguments.
 
-    .. tip:: If the command show something like ``[lavalinkset|llset]``, that means
-        you can invoke the command with ``lavalinkset`` or with ``llset``, this is
-        called an alias.
+  * **Aliases**
+  
+    Each command may have one or more aliases, which are alternative command names
+    we can use to invoke the same command. For example, ``[p]set colour`` can also
+    be invoked with ``[p]set color``.
 
   * **Description**
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -347,7 +347,8 @@ The cog guides are formatted the same. They're divided into 3 sections:
   
     Each command may have one or more aliases, which are alternative command names
     we can use to invoke the same command. For example, ``[p]set colour`` can also
-    be invoked with ``[p]set color``.
+    be invoked with ``[p]set color``. If there are aliases for a command, they will
+    appear just under the syntax.
 
   * **Description**
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -346,7 +346,7 @@ The cog guides are formatted the same. They're divided into 3 sections:
   * **Aliases**
   
     Each command may have one or more aliases, which are alternative command names
-    we can use to invoke the same command. For example, ``[p]set colour`` can also
+    you can use to invoke the same command. For example, ``[p]set colour`` can also
     be invoked with ``[p]set color``. If there are aliases for a command, they will
     appear just under the syntax.
 


### PR DESCRIPTION
Update alias userdoc for updates from #3040 - aliases are no longer represented in the old way (`[colour|color]`), so the getting started guide should be updated accordingly