### PR TITLE
[Mute] Check for the user's role list before unmuting

### DIFF
--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -1602,15 +1602,18 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
             if not role:
                 ret["reason"] = _(MUTE_UNMUTE_ISSUES["role_missing"])
                 return ret
-
-            if guild.id in self._server_mutes:
-                if user.id in self._server_mutes[guild.id]:
-                    del self._server_mutes[guild.id][user.id]
             if not guild.me.guild_permissions.manage_roles or role >= guild.me.top_role:
                 ret["reason"] = _(MUTE_UNMUTE_ISSUES["permissions_issue_role"])
                 return ret
+
             try:
-                await user.remove_roles(role, reason=reason)
+                if role in user.roles:
+                    await user.remove_roles(role, reason=reason)
+                elif guild.id in self._server_mutes and user.id in self._server_mutes[guild.id]:
+                    del self._server_mutes[guild.id][user.id]
+                else:
+                    ret["reason"] = _(MUTE_UNMUTE_ISSUES["already_unmuted"])
+                    return ret
             except discord.errors.Forbidden:
                 ret["reason"] = _(MUTE_UNMUTE_ISSUES["permissions_issue_role"])
                 return ret


### PR DESCRIPTION
Closes #5161

Adds a check if the member was muted

There was a corresponding MUTE_UNMUTE_ISSUE before, but it was only checked for channelwise muting