### PR TITLE
Update some link texts in docs for accessibility

### DIFF
--- a/docs/bot_application_guide.rst
+++ b/docs/bot_application_guide.rst
@@ -56,7 +56,7 @@ Continue to the next section to enable privileged intents.
 Enabling Privileged Intents
 -------------------------------
 .. warning::
-    :ref:`As explained in this page <intents>`, Red Bot requires all intents.
+    :ref:`Red Bot requires all intents. <intents>`
     \This section is required.
 
 1. Make sure you're logged on to the `Discord website <https://discord.com>`_.
@@ -75,6 +75,6 @@ Enabling Privileged Intents
 .. warning::
 
     Red bots with over 100 servers require `bot verification <https://support.discord.com/hc/en-us/articles/360040720412>`_ which is not covered in this guide.
-    Remember that as explained :ref:`here <intents>` we do not support public bots. We encourage you to read that page before scaling up your bot.
+    Remember that :ref:`we do not support public bots <intents>`. We encourage you to read that page before scaling up your bot.
 
 *Parts of this guide have been adapted from* `discord.py intro <https://discordpy.readthedocs.io/en/stable/discord.html#discord-intro>`_ *and* `discord.py privileged intents <https://discordpy.readthedocs.io/en/stable/intents.html#privileged-intents>`_.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -266,14 +266,14 @@ If you want to do it, follow these steps.
     basics of the Unix commands, such as navigating the system files or use
     a terminal text editor.
 
-    You should follow `this guide
+    You should follow `DigitalOcean's Linux basics guide
     <https://www.digitalocean.com/community/tutorials/an-introduction-to-linux-basics>`_
-    from DigitalOcean which will introduce you to the Linux basics.
+    as an introduction.
 
 1. **Find a host**
 
   You need to find a server to host Red. You can rent a VPS (it can be free)
-  on an online service. Please check :ref:`this page <host-list>` for
+  on an online service. Please check :ref:`this list of hosts <host-list>` for
   more information.
 
   You can also buy a Raspberry Pi (~$20), which is a micro-computer that will
@@ -307,7 +307,7 @@ If you want to do it, follow these steps.
 
 3. **Install and set up Red**
 
-  Just follow one of the Linux installation guide. We provide guides for the
+  Follow one of the Linux installation guide. We provide guides for the
   most used distributions. Check the :ref:`home page <main>` and search for
   your distribution.
 
@@ -318,7 +318,7 @@ If you want to do it, follow these steps.
   side task and handle fatal errors, so you can just leave your server running
   and enjoy Red!
 
-  For that, just follow :ref:`this guide <systemd-service-guide>`.
+  For that, follow :ref:`the systemd service guide <systemd-service-guide>`.
 
 .. _getting-started-userdocs:
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -266,9 +266,9 @@ If you want to do it, follow these steps.
     basics of the Unix commands, such as navigating the system files or use
     a terminal text editor.
 
-    You should follow `DigitalOcean's Linux basics guide
+    You should read `DigitalOcean's tutorial: An Introduction to Linux Basics
     <https://www.digitalocean.com/community/tutorials/an-introduction-to-linux-basics>`_
-    as an introduction.
+    if you have not used Linux before.
 
 1. **Find a host**
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -13,7 +13,7 @@ This is a quick start guide for a general usage.
 .. note::
 
     If you haven't installed Red, please do it by following
-    the :ref:`installation guides <main>`.
+    one of the `installation guides <install_guides/index>`.
 
 Assuming you correctly installed Red, you should have a
 window like this:
@@ -307,8 +307,8 @@ If you want to do it, follow these steps.
 
 3. **Install and set up Red**
 
-  Follow one of the Linux installation guide. We provide guides for the
-  most used distributions. Check the :ref:`home page <main>` and search for
+  Follow one of the Linux installation guides. We provide guides for the
+  most used distributions. Check the `list of install guides <install_guides/index>` and search for
   your distribution.
 
 4. **Set up an auto-restart**

--- a/docs/guide_trivia_list_creation.rst
+++ b/docs/guide_trivia_list_creation.rst
@@ -118,7 +118,7 @@ As you've added more questions, your file should look something like this:
     - $25000
 
 You can keep adding questions until you are satisfied, and then you can upload and
-play your very own trivia! See :ref:`here <trivia-command-triviaset-custom>` for more details.
+play your very own trivia! See :ref:`custom trivia settings <trivia-command-triviaset-custom>` for more information.
 
 Still stuck? Take a look at 
 `the core trivia lists <https://github.com/Cog-Creators/Red-DiscordBot/tree/V3/develop/redbot/cogs/trivia/data/lists>`_

--- a/docs/guide_trivia_list_creation.rst
+++ b/docs/guide_trivia_list_creation.rst
@@ -118,7 +118,7 @@ As you've added more questions, your file should look something like this:
     - $25000
 
 You can keep adding questions until you are satisfied, and then you can upload and
-play your very own trivia! See :ref:`custom trivia settings <trivia-command-triviaset-custom>` for more information.
+play your very own trivia! See :ref:`[p]triviaset custom <trivia-command-triviaset-custom>` for more information.
 
 Still stuck? Take a look at 
 `the core trivia lists <https://github.com/Cog-Creators/Red-DiscordBot/tree/V3/develop/redbot/cogs/trivia/data/lists>`_

--- a/docs/host-list.rst
+++ b/docs/host-list.rst
@@ -41,9 +41,9 @@ Hosting on a VPS or Dedicated Server
 
 .. warning::
     Please be aware that a Linux server is controlled through a command line.
-    If you don't know Unix basics, please take a look at `this guide
-    <https://www.digitalocean.com/community/tutorials/an-introduction-to-linux-basics>`_
-    from DigitalOcean which will introduce you to the Linux basics.
+    If you don't know Unix basics, please take a look at
+    `DigitalOcean's tutorial: An Introduction to Linux Basics
+    <https://www.digitalocean.com/community/tutorials/an-introduction-to-linux-basics>`_.
 
 
 ------------

--- a/docs/host-list.rst
+++ b/docs/host-list.rst
@@ -8,7 +8,7 @@ Hosting Information
 
 .. note::
     This doc is written for the :ref:`hosting section <getting-started-hosting>`
-    of the :ref:`getting started <getting-started>` guide. Please take a look
+    of the :ref:`getting started guide <getting-started>`. Please take a look
     if you don't know how to host Red.
 
 

--- a/docs/install_guides/_includes/linux-preamble.rst
+++ b/docs/install_guides/_includes/linux-preamble.rst
@@ -1,5 +1,5 @@
 .. warning::
 
     For safety reasons, DO NOT install Red with a root user. If you are unsure how to create
-    a new user on Linux, see `this guide by DigitalOcean
+    a new user on Linux, see `DigitalOcean's tutorial: How To Create a New Sudo-enabled User
     <https://www.digitalocean.com/community/tutorials/how-to-create-a-new-sudo-enabled-user-on-ubuntu-20-04-quickstart>`_.

--- a/docs/install_guides/windows.rst
+++ b/docs/install_guides/windows.rst
@@ -166,8 +166,7 @@ Once done setting up the instance, run the following command to run Red:
     redbot <your instance name>
 
 It will walk through the initial setup, asking for your token and a prefix.
-You can find out how to obtain a token with
-`this guide <../bot_application_guide>`.
+`See how to obtain a token. <../bot_application_guide>`
 
 .. tip::
    If it's the first time you're using Red, you should check our `getting-started` guide

--- a/docs/intents.rst
+++ b/docs/intents.rst
@@ -123,14 +123,11 @@ The *bandaid fix* is for you to change your bot's prefix to a mention and a good
 still work. You will however lose many functions, namely anything that relies on seeing message content to act. |br|
 The more *proper fix* is also not easy. You will need to justify your need for the message intent to Discord and
 they will only accept "compelling use cases".
-`It is not known <https://gist.github.com/spiralw/091714718718379b6efcdbcaf807a024#q-what-usecases-will-be-valid>`_
-what those even entail at this point, but they have already stated that "parsing commands" is not a valid justification. |br|
-To make the matter worse, Discord is making a huge push for all bot developers to implement
-`slash commands <https://support.discord.com/hc/en-us/articles/1500000368501-Slash-Commands-FAQ>`_, which at the moment
+`It is not known what those even entail <https://gist.github.com/spiralw/091714718718379b6efcdbcaf807a024#q-what-usecases-will-be-valid>`_ at this point, but they have already stated that "parsing commands" is not a valid justification. |br|
+To make the matter worse, Discord is making `a huge push for all bot developers to implement slash commands <https://support.discord.com/hc/en-us/articles/1500000368501-Slash-Commands-FAQ>`_, which at the moment
 are rather lacking in features and cannot cover all the functionalities that standard commands offer. |br|
 Discord staff
-`stated <https://gist.github.com/spiralw/091714718718379b6efcdbcaf807a024#q-if-we-are-granted-this-intent-will-bots-be-sanctioned-if-they-use-it-for-their-own-use-case-but-also-to-continue-to-run-normal-non-slash-commands-or-do-we-assume-that-if-you-are-granted-the-intent-you-are-trusted-with-it-and-are-allowed-to-use-it-for-additional-uses>`_
-that they will want your bot to have slash commands when you ask for message intent. |br|
+`stated that they will want your bot to have slash commands when you ask for message intent <https://gist.github.com/spiralw/091714718718379b6efcdbcaf807a024#q-if-we-are-granted-this-intent-will-bots-be-sanctioned-if-they-use-it-for-their-own-use-case-but-also-to-continue-to-run-normal-non-slash-commands-or-do-we-assume-that-if-you-are-granted-the-intent-you-are-trusted-with-it-and-are-allowed-to-use-it-for-additional-uses>`_. |br|
 Slash commands might very well turn out to be a big undertaking for the Red team to implement, even more now that our
 underlying library, `discord.py <https://github.com/Rapptz/discord.py>`_, has been discontinued. |br|
 The time window that Discord is giving us to adapt is very narrow: **Red will likely not be able to support slash


### PR DESCRIPTION
### Description of the changes
* Update link display texts in accordance with [this article on accessibility](https://usability.yale.edu/web-accessibility/articles/links)
* Remove the word "just" in a couple places because it's not a best practice when writing docs to use it (1 - it's a filler word; 2 - it can make a user feel bad about not understanding)

I'm happy to make any modifications or additional changes if you want, let me know!