### PR TITLE
Remove voice region field in [p]serverinfo

### DIFF
--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -404,7 +404,7 @@ class General(commands.Cog):
             data.add_field(
                 name=_("Utility:"),
                 value=_(
-                    "Owner: {owner}\nVoice region: {region}\nVerif. level: {verif}\nServer ID: {id}{shard_info}"
+                    "Owner: {owner}\nVerif. level: {verif}\nServer ID: {id}{shard_info}"
                 ).format(
                     owner=bold(str(guild.owner)),
                     verif=bold(verif[str(guild.verification_level)]),

--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -265,7 +265,6 @@ class General(commands.Cog):
         voice_channels = humanize_number(len(guild.voice_channels))
         if not details:
             data = discord.Embed(description=created_at, colour=await ctx.embed_colour())
-            data.add_field(name=_("Region"), value=str(guild.region))
             data.add_field(name=_("Users online"), value=f"{online}/{total_users}")
             data.add_field(name=_("Text Channels"), value=text_channels)
             data.add_field(name=_("Voice Channels"), value=voice_channels)
@@ -338,31 +337,6 @@ class General(commands.Cog):
                     )
                 count += 1
 
-            vc_regions = {
-                "vip-us-east": _("__VIP__ US East ") + "\U0001F1FA\U0001F1F8",
-                "vip-us-west": _("__VIP__ US West ") + "\U0001F1FA\U0001F1F8",
-                "vip-amsterdam": _("__VIP__ Amsterdam ") + "\U0001F1F3\U0001F1F1",
-                "eu-west": _("EU West ") + "\U0001F1EA\U0001F1FA",
-                "eu-central": _("EU Central ") + "\U0001F1EA\U0001F1FA",
-                "europe": _("Europe ") + "\U0001F1EA\U0001F1FA",
-                "london": _("London ") + "\U0001F1EC\U0001F1E7",
-                "frankfurt": _("Frankfurt ") + "\U0001F1E9\U0001F1EA",
-                "amsterdam": _("Amsterdam ") + "\U0001F1F3\U0001F1F1",
-                "us-west": _("US West ") + "\U0001F1FA\U0001F1F8",
-                "us-east": _("US East ") + "\U0001F1FA\U0001F1F8",
-                "us-south": _("US South ") + "\U0001F1FA\U0001F1F8",
-                "us-central": _("US Central ") + "\U0001F1FA\U0001F1F8",
-                "singapore": _("Singapore ") + "\U0001F1F8\U0001F1EC",
-                "sydney": _("Sydney ") + "\U0001F1E6\U0001F1FA",
-                "brazil": _("Brazil ") + "\U0001F1E7\U0001F1F7",
-                "hongkong": _("Hong Kong ") + "\U0001F1ED\U0001F1F0",
-                "russia": _("Russia ") + "\U0001F1F7\U0001F1FA",
-                "japan": _("Japan ") + "\U0001F1EF\U0001F1F5",
-                "southafrica": _("South Africa ") + "\U0001F1FF\U0001F1E6",
-                "india": _("India ") + "\U0001F1EE\U0001F1F3",
-                "dubai": _("Dubai ") + "\U0001F1E6\U0001F1EA",
-                "south-korea": _("South Korea ") + "\U0001f1f0\U0001f1f7",
-            }
             verif = {
                 "none": _("0 - None"),
                 "low": _("1 - Low"),
@@ -433,7 +407,6 @@ class General(commands.Cog):
                     "Owner: {owner}\nVoice region: {region}\nVerif. level: {verif}\nServer ID: {id}{shard_info}"
                 ).format(
                     owner=bold(str(guild.owner)),
-                    region=f"**{vc_regions.get(str(guild.region)) or str(guild.region)}**",
                     verif=bold(verif[str(guild.verification_level)]),
                     id=bold(str(guild.id)),
                     shard_info=shard_info,


### PR DESCRIPTION
### Description of the changes
This PR removes the guild region field from serverinfo command, as `guild.region` attribute got deprecated a while back, but was still showing from the API. Now it is set to "deprecated" for all guilds (see attached screenshot).
https://github.com/discord/discord-api-docs/pull/3001

![image](https://user-images.githubusercontent.com/46051820/142710141-5ec4f0fb-0045-4ba1-baf3-6c26184b8e19.png)
