### PR TITLE
Fix issues with loading config.json when it doesn't exist

### DIFF
--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -61,8 +61,11 @@ def create_temp_config():
     default_dirs["STORAGE_TYPE"] = "JSON"
     default_dirs["STORAGE_DETAILS"] = {}
 
-    with config_file.open("r", encoding="utf-8") as fs:
-        config = json.load(fs)
+    try:
+        with config_file.open("r", encoding="utf-8") as fs:
+            config = json.load(fs)
+    except FileNotFoundError:
+        config = {}
 
     config[name] = default_dirs
 

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -46,6 +46,21 @@ if not config_dir:
 config_file = config_dir / "config.json"
 
 
+def load_existing_config():
+    """Get the contents of the config file, or an empty dictionary if it does not exist.
+
+    Returns
+    -------
+    dict
+        The config data.
+    """
+    if not config_file.exists():
+        return {}
+
+    with config_file.open(encoding="utf-8") as fs:
+        return json.load(fs)
+
+
 def create_temp_config():
     """
     Creates a default instance for Red, so it can be ran

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -76,11 +76,7 @@ def create_temp_config():
     default_dirs["STORAGE_TYPE"] = "JSON"
     default_dirs["STORAGE_DETAILS"] = {}
 
-    try:
-        with config_file.open("r", encoding="utf-8") as fs:
-            config = json.load(fs)
-    except FileNotFoundError:
-        config = {}
+    config = load_existing_config()
 
     config[name] = default_dirs
 

--- a/redbot/launcher.py
+++ b/redbot/launcher.py
@@ -16,13 +16,13 @@ import pkg_resources
 from redbot import MIN_PYTHON_VERSION
 from redbot.setup import (
     basic_setup,
-    load_existing_config,
     remove_instance,
     remove_instance_interaction,
     create_backup,
 )
 from redbot.core import __version__, version_info as red_version_info, VersionInfo
 from redbot.core.cli import confirm
+from redbot.core.data_manager import load_existing_config
 
 if sys.platform == "linux":
     import distro  # pylint: disable=import-error

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -37,16 +37,7 @@ except PermissionError:
     sys.exit(1)
 config_file = config_dir / "config.json"
 
-
-def load_existing_config():
-    if not config_file.exists():
-        return {}
-
-    with config_file.open(encoding="utf-8") as fs:
-        return json.load(fs)
-
-
-instance_data = load_existing_config()
+instance_data = data_manager.load_existing_config()
 if instance_data is None:
     instance_list = []
 else:
@@ -54,7 +45,7 @@ else:
 
 
 def save_config(name, data, remove=False):
-    _config = load_existing_config()
+    _config = data_manager.load_existing_config()
     if remove and name in _config:
         _config.pop(name)
     else:


### PR DESCRIPTION
Move `load_existing_config` to `data_manager.py` and add a docstring, and utilise it in `create_temp_config`, so that FileNotFoundError is handled gracefully.

Primarily fixes #5415, tested by changing the path Red looks for the config file (at L46, `data_managager.py`) to a non-existent file.
