### PR TITLE
Make no intents warning stand out

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import NoReturn
 
 import discord
+import rich
 
 # Set the event loop policies here so any subsequent `new_event_loop()`
 # calls, in particular those as a result of the following imports,
@@ -395,10 +396,12 @@ async def run_bot(red: Red, cli_flags: Namespace) -> None:
                 sys.exit(0)
         sys.exit(1)
     except discord.PrivilegedIntentsRequired:
-        print(
+        console = rich.get_console()
+        console.print(
             "Red requires all Privileged Intents to be enabled.\n"
             "You can find out how to enable Privileged Intents with this guide:\n"
-            "https://docs.discord.red/en/stable/bot_application_guide.html#enabling-privileged-intents"
+            "https://docs.discord.red/en/stable/bot_application_guide.html#enabling-privileged-intents",
+            style="red",
         )
         sys.exit(1)
 


### PR DESCRIPTION
### Description of the changes
Use Rich's console print to print the lack of privileged intents warning in red text to make it noticeable. This also has the effect of making the link cyan as well, making it even more noticeable and hopefully helping people click/copy-paste it
This stops the error from 'blending in'.

Top one is old, bottom is new.
![image](https://vex.s-ul.eu/LroSesmS)

Shamelessly stolen from #support, this is what the whole process looks like otherwise:
![image](https://media.discordapp.net/attachments/387398816317440000/862025212245180426/unknown.png)

@kowlin might be interested in this