### PR TITLE
[Core] add `ctx.tick()` to `[p]invite`

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1501,6 +1501,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """
         try:
             await ctx.author.send(await self._invite_url())
+            await ctx.tick()
         except discord.errors.Forbidden:
             await ctx.send(
                 "I couldn't send the invite message to you in DM. "


### PR DESCRIPTION
### Description of the changes

This adds a simple tick reaction on the `[p]invite` command. Previously it just sent the invite url to the author and returned.
