### PR TITLE
[Audio] UX improvements to `[p]summon` command

### DIFF
--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -686,6 +686,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Unable To Join Voice Channel"),
                 description=_("Connection to Lavalink has not yet been established."),
             )
+        await ctx.tick()
 
     @commands.command(name="volume")
     @commands.guild_only()

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -672,6 +672,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     ctx.author.voice.channel,
                     deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
+            await ctx.tick()
         except AttributeError:
             ctx.command.reset_cooldown(ctx)
             return await self.send_embed_msg(
@@ -686,7 +687,6 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Unable To Join Voice Channel"),
                 description=_("Connection to Lavalink has not yet been established."),
             )
-        await ctx.tick()
 
     @commands.command(name="volume")
     @commands.guild_only()

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -667,7 +667,11 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     and ctx.guild.me in ctx.author.voice.channel.members
                 ):
                     ctx.command.reset_cooldown(ctx)
-                    return
+                    return await self.send_embed_msg(
+                        ctx,
+                        title=_("Unable To Do This Action"),
+                        description=_("I am unable to connect two times."),
+                    )
                 await player.move_to(
                     ctx.author.voice.channel,
                     deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -670,7 +670,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     return await self.send_embed_msg(
                         ctx,
                         title=_("Unable To Do This Action"),
-                        description=_("I am unable to connect two times."),
+                        description=_("I am already in your channel."),
                     )
                 await player.move_to(
                     ctx.author.voice.channel,


### PR DESCRIPTION
### Description of the changes
This pr adds an ✅ when you do `[p]summon`.

![summon](https://user-images.githubusercontent.com/63972751/125450629-35371af1-3d32-43b8-9950-fb8256b08291.png)

Edit: It also now send a message when the bot and the command author are already in the same channel, before it was silently returning.