### PR TITLE
Initialize driver before starting the backup

### DIFF
--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -232,7 +232,10 @@ async def create_backup(instance: str, destination_folder: Path = Path.home()) -
     if backend_type != BackendType.JSON:
         await do_migration(backend_type, BackendType.JSON)
     print("Backing up the instance's data...")
+    driver_cls = drivers.get_driver_class()
+    await driver_cls.initialize(**data_manager.storage_details())
     backup_fpath = await red_create_backup(destination_folder)
+    await driver_cls.teardown()
     if backup_fpath is not None:
         print(f"A backup of {instance} has been made. It is at {backup_fpath}")
     else:


### PR DESCRIPTION
### Description of the changes

There is a long time bug with the backup process that affected users of Postgres or Redis (or any driver that requires initialization).

```py
async def create_backup(instance: str, destination_folder: Path = Path.home()) -> None:
    data_manager.load_basic_configuration(instance)
    backend_type = get_current_backend(instance)
    if backend_type != BackendType.JSON:
        await do_migration(backend_type, BackendType.JSON)
    print("Backing up the instance's data...")
    driver_cls = drivers.get_driver_class()
    await driver_cls.initialize(**data_manager.storage_details())
    backup_fpath = await red_create_backup(destination_folder)
    await driver_cls.teardown()
    if backup_fpath is not None:
        print(f"A backup of {instance} has been made. It is at {backup_fpath}")
    else:
        print("Creating the backup failed.")
```

Basically, `do_migration` is actually initializing the driver, but it's almost immediatly tore down. Then, `red_create_backup` is called and needs to call config (RepoManager), but the driver isn't ready at this point.

The JSON doesn't seem to complain if it's not initialized, which is probably why this bug went under cover for so long.

Here's the error I was getting: https://gist.github.com/retke/504191227672cb2216592cdc4f07f7e1

----

Re-initializing the driver fixed the issue on my end, but it may be easier to only initialize and teardown the driver once, which would require a bit more changes. That, or getting rid of that extra config call in `red_create_backup`.

### Side note

For both Postgres and Redis users, seeing the error `Pool is closed` means the same thing, driver is not initialized, and this error is actually pretty common across the bot, so there are probably more bugs like this to fix in Red.