### PR TITLE
Address common issues with load path configuration in docs

### DIFF
--- a/docs/install_guides/_includes/_install-pyenv-and-setup-path.rst
+++ b/docs/install_guides/_includes/_install-pyenv-and-setup-path.rst
@@ -16,4 +16,4 @@ you should run these commands:
     echo 'eval "$(pyenv init -)"' >> "$rcfile"
     echo 'eval "$(pyenv virtualenv-init -)"' >> "$rcfile"
 
-Then **close and reopen to your shell** and run the following command:
+Then **log out and log back in** and run the following command:

--- a/docs/install_guides/_includes/_install-pyenv-and-setup-path.rst
+++ b/docs/install_guides/_includes/_install-pyenv-and-setup-path.rst
@@ -1,0 +1,18 @@
+To install/update pyenv, run the following command:
+
+.. prompt:: bash
+
+    command -v pyenv && pyenv update || curl https://pyenv.run | bash
+
+After this command, you will see a warning about 'pyenv' not being in the load path. To address this,
+you should run these commands:
+
+.. prompt:: bash
+
+    profile=$([ -f ~/.bash_profile ] && echo ~/.bash_profile || echo ~/.profile)
+    printf '%s\n%s\n%s\n' 'export PYENV_ROOT="$HOME/.pyenv"' 'export PATH="$PYENV_ROOT/bin:$PATH"' "$([ -f "$profile" ] && cat "$profile")" > "$profile"
+    echo 'eval "$(pyenv init --path)"' >> "$profile"
+    echo 'eval "$(pyenv init -)"' >> ~/.bashrc
+    echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc
+
+Then **close and reopen to your shell** and run the following command:

--- a/docs/install_guides/_includes/_install-pyenv-and-setup-path.rst
+++ b/docs/install_guides/_includes/_install-pyenv-and-setup-path.rst
@@ -9,7 +9,7 @@ you should run these commands:
 
 .. prompt:: bash
 
-    profile=$([ -n "$ZSH_VERSION" ] && echo ~/.zprofile || [ -f ~/.bash_profile ] && echo ~/.bash_profile || echo ~/.profile)
+    profile=$([ -n "$ZSH_VERSION" ] && echo ~/.zprofile || ([ -f ~/.bash_profile ] && echo ~/.bash_profile || echo ~/.profile))
     rcfile=$([ -n "$ZSH_VERSION" ] && echo ~/.zshrc || echo ~/.bashrc)
     printf '%s\n%s\n%s\n' 'export PYENV_ROOT="$HOME/.pyenv"' 'export PATH="$PYENV_ROOT/bin:$PATH"' "$([ -f "$profile" ] && cat "$profile")" > "$profile"
     echo 'eval "$(pyenv init --path)"' >> "$profile"

--- a/docs/install_guides/_includes/_install-pyenv-and-setup-path.rst
+++ b/docs/install_guides/_includes/_install-pyenv-and-setup-path.rst
@@ -9,10 +9,11 @@ you should run these commands:
 
 .. prompt:: bash
 
-    profile=$([ -f ~/.bash_profile ] && echo ~/.bash_profile || echo ~/.profile)
+    profile=$([ -n "$ZSH_VERSION" ] && [ -f ~/.zprofile ] && echo ~/.zprofile || [ -f ~/.bash_profile ] && echo ~/.bash_profile || echo ~/.profile)
+    rcfile=$([ -n "$ZSH_VERSION" ] && echo ~/.zshrc || echo ~/.bashrc)
     printf '%s\n%s\n%s\n' 'export PYENV_ROOT="$HOME/.pyenv"' 'export PATH="$PYENV_ROOT/bin:$PATH"' "$([ -f "$profile" ] && cat "$profile")" > "$profile"
     echo 'eval "$(pyenv init --path)"' >> "$profile"
-    echo 'eval "$(pyenv init -)"' >> ~/.bashrc
-    echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc
+    echo 'eval "$(pyenv init -)"' >> "$rcfile"
+    echo 'eval "$(pyenv virtualenv-init -)"' >> "$rcfile"
 
 Then **close and reopen to your shell** and run the following command:

--- a/docs/install_guides/_includes/_install-pyenv-and-setup-path.rst
+++ b/docs/install_guides/_includes/_install-pyenv-and-setup-path.rst
@@ -9,7 +9,7 @@ you should run these commands:
 
 .. prompt:: bash
 
-    profile=$([ -n "$ZSH_VERSION" ] && [ -f ~/.zprofile ] && echo ~/.zprofile || [ -f ~/.bash_profile ] && echo ~/.bash_profile || echo ~/.profile)
+    profile=$([ -n "$ZSH_VERSION" ] && echo ~/.zprofile || [ -f ~/.bash_profile ] && echo ~/.bash_profile || echo ~/.profile)
     rcfile=$([ -n "$ZSH_VERSION" ] && echo ~/.zshrc || echo ~/.bashrc)
     printf '%s\n%s\n%s\n' 'export PYENV_ROOT="$HOME/.pyenv"' 'export PATH="$PYENV_ROOT/bin:$PATH"' "$([ -f "$profile" ] && cat "$profile")" > "$profile"
     echo 'eval "$(pyenv init --path)"' >> "$profile"

--- a/docs/install_guides/_includes/install-python-pyenv.rst
+++ b/docs/install_guides/_includes/install-python-pyenv.rst
@@ -6,7 +6,7 @@ On distributions where Python 3.9 needs to be compiled from source, we recommend
 This simplifies the compilation process and has the added bonus of simplifying setting up Red in a
 virtual environment.
 
-.. include:: _install-pyenv-and-setup-path.rst
+.. include:: _includes/_install-pyenv-and-setup-path.rst
 
 .. prompt:: bash
 

--- a/docs/install_guides/_includes/install-python-pyenv.rst
+++ b/docs/install_guides/_includes/install-python-pyenv.rst
@@ -6,14 +6,7 @@ On distributions where Python 3.9 needs to be compiled from source, we recommend
 This simplifies the compilation process and has the added bonus of simplifying setting up Red in a
 virtual environment.
 
-.. prompt:: bash
-
-    command -v pyenv && pyenv update || curl https://pyenv.run | bash
-
-**After this command, you may see a warning about 'pyenv' not being in the load path. Follow the
-instructions given to fix that, then close and reopen your shell.**
-
-Then run the following command:
+.. include:: _install-pyenv-and-setup-path.rst
 
 .. prompt:: bash
 

--- a/docs/install_guides/_includes/install-python38-pyenv.rst
+++ b/docs/install_guides/_includes/install-python38-pyenv.rst
@@ -6,14 +6,7 @@ On distributions where Python 3.8 needs to be compiled from source, we recommend
 This simplifies the compilation process and has the added bonus of simplifying setting up Red in a
 virtual environment.
 
-.. prompt:: bash
-
-    command -v pyenv && pyenv update || curl https://pyenv.run | bash
-
-**After this command, you may see a warning about 'pyenv' not being in the load path. Follow the
-instructions given to fix that, then close and reopen your shell.**
-
-Then run the following command:
+.. include:: _install-pyenv-and-setup-path.rst
 
 .. prompt:: bash
 

--- a/docs/install_guides/_includes/install-python38-pyenv.rst
+++ b/docs/install_guides/_includes/install-python38-pyenv.rst
@@ -6,7 +6,7 @@ On distributions where Python 3.8 needs to be compiled from source, we recommend
 This simplifies the compilation process and has the added bonus of simplifying setting up Red in a
 virtual environment.
 
-.. include:: _install-pyenv-and-setup-path.rst
+.. include:: _includes/_install-pyenv-and-setup-path.rst
 
 .. prompt:: bash
 

--- a/docs/install_guides/mac.rst
+++ b/docs/install_guides/mac.rst
@@ -30,7 +30,7 @@ To fix this, you should run these commands:
 
 .. prompt:: bash
 
-    profile=$([ -n "$ZSH_VERSION" ] && echo ~/.zprofile || [ -f ~/.bash_profile ] && echo ~/.bash_profile || echo ~/.profile)
+    profile=$([ -n "$ZSH_VERSION" ] && echo ~/.zprofile || ([ -f ~/.bash_profile ] && echo ~/.bash_profile || echo ~/.profile))
     echo 'export PATH="$(brew --prefix)/opt/python@3.9/bin:$PATH"' >> "$profile"
     source "$profile"
 

--- a/docs/install_guides/mac.rst
+++ b/docs/install_guides/mac.rst
@@ -30,7 +30,7 @@ To fix this, you should run these commands:
 
 .. prompt:: bash
 
-    profile=$([ -n "$ZSH_VERSION" ] && [ -f ~/.zprofile ] && echo ~/.zprofile || [ -f ~/.bash_profile ] && echo ~/.bash_profile || echo ~/.profile)
+    profile=$([ -n "$ZSH_VERSION" ] && echo ~/.zprofile || [ -f ~/.bash_profile ] && echo ~/.bash_profile || echo ~/.profile)
     echo 'export PATH="$(brew --prefix)/opt/python@3.9/bin:$PATH"' >> "$profile"
     source "$profile"
 

--- a/docs/install_guides/mac.rst
+++ b/docs/install_guides/mac.rst
@@ -22,10 +22,17 @@ one-by-one:
 .. prompt:: bash
 
     brew install python@3.9
-    echo 'export PATH="$(brew --prefix)/opt/python@3.9/bin:$PATH"' >> ~/.profile
-    source ~/.profile
     brew install git
     brew install --cask adoptopenjdk/openjdk/adoptopenjdk11
+
+By default, Python installed through Homebrew is not added to the load path.
+To fix this, you should run these commands:
+
+.. prompt:: bash
+
+    profile=$([ -n "$ZSH_VERSION" ] && [ -f ~/.zprofile ] && echo ~/.zprofile || [ -f ~/.bash_profile ] && echo ~/.bash_profile || echo ~/.profile)
+    echo 'export PATH="$(brew --prefix)/opt/python@3.9/bin:$PATH"' >> "$profile"
+    source "$profile"
 
 .. Include common instructions:
 


### PR DESCRIPTION
### Description of the changes
- Add instructions on how to add pyenv to load path
    - I include support for zsh in pyenv load path instructions because why not
- Make instructions for Mac work when shell-specific profile (.bash_profile/.zprofile) file exists

See docs preview:
- Mac: https://red-discordbot--5356.org.readthedocs.build/en/5356/install_guides/mac.html
- pyenv instructions:
    - Python 3.9 (shown for CentOS but it's same for other OSes): https://red-discordbot--5356.org.readthedocs.build/en/5356/install_guides/centos-7.html#installing-python-with-pyenv
    - Python 3.8 (shown for Raspberry Pi OS): https://red-discordbot--5356.org.readthedocs.build/en/5356/install_guides/raspberry-pi-os-10.html#installing-python-with-pyenv

I know these are somewhat complicated but I expect users will just copy-paste though so it shouldn't particularly matter.

Could use some additional testing.