### PR TITLE
[Alias] Fix double plural grammar in alias docstring

### DIFF
--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -34,7 +34,7 @@ class _TrackingFormatter(Formatter):
 class Alias(commands.Cog):
     """Create aliases for commands.
 
-    Aliases are alternative names shortcuts for commands. They
+    Aliases are alternative names/shortcuts for commands. They
     can act as both a lambda (storing arguments for repeated use)
     or as simply a shortcut to saying "x y z".
 


### PR DESCRIPTION
This does not need to be updated in the cog guide seeing as this docstring is not referenced there.