### PR TITLE
[Audio] Fix UnboundLocalError in edge case

### DIFF
--- a/redbot/cogs/audio/apis/playlist_wrapper.py
+++ b/redbot/cogs/audio/apis/playlist_wrapper.py
@@ -84,7 +84,7 @@ class PlaylistWrapper:
             table = 2
         return table
 
-    async def fetch(self, scope: str, playlist_id: int, scope_id: int) -> PlaylistFetchResult:
+    async def fetch(self, scope: str, playlist_id: int, scope_id: int) -> Optional[PlaylistFetchResult]:
         """Fetch a single playlist."""
         scope_type = self.get_scope_type(scope)
 

--- a/redbot/cogs/audio/apis/playlist_wrapper.py
+++ b/redbot/cogs/audio/apis/playlist_wrapper.py
@@ -107,7 +107,8 @@ class PlaylistWrapper:
                 try:
                     row_result = future.result()
                 except Exception as exc:
-                    debug_exc_log(log, exc, "Failed to completed playlist fetch from database")
+                    debug_exc_log(log, exc, "Failed to complete playlist fetch from database")
+                    return None
             row = row_result.fetchone()
             if row:
                 row = PlaylistFetchResult(*row)
@@ -139,7 +140,7 @@ class PlaylistWrapper:
                     try:
                         row_result = future.result()
                     except Exception as exc:
-                        debug_exc_log(log, exc, "Failed to completed playlist fetch from database")
+                        debug_exc_log(log, exc, "Failed to complete playlist fetch from database")
                         return []
             else:
                 for future in concurrent.futures.as_completed(
@@ -154,7 +155,7 @@ class PlaylistWrapper:
                     try:
                         row_result = future.result()
                     except Exception as exc:
-                        debug_exc_log(log, exc, "Failed to completed playlist fetch from database")
+                        debug_exc_log(log, exc, "Failed to complete playlist fetch from database")
                         return []
         async for row in AsyncIter(row_result):
             output.append(PlaylistFetchResult(*row))
@@ -191,7 +192,8 @@ class PlaylistWrapper:
                 try:
                     row_result = future.result()
                 except Exception as exc:
-                    debug_exc_log(log, exc, "Failed to completed fetch from database")
+                    debug_exc_log(log, exc, "Failed to complete fetch from database")
+                    return []
 
             async for row in AsyncIter(row_result):
                 output.append(PlaylistFetchResult(*row))

--- a/redbot/cogs/audio/apis/playlist_wrapper.py
+++ b/redbot/cogs/audio/apis/playlist_wrapper.py
@@ -84,7 +84,9 @@ class PlaylistWrapper:
             table = 2
         return table
 
-    async def fetch(self, scope: str, playlist_id: int, scope_id: int) -> Optional[PlaylistFetchResult]:
+    async def fetch(
+        self, scope: str, playlist_id: int, scope_id: int
+    ) -> Optional[PlaylistFetchResult]:
         """Fetch a single playlist."""
         scope_type = self.get_scope_type(scope)
 


### PR DESCRIPTION
https://github.com/Cog-Creators/Red-DiscordBot/blob/334cd4fa2a2d89a0df87d8fa72714edb665db2a3/redbot/cogs/audio/apis/playlist_wrapper.py#L107-L111
This exception handling will always lead to an `UnboundLocalError` in `row_result`, as it is not defined when an exception occurs. Though there appears to be no way an exception should be raised under normal conditions, this PR nevertheless fixes that error.

https://github.com/Cog-Creators/Red-DiscordBot/blob/334cd4fa2a2d89a0df87d8fa72714edb665db2a3/redbot/cogs/audio/apis/playlist_wrapper.py#L139-L143
The one location that does not lead to an `UnboundLocalError` handles it by returning the base case for when no playlists are found.

https://github.com/Cog-Creators/Red-DiscordBot/blob/334cd4fa2a2d89a0df87d8fa72714edb665db2a3/redbot/cogs/audio/apis/playlist_wrapper.py#L111-L114
For `fetch`, the base case is `None`, as `fetchone` will return either a row or `None`, and the `None` case simply returns the `None`.

https://github.com/Cog-Creators/Red-DiscordBot/blob/334cd4fa2a2d89a0df87d8fa72714edb665db2a3/redbot/cogs/audio/apis/playlist_wrapper.py#L196-L198
For `fetch_all_converter`, the base case is `[]`, as that is the default value of `output`, and it is returned when no rows are found.

These base cases were used as a return value for the fetch exception handling.
Fixes #5378.

