### PR TITLE
Remove support for Audio's Global API

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Cogs
-/redbot/cogs/audio/** @aikaterna @Drapersniper @PredaaA
+/redbot/cogs/audio/** @aikaterna @PredaaA
 /redbot/cogs/downloader/* @jack1142
 /redbot/cogs/streams/* @palmtree5
 /redbot/cogs/mutes/* @TrustyJAID

--- a/redbot/cogs/audio/apis/global_db.py
+++ b/redbot/cogs/audio/apis/global_db.py
@@ -174,7 +174,7 @@ class GlobalCacheWrapper:
     async def get_perms(self):
         global_api_user = copy(self.cog.global_api_user)
         await self._get_api_key()
-        is_enabled = await self.config.global_db_enabled()
+        is_enabled = False
         if (not is_enabled) or self.api_key is None:
             return global_api_user
         with contextlib.suppress(Exception):

--- a/redbot/cogs/audio/apis/global_db.py
+++ b/redbot/cogs/audio/apis/global_db.py
@@ -174,6 +174,7 @@ class GlobalCacheWrapper:
     async def get_perms(self):
         global_api_user = copy(self.cog.global_api_user)
         await self._get_api_key()
+        # global API is force-disabled right now
         is_enabled = False
         if (not is_enabled) or self.api_key is None:
             return global_api_user

--- a/redbot/cogs/audio/core/commands/audioset.py
+++ b/redbot/cogs/audio/core/commands/audioset.py
@@ -1092,6 +1092,7 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
                 spotify_status=_("Enabled") if has_spotify_cache else _("Disabled"),
                 youtube_status=_("Enabled") if has_youtube_cache else _("Disabled"),
                 lavalink_status=_("Enabled") if has_lavalink_cache else _("Disabled"),
+                # global API is force-disabled right now
                 global_cache=_("Disabled"),
                 num_seconds=self.get_time_string(global_data["global_db_get_timeout"]),
             )

--- a/redbot/cogs/audio/core/commands/audioset.py
+++ b/redbot/cogs/audio/core/commands/audioset.py
@@ -1085,16 +1085,11 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
                 + _("Local Spotify cache:    [{spotify_status}]\n")
                 + _("Local Youtube cache:    [{youtube_status}]\n")
                 + _("Local Lavalink cache:   [{lavalink_status}]\n")
-                + _("Global cache status:    [{global_cache}]\n")
-                + _("Global timeout:         [{num_seconds}]\n")
             ).format(
                 max_age=str(await self.config.cache_age()) + " " + _("days"),
                 spotify_status=_("Enabled") if has_spotify_cache else _("Disabled"),
                 youtube_status=_("Enabled") if has_youtube_cache else _("Disabled"),
                 lavalink_status=_("Enabled") if has_lavalink_cache else _("Disabled"),
-                # global API is force-disabled right now
-                global_cache=_("Disabled"),
-                num_seconds=self.get_time_string(global_data["global_db_get_timeout"]),
             )
         msg += (
             "\n---"
@@ -1422,23 +1417,6 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
         msg += _("I've set the cache age to {age} days").format(age=age)
         await self.config.cache_age.set(age)
         await self.send_embed_msg(ctx, title=_("Setting Changed"), description=msg)
-
-    @commands.is_owner()
-    @command_audioset.group(name="globalapi")
-    async def command_audioset_audiodb(self, ctx: commands.Context):
-        """Change globalapi settings."""
-
-    @command_audioset_audiodb.command(name="timeout")
-    async def command_audioset_audiodb_timeout(
-        self, ctx: commands.Context, timeout: Union[float, int]
-    ):
-        """Set GET request timeout.
-
-        Example: 0.1 = 100ms 1 = 1 second
-        """
-
-        await self.config.global_db_get_timeout.set(timeout)
-        await ctx.send(_("Request timeout set to {time} second(s)").format(time=timeout))
 
     @command_audioset.command(name="persistqueue")
     @commands.admin()

--- a/redbot/cogs/audio/core/commands/audioset.py
+++ b/redbot/cogs/audio/core/commands/audioset.py
@@ -1092,7 +1092,7 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
                 spotify_status=_("Enabled") if has_spotify_cache else _("Disabled"),
                 youtube_status=_("Enabled") if has_youtube_cache else _("Disabled"),
                 lavalink_status=_("Enabled") if has_lavalink_cache else _("Disabled"),
-                global_cache=_("Enabled") if global_data["global_db_enabled"] else _("Disabled"),
+                global_cache=_("Disabled"),
                 num_seconds=self.get_time_string(global_data["global_db_get_timeout"]),
             )
         msg += (
@@ -1426,20 +1426,6 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
     @command_audioset.group(name="globalapi")
     async def command_audioset_audiodb(self, ctx: commands.Context):
         """Change globalapi settings."""
-
-    @command_audioset_audiodb.command(name="toggle")
-    async def command_audioset_audiodb_toggle(self, ctx: commands.Context):
-        """Toggle the server settings.
-
-        Default is OFF
-        """
-        state = await self.config.global_db_enabled()
-        await self.config.global_db_enabled.set(not state)
-        if not state:  # Ensure a call is made if the API is enabled to update user perms
-            self.global_api_user = await self.api_interface.global_cache_api.get_perms()
-        await ctx.send(
-            _("Global DB is {status}").format(status=_("enabled") if not state else _("disabled"))
-        )
 
     @command_audioset_audiodb.command(name="timeout")
     async def command_audioset_audiodb_timeout(

--- a/redbot/cogs/audio/core/tasks/startup.py
+++ b/redbot/cogs/audio/core/tasks/startup.py
@@ -39,7 +39,8 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
         await self.bot.wait_until_red_ready()
         # Unlike most cases, we want the cache to exit before migration.
         try:
-            await self.maybe_message_all_owners()
+            # global API is force-disabled right now
+            # await self.maybe_message_all_owners()
             self.db_conn = APSWConnectionWrapper(
                 str(cog_data_path(self.bot.get_cog("Audio")) / "Audio.db")
             )

--- a/redbot/cogs/audio/core/tasks/startup.py
+++ b/redbot/cogs/audio/core/tasks/startup.py
@@ -39,8 +39,7 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
         await self.bot.wait_until_red_ready()
         # Unlike most cases, we want the cache to exit before migration.
         try:
-            # global API is force-disabled right now
-            # await self.maybe_message_all_owners()
+            await self.maybe_message_all_owners()
             self.db_conn = APSWConnectionWrapper(
                 str(cog_data_path(self.bot.get_cog("Audio")) / "Audio.db")
             )
@@ -254,16 +253,9 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
             return
         if current_notification < 1 <= _OWNER_NOTIFICATION:
             msg = _(
-                """Hello, this message brings you an important update regarding the core Audio cog:
+                """Hello, this message brings you some important information regarding the core Audio cog:
                 
-Starting from Audio v2.3.0+ you can take advantage of the **Global Audio API**, a new service offered by the Cog-Creators organization that allows your bot to greatly reduce the amount of requests done to YouTube / Spotify. This reduces the likelihood of YouTube rate-limiting your bot for making requests too often.
-See `[p]help audioset globalapi` for more information.
-Access to this service is disabled by default and **requires you to explicitly opt-in** to start using it.
-
-An access token is **required** to use this API. To obtain this token you may join <https://discord.gg/red> and run `?audioapi register` in the #testing channel.
-Note: by using this service you accept that your bot's IP address will be disclosed to the Cog-Creators organization and used only for the purpose of providing the Global API service.
-
-On a related note, it is highly recommended that you enable your local cache if you haven't yet.
+It is highly recommended that you enable your local cache if you haven't yet.
 To do so, run `[p]audioset cache 5`. This cache, which stores only metadata, will make repeated audio requests faster and further reduce the likelihood of YouTube rate-limiting your bot. Since it's only metadata the required disk space for this cache is expected to be negligible."""
             )
             await send_to_owners_with_prefix_replaced(self.bot, msg)


### PR DESCRIPTION
The code for interacting with it is still there, this just makes it so that the API is never called + it removes relevant mentions of the Global API in the `audioset` command group.