### PR TITLE
[Config] Add type-hints to _ValueContextManager methods

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -89,10 +89,10 @@ class _ValueCtxManager(Awaitable[_T], AsyncContextManager[_T]):  # pylint: disab
         self.__acquire_lock = acquire_lock
         self.__lock = self.value_obj.get_lock()
 
-    def __await__(self):
+    def __await__(self) -> _T:
         return self.coro.__await__()
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> _T:
         if self.__acquire_lock is True:
             await self.__lock.acquire()
         self.raw_value = await self


### PR DESCRIPTION
Without these type-hints, I've found that PyCharm misidentifies the returned type, causing a number of false positives in static type checking.

### Before these changes:
![image](https://user-images.githubusercontent.com/7438501/134762879-b6eca920-12e9-4ee3-85fe-cff4a1bf2cfa.png)

### After these changes:
![image](https://user-images.githubusercontent.com/7438501/134762897-d10c645d-c99e-4360-9a05-c30017d18211.png)
