### PR TITLE
Fix CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install -U pip setuptools wheel
-        python -m pip install .[all]
+        python -m pip install -e .[all]
         # Set the `CODEQL-PYTHON` environment variable to the Python executable
         # that includes the dependencies
         echo "CODEQL_PYTHON=$(which python)" >> $GITHUB_ENV


### PR DESCRIPTION
Hi :wave: I'm working on the CodeQL analysis of Python, and have looked into your recent problems with the codeql-action, which this PR should solve :blush: 

### Description of the changes

The new pip 21.3 (released 2021-10-11) uses in-tree builds when `pip install .` is used (see [release notes](https://pip.pypa.io/en/stable/news/#v21-3) and [implementation PR](https://github.com/pypa/pip/pull/10495)). This means CodeQL will see all files twice (once in the real location that is part of this repository, and once in the copy in the `build/` dir), which trips up the analysis.

When an editable install is used instead with `pip install -e .`, there is no `build/` dir, so the analysis will work again.

/cc @jack1142