### PR TITLE
[Dev] Use `tick()` when debugs are successful

### DIFF
--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -158,6 +158,7 @@ class Dev(commands.Cog):
         self._last_result = result
         result = self.sanitize_output(ctx, str(result))
 
+        await ctx.tick()
         await ctx.send_interactive(self.get_pages(result), box_lang="py")
 
     @commands.command(name="eval")


### PR DESCRIPTION
Add `ctx.tick()` to `[p]debug` when the debug does not raise an exception. 
There are a few debugs you can run, such as `[p]debug "\t"`, and `[p]debug ""`, which do not respond with anything - leaving questions in the air as to whether something isn't working.

It will also be nice to have this tick, seeing as eval has it too. Although this was a very small change, it has still been tested, and it works.