### PR TITLE
isolate direction of username within modlog

### DIFF
--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -464,10 +464,19 @@ class Case:
                 translated = _("Unknown or Deleted User")
                 user = f"[{translated}] ({self.user})"
             else:
-                user = f"{self.last_known_username} ({self.user})"
+                name = self.last_known_username[:-5]
+                discriminator = self.last_known_username[-4:]
+                user = (
+                    f"\N{FIRST STRONG ISOLATE}{name}"
+                    f"\N{POP DIRECTIONAL ISOLATE}#{discriminator} ({self.user})"
+                )
         else:
+            # isolate the name so that the direction of the discriminator and ID do not get changed
             user = escape_spoilers(
-                filter_invites(f"{self.user} ({self.user.id})")
+                filter_invites(
+                    f"\N{FIRST STRONG ISOLATE}{self.user.name}"
+                    f"\N{POP DIRECTIONAL ISOLATE}#{self.user.discriminator} ({self.user.id})"
+                )
             )  # Invites and spoilers get rendered even in embeds.
 
         if embed:

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -464,6 +464,7 @@ class Case:
                 translated = _("Unknown or Deleted User")
                 user = f"[{translated}] ({self.user})"
             else:
+                # See usage explanation here: https://www.unicode.org/reports/tr9/#Formatting
                 name = self.last_known_username[:-5]
                 discriminator = self.last_known_username[-4:]
                 user = (
@@ -472,6 +473,7 @@ class Case:
                 )
         else:
             # isolate the name so that the direction of the discriminator and ID do not get changed
+            # See usage explanation here: https://www.unicode.org/reports/tr9/#Formatting
             user = escape_spoilers(
                 filter_invites(
                     f"\N{FIRST STRONG ISOLATE}{self.user.name}"


### PR DESCRIPTION
Came up on the Discord as something that could possibly be implemented

Before this PR:
![image](https://user-images.githubusercontent.com/15076013/138753456-d8950bdf-3cab-406f-b2fb-a19d2429992a.png)

After this PR:
![image](https://user-images.githubusercontent.com/15076013/138753483-0c9a13eb-57fe-4ab4-9a96-ece428738e24.png)
