### PR TITLE
[Core] Add toggle for the applications.commands invite scope

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -118,6 +118,7 @@ class RedBase(
             description="Red V3",
             invite_public=False,
             invite_perm=0,
+            invite_commands_scope=False,
             disabled_commands=[],
             disabled_command_msg="That command is disabled.",
             extra_owner_destinations=[],

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1580,7 +1580,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         enabled = not await self.bot._config.invite_commands_scope()
         await self.bot._config.invite_commands_scope.set(enabled)
         if enabled is True:
-            await ctx.send(_("The `applications.commands` scope has been added to the invite URL."))
+            await ctx.send(
+                _("The `applications.commands` scope has been added to the invite URL.")
+            )
         else:
             await ctx.send(
                 _("The `applications.commands` scope has been removed from the invite URL.")

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -377,9 +377,12 @@ class CoreLogic:
             Invite URL.
         """
         app_info = await self.bot.application_info()
-        perms_int = await self.bot._config.invite_perm()
+        data = await self.bot._config.all()
+        commands_scope = data["invite_commands_scope"]
+        scopes = ("bot", "applications.commands") if commands_scope else None
+        perms_int = data["invite_perm"]
         permissions = discord.Permissions(perms_int)
-        return discord.utils.oauth_url(app_info.id, permissions)
+        return discord.utils.oauth_url(app_info.id, permissions, scopes=scopes)
 
     @staticmethod
     async def _can_get_invite_url(ctx):
@@ -1564,6 +1567,24 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """
         await self.bot._config.invite_perm.set(level)
         await ctx.send("The new permissions level has been set.")
+
+    @inviteset.command()
+    async def commandscope(self, ctx: commands.Context):
+        """
+        Add the `applications.commands` scope to your invite URL.
+
+        This allows the usage of slash commands on the servers that invited your bot with that scope.
+
+        Note that previous servers that invited the bot without the scope cannot have slash commands, they will have to invite the bot a second time.
+        """
+        enabled = not await self.bot._config.invite_commands_scope()
+        await self.bot._config.invite_commands_scope.set(enabled)
+        if enabled is True:
+            await ctx.send("The `applications.commands` scope has been added to the invite URL.")
+        else:
+            await ctx.send(
+                "The `applications.commands` scope has been removed from the invite URL."
+            )
 
     @commands.command()
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1580,10 +1580,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         enabled = not await self.bot._config.invite_commands_scope()
         await self.bot._config.invite_commands_scope.set(enabled)
         if enabled is True:
-            await ctx.send("The `applications.commands` scope has been added to the invite URL.")
+            await ctx.send(_("The `applications.commands` scope has been added to the invite URL."))
         else:
             await ctx.send(
-                "The `applications.commands` scope has been removed from the invite URL."
+                _("The `applications.commands` scope has been removed from the invite URL.")
             )
 
     @commands.command()


### PR DESCRIPTION
Adds the `[p]inviteset commandscope` toggle for enabling or disabling the commands scope, given with the URL returned by `[p]invite` .

I feel like the wording is wrong for the docstring, feel free to suggest something better.

----

Requested by Zephyrkul on the server.