### PR TITLE
Add plural forms to the responses of `[p]leave` command

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1600,10 +1600,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             return await ctx.send(_("You need to specify at least one server ID."))
 
         leaving_local_guild = not guilds
-        s = "s" if len(guilds) > 1 else ""
         number = len(guilds)
-        t = "these" if len(guilds) > 1 else "this" 
-        th = "those" if len(guilds) > 1 else "that" 
 
         if leaving_local_guild:
             guilds = (ctx.guild,)
@@ -1611,9 +1608,16 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 _("You haven't passed any server ID. Do you want me to leave this server?")
                 + " (y/n)"
             )
+        if len(guilds) > 1:
+            msg = (
+                _(f"Are you sure you want me to leave these servers?")
+                + " (y/n):\n"
+                + "\n".join(f"- {guild.name} (`{guild.id}`)" for guild in guilds)
+            )
+
         else:
             msg = (
-                _(f"Are you sure you want me to leave {t} server{s}?")
+                _("Are you sure you want me to leave this server")   
                 + " (y/n):\n"
                 + "\n".join(f"- {guild.name} (`{guild.id}`)" for guild in guilds)
             )
@@ -1637,10 +1641,14 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             if pred.result is True:
                 if leaving_local_guild is True:
-                    await ctx.send(_("Alright. Bye :wave:"))
+                    await ctx.send(_("Alright. Bye :wave:")
+                    )
+                if len(guilds) > 1:
+                    await ctx.send(_(f"Alright. Leaving {number} servers...")
+                    )   
                 else:
                     await ctx.send(
-                        _(f"Alright. Leaving {number} server{s}...")
+                        _(f"Alright. Leaving {number} server...")
                     )
                 for guild in guilds:
                     log.debug("Leaving guild '%s' (%s)", guild.name, guild.id)
@@ -1649,7 +1657,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 if leaving_local_guild is True:
                     await ctx.send(_("Alright, I'll stay then. :)"))
                 else:
-                    await ctx.send(_(f"Alright, I'm not leaving {th} server{s}."))
+                    if len(guilds) > 1:
+                        await ctx.send(_("Alright, I'm not leaving those servers."))
+                    else:
+                        await ctx.send(_("Alright, I'm not leaving that server."))  
 
     @commands.command()
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -405,7 +405,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     """
 
     async def red_delete_data_for_user(self, **kwargs):
-        """ Nothing to delete (Core Config is handled in a bot method ) """
+        """Nothing to delete (Core Config is handled in a bot method )"""
         return
 
     @commands.command(hidden=True)
@@ -1617,7 +1617,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         else:
             msg = (
-                _("Are you sure you want me to leave this server")   
+                _("Are you sure you want me to leave this server")
                 + " (y/n):\n"
                 + "\n".join(f"- {guild.name} (`{guild.id}`)" for guild in guilds)
             )
@@ -1641,15 +1641,11 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             if pred.result is True:
                 if leaving_local_guild is True:
-                    await ctx.send(_("Alright. Bye :wave:")
-                    )
+                    await ctx.send(_("Alright. Bye :wave:"))
                 if number > 1:
-                    await ctx.send(_(f"Alright. Leaving {number} servers...")
-                    )   
+                    await ctx.send(_(f"Alright. Leaving {number} servers..."))
                 else:
-                    await ctx.send(
-                        _(f"Alright. Leaving {number} server...")
-                    )
+                    await ctx.send(_(f"Alright. Leaving {number} server..."))
                 for guild in guilds:
                     log.debug("Leaving guild '%s' (%s)", guild.name, guild.id)
                     await guild.leave()
@@ -1660,7 +1656,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                     if number > 1:
                         await ctx.send(_("Alright, I'm not leaving those servers."))
                     else:
-                        await ctx.send(_("Alright, I'm not leaving that server."))    
+                        await ctx.send(_("Alright, I'm not leaving that server."))
 
     @commands.command()
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1615,7 +1615,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                     + " (y/n):\n"
                     + "\n".join(f"- {guild.name} (`{guild.id}`)" for guild in guilds)
                 )
-            else:                
+            else:
                 msg = (
                     _("Are you sure you want me to leave this server?")
                     + " (y/n):\n"

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1590,7 +1590,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         Note: This command is interactive.
 
         **Examples:**
-            - `[p]leave` - Leave the current server.
+            - `[p]leave` - Leaves the current server.
             - `[p]leave "Red - Discord Bot"` - Quotes are necessary when there are spaces in the name.
             - `[p]leave 133049272517001216 240154543684321280` - Leaves multiple servers, using IDs.
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1644,12 +1644,13 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             if pred.result is True:
                 if leaving_local_guild is True:
                     await ctx.send(_("Alright. Bye :wave:"))
-                if number > 1:
-                    await ctx.send(
-                        _("Alright. Leaving {number} servers...").format(number=len(guilds))
-                    )
-                else:
-                    await ctx.send(_("Alright. Leaving one server..."))
+                else:    
+                    if number > 1:
+                        await ctx.send(
+                            _("Alright. Leaving {number} servers...").format(number=len(guilds))
+                        )
+                    else:
+                        await ctx.send(_("Alright. Leaving one server..."))
                 for guild in guilds:
                     log.debug("Leaving guild '%s' (%s)", guild.name, guild.id)
                     await guild.leave()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -405,7 +405,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     """
 
     async def red_delete_data_for_user(self, **kwargs):
-        """Nothing to delete (Core Config is handled in a bot method )"""
+        """Nothing to delete (Core Config is handled in a bot method)"""
         return
 
     @commands.command(hidden=True)
@@ -1590,7 +1590,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         Note: This command is interactive.
 
         **Examples:**
-            - `[p]leave` - Leaves the current server.
+            - `[p]leave` - Leave the current server.
             - `[p]leave "Red - Discord Bot"` - Quotes are necessary when there are spaces in the name.
             - `[p]leave 133049272517001216 240154543684321280` - Leaves multiple servers, using IDs.
 
@@ -1613,14 +1613,14 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             if number > 1:
                 msg = (
-                    _(f"Are you sure you want me to leave these servers?")
-                    + " (y/n):\n"
+                    _("Are you sure you want me to leave these servers?")
+                    + " (yes/no):\n"
                     + "\n".join(f"- {guild.name} (`{guild.id}`)" for guild in guilds)
                 )
             else:
                 msg = (
                     _("Are you sure you want me to leave this server?")
-                    + " (y/n):\n"
+                    + " (yes/no):\n"
                     + f"- {guilds[0].name} (`{guilds[0].id}`)"
                 )
 
@@ -1647,7 +1647,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 else:
                     if number > 1:
                         await ctx.send(
-                            _("Alright. Leaving {number} servers...").format(number=len(guilds))
+                            _("Alright. Leaving {number} servers...").format(number=number)
                         )
                     else:
                         await ctx.send(_("Alright. Leaving one server..."))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1608,7 +1608,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 _("You haven't passed any server ID. Do you want me to leave this server?")
                 + " (y/n)"
             )
-        if len(guilds) > 1:
+        if number > 1:
             msg = (
                 _(f"Are you sure you want me to leave these servers?")
                 + " (y/n):\n"
@@ -1643,7 +1643,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 if leaving_local_guild is True:
                     await ctx.send(_("Alright. Bye :wave:")
                     )
-                if len(guilds) > 1:
+                if number > 1:
                     await ctx.send(_(f"Alright. Leaving {number} servers...")
                     )   
                 else:
@@ -1657,10 +1657,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 if leaving_local_guild is True:
                     await ctx.send(_("Alright, I'll stay then. :)"))
                 else:
-                    if len(guilds) > 1:
+                    if number > 1:
                         await ctx.send(_("Alright, I'm not leaving those servers."))
                     else:
-                        await ctx.send(_("Alright, I'm not leaving that server."))  
+                        await ctx.send(_("Alright, I'm not leaving that server."))    
 
     @commands.command()
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1600,6 +1600,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             return await ctx.send(_("You need to specify at least one server ID."))
 
         leaving_local_guild = not guilds
+        s = "s" if len(guilds) > 1 else ""
+        number = len(guilds)
+        t = "these" if len(guilds) > 1 else "this" 
+        th = "those" if len(guilds) > 1 else "that" 
 
         if leaving_local_guild:
             guilds = (ctx.guild,)
@@ -1609,7 +1613,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             )
         else:
             msg = (
-                _("Are you sure you want me to leave these servers?")
+                _(f"Are you sure you want me to leave {t} server{s}?")
                 + " (y/n):\n"
                 + "\n".join(f"- {guild.name} (`{guild.id}`)" for guild in guilds)
             )
@@ -1636,7 +1640,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                     await ctx.send(_("Alright. Bye :wave:"))
                 else:
                     await ctx.send(
-                        _("Alright. Leaving {number} servers...").format(number=len(guilds))
+                        _(f"Alright. Leaving {number} server{s}...")
                     )
                 for guild in guilds:
                     log.debug("Leaving guild '%s' (%s)", guild.name, guild.id)
@@ -1645,7 +1649,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 if leaving_local_guild is True:
                     await ctx.send(_("Alright, I'll stay then. :)"))
                 else:
-                    await ctx.send(_("Alright, I'm not leaving those servers."))
+                    await ctx.send(_(f"Alright, I'm not leaving {th} server{s}."))
 
     @commands.command()
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1644,7 +1644,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             if pred.result is True:
                 if leaving_local_guild is True:
                     await ctx.send(_("Alright. Bye :wave:"))
-                else:    
+                else:
                     if number > 1:
                         await ctx.send(
                             _("Alright. Leaving {number} servers...").format(number=len(guilds))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1608,19 +1608,19 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 _("You haven't passed any server ID. Do you want me to leave this server?")
                 + " (y/n)"
             )
-        if number > 1:
-            msg = (
-                _(f"Are you sure you want me to leave these servers?")
-                + " (y/n):\n"
-                + "\n".join(f"- {guild.name} (`{guild.id}`)" for guild in guilds)
-            )
-
         else:
-            msg = (
-                _("Are you sure you want me to leave this server")
-                + " (y/n):\n"
-                + "\n".join(f"- {guild.name} (`{guild.id}`)" for guild in guilds)
-            )
+            if number > 1:
+                msg = (
+                    _(f"Are you sure you want me to leave these servers?")
+                    + " (y/n):\n"
+                    + "\n".join(f"- {guild.name} (`{guild.id}`)" for guild in guilds)
+                )
+            else:                
+                msg = (
+                    _("Are you sure you want me to leave this server?")
+                    + " (y/n):\n"
+                    + f"- {guilds[0].name} (`{guilds[0].id}`)"
+                )
 
         for guild in guilds:
             if guild.owner.id == ctx.me.id:
@@ -1643,9 +1643,11 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 if leaving_local_guild is True:
                     await ctx.send(_("Alright. Bye :wave:"))
                 if number > 1:
-                    await ctx.send(_(f"Alright. Leaving {number} servers..."))
+                    await ctx.send(
+                        _("Alright. Leaving {number} servers...").format(number=len(guilds))
+                    )
                 else:
-                    await ctx.send(_(f"Alright. Leaving {number} server..."))
+                    await ctx.send(_("Alright. Leaving one server..."))
                 for guild in guilds:
                     log.debug("Leaving guild '%s' (%s)", guild.name, guild.id)
                     await guild.leave()


### PR DESCRIPTION
### Description of the changes
This PR will improve the response of the `[p]leave` command. Before the response was a little bit messed up but now it will give a better response(idk how to word it).
Before
![leave0](https://user-images.githubusercontent.com/84792368/137387269-4f927586-6365-47d4-aeab-ee5442c75724.PNG)

After: 
![deku](https://user-images.githubusercontent.com/84792368/137385185-40f9bc16-e98a-48eb-8d78-45f37ce80543.PNG)
