### PR TITLE
Update logger names to make them more intuitive

### DIFF
--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -10,7 +10,7 @@ from redbot.core.utils.chat_formatting import box
 from .announcer import Announcer
 from .converters import SelfRole
 
-log = logging.getLogger("red.admin")
+log = logging.getLogger("red.core.cogs.Admin")
 
 T_ = Translator("Admin", __file__)
 

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -16,7 +16,7 @@ from .alias_entry import AliasEntry, AliasCache, ArgParseError
 
 _ = Translator("Alias", __file__)
 
-log = logging.getLogger("red.cogs.alias")
+log = logging.getLogger("red.core.cogs.Alias")
 
 
 class _TrackingFormatter(Formatter):

--- a/redbot/cogs/audio/apis/api_utils.py
+++ b/redbot/cogs/audio/apis/api_utils.py
@@ -16,7 +16,7 @@ from redbot.core.utils.chat_formatting import humanize_list
 from ..errors import InvalidPlaylistScope, MissingAuthor, MissingGuild
 from ..utils import PlaylistScope
 
-log = logging.getLogger("red.cogs.Audio.api.utils")
+log = logging.getLogger("red.core.cogs.Audio.api.utils")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/apis/global_db.py
+++ b/redbot/cogs/audio/apis/global_db.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 _API_URL = "https://api.redbot.app/"
 _ = Translator("Audio", Path(__file__))
-log = logging.getLogger("red.cogs.Audio.api.GlobalDB")
+log = logging.getLogger("red.core.cogs.Audio.api.GlobalDB")
 
 
 class GlobalCacheWrapper:

--- a/redbot/cogs/audio/apis/interface.py
+++ b/redbot/cogs/audio/apis/interface.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from .. import Audio
 
 _ = Translator("Audio", Path(__file__))
-log = logging.getLogger("red.cogs.Audio.api.AudioAPIInterface")
+log = logging.getLogger("red.core.cogs.Audio.api.AudioAPIInterface")
 _TOP_100_US = "https://www.youtube.com/playlist?list=PL4fGSI1pDJn5rWitrRWFKdm-ulaFiIyoK"
 # TODO: Get random from global Cache
 

--- a/redbot/cogs/audio/apis/local_db.py
+++ b/redbot/cogs/audio/apis/local_db.py
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
     from .. import Audio
 
 
-log = logging.getLogger("red.cogs.Audio.api.LocalDB")
+log = logging.getLogger("red.core.cogs.Audio.api.LocalDB")
 _ = Translator("Audio", Path(__file__))
 _SCHEMA_VERSION = 3
 

--- a/redbot/cogs/audio/apis/persist_queue_wrapper.py
+++ b/redbot/cogs/audio/apis/persist_queue_wrapper.py
@@ -34,7 +34,7 @@ from ..sql_statements import (
 )
 from .api_utils import QueueFetchResult
 
-log = logging.getLogger("red.cogs.Audio.api.PersistQueueWrapper")
+log = logging.getLogger("red.core.cogs.Audio.api.PersistQueueWrapper")
 _ = Translator("Audio", Path(__file__))
 
 if TYPE_CHECKING:

--- a/redbot/cogs/audio/apis/playlist_interface.py
+++ b/redbot/cogs/audio/apis/playlist_interface.py
@@ -16,7 +16,7 @@ from ..utils import PlaylistScope
 from .api_utils import PlaylistFetchResult, prepare_config_scope, standardize_scope
 from .playlist_wrapper import PlaylistWrapper
 
-log = logging.getLogger("red.cogs.Audio.api.PlaylistsInterface")
+log = logging.getLogger("red.core.cogs.Audio.api.PlaylistsInterface")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/apis/playlist_wrapper.py
+++ b/redbot/cogs/audio/apis/playlist_wrapper.py
@@ -34,7 +34,7 @@ from ..sql_statements import (
 from ..utils import PlaylistScope
 from .api_utils import PlaylistFetchResult
 
-log = logging.getLogger("red.cogs.Audio.api.Playlists")
+log = logging.getLogger("red.core.cogs.Audio.api.Playlists")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/apis/spotify.py
+++ b/redbot/cogs/audio/apis/spotify.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 _ = Translator("Audio", Path(__file__))
 
-log = logging.getLogger("red.cogs.Audio.api.Spotify")
+log = logging.getLogger("red.core.cogs.Audio.api.Spotify")
 
 
 CATEGORY_ENDPOINT = "https://api.spotify.com/v1/browse/categories"

--- a/redbot/cogs/audio/apis/youtube.py
+++ b/redbot/cogs/audio/apis/youtube.py
@@ -16,7 +16,7 @@ from ..errors import YouTubeApiError
 if TYPE_CHECKING:
     from .. import Audio
 
-log = logging.getLogger("red.cogs.Audio.api.YouTube")
+log = logging.getLogger("red.core.cogs.Audio.api.YouTube")
 _ = Translator("Audio", Path(__file__))
 SEARCH_ENDPOINT = "https://www.googleapis.com/youtube/v3/search"
 

--- a/redbot/cogs/audio/audio_dataclasses.py
+++ b/redbot/cogs/audio/audio_dataclasses.py
@@ -79,7 +79,7 @@ _PARTIALLY_SUPPORTED_VIDEO_EXT: Tuple[str, ...] = (
 _PARTIALLY_SUPPORTED_MUSIC_EXT += _PARTIALLY_SUPPORTED_VIDEO_EXT
 
 
-log = logging.getLogger("red.cogs.Audio.audio_dataclasses")
+log = logging.getLogger("red.core.cogs.Audio.audio_dataclasses")
 
 
 class LocalPath:

--- a/redbot/cogs/audio/core/commands/audioset.py
+++ b/redbot/cogs/audio/core/commands/audioset.py
@@ -24,7 +24,7 @@ from ...utils import CacheLevel, PlaylistScope, has_internal_server
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass, PlaylistConverter, __version__
 
-log = logging.getLogger("red.cogs.Audio.cog.Commands.audioset")
+log = logging.getLogger("red.core.cogs.Audio.cog.Commands.audioset")
 
 _ = Translator("Audio", Path(__file__))
 

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -20,7 +20,7 @@ from redbot.core.utils.predicates import ReactionPredicate
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Commands.player_controller")
+log = logging.getLogger("red.core.cogs.Audio.cog.Commands.player_controller")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/core/commands/equalizer.py
+++ b/redbot/cogs/audio/core/commands/equalizer.py
@@ -17,7 +17,7 @@ from ...equalizer import Equalizer
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Commands.equalizer")
+log = logging.getLogger("red.core.cogs.Audio.cog.Commands.equalizer")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/core/commands/llset.py
+++ b/redbot/cogs/audio/core/commands/llset.py
@@ -10,7 +10,7 @@ from redbot.core.utils.chat_formatting import box
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Commands.lavalink_setup")
+log = logging.getLogger("red.core.cogs.Audio.cog.Commands.lavalink_setup")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/core/commands/localtracks.py
+++ b/redbot/cogs/audio/core/commands/localtracks.py
@@ -14,7 +14,7 @@ from ...audio_dataclasses import LocalPath, Query
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Commands.local_track")
+log = logging.getLogger("red.core.cogs.Audio.cog.Commands.local_track")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/core/commands/miscellaneous.py
+++ b/redbot/cogs/audio/core/commands/miscellaneous.py
@@ -17,7 +17,7 @@ from redbot.core.utils.menus import DEFAULT_CONTROLS, menu
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Commands.miscellaneous")
+log = logging.getLogger("red.core.cogs.Audio.cog.Commands.miscellaneous")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/core/commands/player.py
+++ b/redbot/cogs/audio/core/commands/player.py
@@ -28,7 +28,7 @@ from ...errors import (
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Commands.player")
+log = logging.getLogger("red.core.cogs.Audio.cog.Commands.player")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/core/commands/playlists.py
+++ b/redbot/cogs/audio/core/commands/playlists.py
@@ -32,7 +32,7 @@ from ...utils import PlaylistScope
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass, LazyGreedyConverter, PlaylistConverter
 
-log = logging.getLogger("red.cogs.Audio.cog.Commands.playlist")
+log = logging.getLogger("red.core.cogs.Audio.cog.Commands.playlist")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/core/commands/queue.py
+++ b/redbot/cogs/audio/core/commands/queue.py
@@ -26,7 +26,7 @@ from redbot.core.utils.predicates import ReactionPredicate
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Commands.queue")
+log = logging.getLogger("red.core.cogs.Audio.cog.Commands.queue")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/core/events/__init__.py
+++ b/redbot/cogs/audio/core/events/__init__.py
@@ -6,7 +6,7 @@ from .dpy import DpyEvents
 from .lavalink import LavalinkEvents
 from .red import RedEvents
 
-log = logging.getLogger("red.cogs.Audio.cog.Events")
+log = logging.getLogger("red.core.cogs.Audio.cog.Events")
 
 
 class Events(AudioEvents, DpyEvents, LavalinkEvents, RedEvents, metaclass=CompositeMetaClass):

--- a/redbot/cogs/audio/core/events/cog.py
+++ b/redbot/cogs/audio/core/events/cog.py
@@ -18,7 +18,7 @@ from ...utils import PlaylistScope
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Events.audio")
+log = logging.getLogger("red.core.cogs.Audio.cog.Events.audio")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/core/events/dpy.py
+++ b/redbot/cogs/audio/core/events/dpy.py
@@ -21,7 +21,7 @@ from ...errors import TrackEnqueueError
 from ..abc import MixinMeta
 from ..cog_utils import HUMANIZED_PERM, CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Events.dpy")
+log = logging.getLogger("red.core.cogs.Audio.cog.Events.dpy")
 _ = Translator("Audio", Path(__file__))
 RE_CONVERSION: Final[Pattern] = re.compile('Converting to "(.*)" failed for parameter "(.*)".')
 

--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -15,7 +15,7 @@ from ...errors import DatabaseError, TrackEnqueueError
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Events.lavalink")
+log = logging.getLogger("red.core.cogs.Audio.cog.Events.lavalink")
 ws_audio_log = logging.getLogger("red.Audio.WS.Audio")
 
 _ = Translator("Audio", Path(__file__))

--- a/redbot/cogs/audio/core/events/red.py
+++ b/redbot/cogs/audio/core/events/red.py
@@ -8,7 +8,7 @@ from redbot.core.i18n import Translator
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Events.red")
+log = logging.getLogger("red.core.cogs.Audio.cog.Events.red")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/core/tasks/__init__.py
+++ b/redbot/cogs/audio/core/tasks/__init__.py
@@ -5,7 +5,7 @@ from .lavalink import LavalinkTasks
 from .player import PlayerTasks
 from .startup import StartUpTasks
 
-log = logging.getLogger("red.cogs.Audio.cog.Tasks")
+log = logging.getLogger("red.core.cogs.Audio.cog.Tasks")
 
 
 class Tasks(LavalinkTasks, PlayerTasks, StartUpTasks, metaclass=CompositeMetaClass):

--- a/redbot/cogs/audio/core/tasks/lavalink.py
+++ b/redbot/cogs/audio/core/tasks/lavalink.py
@@ -11,7 +11,7 @@ from ...manager import ServerManager
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Tasks.lavalink")
+log = logging.getLogger("red.core.cogs.Audio.cog.Tasks.lavalink")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/core/tasks/player.py
+++ b/redbot/cogs/audio/core/tasks/player.py
@@ -14,7 +14,7 @@ from ...audio_logging import debug_exc_log
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Tasks.player")
+log = logging.getLogger("red.core.cogs.Audio.cog.Tasks.player")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/core/tasks/startup.py
+++ b/redbot/cogs/audio/core/tasks/startup.py
@@ -22,7 +22,7 @@ from ...utils import task_callback
 from ..abc import MixinMeta
 from ..cog_utils import _OWNER_NOTIFICATION, _SCHEMA_VERSION, CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Tasks.startup")
+log = logging.getLogger("red.core.cogs.Audio.cog.Tasks.startup")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/core/utilities/equalizer.py
+++ b/redbot/cogs/audio/core/utilities/equalizer.py
@@ -14,7 +14,7 @@ from ...equalizer import Equalizer
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Utilities.equalizer")
+log = logging.getLogger("red.core.cogs.Audio.cog.Utilities.equalizer")
 
 
 class EqualizerUtilities(MixinMeta, metaclass=CompositeMetaClass):

--- a/redbot/cogs/audio/core/utilities/formatting.py
+++ b/redbot/cogs/audio/core/utilities/formatting.py
@@ -21,7 +21,7 @@ from ...audio_logging import IS_DEBUG
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Utilities.formatting")
+log = logging.getLogger("red.core.cogs.Audio.cog.Utilities.formatting")
 _ = Translator("Audio", Path(__file__))
 RE_SQUARE = re.compile(r"[\[\]]")
 

--- a/redbot/cogs/audio/core/utilities/local_tracks.py
+++ b/redbot/cogs/audio/core/utilities/local_tracks.py
@@ -17,7 +17,7 @@ from ...errors import TrackEnqueueError
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Utilities.local_tracks")
+log = logging.getLogger("red.core.cogs.Audio.cog.Utilities.local_tracks")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/core/utilities/miscellaneous.py
+++ b/redbot/cogs/audio/core/utilities/miscellaneous.py
@@ -24,7 +24,7 @@ from ...utils import PlaylistScope, task_callback
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass, DataReader
 
-log = logging.getLogger("red.cogs.Audio.cog.Utilities.miscellaneous")
+log = logging.getLogger("red.core.cogs.Audio.cog.Utilities.miscellaneous")
 _ = Translator("Audio", Path(__file__))
 _RE_TIME_CONVERTER: Final[Pattern] = re.compile(r"(?:(\d+):)?([0-5]?[0-9]):([0-5][0-9])")
 _prefer_lyrics_cache = {}

--- a/redbot/cogs/audio/core/utilities/parsers.py
+++ b/redbot/cogs/audio/core/utilities/parsers.py
@@ -9,7 +9,7 @@ import aiohttp
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Utilities.Parsing")
+log = logging.getLogger("red.core.cogs.Audio.cog.Utilities.Parsing")
 
 STREAM_TITLE: Final[re.Pattern] = re.compile(br"StreamTitle='([^']*)';")
 

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -21,7 +21,7 @@ from ...utils import Notifier
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Utilities.player")
+log = logging.getLogger("red.core.cogs.Audio.cog.Utilities.player")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/core/utilities/playlists.py
+++ b/redbot/cogs/audio/core/utilities/playlists.py
@@ -30,7 +30,7 @@ from ...utils import Notifier, PlaylistScope
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Utilities.playlists")
+log = logging.getLogger("red.core.cogs.Audio.cog.Utilities.playlists")
 _ = Translator("Audio", Path(__file__))
 CURRATED_DATA = (
     "https://gist.githubusercontent.com/Drapersniper/cbe10d7053c844f8c69637bb4fd9c5c3/raw/json"

--- a/redbot/cogs/audio/core/utilities/queue.py
+++ b/redbot/cogs/audio/core/utilities/queue.py
@@ -17,7 +17,7 @@ from ...audio_dataclasses import LocalPath, Query
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Utilities.queue")
+log = logging.getLogger("red.core.cogs.Audio.cog.Utilities.queue")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/audio/core/utilities/validation.py
+++ b/redbot/cogs/audio/core/utilities/validation.py
@@ -13,7 +13,7 @@ from ...audio_dataclasses import Query
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
-log = logging.getLogger("red.cogs.Audio.cog.Utilities.validation")
+log = logging.getLogger("red.core.cogs.Audio.cog.Utilities.validation")
 
 _RE_YT_LIST_PLAYLIST: Final[Pattern] = re.compile(
     r"^(https?://)?(www\.)?(youtube\.com|youtu\.?be)(/playlist\?).*(list=)(.*)(&|$)"

--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -22,7 +22,7 @@ from .errors import LavalinkDownloadFailed
 from .utils import task_callback
 
 _ = Translator("Audio", pathlib.Path(__file__))
-log = logging.getLogger("red.Audio.manager")
+log = logging.getLogger("red.core.cogs.Audio.manager")
 JAR_VERSION: Final[str] = "3.3.2.3"
 JAR_BUILD: Final[int] = 1212
 LAVALINK_DOWNLOAD_URL: Final[str] = (

--- a/redbot/cogs/audio/utils.py
+++ b/redbot/cogs/audio/utils.py
@@ -12,7 +12,7 @@ import discord
 from redbot.core import commands
 from redbot.core.i18n import Translator
 
-log = logging.getLogger("red.cogs.Audio.task.callback")
+log = logging.getLogger("red.core.cogs.Audio.task.callback")
 _ = Translator("Audio", Path(__file__))
 
 

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -15,7 +15,7 @@ from .converters import PositiveInt, RawMessageIds, positive_int
 
 _ = Translator("Cleanup", __file__)
 
-log = logging.getLogger("red.cleanup")
+log = logging.getLogger("red.core.cogs.Cleanup")
 
 
 @cog_i18n(_)

--- a/redbot/cogs/downloader/log.py
+++ b/redbot/cogs/downloader/log.py
@@ -1,3 +1,3 @@
 import logging
 
-log = logging.getLogger("red.downloader")
+log = logging.getLogger("red.core.cogs.Downloader")

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -21,7 +21,7 @@ from .converters import positive_int
 
 T_ = Translator("Economy", __file__)
 
-logger = logging.getLogger("red.economy")
+logger = logging.getLogger("red.core.cogs.Economy")
 
 NUM_ENC = "\N{COMBINING ENCLOSING KEYCAP}"
 VARIATION_SELECTOR = "\N{VARIATION SELECTOR-16}"

--- a/redbot/cogs/mod/events.py
+++ b/redbot/cogs/mod/events.py
@@ -8,7 +8,7 @@ from redbot.core.utils.mod import is_mod_or_superior
 from .abc import MixinMeta
 
 _ = i18n.Translator("Mod", __file__)
-log = logging.getLogger("red.mod")
+log = logging.getLogger("red.core.cogs.Mod.events")
 
 
 class Events(MixinMeta):

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -20,7 +20,7 @@ from .abc import MixinMeta
 from .converters import RawUserIds
 from .utils import is_allowed_by_hierarchy
 
-log = logging.getLogger("red.mod")
+log = logging.getLogger("red.core.cogs.Mod")
 _ = i18n.Translator("Mod", __file__)
 
 

--- a/redbot/cogs/mutes/converters.py
+++ b/redbot/cogs/mutes/converters.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from discord.ext.commands.converter import Converter
 from redbot.core import commands
 
-log = logging.getLogger("red.cogs.mutes")
+log = logging.getLogger("red.core.cogs.Mutes")
 
 # the following regex is slightly modified from Red
 # it's changed to be slightly more strict on matching with finditer

--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -49,7 +49,7 @@ MUTE_UNMUTE_ISSUES = {
 }
 _ = T_
 
-log = logging.getLogger("red.cogs.mutes")
+log = logging.getLogger("red.core.cogs.Mutes")
 
 __version__ = "1.0.0"
 

--- a/redbot/cogs/reports/reports.py
+++ b/redbot/cogs/reports/reports.py
@@ -18,7 +18,7 @@ from redbot.core.utils.tunnel import Tunnel
 
 _ = Translator("Reports", __file__)
 
-log = logging.getLogger("red.reports")
+log = logging.getLogger("red.core.cogs.Reports")
 
 
 @cog_i18n(_)

--- a/redbot/cogs/trivia/log.py
+++ b/redbot/cogs/trivia/log.py
@@ -4,4 +4,4 @@ import logging
 
 __all__ = ["LOG"]
 
-LOG = logging.getLogger("red.trivia")
+LOG = logging.getLogger("red.core.cogs.Trivia")

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -56,7 +56,7 @@ CUSTOM_GROUPS = "CUSTOM_GROUPS"
 COMMAND_SCOPE = "COMMAND"
 SHARED_API_TOKENS = "SHARED_API_TOKENS"
 
-log = logging.getLogger("red")
+log = logging.getLogger("red.core")
 
 __all__ = ["RedBase", "Red", "ExitCodes"]
 

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -22,7 +22,7 @@ from .drivers import IdentifierData, get_driver, ConfigCategory, BaseDriver
 
 __all__ = ["Config", "get_latest_confs", "migrate"]
 
-log = logging.getLogger("red.config")
+log = logging.getLogger("red.core.config")
 
 _T = TypeVar("_T")
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -91,7 +91,7 @@ if TYPE_CHECKING:
 
 __all__ = ["Core"]
 
-log = logging.getLogger("red")
+log = logging.getLogger("red.core.commands")
 
 _ = i18n.Translator("Core", __file__)
 

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -24,7 +24,7 @@ __all__ = [
     "storage_type",
 ]
 
-log = logging.getLogger("red.data_manager")
+log = logging.getLogger("red.core.data_manager")
 
 basic_config = None
 

--- a/redbot/core/drivers/json.py
+++ b/redbot/core/drivers/json.py
@@ -20,7 +20,7 @@ _driver_counts = {}
 _finalizers = []
 _locks = defaultdict(asyncio.Lock)
 
-log = logging.getLogger("redbot.json_driver")
+log = logging.getLogger("red.core.driver.json")
 
 
 def finalize_driver(cog_name):

--- a/redbot/core/drivers/log.py
+++ b/redbot/core/drivers/log.py
@@ -7,5 +7,5 @@ if os.getenv("RED_INSPECT_DRIVER_QUERIES"):
 else:
     LOGGING_INVISIBLE = 0
 
-log = logging.getLogger("red.driver")
+log = logging.getLogger("red.core.driver")
 log.invisible = functools.partial(log.log, LOGGING_INVISIBLE)

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -40,7 +40,7 @@ from rich.columns import Columns
 from rich.panel import Panel
 from rich.text import Text
 
-log = logging.getLogger("red")
+log = logging.getLogger("red.core.events")
 
 INTRO = r"""
 ______         _           ______ _                       _  ______       _

--- a/redbot/core/i18n.py
+++ b/redbot/core/i18n.py
@@ -31,7 +31,7 @@ __all__ = [
     "set_contextual_locales_from_guild",
 ]
 
-log = logging.getLogger("red.i18n")
+log = logging.getLogger("red.core.i18n")
 
 _current_locale = ContextVar("_current_locale", default="en-US")
 _current_regional_format = ContextVar("_current_regional_format", default=None)

--- a/redbot/core/rpc.py
+++ b/redbot/core/rpc.py
@@ -8,7 +8,7 @@ from aiohttp_json_rpc.rpc import JsonRpcMethod
 
 import logging
 
-log = logging.getLogger("red.rpc")
+log = logging.getLogger("red.core.rpc")
 
 __all__ = ["RPC", "RPCMixin", "get_name"]
 

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -21,7 +21,7 @@ from redbot.core.utils._internal_utils import safe_delete, create_backup as red_
 from redbot.core import config, data_manager, drivers
 from redbot.core.drivers import BackendType, IdentifierData
 
-conversion_log = logging.getLogger("red.converter")
+conversion_log = logging.getLogger("red.driver.converter")
 
 config_dir = None
 appdir = appdirs.AppDirs("Red-DiscordBot")

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -21,7 +21,7 @@ from redbot.core.utils._internal_utils import safe_delete, create_backup as red_
 from redbot.core import config, data_manager, drivers
 from redbot.core.drivers import BackendType, IdentifierData
 
-conversion_log = logging.getLogger("red.driver.converter")
+conversion_log = logging.getLogger("red.core.driver.converter")
 
 config_dir = None
 appdir = appdirs.AppDirs("Red-DiscordBot")


### PR DESCRIPTION
subjectively improve the logger names to make them more explicit.

I was going through red and notice that we are extremely inconsistent on how we name our loggers, we should improve the consistency here.


I took the liberty to tweak a somewhat used standard, `red.(core.cogs|core).<cog_name.camelcase()>[and a further breakdown if desidered here]

This allows us to control the level of all core cogs, all 3rd part cogs (if they adopt this schema) separately as well as making a lot clearer where something is getting logged from. for example `red.bank` is this the api or the cog? `red.core.bank` and `red.core.cogs.bank` make that uncertainty non existant. 