### PR TITLE
[Downloader] Fix formatting for red version requirement notices

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1496,7 +1496,7 @@ class Downloader(commands.Cog):
                 )
                 if len(outdated_bot_version) > 1
                 else _(
-                    "This cog requires different Red version than you currently "
+                    "\nThis cog requires different Red version than you currently "
                     "have ({current_version}): "
                 )
             ).format(current_version=red_version_info) + humanize_list(outdated_bot_version)


### PR DESCRIPTION
### Description of the changes

This simple change (adding a line break) fixes the formatting in the `[p]cog update` command, for when downloader has both: pinned cog(s), and a cog which has been updated to increment its Red version requirement higher than the current instance's.