### PR TITLE
Fix Case's modified_at attr and its format in message content

### DIFF
--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -283,7 +283,7 @@ class Case:
         .. note::
             This attribute will be of type `int`
             if the Discord user can no longer be found.
-    modified_at: Optional[int]
+    modified_at: Optional[float]
         The UNIX time of the last change to the case.
         `None` if the case was never edited.
     message: Optional[discord.Message]
@@ -310,7 +310,7 @@ class Case:
         until: Optional[int] = None,
         channel: Optional[Union[discord.abc.GuildChannel, int]] = None,
         amended_by: Optional[Union[discord.Object, discord.abc.User, int]] = None,
-        modified_at: Optional[int] = None,  # Who ever said this was an int. You lied. -Kowlin
+        modified_at: Optional[float] = None,
         message: Optional[discord.Message] = None,
         last_known_username: Optional[str] = None,
     ):

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -310,7 +310,7 @@ class Case:
         until: Optional[int] = None,
         channel: Optional[Union[discord.abc.GuildChannel, int]] = None,
         amended_by: Optional[Union[discord.Object, discord.abc.User, int]] = None,
-        modified_at: Optional[int] = None,
+        modified_at: Optional[int] = None,  # Who ever said this was an int. You lied. -Kowlin
         message: Optional[discord.Message] = None,
         last_known_username: Optional[str] = None,
     ):
@@ -454,7 +454,7 @@ class Case:
 
         last_modified = None
         if self.modified_at:
-            last_modified = f"<t:{self.modified_at}>"
+            last_modified = f"<t:{int(self.modified_at)}>"
 
         if isinstance(self.user, int):
             if self.user == 0xDE1:


### PR DESCRIPTION
### Description of the changes
It appears that ``modified_at`` is in fact NOT an int in all cases... Its sometimes a float!