### PR TITLE
[Mutes] Don't send dms to bots

### DIFF
--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -516,6 +516,9 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
         reason: Optional[str],
         duration=None,
     ):
+        if user.bot:
+            return
+        
         if not await self.config.guild(guild).dm():
             return
 

--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -518,7 +518,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
     ):
         if user.bot:
             return
-        
+
         if not await self.config.guild(guild).dm():
             return
 


### PR DESCRIPTION
If you have set `[p]muteset senddm` to true, this error will occur when attempting to mute any bot:

```py
Exception in command 'mute'
Traceback (most recent call last):
  File "/Users/main/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/Users/main/redenv/lib/python3.8/site-packages/redbot/cogs/mutes/mutes.py", line 1180, in mute
    await self._send_dm_notification(
  File "/Users/main/redenv/lib/python3.8/site-packages/redbot/cogs/mutes/mutes.py", line 538, in _send_dm_notification
    if await self.bot.embed_requested(await user.create_dm(), user):
  File "/Users/main/redenv/lib/python3.8/site-packages/discord/member.py", line 142, in general
    return await getattr(self._user, x)(*args, **kwargs)
  File "/Users/main/redenv/lib/python3.8/site-packages/discord/user.py", line 764, in create_dm
    data = await state.http.start_private_message(self.id)
  File "/Users/main/redenv/lib/python3.8/site-packages/discord/http.py", line 254, in request
    raise HTTPException(r, data)
discord.errors.HTTPException: 400 Bad Request (error code: 50007): Cannot send messages to this user

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/main/redenv/lib/python3.8/site-packages/discord/ext/commands/bot.py", line 939, in invoke
    await ctx.command.invoke(ctx)
  File "/Users/main/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 863, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/Users/main/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 94, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: HTTPException: 400 Bad Request (error code: 50007): Cannot send messages to this user
```