### PR TITLE
[Downloader] Suppress NotFound errors in `[p]cog update` command

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1658,7 +1658,8 @@ class Downloader(commands.Cog):
 
             if not pred.result:
                 if can_react:
-                    await query.delete()
+                    with contextlib.suppress(discord.NotFound):
+                        await query.delete()
                 else:
                     await ctx.send(_("OK then."))
                 return

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1652,7 +1652,8 @@ class Downloader(commands.Cog):
             try:
                 await ctx.bot.wait_for(event, check=pred, timeout=30)
             except asyncio.TimeoutError:
-                await query.delete()
+                with contextlib.suppress(discord.NotFound):
+                    await query.delete()
                 return
 
             if not pred.result:


### PR DESCRIPTION
To reproduce this issue:

1. Run `[p]cog update` and wait for the bot to successfully update the cogs.
2. Delete the message that says "Would you like to reload the updated cogs?". This is the message tied to the predicate event.
3. Delete this message within 30 seconds. Then the missing message will try to be deleted, raising a `discord.NotFound` exception.