### PR TITLE
[Docs] Removes LXC as an unsupported hosting platform

### DIFF
--- a/docs/host-list.rst
+++ b/docs/host-list.rst
@@ -21,7 +21,7 @@ First, we would like to make something clear:
 .. warning::
     Due to their inability to handle Red's data structure and meet the
     conditions of being a supported platform; platforms such as Heroku, 
-    Pterodactyl, repl.it, Termux, LXC and alike are **NOT** officially supported. 
+    Pterodactyl, repl.it, Termux and alike are **NOT** officially supported. 
     Docker support found in GitHub is also a work in progress and not ready
     for daily use. Workarounds for getting Red running on those platforms
     are imperfect due to Red's nature. You will not be able to receive


### PR DESCRIPTION
### Description of the changes
LXC is listed as an unsupported hosting platform when a vast majority of VPS rentals utilize that technology. 

While a seemingly pedantic change, broadly declaring that LXCs (and relating technologies) are unsupported would be overreaching; as I don't believe the intent is to require full VMs for Red.