### PR TITLE
[Admin] Add `[p]selfroleset clear` command

### DIFF
--- a/docs/cog_guides/admin.rst
+++ b/docs/cog_guides/admin.rst
@@ -160,6 +160,22 @@ Add a role, or a selection of roles, to the list of available selfroles.
 
 * ``<role>``: The role to add to the list. |role-input|
 
+.. _admin-command-selfroleset-clear:
+
+"""""""""""""""""
+selfroleset clear
+"""""""""""""""""
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]selfroleset clear
+
+**Description**
+
+Clears the list of available selfroles.
+
 .. _admin-command-selfroleset-remove:
 
 """"""""""""""""""

--- a/docs/cog_guides/admin.rst
+++ b/docs/cog_guides/admin.rst
@@ -174,7 +174,7 @@ selfroleset clear
 
 **Description**
 
-Clears the list of available selfroles.
+Clear the list of available selfroles for this server.
 
 .. _admin-command-selfroleset-remove:
 

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -7,6 +7,7 @@ import discord
 from redbot.core import Config, checks, commands
 from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils.chat_formatting import box
+from redbot.core.utils.predicates import MessagePredicate
 from .announcer import Announcer
 from .converters import SelfRole
 

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -512,7 +512,7 @@ class Admin(commands.Cog):
 
     @selfroleset.command(name="clear")
     async def selfroleset_clear(self, ctx: commands.Context):
-        """Clear the list of available selfroles."""
+        """Clear the list of available selfroles for this server."""
         current_selfroles = await self.config.guild(ctx.guild).selfroles()
         
         if not current_selfroles:

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -535,7 +535,7 @@ class Admin(commands.Cog):
                 if not self.pass_user_hierarchy_check(ctx, role):
                     await ctx.send(
                         _(
-                            "I cannot let you remove {role.name} from being a selfrole because that role is higher than or equal to your highest role in the Discord hierarchy."
+                            "I cannot clear the selfroles because the selfrole '{role.name}' is higher than or equal to your highest role in the Discord hierarchy."
                         ).format(role=role)
                     )
                     return

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -529,6 +529,9 @@ class Admin(commands.Cog):
             return
         if pred.result:
             for role in current_selfroles:
+                role = ctx.guild.get_role(role)
+                if role is None:
+                    continue
                 if not self.pass_user_hierarchy_check(ctx, role):
                     await ctx.send(
                         _(

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -3,11 +3,11 @@ import logging
 from typing import Tuple
 
 import discord
-
 from redbot.core import Config, checks, commands
 from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils.chat_formatting import box
 from redbot.core.utils.predicates import MessagePredicate
+
 from .announcer import Announcer
 from .converters import SelfRole
 
@@ -514,7 +514,7 @@ class Admin(commands.Cog):
     async def selfroleset_clear(self, ctx: commands.Context):
         """Clear the list of available selfroles for this server."""
         current_selfroles = await self.config.guild(ctx.guild).selfroles()
-        
+
         if not current_selfroles:
             return await ctx.send(_("There are currently no selfroles."))
 


### PR DESCRIPTION
### Description of the changes

This PR adds `[p]selfroleset clear` which can be used to clear the guild's list of available selfroles.