### PR TITLE
[Mod] fix possible issue in userinfo if joined_at is None

### DIFF
--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -193,9 +193,10 @@ class ModInfo(MixinMeta):
         roles = member.roles[-1:0:-1]
         names, nicks = await self.get_names_and_nicks(member)
 
-        joined_at = member.joined_at.replace(tzinfo=datetime.timezone.utc)
         if is_special:
             joined_at = special_date
+        elif joined_at := member.joined_at:
+            joined_at = joined_at.replace(tzinfo=datetime.timezone.utc)
         user_created = int(member.created_at.replace(tzinfo=datetime.timezone.utc).timestamp())
         voice_state = member.voice
         member_number = (


### PR DESCRIPTION
### Description of the changes
The current code implies that `joined_at` can be `None` (likely, if target is in "lurker" mode). 
However, the current implementation will fail on `joined_at.replace` if `joined_at` is `None`.