### PR TITLE
Improve release correctness and safety by using GH Environments

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -5,8 +5,58 @@ on:
       - "*"
 
 jobs:
-  release_to_pypi:
+  release_information:
     if: github.repository == 'Cog-Creators/Red-DiscordBot'
+    name: GO HERE BEFORE APPROVING
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout repository and install Python
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      # Get version to release
+      - name: Get version to release
+        id: version_to_release
+        run: |
+          python .github/workflows/scripts/bump_version.py
+        env:
+          PYTHONPATH: ${{ github.workspace }}:${{ env.PYTHONPATH }}
+          JUST_RETURN_VERSION: '1'
+
+      # Print release information
+      - name: REVIEW OUTPUT OF THIS STEP BEFORE APPROVING
+        env:
+          TAG_BASE_BRANCH: ${{ github.event.base_ref }}
+          TAG_REF_NAME: ${{ github.ref }}
+          RELEASE_VERSION: ${{ steps.version_to_release.outputs.version }}
+        run: |
+          echo 'Release information:'
+          echo "- Branch the tag was based off: ${TAG_BASE_BRANCH#'refs/heads/'}"
+          echo "- Tag name: ${TAG_REF_NAME#'refs/tags/'}"
+          echo "- Release version: $RELEASE_VERSION"
+
+          echo "TAG_NAME=${TAG_REF_NAME#'refs/tags/'}" >> $GITHUB_ENV
+
+      - name: Ensure the tag name corresponds to the released version
+        env:
+          RELEASE_VERSION: ${{ steps.version_to_release.outputs.version }}
+        run: |
+          if [[ "$TAG_NAME" != "$RELEASE_VERSION" ]]; then
+              echo -n "The tag name ($TAG_NAME) is not the same as"
+              echo " the release version ($RELEASE_VERSION)!"
+              exit 1
+          else
+              echo "The tag name and the release version are the same ($TAG_NAME)."
+              echo 'Continuing...'
+          fi
+
+  release_to_pypi:
+    needs: release_information
+    environment: Release
+    name: Release to PyPI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -33,6 +83,7 @@ jobs:
       contents: write
       pull-requests: write
     needs: release_to_pypi
+    name: Update Red version number to dev
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/scripts/bump_version.py
+++ b/.github/workflows/scripts/bump_version.py
@@ -6,6 +6,10 @@ from typing import Match
 import redbot
 
 
+if int(os.environ.get("JUST_RETURN_VERSION", 0)):
+    print(f"::set-output name=version::{redbot.__version__}")
+
+
 version_info = None
 
 

--- a/.github/workflows/scripts/bump_version.py
+++ b/.github/workflows/scripts/bump_version.py
@@ -8,6 +8,7 @@ import redbot
 
 if int(os.environ.get("JUST_RETURN_VERSION", 0)):
     print(f"::set-output name=version::{redbot.__version__}")
+    sys.exit(0)
 
 
 version_info = None


### PR DESCRIPTION
### Description of the changes
This PR does 2 things to improve release correctness and safety:
1. Make the release workflow require `Release` environment *before* pushing the release to PyPI:
2. A small summary of the release to be able to easily check that what is getting released is what we want to be released
    - This also adds a check that automatically compares the tag name to the version that is getting released to minimize the possibility of human error (though it does not rule out all the cases which is why the human review of the summary is needed)

Here's the current configuration of the `Release` environment:
![image](https://user-images.githubusercontent.com/6032823/123879424-2f06ab80-d941-11eb-82c2-050762ad0456.png)
It would probably be good to move the `PYPI_TOKEN` repository secret to this environment. I wasn't sure whether we should choose just admin core devs or all core devs but I chose admin core devs per the principle of least privileges. The reviewer can be the person that made the release so this is not a bottleneck and seems to be in line with our policies.

#### Test cases
- Correct release
https://github.com/jack1142/Red-DiscordBot/runs/2947260520?check_suite_focus=true
Summary: https://github.com/jack1142/Red-DiscordBot/actions/runs/984437295

- Tag name not corresponding to release version (`3.4.13` vs `3.5.0.dev1`):
https://github.com/jack1142/Red-DiscordBot/runs/2947181460?check_suite_focus=true
Summary: https://github.com/jack1142/Red-DiscordBot/actions/runs/984407534

- Branch the tag was based off being incorrect (`V3/improve_release_safety_test` vs `V3/improve_release_safety_test2`):
https://github.com/jack1142/Red-DiscordBot/runs/2947246411?check_suite_focus=true
Summary: https://github.com/jack1142/Red-DiscordBot/actions/runs/984431767

#### Example of deployment review
![image](https://user-images.githubusercontent.com/6032823/123878572-9885ba80-d93f-11eb-8a3e-53006ddef2a8.png)
