### PR TITLE
Add toggleable notification of deleted messages count in Cleanup

### DIFF
--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -217,7 +217,7 @@ class Cleanup(commands.Cog):
         log.info(reason)
 
         await mass_purge(to_delete, channel)
-        await self.send_optional_notification(len(to_delete), channel, True)
+        await self.send_optional_notification(len(to_delete), channel, subtract_invoking=True)
 
     @cleanup.command()
     @commands.guild_only()
@@ -288,7 +288,7 @@ class Cleanup(commands.Cog):
         log.info(reason)
 
         await mass_purge(to_delete, channel)
-        await self.send_optional_notification(len(to_delete), channel, True)
+        await self.send_optional_notification(len(to_delete), channel, subtract_invoking=True)
 
     @cleanup.command()
     @commands.guild_only()
@@ -397,7 +397,7 @@ class Cleanup(commands.Cog):
         log.info(reason)
 
         await mass_purge(to_delete, channel)
-        await self.send_optional_notification(len(to_delete), channel, True)
+        await self.send_optional_notification(len(to_delete), channel, subtract_invoking=True)
 
     @cleanup.command()
     @commands.guild_only()
@@ -450,7 +450,7 @@ class Cleanup(commands.Cog):
         log.info(reason)
 
         await mass_purge(to_delete, channel)
-        await self.send_optional_notification(len(to_delete), channel, True)
+        await self.send_optional_notification(len(to_delete), channel, subtract_invoking=True)
 
     @cleanup.command()
     @commands.guild_only()
@@ -489,7 +489,7 @@ class Cleanup(commands.Cog):
         log.info(reason)
 
         await mass_purge(to_delete, channel)
-        await self.send_optional_notification(len(to_delete), channel, True)
+        await self.send_optional_notification(len(to_delete), channel, subtract_invoking=True)
 
     @cleanup.command(name="bot")
     @commands.guild_only()
@@ -716,7 +716,7 @@ class Cleanup(commands.Cog):
 
         to_delete.append(ctx.message)
         await mass_purge(to_delete, ctx.channel)
-        await self.send_optional_notification(len(to_delete), ctx.channel, True)
+        await self.send_optional_notification(len(to_delete), ctx.channel, subtract_invoking=True)
 
     @commands.group()
     @commands.admin_or_permissions(manage_messages=True)

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -32,7 +32,7 @@ class Cleanup(commands.Cog):
     def __init__(self, bot: Red):
         super().__init__()
         self.bot = bot
-        self.config = Config.get_conf(self, 8927348724)
+        self.config = Config.get_conf(self, 8927348724, force_registration=True)
         self.config.register_guild(notify=True)
 
     async def red_delete_data_for_user(self, **kwargs):

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -74,7 +74,7 @@ class Cleanup(commands.Cog):
     @staticmethod
     async def get_messages_for_deletion(
         *,
-        channel: discord.TextChannel,
+        channel: Union[discord.TextChannel, discord.DMChannel],
         number: Optional[PositiveInt] = None,
         check: Callable[[discord.Message], bool] = lambda x: True,
         limit: Optional[PositiveInt] = None,
@@ -126,7 +126,11 @@ class Cleanup(commands.Cog):
         return collected
 
     async def send_optional_notification(
-        self, num: int, channel: discord.TextChannel, *, subtract_invoking: bool = False
+        self,
+        num: int,
+        channel: Union[discord.TextChannel, discord.DMChannel],
+        *,
+        subtract_invoking: bool = False,
     ) -> None:
         """
         Sends a notification to the channel that a certain number of messages have been deleted.

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -124,16 +124,21 @@ class Cleanup(commands.Cog):
 
         return collected
 
-    async def send_optional_notification(self, num: int, channel: discord.TextChannel) -> None:
+    async def send_optional_notification(
+        self, num: int, channel: discord.TextChannel, *, subtract_invoking: bool = False
+    ) -> None:
         """
         Sends a notification to the channel that a certain number of messages have been deleted.
         """
         if not hasattr(channel, "guild") or await self.config.guild(channel.guild).notify():
+            if subtract_invoking:
+                num -= 1
             if num == 1:
                 await channel.send(_("1 message was deleted."), delete_after=5)
             else:
                 await channel.send(
-                    _("{num} messages were deleted.").format(num=num), delete_after=5
+                    _("{num} messages were deleted.").format(num=humanize_number(num)),
+                    delete_after=5,
                 )
 
     @staticmethod
@@ -212,7 +217,7 @@ class Cleanup(commands.Cog):
         log.info(reason)
 
         await mass_purge(to_delete, channel)
-        await self.send_optional_notification(len(to_delete), channel)
+        await self.send_optional_notification(len(to_delete), channel, True)
 
     @cleanup.command()
     @commands.guild_only()
@@ -283,7 +288,7 @@ class Cleanup(commands.Cog):
         log.info(reason)
 
         await mass_purge(to_delete, channel)
-        await self.send_optional_notification(len(to_delete), channel)
+        await self.send_optional_notification(len(to_delete), channel, True)
 
     @cleanup.command()
     @commands.guild_only()
@@ -392,7 +397,7 @@ class Cleanup(commands.Cog):
         log.info(reason)
 
         await mass_purge(to_delete, channel)
-        await self.send_optional_notification(len(to_delete), channel)
+        await self.send_optional_notification(len(to_delete), channel, True)
 
     @cleanup.command()
     @commands.guild_only()
@@ -445,7 +450,7 @@ class Cleanup(commands.Cog):
         log.info(reason)
 
         await mass_purge(to_delete, channel)
-        await self.send_optional_notification(len(to_delete), channel)
+        await self.send_optional_notification(len(to_delete), channel, True)
 
     @cleanup.command()
     @commands.guild_only()
@@ -484,7 +489,7 @@ class Cleanup(commands.Cog):
         log.info(reason)
 
         await mass_purge(to_delete, channel)
-        await self.send_optional_notification(len(to_delete), channel)
+        await self.send_optional_notification(len(to_delete), channel, True)
 
     @cleanup.command(name="bot")
     @commands.guild_only()
@@ -711,7 +716,7 @@ class Cleanup(commands.Cog):
 
         to_delete.append(ctx.message)
         await mass_purge(to_delete, ctx.channel)
-        await self.send_optional_notification(len(to_delete), ctx.channel)
+        await self.send_optional_notification(len(to_delete), ctx.channel, True)
 
     @commands.group()
     @commands.admin_or_permissions(manage_messages=True)

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -576,7 +576,7 @@ class Cleanup(commands.Cog):
         log.info(reason)
 
         await mass_purge(to_delete, channel)
-        await self.send_optional_notification(len(to_delete), channel)
+        await self.send_optional_notification(len(to_delete), channel, subtract_invoking=True)
 
     @cleanup.command(name="self")
     @check_self_permissions()
@@ -665,7 +665,7 @@ class Cleanup(commands.Cog):
             await mass_purge(to_delete, channel)
         else:
             await slow_deletion(to_delete)
-        await self.send_optional_notification(len(to_delete), channel)
+        await self.send_optional_notification(len(to_delete), channel, subtract_invoking=can_mass_purge)
 
     @cleanup.command(name="duplicates", aliases=["spam"])
     @commands.guild_only()

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -123,16 +123,18 @@ class Cleanup(commands.Cog):
                     break
 
         return collected
-    
+
     async def send_optional_notification(self, num: int, channel: discord.TextChannel) -> None:
         """
         Sends a notification to the channel that a certain number of messages have been deleted.
         """
-        if not hasattr(channel, 'guild') or await self.config.guild(channel.guild).notify():
+        if not hasattr(channel, "guild") or await self.config.guild(channel.guild).notify():
             if num == 1:
                 await channel.send(_("1 message was deleted."), delete_after=5)
             else:
-                await channel.send(_("{num} messages were deleted.").format(num=num), delete_after=5)
+                await channel.send(
+                    _("{num} messages were deleted.").format(num=num), delete_after=5
+                )
 
     @staticmethod
     async def get_message_from_reference(

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -665,7 +665,9 @@ class Cleanup(commands.Cog):
             await mass_purge(to_delete, channel)
         else:
             await slow_deletion(to_delete)
-        await self.send_optional_notification(len(to_delete), channel, subtract_invoking=can_mass_purge)
+        await self.send_optional_notification(
+            len(to_delete), channel, subtract_invoking=can_mass_purge
+        )
 
     @cleanup.command(name="duplicates", aliases=["spam"])
     @commands.guild_only()


### PR DESCRIPTION
### Description of the changes


Addition of a toggleable notification allowing to see how many messages have been deleted. Defaults to on

Addition of cleanupset commands, locked to admin or manage message until further discussion.


closes #4732 