### PR TITLE
Add test for presence of upper and lower bound on Python version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ license_files =
 
 [options]
 packages = find_namespace:
-python_requires = <3.9
+python_requires = >=3.8.1,<3.9
 include_package_data = True
 install_requires =
     aiohttp==3.7.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ license_files =
 
 [options]
 packages = find_namespace:
-python_requires = >=3.8.1,<3.9
+python_requires = >=3.8.1
 include_package_data = True
 install_requires =
     aiohttp==3.7.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ license_files =
 
 [options]
 packages = find_namespace:
-python_requires = >=3.8.1
+python_requires = <3.9
 include_package_data = True
 install_requires =
     aiohttp==3.7.3

--- a/tests/core/test_version.py
+++ b/tests/core/test_version.py
@@ -1,3 +1,6 @@
+import importlib.metadata
+import pkg_resources
+
 from redbot import core
 from redbot.core import VersionInfo
 
@@ -34,3 +37,17 @@ def test_version_info_lt():
 
 def test_version_info_gt():
     assert VersionInfo.from_str(version_tests[1]) > VersionInfo.from_str(version_tests[0])
+
+
+def test_python_version_has_upper_and_lower_bound():
+    """
+    Due to constant issues in support with Red being installed on a Python version that was not
+    supported by any Red version, it is important that we have both an upper and lower bound set.
+    """
+    requires_python = importlib.metadata.metadata("Red-DiscordBot")["Requires-Python"]
+    assert requires_python is not None
+
+    # `pkg_resources` needs a regular requirement string, so "x" serves as requirement's name here
+    req = pkg_resources.Requirement.parse(f"x{requires_python}")
+    assert any(op in ("<", "<=") for op, version in req.specs)
+    assert any(op in (">", ">=") for op, version in req.specs)


### PR DESCRIPTION
# Enhancement request

#### Describe the enhancement

Due to constant issues in support with Red being installed on a Python version that was not supported by any Red version, it is important that we have both an upper and lower bound set.
This PR adds a test that ensures that this is always the case. This test might have false-negatives if we were to use `~=` or `==` with a wildcard in the future, and not use the `>`/`>=` and `<`/`<=` comparators. It seems rather unlikely that these would be used so if it does happen, the test can just be updated to work with it.

#### Does this enhancement break existing functionality?

- [ ] Yes
- [x] No

#### Link to failing tests

##### No upper-bound
https://github.com/Cog-Creators/Red-DiscordBot/runs/3162462606

##### No lower-bound
https://github.com/Cog-Creators/Red-DiscordBot/runs/3162482116
