### PR TITLE
Make `emptydisconnect` disconnect when all vc members are bots

### DIFF
--- a/redbot/cogs/audio/core/tasks/player.py
+++ b/redbot/cogs/audio/core/tasks/player.py
@@ -28,7 +28,7 @@ class PlayerTasks(MixinMeta, metaclass=CompositeMetaClass):
                 if await self.bot.cog_disabled_in_guild(self, server):
                     continue
 
-                if [self.bot.user] == p.channel.members:
+                if not any(m for m in p.channel.members if not m.bot):
                     stop_times.setdefault(server.id, time.time())
                     pause_times.setdefault(server.id, time.time())
                 else:

--- a/redbot/cogs/audio/core/tasks/player.py
+++ b/redbot/cogs/audio/core/tasks/player.py
@@ -28,7 +28,7 @@ class PlayerTasks(MixinMeta, metaclass=CompositeMetaClass):
                 if await self.bot.cog_disabled_in_guild(self, server):
                     continue
 
-                if not any(m for m in p.channel.members if not m.bot):
+                if p.channel.members and all(m.bot for m in p.channel.members):
                     stop_times.setdefault(server.id, time.time())
                     pause_times.setdefault(server.id, time.time())
                 else:


### PR DESCRIPTION
If two Red instances, both with `audioset emptydisconnect` enabled and `audioset dc` disabled, are for whatever reason in the same voice chat they keep each other from disconnecting. Now the bot disconnects when every user in the voice chat is a bot.