### PR TITLE
Reorganize `[p]set` command group

### DIFF
--- a/docs/cog_guides/core.rst
+++ b/docs/cog_guides/core.rst
@@ -1262,7 +1262,7 @@ helpset resetformatter
 This resets Red's help formatter to the default formatter.
 
 **Example:**
-    - ``[p]helpset resetformatter````
+    - ``[p]helpset resetformatter``
 
 .. _core-command-helpset-resetsettings:
 
@@ -1283,7 +1283,7 @@ This resets Red's help settings to their defaults.
 This may not have an impact when using custom formatters from 3rd party cogs
 
 **Example:**
-    - ``[p]helpset resetsettings````
+    - ``[p]helpset resetsettings``
 
 .. _core-command-helpset-showaliases:
 
@@ -1357,7 +1357,7 @@ Show the current help settings.
 
 
 **Example:**
-    - ``[p]helpset showsettings````
+    - ``[p]helpset showsettings``
 
 .. _core-command-helpset-tagline:
 
@@ -2481,7 +2481,7 @@ Show all external API services along with their keys that have been set.
 Secrets are not shown.
 
 **Example:**
-    - ``[p]set api list````
+    - ``[p]set api list``
 
 .. _core-command-set-api-remove:
 

--- a/docs/cog_guides/core.rst
+++ b/docs/cog_guides/core.rst
@@ -2858,8 +2858,8 @@ set ownernotifications adddestination
 Adds a destination text channel to receive owner notifications.
 
 **Examples:**
-    - ``[p]ownernotifications adddestination #owner-notifications``
-    - ``[p]ownernotifications adddestination 168091848718417920`` - Accepts channel IDs.
+    - ``[p]set ownernotifications adddestination #owner-notifications``
+    - ``[p]set ownernotifications adddestination 168091848718417920`` - Accepts channel IDs.
 
 **Arguments:**
     - ``<channel>`` - The channel to send owner notifications to.
@@ -2881,7 +2881,7 @@ set ownernotifications listdestinations
 Lists the configured extra destinations for owner notifications.
 
 **Example:**
-    - ``[p]ownernotifications listdestinations``
+    - ``[p]set ownernotifications listdestinations``
 
 .. _core-command-set-ownernotifications-optin:
 
@@ -2906,7 +2906,7 @@ This is the default state.
     Additional owners and destinations will not be affected.
 
 **Example:**
-    - ``[p]ownernotifications optin``
+    - ``[p]set ownernotifications optin``
 
 .. _core-command-set-ownernotifications-optout:
 
@@ -2929,7 +2929,7 @@ Opt-out of receiving owner notifications.
     Additional owners and destinations will still receive notifications.
 
 **Example:**
-    - ``[p]ownernotifications optout``
+    - ``[p]set ownernotifications optout``
 
 .. _core-command-set-ownernotifications-removedestination:
 
@@ -2950,8 +2950,8 @@ set ownernotifications removedestination
 Removes a destination text channel from receiving owner notifications.
 
 **Examples:**
-    - ``[p]ownernotifications removedestination #owner-notifications``
-    - ``[p]ownernotifications deletedestination 168091848718417920`` - Accepts channel IDs.
+    - ``[p]set ownernotifications removedestination #owner-notifications``
+    - ``[p]set ownernotifications deletedestination 168091848718417920`` - Accepts channel IDs.
 
 **Arguments:**
     - ``<channel>`` - The channel to stop sending owner notifications to.

--- a/docs/cog_guides/core.rst
+++ b/docs/cog_guides/core.rst
@@ -3042,7 +3042,7 @@ set regionalformat global
 Changes the bot's regional format. This is used for formatting date, time and numbers.
 
 ``language_code`` can be any language code with country code included, e.g. ``en-US``, ``de-DE``, ``fr-FR``, ``pl-PL``, etc.
-Pass "reset" to `language_code` to base regional formatting on bot's locale.
+Pass "reset" to ``language_code`` to base regional formatting on bot's locale.
 
 **Examples:**
     - ``[p]set regionalformat global en-US``
@@ -3073,7 +3073,7 @@ set regionalformat server
 Changes the bot's regional format in this server. This is used for formatting date, time and numbers.
 
 ``language_code`` can be any language code with country code included, e.g. ``en-US``, ``de-DE``, ``fr-FR``, ``pl-PL``, etc.
-Pass "reset" to `language_code` to base regional formatting on bot's locale in this server.
+Pass "reset" to ``language_code`` to base regional formatting on bot's locale in this server.
 
 **Examples:**
     - ``[p]set regionalformat server en-US``

--- a/docs/cog_guides/core.rst
+++ b/docs/cog_guides/core.rst
@@ -1616,8 +1616,6 @@ info
 
 Shows info about Red.
 
-See ``[p]set custominfo`` to customize.
-
 .. _core-command-invite:
 
 ^^^^^^
@@ -2363,71 +2361,6 @@ set
 
 Commands for changing Red's settings.
 
-.. _core-command-set-addadminrole:
-
-""""""""""""""""
-set addadminrole
-""""""""""""""""
-
-.. note:: |guildowner-lock|
-
-**Syntax**
-
-.. code-block:: none
-
-    [p]set addadminrole <role>
-
-**Description**
-
-Adds an admin role for this guild.
-
-Admins have the same access as Mods, plus additional admin level commands like:
- - ``[p]set serverprefix``
- - ``[p]addrole``
- - ``[p]ban``
- - ``[p]ignore guild``
-
- And more.
-
- **Examples:**
-    - ``[p]set addadminrole @Admins``
-    - ``[p]set addadminrole Super Admins``
-
-**Arguments:**
-    - ``<role>`` - The role to add as an admin.
-
-.. _core-command-set-addmodrole:
-
-""""""""""""""
-set addmodrole
-""""""""""""""
-
-.. note:: |guildowner-lock|
-
-**Syntax**
-
-.. code-block:: none
-
-    [p]set addmodrole <role>
-
-**Description**
-
-Adds a moderator role for this guild.
-
-This grants access to moderator level commands like:
- - ``[p]mute``
- - ``[p]cleanup``
- - ``[p]customcommand create``
-
- And more.
-
- **Examples:**
-    - ``[p]set addmodrole @Mods``
-    - ``[p]set addmodrole Loyal Helpers``
-
-**Arguments:**
-    - ``<role>`` - The role to add as a moderator.
-
 .. _core-command-set-api:
 
 """""""
@@ -2506,11 +2439,29 @@ Remove the given services with all their keys and tokens.
 **Arguments:**
     - ``<services...>`` - The services to remove.
 
-.. _core-command-set-avatar:
+.. _core-command-set-bot:
 
-""""""""""
-set avatar
-""""""""""
+"""""""
+set bot
+"""""""
+
+.. note:: |admin-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set bot
+
+**Description**
+
+Commands for changing Red's metadata.
+
+.. _core-command-set-bot-avatar:
+
+""""""""""""""
+set bot avatar
+""""""""""""""
 
 .. note:: |owner-lock|
 
@@ -2518,7 +2469,7 @@ set avatar
 
 .. code-block:: none
 
-    [p]set avatar [url]
+    [p]set bot avatar [url]
 
 **Description**
 
@@ -2527,18 +2478,18 @@ Sets Red's avatar
 Supports either an attachment or an image URL.
 
 **Examples:**
-    - ``[p]set avatar`` - With an image attachment, this will set the avatar.
-    - ``[p]set avatar`` - Without an attachment, this will show the command help.
-    - ``[p]set avatar https://links.flaree.xyz/k95`` - Sets the avatar to the provided url.
+    - ``[p]set bot avatar`` - With an image attachment, this will set the avatar.
+    - ``[p]set bot avatar`` - Without an attachment, this will show the command help.
+    - ``[p]set bot avatar https://links.flaree.xyz/k95`` - Sets the avatar to the provided url.
 
 **Arguments:**
     - ``[url]`` - An image url to be used as an avatar. Leave blank when uploading an attachment.
 
-.. _core-command-set-avatar-remove:
+.. _core-command-set-bot-avatar-remove:
 
-"""""""""""""""""
-set avatar remove
-"""""""""""""""""
+"""""""""""""""""""""
+set bot avatar remove
+"""""""""""""""""""""
 
 .. note:: |owner-lock|
 
@@ -2546,16 +2497,137 @@ set avatar remove
 
 .. code-block:: none
 
-    [p]set avatar remove 
+    [p]set bot avatar remove 
 
-.. tip:: Alias: ``set avatar clear``
+.. tip:: Alias: ``set bot avatar clear``
 
 **Description**
 
 Removes Red's avatar.
 
 **Example:**
-    - ``[p]set avatar remove``
+    - ``[p]set bot avatar remove``
+
+.. _core-command-set-bot-custominfo:
+
+""""""""""""""""""
+set bot custominfo
+""""""""""""""""""
+
+.. note:: |owner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set bot custominfo [text]
+
+**Description**
+
+Customizes a section of ``[p]info``.
+
+The maximum amount of allowed characters is 1024.
+Supports markdown, links and "mentions".
+
+Link example: ``[My link](https://example.com)``
+
+**Examples:**
+    - ``[p]set bot custominfo >>> I can use **markdown** such as quotes, ||spoilers|| and multiple lines.``
+    - ``[p]set bot custominfo Join my [support server](discord.gg/discord)!``
+    - ``[p]set bot custominfo`` - Removes custom info text.
+
+**Arguments:**
+    - ``[text]`` - The custom info text.
+
+.. _core-command-set-bot-description:
+
+"""""""""""""""""""
+set bot description
+"""""""""""""""""""
+
+.. note:: |owner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set bot description [description]
+
+**Description**
+
+Sets the bot's description.
+
+Use without a description to reset.
+This is shown in a few locations, including the help menu.
+
+The maximum description length is 250 characters to ensure it displays properly.
+
+The default is "Red V3".
+
+**Examples:**
+    - ``[p]set bot description`` - Resets the description to the default setting.
+    - ``[p]set bot description MyBot: A Red V3 Bot``
+
+**Arguments:**
+    - ``[description]`` - The description to use for this bot. Leave blank to reset to the default.
+
+.. _core-command-set-bot-nickname:
+
+""""""""""""""""
+set bot nickname
+""""""""""""""""
+
+.. note:: |admin-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set bot nickname [nickname]
+
+**Description**
+
+Sets Red's nickname for the current server.
+
+Maximum length for a nickname is 32 characters.
+
+**Example:**
+    - ``[p]set bot nickname 🎃 SpookyBot 🎃``
+
+**Arguments:**
+    - ``[nickname]`` - The nickname to give the bot. Leave blank to clear the current nickname.
+
+.. _core-command-set-bot-username:
+
+""""""""""""""""
+set bot username
+""""""""""""""""
+
+.. note:: |owner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set bot username <username>
+
+.. tip:: Alias: ``set bot name``
+
+**Description**
+
+Sets Red's username.
+
+Maximum length for a username is 32 characters.
+
+.. Note:: The username of a verified bot cannot be manually changed.
+
+    Please contact Discord support to change it.
+
+**Example:**
+    - ``[p]set bot username BaguetteBot``
+
+**Arguments:**
+    - ``<username>`` - The username to give the bot.
 
 .. _core-command-set-colour:
 
@@ -2591,66 +2663,6 @@ https://discordpy.readthedocs.io/en/stable/ext/commands/api.html#discord.ext.com
 **Arguments:**
     - ``[colour]`` - The colour to use for embeds. Leave blank to set to the default value (red).
 
-.. _core-command-set-competing:
-
-"""""""""""""
-set competing
-"""""""""""""
-
-.. note:: |owner-lock|
-
-**Syntax**
-
-.. code-block:: none
-
-    [p]set competing [competing]
-
-**Description**
-
-Sets Red's competing status.
-
-This will appear as ``Competing in <competing>``.
-
-Maximum length for a competing status is 128 characters.
-
-**Examples:**
-    - ``[p]set competing`` - Clears the activity status.
-    - ``[p]set competing London 2012 Olympic Games``
-
-**Arguments:**
-    - ``[competing]`` - The text to follow ``Competing in``. Leave blank to clear the current activity status.
-
-.. _core-command-set-custominfo:
-
-""""""""""""""
-set custominfo
-""""""""""""""
-
-.. note:: |owner-lock|
-
-**Syntax**
-
-.. code-block:: none
-
-    [p]set custominfo [text]
-
-**Description**
-
-Customizes a section of ``[p]info``.
-
-The maximum amount of allowed characters is 1024.
-Supports markdown, links and "mentions".
-
-Link example: ``[My link](https://example.com)``
-
-**Examples:**
-    - ``[p]set custominfo >>> I can use **markdown** such as quotes, ||spoilers|| and multiple lines.``
-    - ``[p]set custominfo Join my [support server](discord.gg/discord)!``
-    - ``[p]set custominfo`` - Removes custom info text.
-
-**Arguments:**
-    - ``[text]`` - The custom info text.
-
 .. _core-command-set-deletedelay:
 
 """""""""""""""
@@ -2683,38 +2695,6 @@ This is only applied to the current server and not globally.
 **Arguments:**
     - ``[time]`` - The seconds to wait before deleting the command message. Use -1 to disable.
 
-.. _core-command-set-description:
-
-"""""""""""""""
-set description
-"""""""""""""""
-
-.. note:: |owner-lock|
-
-**Syntax**
-
-.. code-block:: none
-
-    [p]set description [description]
-
-**Description**
-
-Sets the bot's description.
-
-Use without a description to reset.
-This is shown in a few locations, including the help menu.
-
-The maximum description length is 250 characters to ensure it displays properly.
-
-The default is "Red V3".
-
-**Examples:**
-    - ``[p]set description`` - Resets the description to the default setting.
-    - ``[p]set description MyBot: A Red V3 Bot``
-
-**Arguments:**
-    - ``[description]`` - The description to use for this bot. Leave blank to reset to the default.
-
 .. _core-command-set-fuzzy:
 
 """""""""
@@ -2740,99 +2720,6 @@ Default is for fuzzy command search to be disabled.
 **Example:**
     - ``[p]set fuzzy``
 
-.. _core-command-set-globallocale:
-
-""""""""""""""""
-set globallocale
-""""""""""""""""
-
-.. note:: |owner-lock|
-
-**Syntax**
-
-.. code-block:: none
-
-    [p]set globallocale <language_code>
-
-**Description**
-
-Changes the bot's default locale.
-
-This will be used when a server has not set a locale, or in DMs.
-
-Go to `Red's Crowdin page <https://translate.discord.red>`_ to see locales that are available with translations.
-
-To reset to English, use "en-US".
-
-**Examples:**
-    - ``[p]set locale en-US``
-    - ``[p]set locale de-DE``
-    - ``[p]set locale fr-FR``
-    - ``[p]set locale pl-PL``
-
-**Arguments:**
-    - ``<language_code>`` - The default locale to use for the bot. This can be any language code with country code included.
-
-.. _core-command-set-globalregionalformat:
-
-""""""""""""""""""""""""
-set globalregionalformat
-""""""""""""""""""""""""
-
-.. note:: |owner-lock|
-
-**Syntax**
-
-.. code-block:: none
-
-    [p]set globalregionalformat [language_code]
-
-.. tip:: Alias: ``set globalregion``
-
-**Description**
-
-Changes the bot's regional format. This is used for formatting date, time and numbers.
-
-``language_code`` can be any language code with country code included, e.g. ``en-US``, ``de-DE``, ``fr-FR``, ``pl-PL``, etc.
-Leave ``language_code`` empty to base regional formatting on bot's locale.
-
-**Examples:**
-    - ``[p]set globalregionalformat en-US``
-    - ``[p]set globalregion de-DE``
-    - ``[p]set globalregionalformat`` - Resets to the locale.
-
-**Arguments:**
-    - ``[language_code]`` - The default region format to use for the bot.
-
-.. _core-command-set-listening:
-
-"""""""""""""
-set listening
-"""""""""""""
-
-.. note:: |owner-lock|
-
-**Syntax**
-
-.. code-block:: none
-
-    [p]set listening [listening]
-
-**Description**
-
-Sets Red's listening status.
-
-This will appear as ``Listening to <listening>``.
-
-Maximum length for a listening status is 128 characters.
-
-**Examples:**
-    - ``[p]set listening`` - Clears the activity status.
-    - ``[p]set listening jams``
-
-**Arguments:**
-    - ``[listening]`` - The text to follow ``Listening to``. Leave blank to clear the current activity status.
-
 .. _core-command-set-locale:
 
 """"""""""
@@ -2854,7 +2741,8 @@ Changes the bot's locale in this server.
 Go to `Red's Crowdin page <https://translate.discord.red>`_ to see locales that are available with translations.
 
 Use "default" to return to the bot's default set language.
-To reset to English, use "en-US".
+
+If you want to change bot's global locale, see ``[p]set locale global`` command.
 
 **Examples:**
     - ``[p]set locale en-US``
@@ -2866,31 +2754,72 @@ To reset to English, use "en-US".
 **Arguments:**
     - ``<language_code>`` - The default locale to use for the bot. This can be any language code with country code included.
 
-.. _core-command-set-nickname:
+.. _core-command-set-locale-global:
 
-""""""""""""
-set nickname
-""""""""""""
+"""""""""""""""""
+set locale global
+"""""""""""""""""
 
-.. note:: |admin-lock|
+.. note:: |owner-lock|
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]set nickname [nickname]
+    [p]set locale global <language_code>
 
 **Description**
 
-Sets Red's nickname for the current server.
+Changes the bot's default locale.
 
-Maximum length for a nickname is 32 characters.
+This will be used when a server has not set a locale, or in DMs.
 
-**Example:**
-    - ``[p]set nickname 🎃 SpookyBot 🎃``
+Go to `Red's Crowdin page <https://translate.discord.red>`_ to see locales that are available with translations.
+
+To reset to English, use "en-US".
+
+**Examples:**
+    - ``[p]set locale global en-US``
+    - ``[p]set locale global de-DE``
+    - ``[p]set locale global fr-FR``
+    - ``[p]set locale global pl-PL``
 
 **Arguments:**
-    - ``[nickname]`` - The nickname to give the bot. Leave blank to clear the current nickname.
+    - ``<language_code>`` - The default locale to use for the bot. This can be any language code with country code included.
+
+.. _core-command-set-locale-server:
+
+"""""""""""""""""
+set locale server
+"""""""""""""""""
+
+.. note:: |guildowner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set locale server <language_code>
+
+.. tip:: Aliases: ``set locale local``, ``set locale guild``
+
+**Description**
+
+Changes the bot's locale in this server.
+
+Go to `Red's Crowdin page <https://translate.discord.red>`_ to see locales that are available with translations.
+
+Use "default" to return to the bot's default set language.
+
+**Examples:**
+    - ``[p]set locale server en-US``
+    - ``[p]set locale server de-DE``
+    - ``[p]set locale server fr-FR``
+    - ``[p]set locale server pl-PL``
+    - ``[p]set locale server default`` - Resets to the global default locale.
+
+**Arguments:**
+    - ``<language_code>`` - The default locale to use for the bot. This can be any language code with country code included.
 
 .. _core-command-set-ownernotifications:
 
@@ -3027,37 +2956,6 @@ Removes a destination text channel from receiving owner notifications.
 **Arguments:**
     - ``<channel>`` - The channel to stop sending owner notifications to.
 
-.. _core-command-set-playing:
-
-"""""""""""
-set playing
-"""""""""""
-
-.. note:: |owner-lock|
-
-**Syntax**
-
-.. code-block:: none
-
-    [p]set playing [game]
-
-.. tip:: Alias: ``set game``
-
-**Description**
-
-Sets Red's playing status.
-
-This will appear as ``Playing <game>`` or ``PLAYING A GAME: <game>`` depending on the context.
-
-Maximum length for a playing status is 128 characters.
-
-**Examples:**
-    - ``[p]set playing`` - Clears the activity status.
-    - ``[p]set playing the keyboard``
-
-**Arguments:**
-    - ``[game]`` - The text to follow ``Playing``. Leave blank to clear the current activity status.
-
 .. _core-command-set-prefix:
 
 """"""""""
@@ -3104,7 +3002,7 @@ set regionalformat
 
 .. code-block:: none
 
-    [p]set regionalformat [language_code]
+    [p]set regionalformat <language_code>
 
 .. tip:: Alias: ``set region``
 
@@ -3113,21 +3011,52 @@ set regionalformat
 Changes the bot's regional format in this server. This is used for formatting date, time and numbers.
 
 ``language_code`` can be any language code with country code included, e.g. ``en-US``, ``de-DE``, ``fr-FR``, ``pl-PL``, etc.
-Leave ``language_code`` empty to base regional formatting on bot's locale in this server.
+Pass "reset" to ``language_code`` to base regional formatting on bot's locale in this server.
+
+If you want to change bot's global regional format, see ``[p]set regionalformat global`` command.
 
 **Examples:**
     - ``[p]set regionalformat en-US``
     - ``[p]set region de-DE``
-    - ``[p]set regionalformat`` - Resets to the locale.
+    - ``[p]set regionalformat reset`` - Resets to the locale.
 
 **Arguments:**
     - ``[language_code]`` - The region format to use for the bot in this server.
 
-.. _core-command-set-removeadminrole:
+.. _core-command-set-regionalformat-global:
 
-"""""""""""""""""""
-set removeadminrole
-"""""""""""""""""""
+"""""""""""""""""""""""""
+set regionalformat global
+"""""""""""""""""""""""""
+
+.. note:: |owner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set regionalformat global <language_code>
+
+**Description**
+
+Changes the bot's regional format. This is used for formatting date, time and numbers.
+
+``language_code`` can be any language code with country code included, e.g. ``en-US``, ``de-DE``, ``fr-FR``, ``pl-PL``, etc.
+Pass "reset" to `language_code` to base regional formatting on bot's locale.
+
+**Examples:**
+    - ``[p]set regionalformat global en-US``
+    - ``[p]set region global de-DE``
+    - ``[p]set regionalformat global reset`` - Resets to the locale.
+
+**Arguments:**
+    - ``[language_code]`` - The default region format to use for the bot.
+
+.. _core-command-set-regionalformat-server:
+
+"""""""""""""""""""""""""
+set regionalformat server
+"""""""""""""""""""""""""
 
 .. note:: |guildowner-lock|
 
@@ -3135,26 +3064,140 @@ set removeadminrole
 
 .. code-block:: none
 
-    [p]set removeadminrole <role>
+    [p]set regionalformat server <language_code>
 
-.. tip:: Aliases: ``set remadmindrole``, ``set deladminrole``, ``set deleteadminrole``
+.. tip:: Aliases: ``set regionalformat local``, ``set regionalformat guild``
+
+**Description**
+
+Changes the bot's regional format in this server. This is used for formatting date, time and numbers.
+
+``language_code`` can be any language code with country code included, e.g. ``en-US``, ``de-DE``, ``fr-FR``, ``pl-PL``, etc.
+Pass "reset" to `language_code` to base regional formatting on bot's locale in this server.
+
+**Examples:**
+    - ``[p]set regionalformat server en-US``
+    - ``[p]set region local de-DE``
+    - ``[p]set regionalformat server reset`` - Resets to the locale.
+
+**Arguments:**
+    - ``[language_code]`` - The region format to use for the bot in this server.
+
+.. _core-command-set-roles:
+
+"""""""""
+set roles
+"""""""""
+
+.. note:: |guildowner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set roles
+
+**Description**
+
+Set server's admin and mod roles for Red.
+
+.. _core-command-set-roles-addadminrole:
+
+""""""""""""""""""""""
+set roles addadminrole
+""""""""""""""""""""""
+
+.. note:: |guildowner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set roles addadminrole <role>
+
+**Description**
+
+Adds an admin role for this guild.
+
+Admins have the same access as Mods, plus additional admin level commands like:
+ - ``[p]set serverprefix``
+ - ``[p]addrole``
+ - ``[p]ban``
+ - ``[p]ignore guild``
+
+ And more.
+
+ **Examples:**
+    - ``[p]set roles addadminrole @Admins``
+    - ``[p]set roles addadminrole Super Admins``
+
+**Arguments:**
+    - ``<role>`` - The role to add as an admin.
+
+.. _core-command-set-roles-addmodrole:
+
+""""""""""""""""""""
+set roles addmodrole
+""""""""""""""""""""
+
+.. note:: |guildowner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set roles addmodrole <role>
+
+**Description**
+
+Adds a moderator role for this guild.
+
+This grants access to moderator level commands like:
+ - ``[p]mute``
+ - ``[p]cleanup``
+ - ``[p]customcommand create``
+
+ And more.
+
+ **Examples:**
+    - ``[p]set roles addmodrole @Mods``
+    - ``[p]set roles addmodrole Loyal Helpers``
+
+**Arguments:**
+    - ``<role>`` - The role to add as a moderator.
+
+.. _core-command-set-roles-removeadminrole:
+
+"""""""""""""""""""""""""
+set roles removeadminrole
+"""""""""""""""""""""""""
+
+.. note:: |guildowner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set roles removeadminrole <role>
+
+.. tip:: Aliases: ``set roles remadmindrole``, ``set roles deladminrole``, ``set roles deleteadminrole``
 
 **Description**
 
 Removes an admin role for this guild.
 
 **Examples:**
-    - ``[p]set removeadminrole @Admins``
-    - ``[p]set removeadminrole Super Admins``
+    - ``[p]set roles removeadminrole @Admins``
+    - ``[p]set roles removeadminrole Super Admins``
 
 **Arguments:**
     - ``<role>`` - The role to remove from being an admin.
 
-.. _core-command-set-removemodrole:
+.. _core-command-set-roles-removemodrole:
 
-"""""""""""""""""
-set removemodrole
-"""""""""""""""""
+"""""""""""""""""""""""
+set roles removemodrole
+"""""""""""""""""""""""
 
 .. note:: |guildowner-lock|
 
@@ -3162,17 +3205,17 @@ set removemodrole
 
 .. code-block:: none
 
-    [p]set removemodrole <role>
+    [p]set roles removemodrole <role>
 
-.. tip:: Aliases: ``set remmodrole``, ``set delmodrole``, ``set deletemodrole``
+.. tip:: Aliases: ``set roles remmodrole``, ``set roles delmodrole``, ``set roles deletemodrole``
 
 **Description**
 
 Removes a mod role for this guild.
 
 **Examples:**
-    - ``[p]set removemodrole @Mods``
-    - ``[p]set removemodrole Loyal Helpers``
+    - ``[p]set roles removemodrole @Mods``
+    - ``[p]set roles removemodrole Loyal Helpers``
 
 **Arguments:**
     - ``<role>`` - The role to remove from being a moderator.
@@ -3268,30 +3311,17 @@ set status
 
 .. code-block:: none
 
-    [p]set status <status>
+    [p]set status
 
 **Description**
 
-Sets Red's status.
+Commands for setting Red's status.
 
-Available statuses:
-    - ``online``
-    - ``idle``
-    - ``dnd``
-    - ``invisible``
+.. _core-command-set-status-competing:
 
-**Examples:**
-    - ``[p]set status online`` - Clears the status.
-    - ``[p]set status invisible``
-
-**Arguments:**
-    - ``<status>`` - One of the available statuses.
-
-.. _core-command-set-streaming:
-
-"""""""""""""
-set streaming
-"""""""""""""
+""""""""""""""""""""
+set status competing
+""""""""""""""""""""
 
 .. note:: |owner-lock|
 
@@ -3299,9 +3329,176 @@ set streaming
 
 .. code-block:: none
 
-    [p]set streaming [(<streamer> <stream_title>)]
+    [p]set status competing [competing]
 
-.. tip:: Aliases: ``set stream``, ``set twitch``
+**Description**
+
+Sets Red's competing status.
+
+This will appear as ``Competing in <competing>``.
+
+Maximum length for a competing status is 128 characters.
+
+**Examples:**
+    - ``[p]set status competing`` - Clears the activity status.
+    - ``[p]set status competing London 2012 Olympic Games``
+
+**Arguments:**
+    - ``[competing]`` - The text to follow ``Competing in``. Leave blank to clear the current activity status.
+
+.. _core-command-set-status-dnd:
+
+""""""""""""""
+set status dnd
+""""""""""""""
+
+.. note:: |owner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set status dnd
+
+.. tip:: Aliases: ``set status donotdisturb``, ``set status busy``
+
+**Description**
+
+Sets Red's status to do not disturb.
+
+.. _core-command-set-status-idle:
+
+"""""""""""""""
+set status idle
+"""""""""""""""
+
+.. note:: |owner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set status idle
+
+.. tip:: Aliases: ``set status away``, ``set status afk``
+
+**Description**
+
+Sets Red's status to idle.
+
+.. _core-command-set-status-invisible:
+
+""""""""""""""""""""
+set status invisible
+""""""""""""""""""""
+
+.. note:: |owner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set status invisible
+
+.. tip:: Alias: ``set status offline``
+
+**Description**
+
+Sets Red's status to invisible.
+
+.. _core-command-set-status-listening:
+
+""""""""""""""""""""
+set status listening
+""""""""""""""""""""
+
+.. note:: |owner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set status listening [listening]
+
+**Description**
+
+Sets Red's listening status.
+
+This will appear as ``Listening to <listening>``.
+
+Maximum length for a listening status is 128 characters.
+
+**Examples:**
+    - ``[p]set status listening`` - Clears the activity status.
+    - ``[p]set status listening jams``
+
+**Arguments:**
+    - ``[listening]`` - The text to follow ``Listening to``. Leave blank to clear the current activity status.
+
+.. _core-command-set-status-online:
+
+"""""""""""""""""
+set status online
+"""""""""""""""""
+
+.. note:: |owner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set status online
+
+**Description**
+
+Sets Red's status to online.
+
+.. _core-command-set-status-playing:
+
+""""""""""""""""""
+set status playing
+""""""""""""""""""
+
+.. note:: |owner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set status playing [game]
+
+.. tip:: Alias: ``set status game``
+
+**Description**
+
+Sets Red's playing status.
+
+This will appear as ``Playing <game>`` or ``PLAYING A GAME: <game>`` depending on the context.
+
+Maximum length for a playing status is 128 characters.
+
+**Examples:**
+    - ``[p]set status playing`` - Clears the activity status.
+    - ``[p]set status playing the keyboard``
+
+**Arguments:**
+    - ``[game]`` - The text to follow ``Playing``. Leave blank to clear the current activity status.
+
+.. _core-command-set-status-streaming:
+
+""""""""""""""""""""
+set status streaming
+""""""""""""""""""""
+
+.. note:: |owner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set status streaming [(<streamer> <stream_title>)]
+
+.. tip:: Aliases: ``set status stream``, ``set status twitch``
 
 **Description**
 
@@ -3315,13 +3512,42 @@ Maximum length for a stream title is 128 characters.
 Leaving both streamer and stream_title empty will clear it.
 
 **Examples:**
-    - ``[p]set stream`` - Clears the activity status.
-    - ``[p]set stream 26 Twentysix is streaming`` - Sets the stream to ``https://www.twitch.tv/26``.
-    - ``[p]set stream https://twitch.tv/26 Twentysix is streaming`` - Sets the URL manually.
+    - ``[p]set status stream`` - Clears the activity status.
+    - ``[p]set status stream 26 Twentysix is streaming`` - Sets the stream to ``https://www.twitch.tv/26``.
+    - ``[p]set status stream https://twitch.tv/26 Twentysix is streaming`` - Sets the URL manually.
 
 **Arguments:**
     - ``<streamer>`` - The twitch streamer to provide a link to. This can be their twitch name or the entire URL.
     - ``<stream_title>`` - The text to follow ``Streaming`` in the status.
+
+.. _core-command-set-status-watching:
+
+"""""""""""""""""""
+set status watching
+"""""""""""""""""""
+
+.. note:: |owner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set status watching [watching]
+
+**Description**
+
+Sets Red's watching status.
+
+This will appear as ``Watching <watching>``.
+
+Maximum length for a watching status is 128 characters.
+
+**Examples:**
+    - ``[p]set status watching`` - Clears the activity status.
+    - ``[p]set status watching [p]help``
+
+**Arguments:**
+    - ``[watching]`` - The text to follow ``Watching``. Leave blank to clear the current activity status.
 
 .. _core-command-set-usebotcolour:
 
@@ -3348,67 +3574,6 @@ Otherwise, the colour used will be the colour of the bot's top role.
 
 **Example:**
     - ``[p]set usebotcolour``
-
-.. _core-command-set-username:
-
-""""""""""""
-set username
-""""""""""""
-
-.. note:: |owner-lock|
-
-**Syntax**
-
-.. code-block:: none
-
-    [p]set username <username>
-
-.. tip:: Alias: ``set name``
-
-**Description**
-
-Sets Red's username.
-
-Maximum length for a username is 32 characters.
-
-.. Note:: The username of a verified bot cannot be manually changed.
-
-    Please contact Discord support to change it.
-
-**Example:**
-    - ``[p]set username BaguetteBot``
-
-**Arguments:**
-    - ``<username>`` - The username to give the bot.
-
-.. _core-command-set-watching:
-
-""""""""""""
-set watching
-""""""""""""
-
-.. note:: |owner-lock|
-
-**Syntax**
-
-.. code-block:: none
-
-    [p]set watching [watching]
-
-**Description**
-
-Sets Red's watching status.
-
-This will appear as ``Watching <watching>``.
-
-Maximum length for a watching status is 128 characters.
-
-**Examples:**
-    - ``[p]set watching`` - Clears the activity status.
-    - ``[p]set watching [p]help``
-
-**Arguments:**
-    - ``[watching]`` - The text to follow ``Watching``. Leave blank to clear the current activity status.
 
 .. _core-command-shutdown:
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -225,7 +225,7 @@ Administrator
 ~~~~~~~~~~~~~
 
 The administrator is defined by its roles. You can set multiple admin roles
-with the ``[p]set addadminrole`` and ``[p]set removeadminrole`` commands.
+with the ``[p]set roles addadminrole`` and ``[p]set roles removeadminrole`` commands.
 
 For example, in the mod cog, an admin can use the ``[p]modset`` command
 which defines the cog settings.
@@ -235,7 +235,7 @@ Moderator
 ~~~~~~~~~
 
 A moderator is a step above the average users. You can set multiple moderator
-roles with the ``[p]set addmodrole`` and ``[p]set removemodrole`` commands.
+roles with the ``[p]set roles addmodrole`` and ``[p]set roles removemodrole`` commands.
 
 For example, in the filter cog, a mod will be able to use the various commands 
 under ``[p]filter`` (such as adding and removing filtered words), but they will

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2171,6 +2171,35 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             await ctx.send(_("Done."))
 
+    @_set_bot.command()
+    @checks.is_owner()
+    async def custominfo(self, ctx: commands.Context, *, text: str = None):
+        """Customizes a section of `[p]info`.
+
+        The maximum amount of allowed characters is 1024.
+        Supports markdown, links and "mentions".
+
+        Link example: `[My link](https://example.com)`
+
+        **Examples:**
+            - `[p]set custominfo >>> I can use **markdown** such as quotes, ||spoilers|| and multiple lines.`
+            - `[p]set custominfo Join my [support server](discord.gg/discord)!`
+            - `[p]set custominfo` - Removes custom info text.
+
+        **Arguments:**
+            - `[text]` - The custom info text.
+        """
+        if not text:
+            await ctx.bot._config.custom_info.clear()
+            await ctx.send(_("The custom text has been cleared."))
+            return
+        if len(text) <= 1024:
+            await ctx.bot._config.custom_info.set(text)
+            await ctx.send(_("The custom text has been set."))
+            await ctx.invoke(self.info)
+        else:
+            await ctx.send(_("Text must be fewer than 1024 characters long."))
+
 # -- End Bot Metadata Commands -- ###
 # -- Bot Status Commands -- ###
 
@@ -2668,6 +2697,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             )
         )
 
+# -- End Set Locale Commands -- ###
 
     @_set.command(name="showsettings")
     async def set_showsettings(self, ctx: commands.Context):
@@ -2938,35 +2968,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             await ctx.send(_("Server prefix set."))
         else:
             await ctx.send(_("Server prefixes set."))
-
-    @_set.command()
-    @checks.is_owner()
-    async def custominfo(self, ctx: commands.Context, *, text: str = None):
-        """Customizes a section of `[p]info`.
-
-        The maximum amount of allowed characters is 1024.
-        Supports markdown, links and "mentions".
-
-        Link example: `[My link](https://example.com)`
-
-        **Examples:**
-            - `[p]set custominfo >>> I can use **markdown** such as quotes, ||spoilers|| and multiple lines.`
-            - `[p]set custominfo Join my [support server](discord.gg/discord)!`
-            - `[p]set custominfo` - Removes custom info text.
-
-        **Arguments:**
-            - `[text]` - The custom info text.
-        """
-        if not text:
-            await ctx.bot._config.custom_info.clear()
-            await ctx.send(_("The custom text has been cleared."))
-            return
-        if len(text) <= 1024:
-            await ctx.bot._config.custom_info.set(text)
-            await ctx.send(_("The custom text has been set."))
-            await ctx.invoke(self.info)
-        else:
-            await ctx.send(_("Text must be fewer than 1024 characters long."))
 
     @_set.group(invoke_without_command=True)
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1987,7 +1987,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     async def _set(self, ctx: commands.Context):
         """Commands for changing [botname]'s settings."""
 
-# -- Bot Metadata Commands -- ###
+    # -- Bot Metadata Commands -- ###
 
     @_set.group(name="bot", aliases=["metadata"])
     async def _set_bot(self, ctx: commands.Context):
@@ -2200,8 +2200,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             await ctx.send(_("Text must be fewer than 1024 characters long."))
 
-# -- End Bot Metadata Commands -- ###
-# -- Bot Status Commands -- ###
+    # -- End Bot Metadata Commands -- ###
+    # -- Bot Status Commands -- ###
 
     async def _set_status(self, ctx: commands.Context, status: discord.Status):
         game = ctx.bot.guilds[0].me.activity if len(ctx.bot.guilds) > 0 else None
@@ -2417,8 +2417,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """Set [botname]'s status to invisible."""
         await self._set_status(ctx, discord.Status.invisible)
 
-# -- End Bot Status Commands -- ###
-# -- Bot Roles Commands -- ###
+    # -- End Bot Status Commands -- ###
+    # -- Bot Roles Commands -- ###
 
     @_set.group(name="roles")
     async def _set_roles(self, ctx: commands.Context):
@@ -2519,8 +2519,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             roles.remove(role.id)
         await ctx.send(_("That role is no longer considered a mod role."))
 
-# -- End Set Roles Commands -- ###
-# -- Set Locale Commands -- ###
+    # -- End Set Roles Commands -- ###
+    # -- Set Locale Commands -- ###
 
     @_set.group(name="locale")
     async def _set_locale_group(self, ctx: commands.Context):
@@ -2697,7 +2697,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             )
         )
 
-# -- End Set Locale Commands -- ###
+    # -- End Set Locale Commands -- ###
 
     @_set.command(name="showsettings")
     async def set_showsettings(self, ctx: commands.Context):
@@ -2893,7 +2893,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         await ctx.bot._config.color.set(colour.value)
         await ctx.send(_("The color has been set."))
 
-    @_set.command(aliases=["prefixes", "globalprefix", "globalprefixes"], require_var_positional=True)
+    @_set.command(
+        aliases=["prefixes", "globalprefix", "globalprefixes"], require_var_positional=True
+    )
     @checks.is_owner()
     async def prefix(self, ctx: commands.Context, *prefixes: str):
         """Sets [botname]'s global prefix(es).

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1995,7 +1995,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
     @checks.is_owner()
     @_set_bot.command(name="description")
-    async def setdescription(self, ctx: commands.Context, *, description: str = ""):
+    async def _set_bot_description(self, ctx: commands.Context, *, description: str = ""):
         """
         Sets the bot's description.
 
@@ -2029,9 +2029,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             ctx.bot.description = description
             await ctx.tick()
 
-    @_set_bot.group(invoke_without_command=True)
+    @_set_bot.group(name="avatar", invoke_without_command=True)
     @checks.is_owner()
-    async def avatar(self, ctx: commands.Context, url: str = None):
+    async def _set_bot_avatar(self, ctx: commands.Context, url: str = None):
         """Sets [botname]'s avatar
 
         Supports either an attachment or an image URL.
@@ -2078,9 +2078,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             await ctx.send(_("Done."))
 
-    @avatar.command(name="remove", aliases=["clear"])
+    @_set_bot_avatar.command(name="remove", aliases=["clear"])
     @checks.is_owner()
-    async def avatar_remove(self, ctx: commands.Context):
+    async def _set_bot_avatar_remove(self, ctx: commands.Context):
         """
         Removes [botname]'s avatar.
 
@@ -2093,7 +2093,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
     @_set_bot.command(name="username", aliases=["name"])
     @checks.is_owner()
-    async def _username(self, ctx: commands.Context, *, username: str):
+    async def _set_bot_username(self, ctx: commands.Context, *, username: str):
         """Sets [botname]'s username.
 
         Maximum length for a username is 32 characters.
@@ -2150,7 +2150,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @_set_bot.command(name="nickname")
     @checks.admin_or_permissions(manage_nicknames=True)
     @commands.guild_only()
-    async def _nickname(self, ctx: commands.Context, *, nickname: str = None):
+    async def _set_bot_nickname(self, ctx: commands.Context, *, nickname: str = None):
         """Sets [botname]'s nickname for the current server.
 
         Maximum length for a nickname is 32 characters.
@@ -2171,9 +2171,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             await ctx.send(_("Done."))
 
-    @_set_bot.command()
+    @_set_bot.command(name="custominfo")
     @checks.is_owner()
-    async def custominfo(self, ctx: commands.Context, *, text: str = None):
+    async def _set_bot_custominfo(self, ctx: commands.Context, *, text: str = None):
         """Customizes a section of `[p]info`.
 
         The maximum amount of allowed characters is 1024.
@@ -2203,21 +2203,16 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     # -- End Bot Metadata Commands -- ###
     # -- Bot Status Commands -- ###
 
-    async def _set_status(self, ctx: commands.Context, status: discord.Status):
-        game = ctx.bot.guilds[0].me.activity if len(ctx.bot.guilds) > 0 else None
-        await ctx.bot.change_presence(status=status, activity=game)
-        return await ctx.send(_("Status changed to {}.").format(status))
-
     @_set.group(name="status")
-    async def _set_status_group(self, ctx: commands.Context):
+    async def _set_status(self, ctx: commands.Context):
         """Commands for setting [botname]'s status."""
 
-    @_set_status_group.command(
+    @_set_status.command(
         name="streaming", aliases=["stream", "twitch"], usage="[(<streamer> <stream_title>)]"
     )
     @checks.bot_in_a_guild()
     @checks.is_owner()
-    async def stream(self, ctx: commands.Context, streamer=None, *, stream_title=None):
+    async def _set_status_stream(self, ctx: commands.Context, streamer=None, *, stream_title=None):
         """Sets [botname]'s streaming status to a twitch stream.
 
         This will appear as `Streaming <stream_title>` or `LIVE ON TWITCH` depending on the context.
@@ -2256,10 +2251,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             await ctx.bot.change_presence(activity=None, status=status)
         await ctx.send(_("Done."))
 
-    @_set_status_group.command(name="playing", aliases=["game"])
+    @_set_status.command(name="playing", aliases=["game"])
     @checks.bot_in_a_guild()
     @checks.is_owner()
-    async def _game(self, ctx: commands.Context, *, game: str = None):
+    async def _set_status_game(self, ctx: commands.Context, *, game: str = None):
         """Sets [botname]'s playing status.
 
         This will appear as `Playing <game>` or `PLAYING A GAME: <game>` depending on the context.
@@ -2288,10 +2283,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             await ctx.send(_("Game cleared."))
 
-    @_set_status_group.command(name="listening")
+    @_set_status.command(name="listening")
     @checks.bot_in_a_guild()
     @checks.is_owner()
-    async def _listening(self, ctx: commands.Context, *, listening: str = None):
+    async def _set_status_listening(self, ctx: commands.Context, *, listening: str = None):
         """Sets [botname]'s listening status.
 
         This will appear as `Listening to <listening>`.
@@ -2323,10 +2318,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             await ctx.send(_("Listening cleared."))
 
-    @_set_status_group.command(name="watching")
+    @_set_status.command(name="watching")
     @checks.bot_in_a_guild()
     @checks.is_owner()
-    async def _watching(self, ctx: commands.Context, *, watching: str = None):
+    async def _set_status_watching(self, ctx: commands.Context, *, watching: str = None):
         """Sets [botname]'s watching status.
 
         This will appear as `Watching <watching>`.
@@ -2354,10 +2349,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             await ctx.send(_("Watching cleared."))
 
-    @_set_status_group.command(name="competing")
+    @_set_status.command(name="competing")
     @checks.bot_in_a_guild()
     @checks.is_owner()
-    async def _competing(self, ctx: commands.Context, *, competing: str = None):
+    async def _set_status_competing(self, ctx: commands.Context, *, competing: str = None):
         """Sets [botname]'s competing status.
 
         This will appear as `Competing in <competing>`.
@@ -2389,47 +2384,52 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             await ctx.send(_("Competing cleared."))
 
-    @_set_status_group.command(name="online")
+    async def _set_my_status(self, ctx: commands.Context, status: discord.Status):
+        game = ctx.bot.guilds[0].me.activity if len(ctx.bot.guilds) > 0 else None
+        await ctx.bot.change_presence(status=status, activity=game)
+        return await ctx.send(_("Status changed to {}.").format(status))
+
+    @_set_status.command(name="online")
     @checks.bot_in_a_guild()
     @checks.is_owner()
     async def _set_status_online(self, ctx: commands.Context):
         """Set [botname]'s status to online."""
-        await self._set_status(ctx, discord.Status.online)
+        await self._set_my_status(ctx, discord.Status.online)
 
-    @_set_status_group.command(name="dnd", aliases=["donotdisturb", "busy"])
+    @_set_status.command(name="dnd", aliases=["donotdisturb", "busy"])
     @checks.bot_in_a_guild()
     @checks.is_owner()
     async def _set_status_dnd(self, ctx: commands.Context):
         """Set [botname]'s status to do not disturb."""
-        await self._set_status(ctx, discord.Status.do_not_disturb)
+        await self._set_my_status(ctx, discord.Status.do_not_disturb)
 
-    @_set_status_group.command(name="idle", aliases=["away", "afk"])
+    @_set_status.command(name="idle", aliases=["away", "afk"])
     @checks.bot_in_a_guild()
     @checks.is_owner()
     async def _set_status_idle(self, ctx: commands.Context):
         """Set [botname]'s status to idle."""
-        await self._set_status(ctx, discord.Status.idle)
+        await self._set_my_status(ctx, discord.Status.idle)
 
-    @_set_status_group.command(name="invisible", aliases=["offline"])
+    @_set_status.command(name="invisible", aliases=["offline"])
     @checks.bot_in_a_guild()
     @checks.is_owner()
     async def _set_status_invisible(self, ctx: commands.Context):
         """Set [botname]'s status to invisible."""
-        await self._set_status(ctx, discord.Status.invisible)
+        await self._set_my_status(ctx, discord.Status.invisible)
 
     # -- End Bot Status Commands -- ###
     # -- Bot Roles Commands -- ###
 
     @_set.group(name="roles")
     async def _set_roles(self, ctx: commands.Context):
-        """Set various permission roles for [botname]."""
+        """Set server's admin and mod roles for [botname]."""
 
-    @_set_roles.command()
+    @_set_roles.command(name="addadminrole")
     @checks.guildowner()
     @commands.guild_only()
-    async def addadminrole(self, ctx: commands.Context, *, role: discord.Role):
+    async def _set_roles_addadminrole(self, ctx: commands.Context, *, role: discord.Role):
         """
-        Adds an admin role for this guild.
+        Adds an admin role for this server.
 
         Admins have the same access as Mods, plus additional admin level commands like:
          - `[p]set serverprefix`
@@ -2452,12 +2452,12 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             roles.append(role.id)
         await ctx.send(_("That role is now considered an admin role."))
 
-    @_set_roles.command()
+    @_set_roles.command(name="addmodrole")
     @checks.guildowner()
     @commands.guild_only()
-    async def addmodrole(self, ctx: commands.Context, *, role: discord.Role):
+    async def _set_roles_addmodrole(self, ctx: commands.Context, *, role: discord.Role):
         """
-        Adds a moderator role for this guild.
+        Adds a moderator role for this server.
 
         This grants access to moderator level commands like:
          - `[p]mute`
@@ -2479,12 +2479,14 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             roles.append(role.id)
         await ctx.send(_("That role is now considered a mod role."))
 
-    @_set_roles.command(aliases=["remadmindrole", "deladminrole", "deleteadminrole"])
+    @_set_roles.command(
+        name="removeadminrole", aliases=["remadmindrole", "deladminrole", "deleteadminrole"]
+    )
     @checks.guildowner()
     @commands.guild_only()
-    async def removeadminrole(self, ctx: commands.Context, *, role: discord.Role):
+    async def _set_roles_removeadminrole(self, ctx: commands.Context, *, role: discord.Role):
         """
-        Removes an admin role for this guild.
+        Removes an admin role for this server.
 
         **Examples:**
             - `[p]set removeadminrole @Admins`
@@ -2499,12 +2501,14 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             roles.remove(role.id)
         await ctx.send(_("That role is no longer considered an admin role."))
 
-    @_set_roles.command(aliases=["remmodrole", "delmodrole", "deletemodrole"])
+    @_set_roles.command(
+        name="removemodrole", aliases=["remmodrole", "delmodrole", "deletemodrole"]
+    )
     @checks.guildowner()
     @commands.guild_only()
-    async def removemodrole(self, ctx: commands.Context, *, role: discord.Role):
+    async def _set_roles_removemodrole(self, ctx: commands.Context, *, role: discord.Role):
         """
-        Removes a mod role for this guild.
+        Removes a mod role for this server.
 
         **Examples:**
             - `[p]set removemodrole @Mods`
@@ -2524,7 +2528,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
     @_set.group(name="locale", invoke_without_command=True)
     @checks.guildowner_or_permissions(manage_guild=True)
-    async def _set_locale_group(self, ctx: commands.Context, language_code: str):
+    async def _set_locale(self, ctx: commands.Context, language_code: str):
         """
         Changes [botname]'s locale in this server.
 
@@ -2549,7 +2553,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             return
         await ctx.invoke(self._set_locale_local, language_code)
 
-    @_set_locale_group.command(name="global")
+    @_set_locale.command(name="global")
     @checks.is_owner()
     async def _set_locale_global(self, ctx: commands.Context, language_code: str):
         """
@@ -2586,7 +2590,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         await i18n.set_contextual_locales_from_guild(self.bot, ctx.guild)
         await ctx.send(_("Global locale has been set."))
 
-    @_set_locale_group.command(name="server", aliases=["local", "guild"])
+    @_set_locale.command(name="server", aliases=["local", "guild"])
     @commands.guild_only()
     @checks.guildowner_or_permissions(manage_guild=True)
     async def _set_locale_local(self, ctx: commands.Context, language_code: str):
@@ -2630,7 +2634,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
     @_set.group(name="regionalformat", aliases=["region"], invoke_without_command=True)
     @checks.guildowner_or_permissions(manage_guild=True)
-    async def _set_regional_format_group(self, ctx: commands.Context, language_code: str):
+    async def _set_regional_format(self, ctx: commands.Context, language_code: str):
         """
         Changes the bot's regional format in this server. This is used for formatting date, time and numbers.
 
@@ -2652,7 +2656,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             return
         await ctx.invoke(self._set_regional_format_local, language_code)
 
-    @_set_regional_format_group.command(name="global")
+    @_set_regional_format.command(name="global")
     @checks.is_owner()
     async def _set_regional_format_global(self, ctx: commands.Context, language_code: str):
         """
@@ -2694,7 +2698,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             )
         )
 
-    @_set_regional_format_group.command(name="server", aliases=["local", "guild"])
+    @_set_regional_format.command(name="server", aliases=["local", "guild"])
     @commands.guild_only()
     @checks.guildowner_or_permissions(manage_guild=True)
     async def _set_regional_format_local(self, ctx: commands.Context, language_code: str):
@@ -2742,7 +2746,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     # -- End Set Locale Commands -- ###
 
     @_set.command(name="showsettings")
-    async def set_showsettings(self, ctx: commands.Context):
+    async def _set_showsettings(self, ctx: commands.Context):
         """
         Show the current settings for [botname].
         """
@@ -2803,7 +2807,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @checks.guildowner_or_permissions(administrator=True)
     @_set.command(name="deletedelay")
     @commands.guild_only()
-    async def deletedelay(self, ctx: commands.Context, time: int = None):
+    async def _set_deletedelay(self, ctx: commands.Context, time: int = None):
         """Set the delay until the bot removes the command message.
 
         Must be between -1 and 60.
@@ -2841,10 +2845,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             else:
                 await ctx.send(_("I will not delete command messages."))
 
-    @_set.command(aliases=["usebotcolor"])
+    @_set.command(name="usebotcolour", aliases=["usebotcolor"])
     @checks.guildowner()
     @commands.guild_only()
-    async def usebotcolour(self, ctx: commands.Context):
+    async def _set_usebotcolour(self, ctx: commands.Context):
         """
         Toggle whether to use the bot owner-configured colour for embeds.
 
@@ -2862,10 +2866,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             )
         )
 
-    @_set.command()
+    @_set.command(name="serverfuzzy")
     @checks.guildowner()
     @commands.guild_only()
-    async def serverfuzzy(self, ctx: commands.Context):
+    async def _set_serverfuzzy(self, ctx: commands.Context):
         """
         Toggle whether to enable fuzzy command search for the server.
 
@@ -2886,9 +2890,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             )
         )
 
-    @_set.command()
+    @_set.command(name="fuzzy")
     @checks.is_owner()
-    async def fuzzy(self, ctx: commands.Context):
+    async def _set_fuzzy(self, ctx: commands.Context):
         """
         Toggle whether to enable fuzzy command search in DMs.
 
@@ -2907,9 +2911,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             )
         )
 
-    @_set.command(aliases=["color"])
+    @_set.command(name="colour", aliases=["color"])
     @checks.is_owner()
-    async def colour(self, ctx: commands.Context, *, colour: discord.Colour = None):
+    async def _set_colour(self, ctx: commands.Context, *, colour: discord.Colour = None):
         """
         Sets a default colour to be used for the bot's embeds.
 
@@ -2936,10 +2940,12 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         await ctx.send(_("The color has been set."))
 
     @_set.command(
-        aliases=["prefixes", "globalprefix", "globalprefixes"], require_var_positional=True
+        name="prefix",
+        aliases=["prefixes", "globalprefix", "globalprefixes"],
+        require_var_positional=True,
     )
     @checks.is_owner()
-    async def prefix(self, ctx: commands.Context, *prefixes: str):
+    async def _set_prefix(self, ctx: commands.Context, *prefixes: str):
         """Sets [botname]'s global prefix(es).
 
         Warning: This is not additive. It will replace all current prefixes.
@@ -2979,10 +2985,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             await ctx.send(_("Prefixes set."))
 
-    @_set.command(aliases=["serverprefixes"])
+    @_set.command(name="serverprefix", aliases=["serverprefixes"])
     @checks.admin_or_permissions(manage_guild=True)
     @commands.guild_only()
-    async def serverprefix(self, ctx: commands.Context, *prefixes: str):
+    async def _set_serverprefix(self, ctx: commands.Context, *prefixes: str):
         """
         Sets [botname]'s server prefix(es).
 
@@ -3013,9 +3019,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             await ctx.send(_("Server prefixes set."))
 
-    @_set.group(invoke_without_command=True)
+    @_set.group(name="api", invoke_without_command=True)
     @checks.is_owner()
-    async def api(self, ctx: commands.Context, service: str, *, tokens: TokenConverter):
+    async def _set_api(self, ctx: commands.Context, service: str, *, tokens: TokenConverter):
         """
         Commands to set, list or remove various external API tokens.
 
@@ -3039,8 +3045,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         await ctx.bot.set_shared_api_tokens(service, **tokens)
         await ctx.send(_("`{service}` API tokens have been set.").format(service=service))
 
-    @api.command(name="list")
-    async def api_list(self, ctx: commands.Context):
+    @_set_api.command(name="list")
+    async def _set_api_list(self, ctx: commands.Context):
         """
         Show all external API services along with their keys that have been set.
 
@@ -3065,8 +3071,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         for page in pagify(joined, ["\n"], shorten_by=16):
             await ctx.send(box(page.lstrip(" "), lang="diff"))
 
-    @api.command(name="remove", require_var_positional=True)
-    async def api_remove(self, ctx: commands.Context, *services: str):
+    @_set_api.command(name="remove", require_var_positional=True)
+    async def _set_api_remove(self, ctx: commands.Context, *services: str):
         """
         Remove the given services with all their keys and tokens.
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -415,10 +415,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
     @commands.command()
     async def info(self, ctx: commands.Context):
-        """Shows info about [botname].
-
-        See `[p]set custominfo` to customize.
-        """
+        """Shows info about [botname]."""
         embed_links = await ctx.embed_requested()
         author_repo = "https://github.com/Twentysix26"
         org_repo = "https://github.com/Cog-Creators"
@@ -2007,8 +2004,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         The default is "Red V3".
 
         **Examples:**
-            - `[p]set description` - Resets the description to the default setting.
-            - `[p]set description MyBot: A Red V3 Bot`
+            - `[p]set bot description` - Resets the description to the default setting.
+            - `[p]set bot description MyBot: A Red V3 Bot`
 
         **Arguments:**
             - `[description]` - The description to use for this bot. Leave blank to reset to the default.
@@ -2037,9 +2034,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         Supports either an attachment or an image URL.
 
         **Examples:**
-            - `[p]set avatar` - With an image attachment, this will set the avatar.
-            - `[p]set avatar` - Without an attachment, this will show the command help.
-            - `[p]set avatar https://links.flaree.xyz/k95` - Sets the avatar to the provided url.
+            - `[p]set bot avatar` - With an image attachment, this will set the avatar.
+            - `[p]set bot avatar` - Without an attachment, this will show the command help.
+            - `[p]set bot avatar https://links.flaree.xyz/k95` - Sets the avatar to the provided url.
 
         **Arguments:**
             - `[url]` - An image url to be used as an avatar. Leave blank when uploading an attachment.
@@ -2085,7 +2082,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         Removes [botname]'s avatar.
 
         **Example:**
-            - `[p]set avatar remove`
+            - `[p]set bot avatar remove`
         """
         async with ctx.typing():
             await ctx.bot.user.edit(avatar=None)
@@ -2102,7 +2099,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             Please contact Discord support to change it.
 
         **Example:**
-            - `[p]set username BaguetteBot`
+            - `[p]set bot username BaguetteBot`
 
         **Arguments:**
             - `<username>` - The username to give the bot.
@@ -2127,7 +2124,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                     "Changing the username timed out. "
                     "Remember that you can only do it up to 2 times an hour."
                     " Use nicknames if you need frequent changes: {command}"
-                ).format(command=inline(f"{ctx.clean_prefix}set nickname"))
+                ).format(command=inline(f"{ctx.clean_prefix}set bot nickname"))
             )
         except discord.HTTPException as e:
             if e.code == 50035:
@@ -2156,7 +2153,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         Maximum length for a nickname is 32 characters.
 
         **Example:**
-            - `[p]set nickname 🎃 SpookyBot 🎃`
+            - `[p]set bot nickname 🎃 SpookyBot 🎃`
 
         **Arguments:**
             - `[nickname]` - The nickname to give the bot. Leave blank to clear the current nickname.
@@ -2182,9 +2179,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         Link example: `[My link](https://example.com)`
 
         **Examples:**
-            - `[p]set custominfo >>> I can use **markdown** such as quotes, ||spoilers|| and multiple lines.`
-            - `[p]set custominfo Join my [support server](discord.gg/discord)!`
-            - `[p]set custominfo` - Removes custom info text.
+            - `[p]set bot custominfo >>> I can use **markdown** such as quotes, ||spoilers|| and multiple lines.`
+            - `[p]set bot custominfo Join my [support server](discord.gg/discord)!`
+            - `[p]set bot custominfo` - Removes custom info text.
 
         **Arguments:**
             - `[text]` - The custom info text.
@@ -2223,9 +2220,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         Leaving both streamer and stream_title empty will clear it.
 
         **Examples:**
-            - `[p]set stream` - Clears the activity status.
-            - `[p]set stream 26 Twentysix is streaming` - Sets the stream to `https://www.twitch.tv/26`.
-            - `[p]set stream https://twitch.tv/26 Twentysix is streaming` - Sets the URL manually.
+            - `[p]set status stream` - Clears the activity status.
+            - `[p]set status stream 26 Twentysix is streaming` - Sets the stream to `https://www.twitch.tv/26`.
+            - `[p]set status stream https://twitch.tv/26 Twentysix is streaming` - Sets the URL manually.
 
         **Arguments:**
             - `<streamer>` - The twitch streamer to provide a link to. This can be their twitch name or the entire URL.
@@ -2262,8 +2259,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         Maximum length for a playing status is 128 characters.
 
         **Examples:**
-            - `[p]set playing` - Clears the activity status.
-            - `[p]set playing the keyboard`
+            - `[p]set status playing` - Clears the activity status.
+            - `[p]set status playing the keyboard`
 
         **Arguments:**
             - `[game]` - The text to follow `Playing`. Leave blank to clear the current activity status.
@@ -2294,8 +2291,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         Maximum length for a listening status is 128 characters.
 
         **Examples:**
-            - `[p]set listening` - Clears the activity status.
-            - `[p]set listening jams`
+            - `[p]set status listening` - Clears the activity status.
+            - `[p]set status listening jams`
 
         **Arguments:**
             - `[listening]` - The text to follow `Listening to`. Leave blank to clear the current activity status."""
@@ -2329,8 +2326,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         Maximum length for a watching status is 128 characters.
 
         **Examples:**
-            - `[p]set watching` - Clears the activity status.
-            - `[p]set watching [p]help`
+            - `[p]set status watching` - Clears the activity status.
+            - `[p]set status watching [p]help`
 
         **Arguments:**
             - `[watching]` - The text to follow `Watching`. Leave blank to clear the current activity status."""
@@ -2360,8 +2357,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         Maximum length for a competing status is 128 characters.
 
         **Examples:**
-            - `[p]set competing` - Clears the activity status.
-            - `[p]set competing London 2012 Olympic Games`
+            - `[p]set status competing` - Clears the activity status.
+            - `[p]set status competing London 2012 Olympic Games`
 
         **Arguments:**
             - `[competing]` - The text to follow `Competing in`. Leave blank to clear the current activity status."""
@@ -2440,8 +2437,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
          And more.
 
          **Examples:**
-            - `[p]set addadminrole @Admins`
-            - `[p]set addadminrole Super Admins`
+            - `[p]set roles addadminrole @Admins`
+            - `[p]set roles addadminrole Super Admins`
 
         **Arguments:**
             - `<role>` - The role to add as an admin.
@@ -2467,8 +2464,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
          And more.
 
          **Examples:**
-            - `[p]set addmodrole @Mods`
-            - `[p]set addmodrole Loyal Helpers`
+            - `[p]set roles addmodrole @Mods`
+            - `[p]set roles addmodrole Loyal Helpers`
 
         **Arguments:**
             - `<role>` - The role to add as a moderator.
@@ -2489,8 +2486,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         Removes an admin role for this server.
 
         **Examples:**
-            - `[p]set removeadminrole @Admins`
-            - `[p]set removeadminrole Super Admins`
+            - `[p]set roles removeadminrole @Admins`
+            - `[p]set roles removeadminrole Super Admins`
 
         **Arguments:**
             - `<role>` - The role to remove from being an admin.
@@ -2511,8 +2508,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         Removes a mod role for this server.
 
         **Examples:**
-            - `[p]set removemodrole @Mods`
-            - `[p]set removemodrole Loyal Helpers`
+            - `[p]set roles removemodrole @Mods`
+            - `[p]set roles removemodrole Loyal Helpers`
 
         **Arguments:**
             - `<role>` - The role to remove from being a moderator.
@@ -2644,9 +2641,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         If you want to change bot's global regional format, see `[p]set regionalformat global` command.
 
         **Examples:**
-            - `[p]set regionalformat server en-US`
-            - `[p]set region local de-DE`
-            - `[p]set regionalformat server reset` - Resets to the locale.
+            - `[p]set regionalformat en-US`
+            - `[p]set region de-DE`
+            - `[p]set regionalformat reset` - Resets to the locale.
 
         **Arguments:**
             - `[language_code]` - The region format to use for the bot in this server.

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1987,6 +1987,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     # -- Bot Metadata Commands -- ###
 
     @_set.group(name="bot", aliases=["metadata"])
+    @checks.admin_or_permissions(manage_nicknames=True)
     async def _set_bot(self, ctx: commands.Context):
         """Commands for changing [botname]'s metadata."""
 
@@ -2201,6 +2202,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     # -- Bot Status Commands -- ###
 
     @_set.group(name="status")
+    @checks.bot_in_a_guild()
+    @checks.is_owner()
     async def _set_status(self, ctx: commands.Context):
         """Commands for setting [botname]'s status."""
 
@@ -2418,6 +2421,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     # -- Bot Roles Commands -- ###
 
     @_set.group(name="roles")
+    @checks.guildowner()
+    @commands.guild_only()
     async def _set_roles(self, ctx: commands.Context):
         """Set server's admin and mod roles for [botname]."""
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2972,7 +2972,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             guild = ctx.guild
             admin_role_ids = guild_data["admin_role"]
             admin_role_names = [r.name for r in guild.roles if r.id in admin_role_ids]
-            admin_roles_str = humanize_list(admin_role_names) if admin_role_names else _("Not Set.")
+            admin_roles_str = (
+                humanize_list(admin_role_names) if admin_role_names else _("Not Set.")
+            )
             mod_role_ids = guild_data["mod_role"]
             mod_role_names = [r.name for r in guild.roles if r.id in mod_role_ids]
             mod_roles_str = humanize_list(mod_role_names) if mod_role_names else _("Not Set.")

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2441,7 +2441,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
          And more.
 
-         **Examples:**
+        **Examples:**
             - `[p]set roles addadminrole @Admins`
             - `[p]set roles addadminrole Super Admins`
 
@@ -2468,7 +2468,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
          And more.
 
-         **Examples:**
+        **Examples:**
             - `[p]set roles addmodrole @Mods`
             - `[p]set roles addmodrole Loyal Helpers`
 
@@ -2757,10 +2757,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             guild = ctx.guild
             admin_role_ids = guild_data["admin_role"]
             admin_role_names = [r.name for r in guild.roles if r.id in admin_role_ids]
-            admin_roles_str = humanize_list(admin_role_names) if admin_role_names else "Not Set."
+            admin_roles_str = humanize_list(admin_role_names) if admin_role_names else _("Not Set.")
             mod_role_ids = guild_data["mod_role"]
             mod_role_names = [r.name for r in guild.roles if r.id in mod_role_ids]
-            mod_roles_str = humanize_list(mod_role_names) if mod_role_names else "Not Set."
+            mod_roles_str = humanize_list(mod_role_names) if mod_role_names else _("Not Set.")
 
             guild_locale = await i18n.get_locale_from_guild(self.bot, ctx.guild)
             guild_regional_format = (


### PR DESCRIPTION
This has been a long time overdue. Reorganized the ``set`` command to be shorter and more tidy. While keeping the most accessed commands on top (looking at you ``set prefix``).

The following has been moved:
 * ``set username`` -> ``set bot username``
 * ``set nickname`` -> ``set bot nickname``
 * ``set avatar`` -> ``set bot avatar``
 * ``set description`` -> ``set bot description``
 * ``set custominfo`` -> ``set bot custominfo``
 * All activity commands -> Moved to ``set status``
 * All status commands -> Moved to ``set status``
 * ``set globallocale``& ``set locale`` -> ``set locale global`` & ``set locale server`` respectively (additionally, ``set locale`` acts as a shorthand for ``set locale server``)
 * ``set globalregionallocale``& ``set regionallocale`` -> ``set regionalformat global`` & ``set regionalformat server`` respectively (additionally, ``set regionalformat`` acts as a shorthand for ``set regionalformat server``)