### PR TITLE
[Docs] Fix argument formatting in Admin cog guide 

### DIFF
--- a/docs/cog_guides/admin.rst
+++ b/docs/cog_guides/admin.rst
@@ -232,7 +232,7 @@ as yourself, the command author.
 * ``<role>``: The role to remove. |role-input-quotes|
 
 * ``[user]``: The member to remove the role from. |member-input| Defaults
-    to the command author.
+  to the command author.
 
 .. _admin-command-editrole:
 


### PR DESCRIPTION
### Description of the changes

I noticed that the user argument of the removerole command in the admin cog guide had been formatted with two additional spaces, meaning that it ended up formatting weirdly in the docs (see attached image). This PR will fix that issue

![87A130C3-9231-4EEB-B8A9-C23895D39A97](https://user-images.githubusercontent.com/67752638/129644005-31f00e6a-4234-446e-a658-57a688624b53.jpeg)
