### PR TITLE
Rename RedBase to Red, remove the old Red

### DIFF
--- a/docs/changelog_3_3_0.rst
+++ b/docs/changelog_3_3_0.rst
@@ -253,7 +253,7 @@ Developer changelog
 Core Bot
 ********
 
-- Added `bot.set_prefixes() <RedBase.set_prefixes()>` method that allows developers to set global/server prefixes (:issue:`3890`)
+- Added `bot.set_prefixes() <Red.set_prefixes()>` method that allows developers to set global/server prefixes (:issue:`3890`)
 
 
 Documentation changes

--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -153,14 +153,14 @@ Developer changelog
 
     Here's the list of the methods that were added to the ``bot`` object:
 
-        - `Red.add_to_blacklist() <RedBase.add_to_blacklist()>`
-        - `Red.remove_from_blacklist() <RedBase.remove_from_blacklist()>`
-        - `Red.get_blacklist() <RedBase.get_blacklist()>`
-        - `Red.clear_blacklist() <RedBase.clear_blacklist()>`
-        - `Red.add_to_whitelist() <RedBase.add_to_whitelist()>`
-        - `Red.remove_from_whitelist() <RedBase.remove_from_whitelist()>`
-        - `Red.get_whitelist() <RedBase.get_whitelist()>`
-        - `Red.clear_whitelist() <RedBase.clear_whitelist()>`
+        - `Red.add_to_blacklist()`
+        - `Red.remove_from_blacklist()`
+        - `Red.get_blacklist()`
+        - `Red.clear_blacklist()`
+        - `Red.add_to_whitelist()`
+        - `Red.remove_from_whitelist()`
+        - `Red.get_whitelist()`
+        - `Red.clear_whitelist()`
 
 - Added `CommandConverter` and `CogConverter` to the ``redbot.core.commands`` package (:issue:`5037`)
 
@@ -479,7 +479,7 @@ Developer changelog
 - Deprecated importing ``GuildConverter`` from ``redbot.core.commands.converter`` namespace (:issue:`4928`)
 
     - ``discord.Guild`` or ``GuildConverter`` from ``redbot.core.commands`` should be used instead
-- Added ``guild`` parameter to `bot.allowed_by_whitelist_blacklist() <RedBase.allowed_by_whitelist_blacklist()>` which is meant to replace the deprecated ``guild_id`` parameter (:issue:`4905`, :issue:`4914`)
+- Added ``guild`` parameter to `bot.allowed_by_whitelist_blacklist() <Red.allowed_by_whitelist_blacklist()>` which is meant to replace the deprecated ``guild_id`` parameter (:issue:`4905`, :issue:`4914`)
 
     - Read the method's documentation for more information
 - Fixed ``on_red_api_tokens_update`` not being dispatched when the tokens were removed with ``[p]set api remove`` (:issue:`4916`, :issue:`4917`)
@@ -675,8 +675,8 @@ Dev Cog
 
     - Variables can be added and removed from the environment of Dev cog using two new methods:
 
-        - `bot.add_dev_env_value() <RedBase.add_dev_env_value()>`
-        - `bot.remove_dev_env_value() <RedBase.remove_dev_env_value()>`
+        - `bot.add_dev_env_value() <Red.add_dev_env_value()>`
+        - `bot.remove_dev_env_value() <Red.remove_dev_env_value()>`
 
 
 Documentation changes
@@ -1067,9 +1067,9 @@ Core Bot
     - New function added: `redbot.core.i18n.set_contextual_locales_from_guild()`
     - Contextual locale is automatically set for commands and only needs to be done manually for things like event listeners; see `recommendations-for-cog-creators` for more information
 
-- Added `bot.remove_shared_api_services() <RedBase.remove_shared_api_services()>` to remove all keys and tokens associated with an API service (:issue:`4370`)
-- Added an option to return all tokens for an API service if ``service_name`` is not specified in `bot.get_shared_api_tokens() <RedBase.get_shared_api_tokens()>` (:issue:`4370`)
-- Added `bot.get_or_fetch_user() <RedBase.get_or_fetch_user()>` and `bot.get_or_fetch_member() <RedBase.get_or_fetch_member()>` methods (:issue:`4403`, :issue:`4402`)
+- Added `bot.remove_shared_api_services() <Red.remove_shared_api_services()>` to remove all keys and tokens associated with an API service (:issue:`4370`)
+- Added an option to return all tokens for an API service if ``service_name`` is not specified in `bot.get_shared_api_tokens() <Red.get_shared_api_tokens()>` (:issue:`4370`)
+- Added `bot.get_or_fetch_user() <Red.get_or_fetch_user()>` and `bot.get_or_fetch_member() <Red.get_or_fetch_member()>` methods (:issue:`4403`, :issue:`4402`)
 - Moved ``redbot.core.checks.bot_in_a_guild()`` to `redbot.core.commands.bot_in_a_guild()` (old name has been left as an alias) (:issue:`4515`, :issue:`4510`)
 
 Bank
@@ -1232,7 +1232,7 @@ Core Bot
 
 - Added cog disabling API (:issue:`4043`, :issue:`3945`)
 
-    - New methods added: `bot.cog_disabled_in_guild() <RedBase.cog_disabled_in_guild()>`, `bot.cog_disabled_in_guild_raw() <RedBase.cog_disabled_in_guild_raw()>`
+    - New methods added: `bot.cog_disabled_in_guild() <Red.cog_disabled_in_guild()>`, `bot.cog_disabled_in_guild_raw() <Red.cog_disabled_in_guild_raw()>`
     - Cog disabling is automatically applied for commands and only needs to be done manually for things like event listeners; see `recommendations-for-cog-creators` for more information
 
 - Added data request API (:issue:`4045`,  :issue:`4169`)
@@ -1242,9 +1242,9 @@ Core Bot
     - These methods and variables should be added by all cogs according to their documentation; see `recommendations-for-cog-creators` for more information
     - New ``info.json`` key added: ``end_user_data_statement``; see `Info.json format documentation <info-json-format>` for more information
 
-- Added `bot.message_eligible_as_command() <RedBase.message_eligible_as_command()>` utility method which can be used to determine if a message may be responded to as a command (:issue:`4077`)
+- Added `bot.message_eligible_as_command() <Red.message_eligible_as_command()>` utility method which can be used to determine if a message may be responded to as a command (:issue:`4077`)
 - Added a provisional API for replacing the help formatter. See `documentation <framework-commands-help>` for more details (:issue:`4011`)
-- `bot.ignored_channel_or_guild() <RedBase.ignored_channel_or_guild()>` now accepts `discord.Message` objects (:issue:`4077`)
+- `bot.ignored_channel_or_guild() <Red.ignored_channel_or_guild()>` now accepts `discord.Message` objects (:issue:`4077`)
 - `commands.NoParseOptional <NoParseOptional>` is no longer provisional and is now fully supported part of API (:issue:`4142`)
 - Red no longer fails to run subcommands of a command group allowed or denied by permission hook (:issue:`3956`)
 - Autohelp in group commands is now sent *after* invoking the group, which allows before invoke hooks to prevent autohelp from getting triggered (:issue:`4129`)

--- a/docs/framework_apikeys.rst
+++ b/docs/framework_apikeys.rst
@@ -69,9 +69,13 @@ Additional References
 .. py:currentmodule:: redbot.core.bot
 
 .. automethod:: Red.get_shared_api_tokens
+    :noindex:
 
 .. automethod:: Red.set_shared_api_tokens
+    :noindex:
 
 .. automethod:: Red.remove_shared_api_tokens
+    :noindex:
 
 .. automethod:: Red.remove_shared_api_services
+    :noindex:

--- a/docs/framework_bot.rst
+++ b/docs/framework_bot.rst
@@ -6,18 +6,12 @@ Bot
 
 .. automodule:: redbot.core.bot
 
-RedBase
-^^^^^^^
-
-.. autoclass:: RedBase
-    :members:
-    :exclude-members: get_context
-
-    .. automethod:: register_rpc_handler
-    .. automethod:: unregister_rpc_handler
-
 Red
 ^^^
 
 .. autoclass:: Red
     :members:
+    :exclude-members: get_context
+
+    .. automethod:: register_rpc_handler
+    .. automethod:: unregister_rpc_handler

--- a/docs/framework_rpc.rst
+++ b/docs/framework_rpc.rst
@@ -64,4 +64,4 @@ All cog-based methods expect their parameter list to take one argument, a JSON o
 API Reference
 *************
 
-Please see the :class:`redbot.core.bot.RedBase` class for details on the RPC handler register and unregister methods.
+Please see the :class:`redbot.core.bot.Red` class for details on the RPC handler register and unregister methods.

--- a/docs/guide_cog_creators.rst
+++ b/docs/guide_cog_creators.rst
@@ -145,7 +145,7 @@ While not required for approved Cog Creators, they are still recommended in orde
   - Values provided make sense. (eg. no negative numbers for payday)
   - Don't unsafely use user input for things like database input.
 
-- Check events against `bot.cog_disabled_in_guild() <RedBase.cog_disabled_in_guild()>`\
+- Check events against `bot.cog_disabled_in_guild() <Red.cog_disabled_in_guild()>`\
 
   - Not all events need to be checked, only those that interact with a guild.
   - Some discretion may apply, for example,

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -60,7 +60,7 @@ SHARED_API_TOKENS = "SHARED_API_TOKENS"
 
 log = logging.getLogger("red")
 
-__all__ = ["RedBase", "Red", "ExitCodes"]
+__all__ = ("Red", "ExitCodes")
 
 NotMessage = namedtuple("NotMessage", "guild")
 
@@ -79,14 +79,10 @@ def _is_submodule(parent, child):
 # d.py autoshardedbot should be at the end
 # all of our mixins should happen before,
 # and must include a call to super().__init__ unless they do not provide an init
-class RedBase(
+class Red(
     commands.GroupMixin, RPCMixin, dpy_commands.bot.AutoShardedBot
 ):  # pylint: disable=no-member # barely spurious warning caused by shadowing
-    """
-    The historical reasons for this mixin no longer apply
-    and only remains temporarily to not break people
-    relying on the publicly exposed bases existing.
-    """
+    """Our subclass of discord.ext.commands.AutoShardedBot"""
 
     def __init__(self, *args, cli_flags=None, bot_dir: Path = Path.cwd(), **kwargs):
         self._shutdown_mode = ExitCodes.CRITICAL
@@ -2001,13 +1997,6 @@ class RedBase(
             failed_cogs=failures["cog"],
             unhandled=failures["unhandled"],
         )
-
-
-# This can be removed, and the parent class renamed as a breaking change
-class Red(RedBase):
-    """
-    Our subclass of discord.ext.commands.AutoShardedBot
-    """
 
 
 class ExitCodes(IntEnum):


### PR DESCRIPTION
### Description of the changes
The separation of `RedBase` and `Red` is no longer needed (historically, this was used to aid with user bots usage) and so this PR joins them.