### PR TITLE
Specify that cleanup commands remove messages from current channel

### DIFF
--- a/docs/cog_guides/cleanup.rst
+++ b/docs/cog_guides/cleanup.rst
@@ -150,7 +150,7 @@ cleanup bot
 
 **Description**
 
-Clean up command messages and messages from the bot.
+Clean up command messages and messages from the bot in the current channel.
 
 Can only cleanup custom commands and alias commands if those cogs are loaded.
 

--- a/docs/cog_guides/cleanup.rst
+++ b/docs/cog_guides/cleanup.rst
@@ -255,7 +255,7 @@ cleanup text
 
 **Description**
 
-Delete the last X messages matching the specified text.
+Delete the last X messages matching the specified text in the current channel.
 
 Example:
     - ``[p]cleanup text "test" 5``

--- a/docs/cog_guides/cleanup.rst
+++ b/docs/cog_guides/cleanup.rst
@@ -199,7 +199,7 @@ cleanup self
 
 **Description**
 
-Clean up messages owned by the bot.
+Clean up messages owned by the bot in the current channel.
 
 By default, all messages are cleaned. If a second argument is specified,
 it is used for pattern matching - only messages containing the given text will be deleted.

--- a/docs/cog_guides/cleanup.rst
+++ b/docs/cog_guides/cleanup.rst
@@ -283,7 +283,7 @@ cleanup user
 
 **Description**
 
-Delete the last X messages from a specified user.
+Delete the last X messages from a specified user in the current channel.
 
 Examples:
     - ``[p]cleanup user @Twentysix 2``

--- a/docs/cog_guides/cleanup.rst
+++ b/docs/cog_guides/cleanup.rst
@@ -175,7 +175,7 @@ cleanup messages
 
 **Description**
 
-Delete the last X messages.
+Delete the last X messages in the current channel.
 
 Example:
     - ``[p]cleanup messages 26``

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -561,7 +561,7 @@ class Cleanup(commands.Cog):
         match_pattern: str = None,
         delete_pinned: bool = False,
     ):
-        """Clean up messages owned by the bot.
+        """Clean up messages owned by the bot in the current channel.
 
         By default, all messages are cleaned. If a second argument is specified,
         it is used for pattern matching - only messages containing the given text will be deleted.

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -435,7 +435,7 @@ class Cleanup(commands.Cog):
     async def messages(
         self, ctx: commands.Context, number: positive_int, delete_pinned: bool = False
     ):
-        """Delete the last X messages.
+        """Delete the last X messages in the current channel.
 
         Example:
             - `[p]cleanup messages 26`

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -473,7 +473,7 @@ class Cleanup(commands.Cog):
     async def cleanup_bot(
         self, ctx: commands.Context, number: positive_int, delete_pinned: bool = False
     ):
-        """Clean up command messages and messages from the bot.
+        """Clean up command messages and messages from the bot in the current channel.
 
         Can only cleanup custom commands and alias commands if those cogs are loaded.
 

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -151,7 +151,7 @@ class Cleanup(commands.Cog):
     async def text(
         self, ctx: commands.Context, text: str, number: positive_int, delete_pinned: bool = False
     ):
-        """Delete the last X messages matching the specified text.
+        """Delete the last X messages matching the specified text in the current channel.
 
         Example:
             - `[p]cleanup text "test" 5`

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -206,7 +206,7 @@ class Cleanup(commands.Cog):
     async def user(
         self, ctx: commands.Context, user: str, number: positive_int, delete_pinned: bool = False
     ):
-        """Delete the last X messages from a specified user.
+        """Delete the last X messages from a specified user in the current channel.
 
         Examples:
             - `[p]cleanup user @Twentysix 2`


### PR DESCRIPTION
# Bugfix request

#### Describe the bug being fixed

The command only deletes the messages of the user from the *current channel*, not all channels.