### PR TITLE
[Downloader] Allow removal of multiple repos

### DIFF
--- a/docs/cog_guides/downloader.rst
+++ b/docs/cog_guides/downloader.rst
@@ -461,14 +461,15 @@ repo delete
 
 **Description**
 
-Remove a repo and its files.
+Remove repos and their files.
 
-Example:
+Examples:
     - ``[p]repo delete 26-Cogs``
+    - ``[p]repo delete 26-Cogs Laggrons-Dumb-Cogs``
 
 **Arguments**
 
-- ``<repo>`` The name of an already added repo
+- ``<repos...>`` The repo or repos to remove.
 
 .. _downloader-command-repo-info:
 

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -605,7 +605,7 @@ class Downloader(commands.Cog):
                 if len(repos) > 1
                 else _("Successfully deleted the repo: ")
             )
-            + humanize_list([i.name for i in set(repos)])
+            + humanize_list([inline(i.name) for i in set(repos)])
         )
 
     @repo.command(name="list")

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -583,23 +583,30 @@ class Downloader(commands.Cog):
             if repo.install_msg:
                 await ctx.send(repo.install_msg.replace("[p]", ctx.clean_prefix))
 
-    @repo.command(name="delete", aliases=["remove", "del"])
-    async def _repo_del(self, ctx: commands.Context, repo: Repo) -> None:
+    @repo.command(name="delete", aliases=["remove", "del"], require_var_positional=True)
+    async def _repo_del(self, ctx: commands.Context, *repos: Repo) -> None:
         """
-        Remove a repo and its files.
+        Remove repos and their files.
 
-        Example:
+        Examples:
             - `[p]repo delete 26-Cogs`
+            - `[p]repo delete 26-Cogs Laggrons-Dumb-Cogs`
 
         **Arguments**
 
-        - `<repo>` The name of an already added repo
+        - `<repos...>` The repo or repos to remove.
         """
-        await self._repo_manager.delete_repo(repo.name)
+        for repo in set(repos):
+            await self._repo_manager.delete_repo(repo.name)
 
-        await ctx.send(
-            _("The repo `{repo.name}` has been deleted successfully.").format(repo=repo)
-        )
+        if len(repos) == 1:
+            await ctx.send(
+                _("The repo `{repo.name}` has been deleted successfully.").format(repo=repo)
+            )
+        else:
+            await ctx.send(
+                _("Successfully deleted repos: ") + humanize_list([i.name for i in set(repos)])
+            )
 
     @repo.command(name="list")
     async def _repo_list(self, ctx: commands.Context) -> None:

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -599,14 +599,13 @@ class Downloader(commands.Cog):
         for repo in set(repos):
             await self._repo_manager.delete_repo(repo.name)
 
-        if len(repos) == 1:
-            await ctx.send(
-                _("The repo `{repo.name}` has been deleted successfully.").format(repo=repo)
-            )
-        else:
-            await ctx.send(
-                _("Successfully deleted repos: ") + humanize_list([i.name for i in set(repos)])
-            )
+        await ctx.send(
+            (
+                _("Successfully deleted repos: ")
+                if len(repos) > 1
+                else _("Successfully deleted the repo: ")
+            ) + humanize_list([i.name for i in set(repos)])
+        )
 
     @repo.command(name="list")
     async def _repo_list(self, ctx: commands.Context) -> None:

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -604,7 +604,8 @@ class Downloader(commands.Cog):
                 _("Successfully deleted repos: ")
                 if len(repos) > 1
                 else _("Successfully deleted the repo: ")
-            ) + humanize_list([i.name for i in set(repos)])
+            )
+            + humanize_list([i.name for i in set(repos)])
         )
 
     @repo.command(name="list")


### PR DESCRIPTION
This will make removing repos similar to removing cogs.

I've chosen to use the same format for multi repo removal as in the `cog uninstall` command for continuity.

Closes #4765