### PR TITLE
Allow mocking attachment-only msg, fix docstring, small refactor

### DIFF
--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -340,13 +340,21 @@ class Dev(commands.Cog):
 
     @commands.command(name="mockmsg")
     @checks.is_owner()
-    async def mock_msg(self, ctx, user: discord.Member, *, content: str):
+    async def mock_msg(self, ctx, user: discord.Member, *, content: str = None):
         """Dispatch a message event as if it were sent by a different user.
 
         Current message is used as a base (including attachments, embeds, etc.),
         the content and author of the message are replaced with the given arguments.
+
+        Note: If `content` isn't passed, the message needs to contain embeds, attachments,
+        or anything else that makes the message non-empty.
         """
-        msg = copy(ctx.message)
+        msg = ctx.message
+        if content is None and not msg.embeds and not msg.attachments:
+            # DEP-WARN: add `msg.stickers` when adding d.py 2.0
+            await ctx.send_help()
+            return
+        msg = copy(msg)
         msg.author = user
         msg.content = content
 

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -343,21 +343,14 @@ class Dev(commands.Cog):
     async def mock_msg(self, ctx, user: discord.Member, *, content: str):
         """Dispatch a message event as if it were sent by a different user.
 
-        Only reads the raw content of the message. Attachments, embeds etc. are
-        ignored.
+        Current message is used as a base (including attachments, embeds, etc.),
+        the content and author of the message are replaced with the given arguments.
         """
-        old_author = ctx.author
-        old_content = ctx.message.content
-        ctx.message.author = user
-        ctx.message.content = content
+        msg = copy(ctx.message)
+        msg.author = user
+        msg.content = content
 
-        ctx.bot.dispatch("message", ctx.message)
-
-        # If we change the author and content back too quickly,
-        # the bot won't process the mocked message in time.
-        await asyncio.sleep(2)
-        ctx.message.author = old_author
-        ctx.message.content = old_content
+        ctx.bot.dispatch("message", msg)
 
     @commands.command()
     @checks.is_owner()

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -340,7 +340,7 @@ class Dev(commands.Cog):
 
     @commands.command(name="mockmsg")
     @checks.is_owner()
-    async def mock_msg(self, ctx, user: discord.Member, *, content: str = None):
+    async def mock_msg(self, ctx, user: discord.Member, *, content: str = ""):
         """Dispatch a message event as if it were sent by a different user.
 
         Current message is used as a base (including attachments, embeds, etc.),
@@ -350,7 +350,7 @@ class Dev(commands.Cog):
         or anything else that makes the message non-empty.
         """
         msg = ctx.message
-        if content is None and not msg.embeds and not msg.attachments:
+        if not content and not msg.embeds and not msg.attachments:
             # DEP-WARN: add `msg.stickers` when adding d.py 2.0
             await ctx.send_help()
             return


### PR DESCRIPTION
### Description of the changes
I don't think there's a good reason for this weird shenanigans over just making a copy of the message object as we do in `[p]mock`.
I also fixed the command docstring.