### PR TITLE
[Mutes] Fix NotFound error when trying to delete message

### DIFF
--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -1030,7 +1030,8 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
             try:
                 await ctx.bot.wait_for(event, check=pred, timeout=30)
             except asyncio.TimeoutError:
-                await query.delete()
+                with contextlib.suppress(discord.NotFound):
+                    await query.delete()
                 return False
 
             if not pred.result:

--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -1036,7 +1036,8 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
 
             if not pred.result:
                 if can_react:
-                    await query.delete()
+                    with contextlib.suppress(discord.NotFound):
+                        await query.delete()
                 else:
                     await ctx.send(_("OK then."))
 
@@ -1243,12 +1244,14 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
         try:
             await ctx.bot.wait_for(event, check=pred, timeout=30)
         except asyncio.TimeoutError:
-            await query.delete()
+            with contextlib.suppress(discord.NotFound):
+                await query.delete()
             return
 
         if not pred.result:
             if can_react:
-                await query.delete()
+                with contextlib.suppress(discord.NotFound):
+                    await query.delete()
             else:
                 await ctx.send(_("OK then."))
             return


### PR DESCRIPTION
### Description of the changes

Fixes an issue when `discord.NotFound` is raised when the query is not found.