### PR TITLE
Fix Filter - None issue

### DIFF
--- a/redbot/cogs/filter/filter.py
+++ b/redbot/cogs/filter/filter.py
@@ -442,7 +442,7 @@ class Filter(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
-        if isinstance(message.channel, discord.abc.PrivateChannel):
+        if message.guild is None:
             return
 
         if await self.bot.cog_disabled_in_guild(self, message.guild):


### PR DESCRIPTION
This can happen in cases where guild is None and it tries to compare a None object. 