### PR TITLE
Check if branch exists before updating

### DIFF
--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -126,6 +126,7 @@ class Repo(RepoJSONMixin):
         "git -C {path} log --diff-filter=D --pretty=format:%H -n 1 {descendant_rev}"
         " -- {module_name}/__init__.py"
     )
+    GIT_VERIFY_BRANCH = "git -C {path} show-ref --quiet --verify refs/heads/{branch}"
 
     PIP_INSTALL = "{python} -m pip install -U -t {target_dir} {reqs}"
 
@@ -246,6 +247,22 @@ class Repo(RepoJSONMixin):
 
         """
         return await self.latest_commit() == self.commit
+
+    async def is_branch(self) -> bool:
+        """
+        Check if the branch assosiated with the repo is a tag.
+
+        Returns
+        -------
+        bool
+            `True` if branch is a tag or `False` otherwise
+        """
+        git_command = ProcessFormatter().format(
+            self.GIT_VERIFY_BRANCH, branch=self.branch, path=self.folder_path
+        )
+        p = await self._run(git_command)
+
+        return p.returncode == 0
 
     async def _get_file_update_statuses(
         self, old_rev: str, new_rev: Optional[str] = None
@@ -815,6 +832,9 @@ class Repo(RepoJSONMixin):
         -------
         `UpdateError` - if git pull results with non-zero exit code
         """
+        if not await self.is_branch():
+            return self.commit, self.commit
+
         old_commit = await self.latest_commit()
 
         await self.hard_reset()

--- a/tests/cogs/downloader/test_downloader.py
+++ b/tests/cogs/downloader/test_downloader.py
@@ -324,6 +324,7 @@ async def test_update(mocker, repo):
     new_commit = "a0ccc2390883c85a361f5a90c72e1b07958939fa"
     m = _mock_run(mocker, repo, 0)
     _mock_setup_repo(mocker, repo, new_commit)
+    mocker.patch.object(repo, "is_branch", autospec=True, return_value=True)
     mocker.patch.object(repo, "latest_commit", autospec=True, return_value=old_commit)
     mocker.patch.object(repo, "hard_reset", autospec=True, return_value=None)
     ret = await repo.update()


### PR DESCRIPTION
Checks is the branch used for the repo exists using `git show-ref --quiet --verify` before trying to update

closes #3397
