### PR TITLE
[Warnings] Warn mod if 0 or less points are given

### DIFF
--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -395,6 +395,8 @@ class Warnings(commands.Cog):
             if (reason_type := registered_reasons.get(reason.lower())) is None:
                 msg = _("That is not a registered reason!")
                 if custom_allowed:
+                    if points <= 0:
+                        return await ctx.send(_("You cannot apply 0 or less points."))
                     reason_type = {"description": reason, "points": points}
                 else:
                     # logic taken from `[p]permissions canrun`


### PR DESCRIPTION
This adds a warning message for when `allowcustomreasons` is enabled and a moderator applies 0 or less points

Fixes #5119