### PR TITLE
Ensure nothing initializes colorama when it isn't needed

### DIFF
--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -191,6 +191,29 @@ def _update_event_loop_policy():
             _asyncio.set_event_loop_policy(_uvloop.EventLoopPolicy())
 
 
+def _ensure_no_colorama():
+    # a hacky way to ensure that nothing initialises colorama
+    # if we're not running with legacy Windows command line mode
+    from rich.console import detect_legacy_windows
+
+    if not detect_legacy_windows():
+        import colorama
+        import colorama.initialise
+
+        colorama.deinit()
+
+        def _colorama_wrap_stream(stream, *args, **kwargs):
+            return stream
+
+        colorama.wrap_stream = _colorama_wrap_stream
+        colorama.initialise.wrap_stream = _colorama_wrap_stream
+
+
+def _early_init():
+    _update_event_loop_policy()
+    _ensure_no_colorama()
+
+
 __version__ = "3.4.10.dev1"
 version_info = VersionInfo.from_str(__version__)
 

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -22,9 +22,9 @@ import discord
 # Set the event loop policies here so any subsequent `new_event_loop()`
 # calls, in particular those as a result of the following imports,
 # return the correct loop object.
-from redbot import _update_event_loop_policy, __version__
+from redbot import _early_init, __version__
 
-_update_event_loop_policy()
+_early_init()
 
 import redbot.logging
 from redbot.core.bot import Red, ExitCodes

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -9,6 +9,10 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Dict, Any, Optional, Union
 
+from redbot import _early_init
+
+_early_init()
+
 import appdirs
 import click
 


### PR DESCRIPTION
# Bugfix request

#### Describe the bug being fixed

Before this change, `apsw` and `tqdm` called `colorama.init()` causing the colors to break when using Windows Terminal.

#### Anything we need to know about this fix?
The reviewer should ensure that the colors (and terminal output in general) work properly both on Windows Terminal and on the Command Prompt (cmd.exe).
Might also be worth checking that the tqdm progress bar works properly on both as well which you can easily check by removing the Audio's jar and loading Audio after.
