### PR TITLE
[Mod] Indicate successful run in `[p]voicekick`

### DIFF
--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -802,6 +802,7 @@ class KickBanMixin(MixinMeta):
                 until=None,
                 channel=case_channel,
             )
+            await ctx.send(_("User has been kicked from the voice channel."))
 
     @commands.command()
     @commands.guild_only()


### PR DESCRIPTION
### Description of the changes
This PR will send a message that the user has been successfully kicked from the vc when `[p]voicekick` is used to kick someone from a vc.
Before it used to kick the user from vc silently without any message or tick.
![voicekick](https://user-images.githubusercontent.com/84792368/135730585-605f696a-f483-4e5a-9f21-8bd1e01baf05.PNG)
