### PR TITLE
[modlog] Fix broken timestamp

### DIFF
--- a/redbot/cogs/modlog/modlog.py
+++ b/redbot/cogs/modlog/modlog.py
@@ -250,7 +250,7 @@ class ModLog(commands.Cog):
         to_modify = {"reason": reason}
         if case_obj.moderator != author:
             to_modify["amended_by"] = author
-        to_modify["modified_at"] = ctx.message.created_at.replace(tzinfo=timezone.utc).timestamp()
+        to_modify["modified_at"] = int(ctx.message.created_at.replace(tzinfo=timezone.utc).timestamp())
         await case_obj.edit(to_modify)
         await ctx.send(
             _("Reason for case #{num} has been updated.").format(num=case_obj.case_number)


### PR DESCRIPTION
### Description of the changes

Converted timestamp from a float to an int as floats do not work with Discord's timestamp

![notworktimestamp](https://user-images.githubusercontent.com/46342195/134115342-bfc4fe46-ce07-49c2-a346-ea5f9b6877af.png)

![yesworktimestamp](https://user-images.githubusercontent.com/46342195/134115360-89535021-fc30-4b12-bbe2-fb2863b06093.png)

