### PR TITLE
Fix descriptions for examples of ID-based command invocations in Mod

### DIFF
--- a/docs/cog_guides/mod.rst
+++ b/docs/cog_guides/mod.rst
@@ -92,7 +92,7 @@ Kick a user.
 **Example Usage**
 
 * ``[p]kick 428675506947227648 wanted to be kicked.``
-    This will kick user with ID 428675506947227648 from the server.
+    This will kick the user with ID 428675506947227648 from the server.
 * ``[p]kick @Twentysix wanted to be kicked.``
     This will kick Twentysix from the server.
 

--- a/docs/cog_guides/mod.rst
+++ b/docs/cog_guides/mod.rst
@@ -58,7 +58,7 @@ Ban a user from this server and optionally delete days of messages.
 **Example Usage**
 
 * ``[p]ban 428675506947227648 7 Continued to spam after told to stop.``
-    This will ban Twentysix and it will delete 7 days worth of messages.
+    This will ban the user with ID 428675506947227648 and it will delete 7 days worth of messages.
 * ``[p]ban @Twentysix 7 Continued to spam after told to stop.``
     This will ban Twentysix and it will delete 7 days worth of messages.
 
@@ -92,7 +92,7 @@ Kick a user.
 **Example Usage**
 
 * ``[p]kick 428675506947227648 wanted to be kicked.``
-    This will kick Twentysix from the server.
+    This will kick user with ID 428675506947227648 from the server.
 * ``[p]kick @Twentysix wanted to be kicked.``
     This will kick Twentysix from the server.
 
@@ -642,7 +642,7 @@ Temporarily ban a user from this server.
 * ``[p]tempban @Twentysix 15m You need a timeout``
     This will ban Twentysix for 15 minutes.
 * ``[p]tempban 428675506947227648 1d2h15m 5 Evil person``
-    This will ban the user for 1 day 2 hours 15 minutes and will delete the last 5 days of their messages.
+    This will ban the user with ID 428675506947227648 for 1 day 2 hours 15 minutes and will delete the last 5 days of their messages.
 
 .. _mod-command-unban:
 

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -296,7 +296,7 @@ class KickBanMixin(MixinMeta):
 
         Examples:
            - `[p]kick 428675506947227648 wanted to be kicked.`
-            This will kick Twentysix from the server.
+            This will kick user with ID 428675506947227648 from the server.
            - `[p]kick @Twentysix wanted to be kicked.`
             This will kick Twentysix from the server.
 
@@ -382,7 +382,7 @@ class KickBanMixin(MixinMeta):
 
         Examples:
            - `[p]ban 428675506947227648 7 Continued to spam after told to stop.`
-            This will ban the User ID 428675506947227648 and it will delete 7 days worth of messages.
+            This will ban the user with ID 428675506947227648 and it will delete 7 days worth of messages.
            - `[p]ban @Twentysix 7 Continued to spam after told to stop.`
             This will ban Twentysix and it will delete 7 days worth of messages.
 
@@ -597,7 +597,7 @@ class KickBanMixin(MixinMeta):
            - `[p]tempban @Twentysix 15m You need a timeout`
             This will ban Twentysix for 15 minutes.
            - `[p]tempban 428675506947227648 1d2h15m 5 Evil person`
-            This will ban the user for 1 day 2 hours 15 minutes and will delete the last 5 days of their messages.
+            This will ban the user with ID 428675506947227648 for 1 day 2 hours 15 minutes and will delete the last 5 days of their messages.
         """
         guild = ctx.guild
         author = ctx.author

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -382,7 +382,7 @@ class KickBanMixin(MixinMeta):
 
         Examples:
            - `[p]ban 428675506947227648 7 Continued to spam after told to stop.`
-            This will ban Twentysix and it will delete 7 days worth of messages.
+            This will ban the User ID 428675506947227648 and it will delete 7 days worth of messages.
            - `[p]ban @Twentysix 7 Continued to spam after told to stop.`
             This will ban Twentysix and it will delete 7 days worth of messages.
 

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -296,7 +296,7 @@ class KickBanMixin(MixinMeta):
 
         Examples:
            - `[p]kick 428675506947227648 wanted to be kicked.`
-            This will kick user with ID 428675506947227648 from the server.
+            This will kick the user with ID 428675506947227648 from the server.
            - `[p]kick @Twentysix wanted to be kicked.`
             This will kick Twentysix from the server.
 


### PR DESCRIPTION
### Description of the changes

The example command in [kickban.py#L385](https://github.com/Cog-Creators/Red-DiscordBot/blob/a0a433b13d698250ba6689fb07889ea507127c68/redbot/cogs/mod/kickban.py#L385) stated 
`[p]ban 428675506947227648 7 Continued to spam after told to stop.
This will ban Twentysix and it will delete 7 days worth of messages.`

The description is inconsistent with the example command. Changed the example command description to 
`This will ban the User ID 428675506947227648 and it will delete 7 days worth of messages.`