### PR TITLE
Fix typo in exception found in `bot.add_dev_env_value()`

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -348,7 +348,7 @@ class RedBase(
             "__name__",
             "__builtins__",
         ]:
-            raise RuntimeError(f"The name {name} is reserved for default environement.")
+            raise RuntimeError(f"The name {name} is reserved for default environment.")
         if name in dev.env_extensions:
             raise RuntimeError(f"The name {name} is already used.")
         dev.env_extensions[name] = value


### PR DESCRIPTION
### Description of the changes

This PR fixes a small typo found in one of the exceptions raised in the `bot.add_dev_env_value()` function.