### PR TITLE
Do not include expected wait_for responses in translated strings

### DIFF
--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -55,9 +55,10 @@ class Cleanup(commands.Cog):
             return True
 
         prompt = await ctx.send(
-            _("Are you sure you want to delete {number} messages? (y/n)").format(
+            _("Are you sure you want to delete {number} messages?").format(
                 number=humanize_number(number)
             )
+            + " (yes/no)"
         )
         response = await ctx.bot.wait_for("message", check=MessagePredicate.same_context(ctx))
 

--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -163,7 +163,7 @@ class CommandObj:
         author = ctx.message.author
 
         if ask_for and not response:
-            await ctx.send(_("Do you want to create a 'randomized' custom command? (y/n)"))
+            await ctx.send(_("Do you want to create a 'randomized' custom command?") + " (yes/no)")
 
             pred = MessagePredicate.yes_or_no(ctx)
             try:

--- a/redbot/cogs/downloader/checks.py
+++ b/redbot/cogs/downloader/checks.py
@@ -2,6 +2,7 @@ import asyncio
 
 from redbot.core import commands
 from redbot.core.i18n import Translator
+from redbot.core.utils.chat_formatting import bold
 from redbot.core.utils.predicates import MessagePredicate
 
 __all__ = ["do_install_agreement"]
@@ -13,7 +14,7 @@ REPO_INSTALL_MSG = _(
     "You're about to add a 3rd party repository. The creator of Red"
     " and its community have no responsibility for any potential "
     "damage that the content of 3rd party repositories might cause."
-    "\n\nBy typing '**I agree**' you declare that you have read and"
+    "\n\nBy typing '{confirmation_message}' you declare that you have read and"
     " fully understand the above message. This message won't be "
     "shown again until the next reboot.\n\nYou have **30** seconds"
     " to reply to this message."
@@ -26,7 +27,7 @@ async def do_install_agreement(ctx: commands.Context) -> bool:
     if downloader is None or downloader.already_agreed:
         return True
 
-    await ctx.send(T_(REPO_INSTALL_MSG))
+    await ctx.send(T_(REPO_INSTALL_MSG).format(confirmation_message=bold("I agree")))
 
     try:
         await ctx.bot.wait_for(

--- a/redbot/cogs/downloader/checks.py
+++ b/redbot/cogs/downloader/checks.py
@@ -7,19 +7,7 @@ from redbot.core.utils.predicates import MessagePredicate
 
 __all__ = ["do_install_agreement"]
 
-T_ = Translator("DownloaderChecks", __file__)
-
-_ = lambda s: s
-REPO_INSTALL_MSG = _(
-    "You're about to add a 3rd party repository. The creator of Red"
-    " and its community have no responsibility for any potential "
-    "damage that the content of 3rd party repositories might cause."
-    "\n\nBy typing '{confirmation_message}' you declare that you have read and"
-    " fully understand the above message. This message won't be "
-    "shown again until the next reboot.\n\nYou have **30** seconds"
-    " to reply to this message."
-)
-_ = T_
+_ = Translator("DownloaderChecks", __file__)
 
 
 async def do_install_agreement(ctx: commands.Context) -> bool:
@@ -27,11 +15,24 @@ async def do_install_agreement(ctx: commands.Context) -> bool:
     if downloader is None or downloader.already_agreed:
         return True
 
-    await ctx.send(T_(REPO_INSTALL_MSG).format(confirmation_message=bold("I agree")))
+    confirmation_message = "I agree"
+    await ctx.send(
+        _(
+            "You're about to add a 3rd party repository. The creator of Red"
+            " and its community have no responsibility for any potential "
+            "damage that the content of 3rd party repositories might cause."
+            "\n\nBy typing '{confirmation_message}' you declare that you have read and"
+            " fully understand the above message. This message won't be "
+            "shown again until the next reboot.\n\nYou have **30** seconds"
+            " to reply to this message."
+        ).format(confirmation_message=bold(confirmation_message))
+    )
 
     try:
         await ctx.bot.wait_for(
-            "message", check=MessagePredicate.lower_equal_to("i agree", ctx), timeout=30
+            "message",
+            check=MessagePredicate.lower_equal_to(confirmation_message.lower(), ctx),
+            timeout=30,
         )
     except asyncio.TimeoutError:
         await ctx.send(_("Your response has timed out, please try again."))

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1645,7 +1645,7 @@ class Downloader(commands.Cog):
             )
             can_react = ctx.channel.permissions_for(ctx.me).add_reactions
             if not can_react:
-                message += " (y/n)"
+                message += " (yes/no)"
             query: discord.Message = await ctx.send(message)
             if can_react:
                 # noinspection PyAsyncCall

--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -13,7 +13,13 @@ from .voicemutes import VoiceMutes
 from redbot.core.bot import Red
 from redbot.core import commands, checks, i18n, modlog, Config
 from redbot.core.utils import AsyncIter, bounded_gather
-from redbot.core.utils.chat_formatting import bold, humanize_timedelta, humanize_list, pagify
+from redbot.core.utils.chat_formatting import (
+    bold,
+    humanize_timedelta,
+    humanize_list,
+    inline,
+    pagify,
+)
 from redbot.core.utils.mod import get_audit_reason
 from redbot.core.utils.menus import start_adding_reactions
 from redbot.core.utils.predicates import MessagePredicate, ReactionPredicate
@@ -983,9 +989,9 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
         command_2 = f"{ctx.clean_prefix}muteset makerole"
         msg = _(
             "This server does not have a mute role setup. "
-            " You can setup a mute role with `{command_1}` or"
-            "`{command_2}` if you just want a basic role created setup.\n\n"
-        ).format(command_1=command_1, command_2=command_2)
+            " You can setup a mute role with {command_1} or"
+            "{command_2} if you just want a basic role created setup.\n\n"
+        )
         mute_role_id = await self.config.guild(ctx.guild).mute_role()
         mute_role = ctx.guild.get_role(mute_role_id)
         sent_instructions = await self.config.guild(ctx.guild).sent_instructions()
@@ -1014,10 +1020,16 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
                 )
             else:
                 msg += _(
-                    "Saying `yes` will continue "
+                    "Saying {response_1} will continue "
                     "the mute with overwrites and stop this message from appearing again, "
-                    "saying `no` will end the mute attempt."
+                    "saying {response_2} will end the mute attempt."
                 )
+            msg = msg.format(
+                command_1=inline(command_1),
+                command_2=inline(command_2),
+                response_1=inline("yes"),
+                response_2=inline("no"),
+            )
             query: discord.Message = await ctx.send(msg)
             if can_react:
                 # noinspection PyAsyncCall

--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -990,7 +990,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
         msg = _(
             "This server does not have a mute role setup. "
             " You can setup a mute role with {command_1} or"
-            "{command_2} if you just want a basic role created setup.\n\n"
+            " {command_2} if you just want a basic role created setup.\n\n"
         )
         mute_role_id = await self.config.guild(ctx.guild).mute_role()
         mute_role = ctx.guild.get_role(mute_role_id)

--- a/redbot/cogs/permissions/permissions.py
+++ b/redbot/cogs/permissions/permissions.py
@@ -705,7 +705,7 @@ class Permissions(commands.Cog):
             finally:
                 await msg.delete()
         else:
-            await ctx.send(_("Are you sure? (y/n)"))
+            await ctx.send(_("Are you sure?") + " (yes/no)")
             pred = MessagePredicate.yes_or_no(ctx)
             try:
                 await ctx.bot.wait_for("message", check=pred, timeout=30)

--- a/redbot/cogs/trivia/trivia.py
+++ b/redbot/cogs/trivia/trivia.py
@@ -675,7 +675,7 @@ class Trivia(commands.Cog):
 
             can_react = ctx.channel.permissions_for(ctx.me).add_reactions
             if not can_react:
-                overwrite_message += " (y/n)"
+                overwrite_message += " (yes/no)"
 
             overwrite_message_object: discord.Message = await ctx.send(overwrite_message)
             if can_react:

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2690,7 +2690,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                     "Warning: A prefix is above the recommended length (20 characters).\n"
                     "Do you want to continue?"
                 )
-                + "(yes/no)"
+                + " (yes/no)"
             )
             pred = MessagePredicate.yes_or_no(ctx)
             try:

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1605,12 +1605,12 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             guilds = (ctx.guild,)
             msg = (
                 _("You haven't passed any server ID. Do you want me to leave this server?")
-                + " (y/n)"
+                + " (yes/no)"
             )
         else:
             msg = (
                 _("Are you sure you want me to leave these servers?")
-                + " (y/n):\n"
+                + " (yes/no):\n"
                 + "\n".join(f"- {guild.name} (`{guild.id}`)" for guild in guilds)
             )
 
@@ -2688,8 +2688,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             await ctx.send(
                 _(
                     "Warning: A prefix is above the recommended length (20 characters).\n"
-                    "Do you want to continue? (y/n)"
+                    "Do you want to continue?"
                 )
+                + "(yes/no)"
             )
             pred = MessagePredicate.yes_or_no(ctx)
             try:


### PR DESCRIPTION
### Description of the changes
This should remove all occurrences of translatable strings including the responses expected by us in `bot.wait_for()` even though we do not actually support translated variants. Also, expands `(y/n)` to full `(yes/no)` to avoid any confusion on what these mean.

Fixes #5363