### PR TITLE
Handle os error in cogmanager with "friendly" message

### DIFF
--- a/redbot/core/cog_manager.py
+++ b/redbot/core/cog_manager.py
@@ -357,7 +357,7 @@ class CogManagerUI(commands.Cog):
             await ctx.send(
                 _(
                     "That path does not exist or does not point to a valid directory. \nCheck that your path does not contain any {quotation_mark}, {apostrophe} or other invalid characters."
-                ).format(quotation_mark='``"``', apostrophe="``'``")
+                ).format(quotation_mark='`"`', apostrophe="`'`")
             )
             return
         try:

--- a/redbot/core/cog_manager.py
+++ b/redbot/core/cog_manager.py
@@ -347,10 +347,19 @@ class CogManagerUI(commands.Cog):
         """
         Add a path to the list of available cog paths.
         """
-        if not path.is_dir():
-            await ctx.send(_("That path does not exist or does not point to a valid directory."))
+        try:
+            if not path.is_dir():
+                await ctx.send(
+                    _("That path does not exist or does not point to a valid directory.")
+                )
+                return
+        except OSError:
+            await ctx.send(
+                _(
+                    "That path does not exist or does not point to a valid directory. \nCheck that your path does not contain any {quotation_mark}, {apostrophe} or other invalid characters."
+                ).format(quotation_mark='``"``', apostrophe="``'``")
+            )
             return
-
         try:
             await ctx.bot._cog_mgr.add_path(path)
         except ValueError as e:


### PR DESCRIPTION
### Description of the changes
Closes #5138

Seems like pathlib was not happy with special characters.

I have played around with the original issue a bit and it seems to me that the " and ' together with \ in the case described by @jack1142 are the issue.
![image](https://user-images.githubusercontent.com/57032623/135597240-b6c7f3b9-0ef6-4de5-9568-1d794e60b8d3.png)

Since \ is discord's escape character I also tried escaping the \ with another \ ("C:\\") which also produced the error.