### PR TITLE
Remove old note about updating Red in Unix install guides

### DIFF
--- a/docs/install_guides/_includes/install-and-setup-red-unix.rst
+++ b/docs/install_guides/_includes/install-and-setup-red-unix.rst
@@ -21,10 +21,6 @@ Or, to install with PostgreSQL support:
     python -m pip install -U "Red-DiscordBot[postgres]"
 
 
-.. note::
-
-    These commands are also used for updating Red
-
 --------------------------
 Setting Up and Running Red
 --------------------------


### PR DESCRIPTION
### Description of the changes
This was removed long ago from the Windows guide (#4119) but it seems like we never got around to removing it from Unix install guides as well.
This note is rather inaccurate and the source of truth for updating Red is available in the Updating Red document.
