### PR TITLE
[Docs] Fix warning block in Mod cog guide

### DIFF
--- a/docs/cog_guides/mod.rst
+++ b/docs/cog_guides/mod.rst
@@ -282,7 +282,7 @@ modset hierarchy
 
 Toggle role hierarchy check for mods and admins.
 
-..warning:: Disabling this setting will allow mods to take actions on users above them in the role hierarchy!
+.. warning:: Disabling this setting will allow mods to take actions on users above them in the role hierarchy!
 
 This is enabled by default.
 


### PR DESCRIPTION
### Description of the changes

This PR fixes a warning block in the Mod cog guide which required an extra space in order to render properly in the docs. The below screenshot shows where it doesn't render.

![image](https://user-images.githubusercontent.com/67752638/129708282-b13d8dea-0878-4c16-a871-b5eeaab79de4.png)
