### PR TITLE
Update Dev's code block regex to support `python` language

### DIFF
--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -28,7 +28,7 @@ https://github.com/Rapptz/RoboDanny/blob/master/cogs/repl.py
 
 _ = Translator("Dev", __file__)
 
-START_CODE_BLOCK_RE = re.compile(r"^((```py)(?=\s)|(```python)(?=\s)|(```))")
+START_CODE_BLOCK_RE = re.compile(r"^((```py(thon)?)(?=\s)|(```))")
 
 
 @cog_i18n(_)

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -28,7 +28,7 @@ https://github.com/Rapptz/RoboDanny/blob/master/cogs/repl.py
 
 _ = Translator("Dev", __file__)
 
-START_CODE_BLOCK_RE = re.compile(r"^((```py)(?=\s)|(```))")
+START_CODE_BLOCK_RE = re.compile(r"^((```py)(?=\s)|(```py)(?=\s)|(```))")
 
 
 @cog_i18n(_)

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -28,7 +28,7 @@ https://github.com/Rapptz/RoboDanny/blob/master/cogs/repl.py
 
 _ = Translator("Dev", __file__)
 
-START_CODE_BLOCK_RE = re.compile(r"^((```py)(?=\s)|(```py)(?=\s)|(```))")
+START_CODE_BLOCK_RE = re.compile(r"^((```py)(?=\s)|(```python)(?=\s)|(```))")
 
 
 @cog_i18n(_)


### PR DESCRIPTION
"python" as syntax in codeblocks wasn`t recognized. "py" however was. this PR fixes that