### PR TITLE
Make invite URL part of public API

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1310,7 +1310,6 @@ class Red(
         Generates the invite URL for the bot.
 
         Does not check if invites are public.
-        To check if invites are public, use `is_invite_public()`.
         To check if invites are public, use `Bot.is_invite_public()`.
 
         Returns

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1318,13 +1318,12 @@ class Red(
         str
             Invite URL.
         """
-        app_info = self._app_info
         data = await self._config.all()
         commands_scope = data["invite_commands_scope"]
         scopes = ("bot", "applications.commands") if commands_scope else None
         perms_int = data["invite_perm"]
         permissions = discord.Permissions(perms_int)
-        return discord.utils.oauth_url(app_info.id, permissions, scopes=scopes)
+        return discord.utils.oauth_url(self._app_info.id, permissions, scopes=scopes)
 
     async def is_invite_url_public(self) -> bool:
         """

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1318,7 +1318,7 @@ class Red(
         str
             Invite URL.
         """
-        app_info = await self._app_info
+        app_info = self._app_info
         data = await self._config.all()
         commands_scope = data["invite_commands_scope"]
         scopes = ("bot", "applications.commands") if commands_scope else None

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1309,6 +1309,8 @@ class Red(
         """
         Generates the invite URL for the bot.
 
+        Does not check if invites are public.
+
         Returns
         -------
         str

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1309,8 +1309,9 @@ class Red(
         """
         Generates the invite URL for the bot.
 
-        Does not check if invites are public.
-        To check if invites are public, use `Red.is_invite_url_public()`.
+        Does not check if the invite URL is configured to be public
+        with ``[p]inviteset public``. To check if invites are public,
+        use `Red.is_invite_url_public()`.
 
         Returns
         -------
@@ -1327,15 +1328,12 @@ class Red(
 
     async def is_invite_url_public(self) -> bool:
         """
-        Determines if invites are set to public.
-
-        This is determined by if bot owner has toggled
-        [p]inviteset public.
+        Determines if invite URL is configured to be public with ``[p]inviteset public``.
 
         Returns
         -------
         bool
-            :code:`True` if invite url is public.
+            :code:`True` if the invite URL is public.
         """
         return await self._config.invite_public()
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1310,19 +1310,35 @@ class Red(
         Generates the invite URL for the bot.
 
         Does not check if invites are public.
+        To check if invites are public, use `is_invite_public()`.
+        To check if invites are public, use `Bot.is_invite_public()`.
 
         Returns
         -------
         str
             Invite URL.
         """
-        app_info = await self.bot.application_info()
+        app_info = await self._app_info
         data = await self._config.all()
         commands_scope = data["invite_commands_scope"]
         scopes = ("bot", "applications.commands") if commands_scope else None
         perms_int = data["invite_perm"]
         permissions = discord.Permissions(perms_int)
         return discord.utils.oauth_url(app_info.id, permissions, scopes=scopes)
+
+    async def is_invite_url_public(self) -> bool:
+        """
+        Determines if invites are set to public.
+
+        This is determined by if bot owner has toggled
+        [p]inviteset public.
+
+        Returns
+        -------
+        bool
+            :code:`True` if invite url is public.
+        """
+        return await self._config.invite_public()
 
     async def is_admin(self, member: discord.Member) -> bool:
         """Checks if a member is an admin of their guild."""

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1305,6 +1305,23 @@ class Red(
         """
         return user.id in self.owner_ids
 
+    async def get_invite_url(self) -> str:
+        """
+        Generates the invite URL for the bot.
+
+        Returns
+        -------
+        str
+            Invite URL.
+        """
+        app_info = await self.bot.application_info()
+        data = await self.bot._config.all()
+        commands_scope = data["invite_commands_scope"]
+        scopes = ("bot", "applications.commands") if commands_scope else None
+        perms_int = data["invite_perm"]
+        permissions = discord.Permissions(perms_int)
+        return discord.utils.oauth_url(app_info.id, permissions, scopes=scopes)
+
     async def is_admin(self, member: discord.Member) -> bool:
         """Checks if a member is an admin of their guild."""
         try:

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1310,7 +1310,8 @@ class Red(
         Generates the invite URL for the bot.
 
         Does not check if invites are public.
-        To check if invites are public, use `Bot.is_invite_public()`.
+        To check if invites are public, use `Bot.is_invite_url_public()`.
+        To check if invites are public, use `is_invite_url_public()`.
 
         Returns
         -------

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1317,7 +1317,7 @@ class Red(
             Invite URL.
         """
         app_info = await self.bot.application_info()
-        data = await self.bot._config.all()
+        data = await self._config.all()
         commands_scope = data["invite_commands_scope"]
         scopes = ("bot", "applications.commands") if commands_scope else None
         perms_int = data["invite_perm"]

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1310,8 +1310,7 @@ class Red(
         Generates the invite URL for the bot.
 
         Does not check if invites are public.
-        To check if invites are public, use `Bot.is_invite_url_public()`.
-        To check if invites are public, use `is_invite_url_public()`.
+        To check if invites are public, use `Red.is_invite_url_public()`.
 
         Returns
         -------

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -372,7 +372,6 @@ class CoreLogic:
         """
         return {"redbot": __version__, "discordpy": discord.__version__}
 
-
     @staticmethod
     async def _can_get_invite_url(ctx):
         is_owner = await ctx.bot.is_owner(ctx.author)

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -372,22 +372,6 @@ class CoreLogic:
         """
         return {"redbot": __version__, "discordpy": discord.__version__}
 
-    async def _invite_url(self) -> str:
-        """
-        Generates the invite URL for the bot.
-
-        Returns
-        -------
-        str
-            Invite URL.
-        """
-        app_info = await self.bot.application_info()
-        data = await self.bot._config.all()
-        commands_scope = data["invite_commands_scope"]
-        scopes = ("bot", "applications.commands") if commands_scope else None
-        perms_int = data["invite_perm"]
-        permissions = discord.Permissions(perms_int)
-        return discord.utils.oauth_url(app_info.id, permissions, scopes=scopes)
 
     @staticmethod
     async def _can_get_invite_url(ctx):
@@ -1487,7 +1471,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             - `[p]invite`
         """
         try:
-            await ctx.author.send(await self._invite_url())
+            await ctx.author.send(await self.bot.get_invite_url)
             await ctx.tick()
         except discord.errors.Forbidden:
             await ctx.send(

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -112,7 +112,7 @@ class CoreLogic:
         self.bot.register_rpc_handler(self._name)
         self.bot.register_rpc_handler(self._prefixes)
         self.bot.register_rpc_handler(self._version_info)
-        self.bot.register_rpc_handler(bot.invite_url)
+        self.bot.register_rpc_handler(self._invite_url)
 
     async def _load(
         self, pkg_names: Iterable[str]
@@ -371,6 +371,17 @@ class CoreLogic:
             `redbot` and `discordpy` keys containing version information for both.
         """
         return {"redbot": __version__, "discordpy": discord.__version__}
+
+    async def _invite_url(self) -> str:
+        """
+        Generates the invite URL for the bot.
+
+        Returns
+        -------
+        str
+            Invite URL.
+        """
+        return self.bot.get_invite_url()
 
     @staticmethod
     async def _can_get_invite_url(ctx):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -381,7 +381,7 @@ class CoreLogic:
         str
             Invite URL.
         """
-        return self.bot.get_invite_url()
+        return await self.bot.get_invite_url()
 
     @staticmethod
     async def _can_get_invite_url(ctx):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1470,7 +1470,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             - `[p]invite`
         """
         try:
-            await ctx.author.send(await self.bot.get_invite_url)
+            await ctx.author.send(await self.bot.get_invite_url())
             await ctx.tick()
         except discord.errors.Forbidden:
             await ctx.send(

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -112,7 +112,7 @@ class CoreLogic:
         self.bot.register_rpc_handler(self._name)
         self.bot.register_rpc_handler(self._prefixes)
         self.bot.register_rpc_handler(self._version_info)
-        self.bot.register_rpc_handler(self._invite_url)
+        self.bot.register_rpc_handler(bot.invite_url)
 
     async def _load(
         self, pkg_names: Iterable[str]


### PR DESCRIPTION
### Description of the changes
Adds invite as a public API, refactored command to use the public API instead as there's no difference from private and public for that. 

Resolves #5152 