### PR TITLE
[Audio] Update Lavalink.jar build

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -24,7 +24,7 @@ from .utils import task_callback
 _ = Translator("Audio", pathlib.Path(__file__))
 log = logging.getLogger("red.Audio.manager")
 JAR_VERSION: Final[str] = "3.3.2.3"
-JAR_BUILD: Final[int] = 1233
+JAR_BUILD: Final[int] = 1238
 LAVALINK_DOWNLOAD_URL: Final[str] = (
     "https://github.com/Cog-Creators/Lavalink-Jars/releases/download/"
     f"{JAR_VERSION}_{JAR_BUILD}/"


### PR DESCRIPTION
Update audio's manager for the new jar.

```
Fix for age-restricted track fetching.
Fix for yt music searching.
Fix for Soundcloud playback.
```
