### PR TITLE
[Downloader] Fix a potential permission error when installing a package with pip

### DIFF
--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -963,7 +963,8 @@ class Repo(RepoJSONMixin):
         p = await self._run(
             ProcessFormatter().format(
                 self.PIP_INSTALL, python=executable, target_dir=target_dir, reqs=requirements
-            )
+            ),
+            cwd=target_dir,
         )
 
         if p.returncode != 0:


### PR DESCRIPTION
### Description of the changes
When installing a package with pip with the target option as we are doing here, some package are installing files in the cwd (which is the cwd of the redbot cmd), to make things clean (files being put in unintended folder) and make sure we have file perms on the folder, we should define the cwd on one of our folder, defining it on the lib folder works.

Example of a package that does this is `greenlet`, when putting it as a req on a cog, on cog install, it will create a file `include/site/python3.8/greenlet/greenlet.h` in the cwd of the redbot cmd. 
(Note: in that example, when the target option is not used, the file gets put in the venv folder, so the lib folder seems like the best place to put that file) 

