### PR TITLE
Respects quotes in set api

### DIFF
--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -192,11 +192,13 @@ else:
         def __init__(self, *expected_keys: str, delims: Optional[List[str]] = None):
             self.expected_keys = expected_keys
             self.delims = delims or [" "]
-            self.pattern = re.compile(r"|".join(re.escape(d) for d in self.delims))
+            self.pattern = re.compile(
+                r"(?:[^" + r"".join(re.escape(d) for d in self.delims) + '"]|"(?:\\.|[^"])*")+'
+            )  # Regex credit to https://stackoverflow.com/a/16710842
 
         async def convert(self, ctx: "Context", argument: str) -> Dict[str, str]:
             ret: Dict[str, str] = {}
-            args = self.pattern.split(argument)
+            args = self.pattern.findall(argument)
 
             if len(args) % 2 != 0:
                 raise BadArgument()

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -193,13 +193,12 @@ else:
             self.expected_keys = expected_keys
             self.delims = delims or [" "]
             self.pattern = re.compile(
-                r"(?:[^" + r"".join(re.escape(d) for d in self.delims) + '"]|"(?:\\.|[^"])*")+'
+                r"(?:[^" + r"".join(re.escape(d) for d in self.delims) + r'"]|"(?:\\.|[^"])*")+'
             )  # Regex credit to https://stackoverflow.com/a/16710842
 
         async def convert(self, ctx: "Context", argument: str) -> Dict[str, str]:
             ret: Dict[str, str] = {}
-            args = self.pattern.findall(argument)
-
+            args = [a.strip('"') for a in self.pattern.findall(argument)]
             if len(args) % 2 != 0:
                 raise BadArgument()
 


### PR DESCRIPTION
### Description of the changes

Uses a regex pattern that respects quotes and uses findall instead of split.

![image](https://user-images.githubusercontent.com/955640/130834956-70c67d00-e965-4719-92e1-6927d238024b.png)


Closes #5222 

Alternative to #5226 