### PR TITLE
Move modlog guide to correct place in the labeler configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -131,9 +131,11 @@
   - redbot/core/modlog.py
   # Docs
   - docs/framework_modlog.rst
-  - docs/cog_guides/modlog.rst
 "Category: Modlog Cog":
+  # Source
   - redbot/cogs/modlog/*
+  # Docs
+  - docs/cog_guides/modlog.rst
 "Category: Mutes Cog":
   # Source
   - redbot/cogs/mutes/*


### PR DESCRIPTION
The path to the modlog cog should appear under the Modlog Cog label, and not the Modlog API label.