### PR TITLE
[Docs] Add Oracle Cloud $300 credits to hosting guide

### DIFF
--- a/docs/host-list.rst
+++ b/docs/host-list.rst
@@ -145,6 +145,7 @@ Free Hosting
  Oracle Cloud and Google Cloud offer always free tiers with limited resources.
 
 | Additionally, new Google Cloud customers get a $300 credit which is valid for 3 months.
+ New Oracle Cloud customers also get $300 of free credit, but only valid for 30 days.
 
 | Excluding the above, there is no recommended free VPS host. Persuasion of
  another individual for hosting Red is an option, albeit low in success rate.


### PR DESCRIPTION
### Description of the changes
Oracle Cloud offers $300 of free credits, valid for 30 days, so this has been added to where the same is mentioned for GCP.

Let's not be Googleist :)