### PR TITLE
[Warnings] Allow for 0 point warnings

### DIFF
--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -395,8 +395,8 @@ class Warnings(commands.Cog):
             if (reason_type := registered_reasons.get(reason.lower())) is None:
                 msg = _("That is not a registered reason!")
                 if custom_allowed:
-                    if points <= 0:
-                        return await ctx.send(_("You cannot apply 0 or less points."))
+                    if points < 0:
+                        return await ctx.send(_("You cannot apply negative points."))
                     reason_type = {"description": reason, "points": points}
                 else:
                     # logic taken from `[p]permissions canrun`


### PR DESCRIPTION
### Description of the changes
Allows moderators to apply 0 points. Fixes #5177 