### PR TITLE
Add a per guild max volume setting

### DIFF
--- a/redbot/cogs/audio/core/__init__.py
+++ b/redbot/cogs/audio/core/__init__.py
@@ -132,6 +132,7 @@ class Audio(
             jukebox=False,
             jukebox_price=0,
             maxlength=0,
+            max_volume=150,
             notify=False,
             prefer_lyrics=False,
             repeat=False,

--- a/redbot/cogs/audio/core/commands/audioset.py
+++ b/redbot/cogs/audio/core/commands/audioset.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import logging
 import os
+from re import M
 import tarfile
 from pathlib import Path
 
@@ -960,6 +961,8 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
         is_owner = await self.bot.is_owner(ctx.author)
         global_data = await self.config.all()
         data = await self.config.guild(ctx.guild).all()
+
+        auto_deafen = _("Enabled") if data["auto_deafen"] else _("Disabled")
         dj_role_obj = ctx.guild.get_role(data["dj_role"])
         dj_enabled = data["dj_enabled"]
         emptydc_enabled = data["emptydc_enabled"]
@@ -972,6 +975,7 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
         dc = data["disconnect"]
         autoplay = data["auto_play"]
         maxlength = data["maxlength"]
+        maxvolume = data["max_volume"]
         vote_percent = data["vote_percent"]
         current_level = CacheLevel(global_data["cache_level"])
         song_repeat = _("Enabled") if data["repeat"] else _("Disabled")
@@ -980,7 +984,6 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
         song_notify = _("Enabled") if data["notify"] else _("Disabled")
         song_status = _("Enabled") if global_data["status"] else _("Disabled")
         persist_queue = _("Enabled") if data["persist_queue"] else _("Disabled")
-        auto_deafen = _("Enabled") if data["auto_deafen"] else _("Disabled")
 
         countrycode = data["country_code"]
 
@@ -994,6 +997,9 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
         autoplaylist = data["autoplaylist"]
         vote_enabled = data["vote_enabled"]
         msg = "----" + _("Server Settings") + "----        \n"
+        msg += _("Auto-deafen:      [{auto_deafen}]\n").format(
+            auto_deafen=auto_deafen,
+        )
         msg += _("Auto-disconnect:  [{dc}]\n").format(dc=_("Enabled") if dc else _("Disabled"))
         msg += _("Auto-play:        [{autoplay}]\n").format(
             autoplay=_("Enabled") if autoplay else _("Disabled")
@@ -1018,23 +1024,23 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
                 tracklength=self.get_time_string(maxlength)
             )
         msg += _(
+            "Max volume:       [{max_volume}%]\n"
+            "Persist queue:    [{persist_queue}]\n"
             "Repeat:           [{repeat}]\n"
             "Shuffle:          [{shuffle}]\n"
             "Shuffle bumped:   [{bumpped_shuffle}]\n"
             "Song notify msgs: [{notify}]\n"
             "Songs as status:  [{status}]\n"
-            "Persist queue:    [{persist_queue}]\n"
             "Spotify search:   [{countrycode}]\n"
-            "Auto-Deafen:      [{auto_deafen}]\n"
         ).format(
+            max_volume=maxvolume,
             countrycode=countrycode,
+            persist_queue=persist_queue,
             repeat=song_repeat,
             shuffle=song_shuffle,
             notify=song_notify,
             status=song_status,
             bumpped_shuffle=bumpped_shuffle,
-            persist_queue=persist_queue,
-            auto_deafen=auto_deafen,
         )
         if thumbnail:
             msg += _("Thumbnails:       [{0}]\n").format(
@@ -1454,3 +1460,39 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Restarting Lavalink"),
                 description=_("It can take a couple of minutes for Lavalink to fully start up."),
             )
+
+    @command_audioset.command(usage="<maximum volume>", name="maxvolume")
+    @commands.guild_only()
+    @commands.admin_or_permissions(manage_roles=True)
+    async def command_audioset_maxvolume(self, ctx: commands.Context, max_volume: int):
+        """Set the maximum volume allowed in this server."""
+        if max_volume < 1:
+            return await self.send_embed_msg(
+                ctx,
+                title=_("Error"),
+                description=_("Music without sound isn't music at all. Try setting the volume higher then 0%.")
+            )
+        elif max_volume > 150:
+            max_volume = 150
+            await self.send_embed_msg(
+                ctx,
+                title=_("Setting changed"),
+                description=_("The maximum volume has been limited to 150%, be easy on your ears.")
+            )
+        else:
+            await self.send_embed_msg(
+                ctx,
+                title=_("Setting changed"),
+                description=_("The maximum volume has been limited to {max_volume}%.").format(
+                    max_volume=max_volume
+                ),
+            )
+        current_volume = await self.config.guild(ctx.guild).volume()
+        if current_volume > max_volume:
+            await self.config.guild(ctx.guild).volume.set(max_volume)
+            if self._player_check(ctx):
+                player = lavalink.get_player(ctx.guild.id)
+                await player.set_volume(max_volume)
+                player.store("notify_channel", ctx.channel.id)
+
+        await self.config.guild(ctx.guild).max_volume.set(max_volume)

--- a/redbot/cogs/audio/core/commands/audioset.py
+++ b/redbot/cogs/audio/core/commands/audioset.py
@@ -1469,14 +1469,18 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
             return await self.send_embed_msg(
                 ctx,
                 title=_("Error"),
-                description=_("Music without sound isn't music at all. Try setting the volume higher then 0%.")
+                description=_(
+                    "Music without sound isn't music at all. Try setting the volume higher then 0%."
+                ),
             )
         elif max_volume > 150:
             max_volume = 150
             await self.send_embed_msg(
                 ctx,
                 title=_("Setting changed"),
-                description=_("The maximum volume has been limited to 150%, be easy on your ears.")
+                description=_(
+                    "The maximum volume has been limited to 150%, be easy on your ears."
+                ),
             )
         else:
             await self.send_embed_msg(

--- a/redbot/cogs/audio/core/commands/audioset.py
+++ b/redbot/cogs/audio/core/commands/audioset.py
@@ -2,7 +2,6 @@ import asyncio
 import contextlib
 import logging
 import os
-from re import M
 import tarfile
 from pathlib import Path
 

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -696,6 +696,8 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
             ctx.guild.id, await self.config.guild(ctx.guild).dj_enabled()
         )
         can_skip = await self._can_instaskip(ctx, ctx.author)
+        max_volume = await self.config.guild(ctx.guild).max_volume()
+
         if not vol:
             vol = await self.config.guild(ctx.guild).volume()
             embed = discord.Embed(title=_("Current Volume:"), description=f"{vol}%")
@@ -720,7 +722,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 description=_("You need the DJ role to change the volume."),
             )
 
-        vol = max(0, min(vol, 150))
+        vol = max(0, min(vol, max_volume))
         await self.config.guild(ctx.guild).volume.set(vol)
         if self._player_check(ctx):
             player = lavalink.get_player(ctx.guild.id)


### PR DESCRIPTION
### Description of the changes
This PR adds a per guild max volume setting.

The code will lower the current volume if its set too high after setting a new max. This also applies to any live players.