### PR TITLE
[Mod] Check if guild is unavailable in tempban expirations

### DIFF
--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -243,7 +243,7 @@ class KickBanMixin(MixinMeta):
         async for guild_id, guild_data in AsyncIter(guilds_data.items(), steps=100):
             if not (guild := self.bot.get_guild(guild_id)):
                 continue
-            if not guild.me or not guild.me.guild_permissions.ban_members:
+            if guild.unavailable or not guild.me.guild_permissions.ban_members:
                 continue
             if await self.bot.cog_disabled_in_guild(self, guild):
                 continue

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -243,7 +243,7 @@ class KickBanMixin(MixinMeta):
         async for guild_id, guild_data in AsyncIter(guilds_data.items(), steps=100):
             if not (guild := self.bot.get_guild(guild_id)):
                 continue
-            if not guild.me.guild_permissions.ban_members:
+            if not guild.me or not guild.me.guild_permissions.ban_members:
                 continue
             if await self.bot.cog_disabled_in_guild(self, guild):
                 continue


### PR DESCRIPTION
### Description of the changes
Fixes `guild.me` being None errors when the guild is unavailable.
```py
AttributeError: 'NoneType' object has no attribute 'guild_permissions'
  File "mod/kickban.py", line 235, in tempban_expirations_task
    await self._check_tempban_expirations()
  File "mod/kickban.py", line 246, in _check_tempban_expirations
    if not guild.me.guild_permissions.ban_members:
```