### PR TITLE
Add Debian 11 to install guide and clarify "Buster" as Debian 10

### DIFF
--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -124,23 +124,6 @@ with apt:
 
 .. prompt:: bash
 
-    sudo apt -y install python3 python3-dev python3-venv python3-pip git openjdk-11-jre-headless build-essential nano
-
-Continue by `creating-venv-linux`.
-
----
-
-.. _install-debian11:
-
-~~~~~~~~~~~~~~~~~~~~
-Debian 11 Bullseye
-~~~~~~~~~~~~~~~~~~~~
-
-Debian 11 "Bullseye" has all required packages available in official repositories. Install them
-with apt:
-
-.. prompt:: bash
-
     sudo apt update
     sudo apt -y install python3 python3-dev python3-venv python3-pip git openjdk-11-jre-headless build-essential nano
 

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -116,6 +116,23 @@ Debian/Raspbian Buster. This guide will tell you how. First, run the following c
 
 Complete the rest of the installation by `installing Python 3.8 with pyenv <install-python-pyenv>`.
 
+---
+
+.. _instal-debian11:
+
+~~~~~~~~~~~~~~~~~~~~
+Debian 11 Bullseye
+~~~~~~~~~~~~~~~~~~~~
+
+Debian 11 "Bullseye" has all required packages available in official repositories. Install them
+with apt:
+
+.. prompt:: bash
+
+    sudo apt -y install python3 python3-dev python3-venv python3-pip git openjdk-11-jre-headless build-essential nano
+
+Continue by `creating-venv-linux`.
+
 ----
 
 .. _install-fedora:

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -101,9 +101,9 @@ Complete the rest of the installation by `installing Python 3.8 with pyenv <inst
 .. _install-debian:
 .. _install-raspbian:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-Debian and Raspbian Buster
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Debian 10 Buster and Raspberry Pi OS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 We recommend installing pyenv as a method of installing non-native versions of python on
 Debian/Raspbian Buster. This guide will tell you how. First, run the following commands:

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -113,7 +113,7 @@ Complete the rest of the installation by `installing Python 3.9 with pyenv <inst
 
 ---
 
-.. _instal-debian11:
+.. _install-debian11:
 
 ~~~~~~~~~~~~~~~~~~~~
 Debian 11 Bullseye

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -118,7 +118,7 @@ Complete the rest of the installation by `installing Python 3.8 with pyenv <inst
 
 ---
 
-.. _instal-debian11:
+.. _install-debian11:
 
 ~~~~~~~~~~~~~~~~~~~~
 Debian 11 Bullseye

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -129,6 +129,7 @@ with apt:
 
 .. prompt:: bash
 
+    sudo apt update
     sudo apt -y install python3 python3-dev python3-venv python3-pip git openjdk-11-jre-headless build-essential nano
 
 Continue by `creating-venv-linux`.

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -111,6 +111,23 @@ Debian/Raspbian Buster. This guide will tell you how. First, run the following c
 
 Complete the rest of the installation by `installing Python 3.9 with pyenv <install-python-pyenv>`.
 
+---
+
+.. _instal-debian11:
+
+~~~~~~~~~~~~~~~~~~~~
+Debian 11 Bullseye
+~~~~~~~~~~~~~~~~~~~~
+
+Debian 11 "Bullseye" has all required packages available in official repositories. Install them
+with apt:
+
+.. prompt:: bash
+
+    sudo apt -y install python3 python3-dev python3-venv python3-pip git openjdk-11-jre-headless build-essential nano
+
+Continue by `creating-venv-linux`.
+
 ----
 
 .. _install-fedora:

--- a/docs/install_linux_mac.rst
+++ b/docs/install_linux_mac.rst
@@ -96,9 +96,9 @@ Complete the rest of the installation by `installing Python 3.9 with pyenv <inst
 .. _install-debian:
 .. _install-raspbian:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-Debian and Raspbian Buster
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Debian 10 Buster and Raspberry Pi OS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 We recommend installing pyenv as a method of installing non-native versions of python on
 Debian/Raspbian Buster. This guide will tell you how. First, run the following commands:


### PR DESCRIPTION
### Description of the changes

Quick update to the installation instructions to add Debian 11 "Bullseye" instructions. As per #5213, the instructions for Ubuntu 20.04 worked fine, Red installed without problems and no Git errors when adding a repo and some cogs.

There's also a quick update to the heading for Debian Buster to better clarify that it's referring to Debian 10 and then Raspberry Pi OS being based on it.

Fixes #5213 