### PR TITLE
Add commands for editing aliases

### DIFF
--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -343,7 +343,7 @@ class Alias(commands.Cog):
     @commands.guild_only()
     async def _edit_alias(self, ctx: commands.Context, alias_name: str, *, command):
         """Edit an existing alias in the present server."""
-
+        # region Alias Add Validity Checking
         alias = await self._aliases.get_alias(ctx.guild, alias_name)
         if not alias:
             await ctx.send(
@@ -355,11 +355,10 @@ class Alias(commands.Cog):
         if not given_command_exists:
             await ctx.send(_("You attempted to edit an alias to a command that doesn't exist."))
             return
-
         # endregion
+
         # So we figured it is a valid alias and the command exists
         # we can go ahead editing the command
-
         try:
             if await self._aliases.edit_alias(ctx, alias_name, command):
                 await ctx.send(
@@ -368,7 +367,7 @@ class Alias(commands.Cog):
                     )
                 )
             else:
-                # This part should never be reached under normal circumstances
+                # This part should technically never be reached...
                 await ctx.send(
                     _("Alias with name `{name}` was not found.").format(name=alias_name)
                 )
@@ -379,7 +378,7 @@ class Alias(commands.Cog):
     @global_.command(name="edit")
     async def _edit_global_alias(self, ctx: commands.Context, alias_name: str, *, command):
         """Edit an existing global alias."""
-
+        # region Alias Add Validity Checking
         alias = await self._aliases.get_alias(None, alias_name)
         if not alias:
             await ctx.send(
@@ -401,10 +400,10 @@ class Alias(commands.Cog):
                     )
                 )
             else:
+                # This part should technically never be reached...
                 await ctx.send(
                     _("Alias with name `{name}` was not found.").format(name=alias_name)
                 )
-
         except ArgParseError as e:
             return await ctx.send(" ".join(e.args))
 

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -338,6 +338,76 @@ class Alias(commands.Cog):
             )
         )
 
+    @checks.mod_or_permissions(manage_guild=True)
+    @alias.command(name="edit")
+    @commands.guild_only()
+    async def _edit_alias(self, ctx: commands.Context, alias_name: str, *, command):
+        """Edit an existing alias in the present server."""
+
+        alias = await self._aliases.get_alias(ctx.guild, alias_name)
+        if not alias:
+            await ctx.send(
+                _("The alias with the name {name} does not exist.").format(name=alias_name)
+            )
+            return
+
+        given_command_exists = self.bot.get_command(command.split(maxsplit=1)[0]) is not None
+        if not given_command_exists:
+            await ctx.send(_("You attempted to edit an alias to a command that doesn't exist."))
+            return
+
+        # endregion
+        # So we figured it is a valid alias and the command exists
+        # we can go ahead editing the command
+
+        try:
+            if await self._aliases.edit_alias(ctx, alias_name, command):
+                await ctx.send(
+                    _("The alias with the trigger `{name}` has been edited sucessfully.").format(
+                        name=alias_name
+                    )
+                )
+            else:
+                # This part should never be reached under normal circumstances
+                await ctx.send(
+                    _("Alias with name `{name}` was not found.").format(name=alias_name)
+                )
+        except ArgParseError as e:
+            return await ctx.send(" ".join(e.args))
+
+    @checks.is_owner()
+    @global_.command(name="edit")
+    async def _edit_global_alias(self, ctx: commands.Context, alias_name: str, *, command):
+        """Edit an existing global alias."""
+
+        alias = await self._aliases.get_alias(None, alias_name)
+        if not alias:
+            await ctx.send(
+                _("The alias with the name {name} does not exist.").format(name=alias_name)
+            )
+            return
+
+        given_command_exists = self.bot.get_command(command.split(maxsplit=1)[0]) is not None
+        if not given_command_exists:
+            await ctx.send(_("You attempted to edit an alias to a command that doesn't exist."))
+            return
+        # endregion
+
+        try:
+            if await self._aliases.edit_alias(ctx, alias_name, command, global_=True):
+                await ctx.send(
+                    _("The alias with the trigger `{name}` has been edited sucessfully.").format(
+                        name=alias_name
+                    )
+                )
+            else:
+                await ctx.send(
+                    _("Alias with name `{name}` was not found.").format(name=alias_name)
+                )
+
+        except ArgParseError as e:
+            return await ctx.send(" ".join(e.args))
+
     @alias.command(name="help")
     async def _help_alias(self, ctx: commands.Context, alias_name: str):
         """Try to execute help for the base command of the alias."""

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -342,7 +342,7 @@ class Alias(commands.Cog):
     @alias.command(name="edit")
     @commands.guild_only()
     async def _edit_alias(self, ctx: commands.Context, alias_name: str, *, command):
-        """Edit an existing alias in the present server."""
+        """Edit an existing alias in this server."""
         # region Alias Add Validity Checking
         alias = await self._aliases.get_alias(ctx.guild, alias_name)
         if not alias:

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -369,7 +369,7 @@ class Alias(commands.Cog):
             else:
                 # This part should technically never be reached...
                 await ctx.send(
-                    _("Alias with name `{name}` was not found.").format(name=alias_name)
+                    _("Alias with the name `{name}` was not found.").format(name=alias_name)
                 )
         except ArgParseError as e:
             return await ctx.send(" ".join(e.args))
@@ -402,7 +402,7 @@ class Alias(commands.Cog):
             else:
                 # This part should technically never be reached...
                 await ctx.send(
-                    _("Alias with name `{name}` was not found.").format(name=alias_name)
+                    _("Alias with the name `{name}` was not found.").format(name=alias_name)
                 )
         except ArgParseError as e:
             return await ctx.send(" ".join(e.args))

--- a/redbot/cogs/alias/alias_entry.py
+++ b/redbot/cogs/alias/alias_entry.py
@@ -187,9 +187,11 @@ class AliasCache:
 
         return None
 
-    async def add_alias(
-        self, ctx: commands.Context, alias_name: str, command: str, global_: bool = False
-    ) -> AliasEntry:
+    @staticmethod
+    def format_command_for_alias(command: str) -> str:
+        # This was present in add_alias previously
+        # Made this into a separate method so as to reuse the same code in edit_alias
+
         indices = findall(r"{(\d*)}", command)
         if indices:
             try:
@@ -206,6 +208,13 @@ class AliasCache:
                     + ", ".join(str(i + low) for i in gaps)
                 )
             command = command.format(*(f"{{{i}}}" for i in range(-low, high + low + 1)))
+        return command
+
+    async def add_alias(
+        self, ctx: commands.Context, alias_name: str, command: str, global_: bool = False
+    ) -> AliasEntry:
+
+        command = self.format_command_for_alias(command)
 
         if global_:
             alias = AliasEntry(alias_name, command, ctx.author.id, None)
@@ -224,6 +233,31 @@ class AliasCache:
             curr_aliases.append(alias.to_json())
 
         return alias
+
+    async def edit_alias(
+        self, ctx: commands.Context, alias_name: str, command: str, global_: bool = False
+    ) -> bool:
+        if global_:
+            settings = self.config
+        else:
+            settings = self.config.guild(ctx.guild)
+
+        async with settings.entries() as aliases:
+            for index, alias in enumerate(aliases):
+                if alias["name"] == alias_name:
+
+                    alias_edited = AliasEntry.from_json(alias)
+                    alias_edited.command = self.format_command_for_alias(command)
+                    aliases[index] = alias_edited.to_json()
+
+                    if self._cache_enabled:
+                        if global_:
+                            self._aliases[None][alias_edited.name] = alias_edited
+                        else:
+                            self._aliases[ctx.guild.id][alias_edited.name] = alias_edited
+                    return True
+
+        return False
 
     async def delete_alias(
         self, ctx: commands.Context, alias_name: str, global_: bool = False

--- a/redbot/cogs/alias/alias_entry.py
+++ b/redbot/cogs/alias/alias_entry.py
@@ -191,7 +191,6 @@ class AliasCache:
     def format_command_for_alias(command: str) -> str:
         # This was present in add_alias previously
         # Made this into a separate method so as to reuse the same code in edit_alias
-
         indices = findall(r"{(\d*)}", command)
         if indices:
             try:
@@ -213,7 +212,6 @@ class AliasCache:
     async def add_alias(
         self, ctx: commands.Context, alias_name: str, command: str, global_: bool = False
     ) -> AliasEntry:
-
         command = self.format_command_for_alias(command)
 
         if global_:

--- a/redbot/cogs/alias/alias_entry.py
+++ b/redbot/cogs/alias/alias_entry.py
@@ -235,6 +235,8 @@ class AliasCache:
     async def edit_alias(
         self, ctx: commands.Context, alias_name: str, command: str, global_: bool = False
     ) -> bool:
+        command = self.format_command_for_alias(command)
+
         if global_:
             settings = self.config
         else:
@@ -243,9 +245,8 @@ class AliasCache:
         async with settings.entries() as aliases:
             for index, alias in enumerate(aliases):
                 if alias["name"] == alias_name:
-
                     alias_edited = AliasEntry.from_json(alias)
-                    alias_edited.command = self.format_command_for_alias(command)
+                    alias_edited.command = command
                     aliases[index] = alias_edited.to_json()
 
                     if self._cache_enabled:


### PR DESCRIPTION
As discussed in the [#feature-ideas](https://canary.discord.com/channels/133049272517001216/133049878837329920/831781562751254528) in discord,
This PR adds `[p]alias edit` and `[p]alias global edit` which can edit existing alias commands.
