### PR TITLE
Document parameters in remaining chat_formatting functions

### DIFF
--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -16,6 +16,11 @@ _ = Translator("UtilsChatFormatting", __file__)
 def error(text: str) -> str:
     """Get text prefixed with an error emoji.
 
+    Parameters
+    ----------
+    text : str
+        The text to be prefixed.
+
     Returns
     -------
     str
@@ -27,6 +32,11 @@ def error(text: str) -> str:
 
 def warning(text: str) -> str:
     """Get text prefixed with a warning emoji.
+
+    Parameters
+    ----------
+    text : str
+        The text to be prefixed.
 
     Returns
     -------
@@ -40,6 +50,11 @@ def warning(text: str) -> str:
 def info(text: str) -> str:
     """Get text prefixed with an info emoji.
 
+    Parameters
+    ----------
+    text : str
+        The text to be prefixed.
+
     Returns
     -------
     str
@@ -51,6 +66,11 @@ def info(text: str) -> str:
 
 def question(text: str) -> str:
     """Get text prefixed with a question emoji.
+
+    Parameters
+    ----------
+    text : str
+        The text to be prefixed.
 
     Returns
     -------


### PR DESCRIPTION
### Description of the changes

Adds parameters to the remaining chat formatting functions without parameters, so that they appear in the docs *with* parameters. I noticed some inconsistency between various functions and whether they had parameters in their docstrings, regardless of the number of arguments the function takes.

For example, `inline` and `quote` functions include parameters inside the docstring, despite only having one argument in the function's signature. The functions contained in this PR also only have one parameter each, therefore it would be nice for consistency measures to provide these functions with parameters in their docstrings too.

TLDR; adds parameters to function docstrings if they don't have parameters in their docstrings.
