### PR TITLE
Fix the bug with Twitch display name being set as Twitch login

### DIFF
--- a/docs/cog_guides/streams.rst
+++ b/docs/cog_guides/streams.rst
@@ -200,7 +200,10 @@ Use ``{mention}`` in the message to insert the selected mentions.
 
 Use ``{stream}`` in the message to insert the channel or user name.
 
-For example: ``[p]streamset message mention {mention}, {stream} is live!``
+Use ``{stream.display_name}`` in the message to insert the channel's display name
+(on Twitch, this may be different from ``{stream}``).
+
+For example: ``[p]streamset message mention {mention}, {stream.display_name} is live!``
 
 **Arguments**
 
@@ -224,7 +227,10 @@ Sets a stream alert message for when mentions are disabled.
 
 Use ``{stream}`` in the message to insert the channel or user name.
 
-For example: ``[p]streamset message nomention {stream} is live!``
+Use ``{stream.display_name}`` in the message to insert the channel's display name
+(on Twitch, this may be different from ``{stream}``).
+
+For example: ``[p]streamset message nomention {stream.display_name} is live!``
 
 **Arguments**
 

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -809,10 +809,12 @@ class Streams(commands.Cog):
                                 content = content.replace("{stream}", str(stream.name))
                                 content = content.replace("{mention}", mention_str)
                             else:
-                                content = _("{mention}, {stream.display_name} is live!").format(
+                                content = _("{mention}, {display_name} is live!").format(
                                     mention=mention_str,
-                                    stream=escape(
-                                        str(stream.name), mass_mentions=True, formatting=True
+                                    display_name=escape(
+                                        str(stream.display_name),
+                                        mass_mentions=True,
+                                        formatting=True,
                                     ),
                                 )
                         else:
@@ -829,9 +831,11 @@ class Streams(commands.Cog):
                                 )
                                 content = content.replace("{stream}", str(stream.name))
                             else:
-                                content = _("{stream.display_name} is live!").format(
-                                    stream=escape(
-                                        str(stream.name), mass_mentions=True, formatting=True
+                                content = _("{display_name} is live!").format(
+                                    display_name=escape(
+                                        str(stream.display_name),
+                                        mass_mentions=True,
+                                        formatting=True,
                                     )
                                 )
                         await self._send_stream_alert(stream, channel, embed, content)

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -807,7 +807,7 @@ class Streams(commands.Cog):
                                 content = content.replace("{stream}", str(stream.name))
                                 content = content.replace("{mention}", mention_str)
                             else:
-                                content = _("{mention}, {stream} is live!").format(
+                                content = _("{mention}, {stream.display_name} is live!").format(
                                     mention=mention_str,
                                     stream=escape(
                                         str(stream.name), mass_mentions=True, formatting=True
@@ -827,7 +827,7 @@ class Streams(commands.Cog):
                                 )
                                 content = content.replace("{stream}", str(stream.name))
                             else:
-                                content = _("{stream} is live!").format(
+                                content = _("{stream.display_name} is live!").format(
                                     stream=escape(
                                         str(stream.name), mass_mentions=True, formatting=True
                                     )

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -801,6 +801,9 @@ class Streams(commands.Cog):
                                 content = content.replace(
                                     "{stream.name}", str(stream.name)
                                 )  # Backwards compatibility
+                                content = content.replace(
+                                    "{stream.display_name}", str(stream.display_name)
+                                )
                                 content = content.replace("{stream}", str(stream.name))
                                 content = content.replace("{mention}", mention_str)
                             else:
@@ -819,6 +822,9 @@ class Streams(commands.Cog):
                                 content = content.replace(
                                     "{stream.name}", str(stream.name)
                                 )  # Backwards compatibility
+                                content = content.replace(
+                                    "{stream.display_name}", str(stream.display_name)
+                                )
                                 content = content.replace("{stream}", str(stream.name))
                             else:
                                 content = _("{stream} is live!").format(

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -528,9 +528,10 @@ class Streams(commands.Cog):
         """Set stream alert message when mentions are enabled.
 
         Use `{mention}` in the message to insert the selected mentions.
-        Use `{stream}` in the message to insert the channel or user name.
+        Use `{stream}` in the message to insert the channel or username.
+        Use `{stream.display_name}` in the message to insert the channel's display name (on Twitch, this may be different from `{stream}`).
 
-        For example: `[p]streamset message mention {mention}, {stream} is live!`
+        For example: `[p]streamset message mention {mention}, {stream.display_name} is live!`
         """
         guild = ctx.guild
         await self.config.guild(guild).live_message_mention.set(message)
@@ -541,9 +542,10 @@ class Streams(commands.Cog):
     async def without_mention(self, ctx: commands.Context, *, message: str):
         """Set stream alert message when mentions are disabled.
 
-        Use `{stream}` in the message to insert the channel or user name.
+        Use `{stream}` in the message to insert the channel or username.
+        Use `{stream.display_name}` in the message to insert the channel's display name (on Twitch, this may be different from `{stream}`).
 
-        For example: `[p]streamset message nomention {stream} is live!`
+        For example: `[p]streamset message nomention {stream.display_name} is live!`
         """
         guild = ctx.guild
         await self.config.guild(guild).live_message_nomention.set(message)

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -314,7 +314,7 @@ class TwitchStream(Stream):
     def display_name(self) -> Optional[str]:
         return self._display_name or self.name
 
-    @property
+    @display_name.setter
     def display_name(self, value: str) -> None:
         self._display_name = value
 

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -65,6 +65,10 @@ class Stream:
         self.messages = kwargs.pop("messages", [])
         self.type = self.__class__.__name__
 
+    @property
+    def display_name(self) -> Optional[str]:
+        return self.name
+
     async def is_online(self):
         raise NotImplementedError()
 
@@ -299,11 +303,20 @@ class TwitchStream(Stream):
 
     def __init__(self, **kwargs):
         self.id = kwargs.pop("id", None)
+        self._display_name = None
         self._client_id = kwargs.pop("token", None)
         self._bearer = kwargs.pop("bearer", None)
         self._rate_limit_resets: set = set()
         self._rate_limit_remaining: int = 0
         super().__init__(**kwargs)
+
+    @property
+    def display_name(self) -> Optional[str]:
+        return self._display_name or self.name
+
+    @property
+    def display_name(self, value: str) -> None:
+        self._display_name = value
 
     async def wait_for_rate_limit_reset(self) -> None:
         """Check rate limits in response header and ensure we're following them.
@@ -378,7 +391,7 @@ class TwitchStream(Stream):
                 final_data["view_count"] = user_profile_data["view_count"]
 
             stream_data = stream_data["data"][0]
-            final_data["user_name"] = self.name = stream_data["user_name"]
+            final_data["user_name"] = self.display_name = stream_data["user_name"]
             final_data["game_name"] = stream_data["game_name"]
             final_data["thumbnail_url"] = stream_data["thumbnail_url"]
             final_data["title"] = stream_data["title"]


### PR DESCRIPTION
# Bugfix request

#### Describe the bug being fixed

Fixes #5050

Adds `{stream.display_name}` replacement field that can be used in stream message to have it be replaced with streamer's display name.
On Twitch, this can be different from streamer's login - either having different casing OR completely different when the streamer uses the localized display name (available for Chinese, Japanese, and Korean streamers).
On all other platforms this is the same as `{stream}`, at least for now.