### PR TITLE
[Streams] Check non-existent streams more than once

### DIFF
--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -31,7 +31,7 @@ from datetime import datetime
 from collections import defaultdict
 from typing import Optional, List, Tuple, Union, Dict
 
-MAX_RETRY_COUNT = 20
+MAX_RETRY_COUNT = 10
 
 _ = Translator("Streams", __file__)
 log = logging.getLogger("red.core.cogs.Streams")

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -31,7 +31,7 @@ from datetime import datetime
 from collections import defaultdict
 from typing import Optional, List, Tuple, Union, Dict
 
-MAX_RETRY_COUNT = 5
+MAX_RETRY_COUNT = 20
 
 _ = Translator("Streams", __file__)
 log = logging.getLogger("red.core.cogs.Streams")

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -31,6 +31,8 @@ from datetime import datetime
 from collections import defaultdict
 from typing import Optional, List, Tuple, Union, Dict
 
+MAX_RETRY_COUNT = 5
+
 _ = Translator("Streams", __file__)
 log = logging.getLogger("red.core.cogs.Streams")
 
@@ -747,8 +749,14 @@ class Streams(commands.Cog):
                     else:
                         embed = await stream.is_online()
                 except StreamNotFound:
-                    log.info("Stream with name %s no longer exists. Removing...", stream.name)
-                    to_remove.append(stream)
+                    if stream.retry_count > MAX_RETRY_COUNT:
+                        log.info("Stream with name %s no longer exists. Removing...", stream.name)
+                        to_remove.append(stream)
+                    else:
+                        log.info(
+                            "Stream with name %s seems to not exist, will retry later", stream.name
+                        )
+                        stream.retry_count += 1
                     continue
                 except OfflineStream:
                     if not stream.messages:

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -132,6 +132,10 @@ class YoutubeStream(Stream):
                     raise StreamNotFound()
                 rssdata = await r.text()
 
+        # Reset the retry count since we successfully got information about this
+        # channel's streams
+        self.retry_count = 0
+
         if self.not_livestreams:
             self.not_livestreams = list(dict.fromkeys(self.not_livestreams))
 
@@ -191,11 +195,6 @@ class YoutubeStream(Stream):
                             self.livestreams.remove(video_id)
         log.debug(f"livestreams for {self.name}: {self.livestreams}")
         log.debug(f"not_livestreams for {self.name}: {self.not_livestreams}")
-
-        # Reset the retry count since we successfully got information about this
-        # channel's streams
-        self.retry_count = 0
-
         # This is technically redundant since we have the
         # info from the RSS ... but incase you don't wanna deal with fully rewritting the
         # code for this part, as this is only a 2 quota query.


### PR DESCRIPTION
### Description of the changes
**Background**:
For YouTube streams, it seems like the YouTube RSS feed sometimes returns a HTTP 404 for a channel, even though the channel exists. This causes #5195.

This PR attempts to fix #5195 by doing the following:
- Declare a new attribute `retry_count` in the `Stream` base class.
- Increment `retry_count` every time we fail to find the stream. In the case of YouTube, this happens when we get an HTTP 404 response from the RSS feed.
- Reset the `retry_count` to zero when we successfully fetch data.
- If we fail to reach it after `MAX_RETRY_COUNT` retries, then we declare the stream as non-existent, and purge it from the list of streams we check.

**Testing**:
- Please see comments below
- Check interval is ~3 minutes.