### PR TITLE
Make the indexing argument optional in leaderboard command

### DIFF
--- a/docs/cog_guides/economy.rst
+++ b/docs/cog_guides/economy.rst
@@ -472,6 +472,7 @@ Print the leaderboard.
 Defaults to top 10.
 
 Examples:
+    - ``[p]leaderboard yes`` - Shows the leaderboard from all servers.
     - ``[p]leaderboard``
     - ``[p]leaderboard 50`` - Shows the top 50 instead of top 10.
     - ``[p]leaderboard 100 yes`` - Shows the top 100 from all servers.

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -561,6 +561,7 @@ class Economy(commands.Cog):
 
         Examples:
             - `[p]leaderboard`
+            - `[p]leaderboard yes` - Shows the leaderboard from all servers.
             - `[p]leaderboard 50` - Shows the top 50 instead of top 10.
             - `[p]leaderboard 100 yes` - Shows the top 100 from all servers.
 

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -4,7 +4,7 @@ import random
 from collections import defaultdict, deque, namedtuple
 from enum import Enum
 from math import ceil
-from typing import cast, Iterable, Union, Literal
+from typing import cast, Iterable, Union, Literal, Optional
 
 import discord
 
@@ -554,7 +554,7 @@ class Economy(commands.Cog):
 
     @commands.command()
     @guild_only_check()
-    async def leaderboard(self, ctx: commands.Context, top: int = 10, show_global: bool = False):
+    async def leaderboard(self, ctx: commands.Context, top: Optional[int] = 10, show_global: bool = False):
         """Print the leaderboard.
 
         Defaults to top 10.

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -554,7 +554,9 @@ class Economy(commands.Cog):
 
     @commands.command()
     @guild_only_check()
-    async def leaderboard(self, ctx: commands.Context, top: Optional[int] = 10, show_global: bool = False):
+    async def leaderboard(
+        self, ctx: commands.Context, top: Optional[int] = 10, show_global: bool = False
+    ):
         """Print the leaderboard.
 
         Defaults to top 10.


### PR DESCRIPTION
### Description of the changes

Adds an Optional typehint to the "top" argument in the leaderboard command, allowing you to pass the global argument without having to provide the indexing argument.
