### PR TITLE
Fix resume for auto play which was broken in RLL 0.8.0 update.

### DIFF
--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -54,7 +54,6 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
         disconnect = guild_data["disconnect"]
         if event_type == lavalink.LavalinkEvents.FORCED_DISCONNECT:
             self.bot.dispatch("red_audio_audio_disconnect", guild)
-            await self.config.guild_from_id(guild_id=guild_id).currently_auto_playing_in.set([])
             self._ll_guild_updates.discard(guild.id)
             return
 

--- a/redbot/cogs/audio/core/tasks/lavalink.py
+++ b/redbot/cogs/audio/core/tasks/lavalink.py
@@ -124,4 +124,6 @@ class LavalinkTasks(MixinMeta, metaclass=CompositeMetaClass):
                 "See above tracebacks for details."
             )
             return
+        if external:
+            await asyncio.sleep(5)
         self._restore_task = asyncio.create_task(self.restore_players())


### PR DESCRIPTION
Autoresume is currently partially broken, but it wasn't caught due to `[p]audioset restart` being borked.

to test this fix to the following:

- `[p]autoplay` 
- give it 10s 
- `[p]audioset restart`

Expected behaviour is that it should restore the player.


Things to keep note of:
1- running `[p]disconnect` 
2- running `[p]stop` 
3- kicking the bot from vc.

The 3 points about should not resume when you run `[p]reload audio` or `[p]audioset restart` 

1. Moving the bot to another VC.
2. Running `[p]pause`
3. Running `[p]summon` 

These 3 should resume when you run `[p]reload audio`  or `[p]audioset restart` 