### PR TITLE
Update `[p]addpath` to use consume rest on the path argument

### DIFF
--- a/redbot/core/cog_manager.py
+++ b/redbot/core/cog_manager.py
@@ -343,7 +343,7 @@ class CogManagerUI(commands.Cog):
 
     @commands.command()
     @checks.is_owner()
-    async def addpath(self, ctx: commands.Context, path: Path):
+    async def addpath(self, ctx: commands.Context, *, path: Path):
         """
         Add a path to the list of available cog paths.
         """


### PR DESCRIPTION
[p]addpath doesn't take in spaces. This pr just does that by consuming rest so that noobs like me don't fail in adding path.