### PR TITLE
[Help] Let owners set menu reaction timeout

### DIFF
--- a/docs/cog_guides/core.rst
+++ b/docs/cog_guides/core.rst
@@ -1201,7 +1201,7 @@ helpset reacttimeout
 
 .. code-block:: none
 
-    [p]helpset reacttimeout <limit>
+    [p]helpset reacttimeout <seconds>
 
 **Description**
 

--- a/docs/cog_guides/core.rst
+++ b/docs/cog_guides/core.rst
@@ -1190,7 +1190,6 @@ mean some pages will exceed this limit.
 **Arguments:**
     - ``<limit>`` - The max amount of characters to show per page in the help message.
 
-
 .. _core-command-helpset-reacttimeout:
 
 """"""""""""""""""""
@@ -1218,7 +1217,6 @@ The timeout has to be between 15 and 300 seconds.
 
 **Arguments:**
     - ``<seconds>`` - The timeout, in seconds, of the reactions.
-
 
 .. _core-command-helpset-resetformatter:
 

--- a/docs/cog_guides/core.rst
+++ b/docs/cog_guides/core.rst
@@ -1190,6 +1190,36 @@ mean some pages will exceed this limit.
 **Arguments:**
     - ``<limit>`` - The max amount of characters to show per page in the help message.
 
+
+.. _core-command-helpset-reacttimeout:
+
+""""""""""""""""""""
+helpset reacttimeout
+""""""""""""""""""""
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]helpset reacttimeout <limit>
+
+**Description**
+
+Set the timeout for reactions, if menus are enabled.
+
+The default is 30 seconds.
+The timeout has to be between 15 and 300 seconds.
+
+**Examples:**
+    - ``[p]helpset reacttimeout 30`` - The default timeout.
+    - ``[p]helpset reacttimeout 60`` - Timeout of 1 minute.
+    - ``[p]helpset reacttimeout 15`` - Minimum allowed timeout.
+    - ``[p]helpset reacttimeout 300`` - Max allowed timeout (5 mins).
+
+**Arguments:**
+    - ``<seconds>`` - The timeout, in seconds, of the reactions.
+
+
 .. _core-command-helpset-resetformatter:
 
 """"""""""""""""""""""

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -115,6 +115,7 @@ class RedBase(
             help__verify_exists=False,
             help__tagline="",
             help__use_tick=False,
+            help__react_timeout=30,
             description="Red V3",
             invite_public=False,
             invite_perm=0,

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -78,6 +78,7 @@ class HelpSettings:
     tagline: str = ""
     delete_delay: int = 0
     use_tick: bool = False
+    react_timeout: int = 30
 
     # Contrib Note: This is intentional to not accept the bot object
     # There are plans to allow guild and user specific help settings
@@ -131,6 +132,7 @@ class HelpSettings:
             "\nHelp shows unusable commands when asked directly: {verify_exists}"
             "\nDelete delay: {delete_delay}"
             "\nReact with a checkmark when help is sent via DM: {use_tick}"
+            "\nReaction timeout (only used if menus are used): {react_timeout} seconds"
             "{tagline_info}"
         ).format_map(data)
 
@@ -857,7 +859,9 @@ class RedHelpFormatter(HelpFormatterABC):
             m = await (ctx.send(embed=pages[0]) if embed else ctx.send(pages[0]))
             c = menus.DEFAULT_CONTROLS if len(pages) > 1 else {"\N{CROSS MARK}": menus.close_menu}
             # Allow other things to happen during menu timeout/interaction.
-            asyncio.create_task(menus.menu(ctx, pages, c, message=m))
+            asyncio.create_task(
+                menus.menu(ctx, pages, c, message=m, timeout=help_settings.react_timeout)
+            )
             # menu needs reactions added manually since we fed it a message
             menus.start_adding_reactions(m, c.keys())
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3354,7 +3354,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             - `[p]helpset reacttimeout 300` - Max allowed timeout (5 mins).
 
         **Arguments:**
-            - `<seconds>` - The timeout in seconds of the reactions.
+            - `<seconds>` - The timeout, in seconds, of the reactions.
         """
         if seconds < 15:
             await ctx.send(_("You must give a value of at least 15 seconds!"))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3340,7 +3340,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             await ctx.send(_("Done. The delete delay has been set to {} seconds.").format(seconds))
 
     @helpset.command(name="reacttimeout")
-    @commands.bot_has_permissions(manage_messages=True)
     async def helpset_reacttimeout(self, ctx: commands.Context, seconds: int):
         """Set the timeout for reactions, if menus are enabled.
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3339,6 +3339,32 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             await ctx.send(_("Done. The delete delay has been set to {} seconds.").format(seconds))
 
+    @helpset.command(name="reacttimeout")
+    @commands.bot_has_permissions(manage_messages=True)
+    async def helpset_reacttimeout(self, ctx: commands.Context, seconds: int):
+        """Set the timeout for reactions, if menus are enabled.
+
+        The default is 30 seconds, and it has to be between 15 and 300 seconds.
+
+        **Examples:**
+            - `[p]helpset reacttimeout 30` - The default timeout.
+            - `[p]helpset reacttimeout 60` - Timeout of 1 minute.
+            - `[p]helpset reacttimeout 15` - Minimum allowed timeout.
+            - `[p]helpset reacttimeout 300` - Max allowed timeout (5 mins).
+
+        **Arguments:**
+            - `<seconds>` - The timeout in seconds of the reactions.
+        """
+        if seconds < 15:
+            await ctx.send(_("You must give a value of at least 15 seconds!"))
+            return
+        if seconds > 300:
+            await ctx.send(_("The timeout cannot be greater than 5 minutes!"))
+            return
+
+        await ctx.bot._config.help.react_timeout.set(seconds)
+        await ctx.send(_("Done. The reaction timeout has been set to {} seconds.").format(seconds))
+
     @helpset.command(name="tagline")
     async def helpset_tagline(self, ctx: commands.Context, *, tagline: str = None):
         """

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3344,7 +3344,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     async def helpset_reacttimeout(self, ctx: commands.Context, seconds: int):
         """Set the timeout for reactions, if menus are enabled.
 
-        The default is 30 seconds, and it has to be between 15 and 300 seconds.
+        The default is 30 seconds.
+        The timeout has to be between 15 and 300 seconds.
 
         **Examples:**
             - `[p]helpset reacttimeout 30` - The default timeout.


### PR DESCRIPTION
### Description of the changes
Closes #4074

Allow bot owners to set the timeout for reactions on the help command with `helpset reacttimeout`. The default is still 30 seconds.

There is a min of 15 seconds and a max of 300 seconds/5 mins. These could be changed.

This has roughly copied the delete delay command.