### PR TITLE
[Mutes] Update new channels

### DIFF
--- a/docs/cog_guides/mutes.rst
+++ b/docs/cog_guides/mutes.rst
@@ -119,6 +119,36 @@ muteset
 
 Mute settings.
 
+.. _mutes-command-muteset-autoupdate:
+
+""""""""""""""""""
+muteset autoupdate
+""""""""""""""""""
+
+.. note:: |admin-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]muteset autoupdate <true_or_false>
+
+**Description**
+
+Defines if the bot should auto-update new channels for the mute role.
+
+If this is enabled, when a new channel is created on the server (text, voice
+or category), the bot will edit its permissions and deny the permissions of
+sending messages, adding reactions and speaking to the mute role.
+
+.. warning:: You must have configured a mute role with
+    :ref:`muteset role <mutes-command-muteset-role>` or
+    :ref:`muteset makerole <mutes-command-muteset-makerole>` before using this.
+
+**Arguments**
+
+* ``<true_or_false>``: Whether to enable or disable this setting, must provide ``true`` or ``false``.
+
 .. _mutes-command-muteset-defaulttime:
 
 """""""""""""""""""

--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -826,12 +826,14 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
         default_time = timedelta(seconds=data["default_time"])
         msg = _(
             "Mute Role: {role}\n"
+            "Update new channels: {auto_update}\n"
             "Notification Channel: {channel}\n"
             "Default Time: {time}\n"
             "Send DM: {dm}\n"
             "Show moderator: {show_mod}"
         ).format(
             role=mute_role.mention if mute_role else _("None"),
+            auto_update=data["auto_update"],
             channel=notification_channel.mention if notification_channel else _("None"),
             time=humanize_timedelta(timedelta=default_time) if default_time else _("None"),
             dm=data["dm"],


### PR DESCRIPTION
This adds a toggle under `[p]muteset autoupdate` for updating the permissions of new channels for the mute role.

Resolves #5111 