### PR TITLE
Remove currently deprecated functionality

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -52,7 +52,7 @@ from .settings_caches import (
 )
 from .rpc import RPCMixin
 from .utils import common_filters, AsyncIter
-from .utils._internal_utils import deprecated_removed, send_to_owners_with_prefix_replaced
+from .utils._internal_utils import send_to_owners_with_prefix_replaced
 
 CUSTOM_GROUPS = "CUSTOM_GROUPS"
 COMMAND_SCOPE = "COMMAND"
@@ -682,7 +682,6 @@ class Red(
         *,
         who_id: Optional[int] = None,
         guild: Optional[discord.Guild] = None,
-        guild_id: Optional[int] = None,
         role_ids: Optional[List[int]] = None,
     ) -> bool:
         """
@@ -695,7 +694,7 @@ class Red(
 
         If omiting a user or member, you must provide a value for ``who_id``
 
-        You may also provide a value for ``guild_id`` in this case
+        You may also provide a value for ``guild`` in this case
 
         If providing a member by guild and member ids,
         you should supply ``role_ids`` as well
@@ -714,18 +713,8 @@ class Red(
             When used in conjunction with a provided value for ``who_id``, checks
             the lists for the corresponding guild as well.
             This is ignored when ``who`` is passed.
-        guild_id : Optional[int]
-            When used in conjunction with a provided value for ``who_id``, checks
-            the lists for the corresponding guild as well. This should not be used
-            as it has unfixable bug that can cause it to raise an exception when
-            the guild with the given ID couldn't have been found.
-            This is ignored when ``who`` is passed.
-
-            .. deprecated-removed:: 3.4.8 30
-                Use ``guild`` parameter instead.
-
         role_ids : Optional[List[int]]
-            When used with both ``who_id`` and ``guild_id``, checks the role ids provided.
+            When used with both ``who_id`` and ``guild``, checks the role ids provided.
             This is required for accurate checking of members in a guild if providing ids.
             This is ignored when ``who`` is passed.
 
@@ -749,18 +738,6 @@ class Red(
                 raise TypeError("Must provide a value for either `who` or `who_id`")
             mocked = True
             who = discord.Object(id=who_id)
-            if guild_id:
-                deprecated_removed(
-                    "`guild_id` parameter",
-                    "3.4.8",
-                    30,
-                    "Use `guild` parameter instead.",
-                    stacklevel=2,
-                )
-                if guild:
-                    raise ValueError(
-                        "`guild_id` should not be passed when `guild` is already passed."
-                    )
         else:
             guild = getattr(who, "guild", None)
 
@@ -776,15 +753,6 @@ class Red(
             global_blacklist = await self.get_blacklist()
             if who.id in global_blacklist:
                 return False
-
-        if mocked and guild_id:
-            guild = self.get_guild(guild_id)
-            if guild is None:
-                # this is an AttributeError due to backwards-compatibility concerns
-                raise AttributeError(
-                    "Couldn't get the guild with the given ID. `guild` parameter needs to be used"
-                    " over the deprecated `guild_id` to resolve this."
-                )
 
         if guild:
             if guild.owner_id == who.id:

--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -20,7 +20,6 @@ from typing import (
     Type,
     TypeVar,
     Literal as Literal,
-    Any,
     Union as UserInputOptional,
 )
 
@@ -203,48 +202,6 @@ def parse_relativedelta(
             )
         return delta
     return None
-
-
-class _GuildConverter(discord.Guild):
-    """Converts to a `discord.Guild` object.
-
-    The lookup strategy is as follows (in order):
-
-    1. Lookup by ID.
-    2. Lookup by name.
-
-    .. deprecated-removed:: 3.4.8 60
-        ``GuildConverter`` is now only provided within ``redbot.core.commands`` namespace.
-    """
-
-    @classmethod
-    async def convert(cls, ctx: "Context", argument: str) -> discord.Guild:
-        return await dpy_commands.GuildConverter().convert(ctx, argument)
-
-
-_GuildConverter.__name__ = "GuildConverter"
-
-
-def __getattr__(name: str, *, stacklevel: int = 2) -> Any:
-    # Let me just say it one more time... This is awesome! (PEP-562)
-    if name == "GuildConverter":
-        # let's not waste time on importing this when we don't need it
-        # (and let's not put in the public API)
-        from redbot.core.utils._internal_utils import deprecated_removed
-
-        deprecated_removed(
-            "`GuildConverter` from `redbot.core.commands.converter` namespace",
-            "3.4.8",
-            60,
-            "Use `GuildConverter` from `redbot.core.commands` namespace instead.",
-            stacklevel=2,
-        )
-        return globals()["_GuildConverter"]
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__() -> List[str]:
-    return [*globals().keys(), "GuildConverter"]
 
 
 # Below this line are a lot of lies for mypy about things that *end up* correct when

--- a/redbot/core/utils/mod.py
+++ b/redbot/core/utils/mod.py
@@ -1,12 +1,10 @@
 import asyncio
-import warnings
 from datetime import timedelta
 from typing import List, Iterable, Union, TYPE_CHECKING, Dict
 
 import discord
 
 if TYPE_CHECKING:
-    from .. import Config
     from ..bot import Red
     from ..commands import Context
 
@@ -94,21 +92,6 @@ def get_audit_reason(author: discord.Member, reason: str = None, *, shorten: boo
     if shorten and len(audit_reason) > 512:
         audit_reason = f"{audit_reason[:509]}..."
     return audit_reason
-
-
-async def is_allowed_by_hierarchy(
-    bot: "Red", settings: "Config", guild: discord.Guild, mod: discord.Member, user: discord.Member
-):
-    warnings.warn(
-        "`is_allowed_by_hierarchy()` is deprecated since Red 3.4.1"
-        " and will be removed in the first minor release after 2020-11-31.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    if not await settings.guild(guild).respect_hierarchy():
-        return True
-    is_special = mod == guild.owner or await bot.is_owner(mod)
-    return mod.top_role > user.top_role or is_special
 
 
 async def is_mod_or_superior(


### PR DESCRIPTION
### Description of the changes
Removes:
- ``guild_id`` parameter to ``Red.allowed_by_whitelist_blacklist()`` as it has been replaced by the ``guild`` parameter
- `redbot.core.commands.converter.GuildConverter` which is now only available as `redbot.core.commands.GuildConverter`
- `redbot.core.utils.mod.is_allowed_by_hierarchy()` which was an internal function that was never meant to be exposed

Each of these has already been deprecated and was just waiting for the next 3.x.0 release.