### PR TITLE
Add a tick on traceback command when it's sent to DMs

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1456,7 +1456,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """
         if not public:
             destination = ctx.author
-            await ctx.tick()
         else:
             destination = ctx.channel
 
@@ -1472,6 +1471,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                     return
         else:
             await ctx.send(_("No exception has occurred yet."))
+        if not public:
+            await ctx.tick()
 
     @commands.command()
     @commands.check(CoreLogic._can_get_invite_url)

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1469,10 +1469,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                         "Either you blocked me or you disabled DMs in this server."
                     )
                     return
-        else:
-            await ctx.send(_("No exception has occurred yet."))
         if not public:
             await ctx.tick()
+        else:
+            await ctx.send(_("No exception has occurred yet."))
 
     @commands.command()
     @commands.check(CoreLogic._can_get_invite_url)

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1456,6 +1456,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """
         if not public:
             destination = ctx.author
+            await ctx.tick()
         else:
             destination = ctx.channel
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1469,8 +1469,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                         "Either you blocked me or you disabled DMs in this server."
                     )
                     return
-        if not public:
-            await ctx.tick()
+            if not public:
+                await ctx.tick()
         else:
             await ctx.send(_("No exception has occurred yet."))
 


### PR DESCRIPTION
### Description of the changes

This only add a ✅ when the traceback is sent to dm.