### PR TITLE
Use discord native timestamp in [p]uptime

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -561,7 +561,11 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         delta = datetime.datetime.utcnow() - self.bot.uptime
         uptime = self.bot.uptime.replace(tzinfo=datetime.timezone.utc)
         uptime_str = humanize_timedelta(timedelta=delta) or _("Less than one second.")
-        await ctx.send(_(f"Been up for: **{uptime_str}** (since <t:{int(uptime.timestamp())}:f>)"))
+        await ctx.send(
+            _(f"Been up for: **{time_quantity}** (since {timestamp})").format(
+                time_quantity=uptime_str, timestamp=f"<t:{int(uptime.timestamp())}:f>"
+            )
+        )
 
     @commands.group(cls=commands.commands._AlwaysAvailableGroup)
     async def mydata(self, ctx: commands.Context):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -558,14 +558,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @commands.command()
     async def uptime(self, ctx: commands.Context):
         """Shows [botname]'s uptime."""
-        since = ctx.bot.uptime.strftime("%Y-%m-%d %H:%M:%S")
-        delta = datetime.datetime.utcnow() - self.bot.uptime
-        uptime_str = humanize_timedelta(timedelta=delta) or _("Less than one second")
-        await ctx.send(
-            _("Been up for: **{time_quantity}** (since {timestamp} UTC)").format(
-                time_quantity=uptime_str, timestamp=since
-            )
-        )
+        delta = datetime.utcnow() - self.bot.uptime
+        uptime = self.bot.uptime.replace(tzinfo=timezone.utc)
+        uptime_str = humanize_timedelta(timedelta=delta) or ("Less than one second.")
+        await ctx.send(_(f"Been up for: **{uptime_str}** (since <t:{int(uptime.timestamp())}:f>)"))
 
     @commands.group(cls=commands.commands._AlwaysAvailableGroup)
     async def mydata(self, ctx: commands.Context):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -562,7 +562,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         uptime = self.bot.uptime.replace(tzinfo=datetime.timezone.utc)
         uptime_str = humanize_timedelta(timedelta=delta) or _("Less than one second.")
         await ctx.send(
-            _(f"Been up for: **{time_quantity}** (since {timestamp})").format(
+            _("Been up for: **{time_quantity}** (since {timestamp})").format(
                 time_quantity=uptime_str, timestamp=f"<t:{int(uptime.timestamp())}:f>"
             )
         )

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -559,7 +559,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     async def uptime(self, ctx: commands.Context):
         """Shows [botname]'s uptime."""
         delta = datetime.datetime.utcnow() - self.bot.uptime
-        uptime = self.bot.uptime.replace(tzinfo=timezone.utc)
+        uptime = self.bot.uptime.replace(tzinfo=datetime.timezone.utc)
         uptime_str = humanize_timedelta(timedelta=delta) or _("Less than one second.")
         await ctx.send(_(f"Been up for: **{uptime_str}** (since <t:{int(uptime.timestamp())}:f>)"))
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -558,7 +558,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @commands.command()
     async def uptime(self, ctx: commands.Context):
         """Shows [botname]'s uptime."""
-        delta = datetime.utcnow() - self.bot.uptime
+        delta = datetime.datetime.utcnow() - self.bot.uptime
         uptime = self.bot.uptime.replace(tzinfo=timezone.utc)
         uptime_str = humanize_timedelta(timedelta=delta) or _("Less than one second.")
         await ctx.send(_(f"Been up for: **{uptime_str}** (since <t:{int(uptime.timestamp())}:f>)"))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -560,7 +560,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """Shows [botname]'s uptime."""
         delta = datetime.utcnow() - self.bot.uptime
         uptime = self.bot.uptime.replace(tzinfo=timezone.utc)
-        uptime_str = humanize_timedelta(timedelta=delta) or ("Less than one second.")
+        uptime_str = humanize_timedelta(timedelta=delta) or _("Less than one second.")
         await ctx.send(_(f"Been up for: **{uptime_str}** (since <t:{int(uptime.timestamp())}:f>)"))
 
     @commands.group(cls=commands.commands._AlwaysAvailableGroup)


### PR DESCRIPTION
### Description of the changes

Since it wasn't already added, i've added the new discord's timestamp on `since` only to show current timezone.

![5a2rJqX2i](https://user-images.githubusercontent.com/63972751/133459780-3ca24db1-568a-4cde-8a15-e5b9012e7129.png)
