### PR TITLE
Make embeds in help output consistent

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1208,18 +1208,27 @@ class Red(
         channel: Union[discord.abc.GuildChannel, discord.abc.PrivateChannel],
         user: discord.abc.User,
         command: Optional[commands.Command] = None,
+        *,
+        check_permissions: bool = False,
     ) -> bool:
         """
         Determine if an embed is requested for a response.
 
-        Parameters
-        ----------
+        Arguments
+        ---------
         channel : `discord.abc.GuildChannel` or `discord.abc.PrivateChannel`
             The channel to check embed settings for.
         user : `discord.abc.User`
             The user to check embed settings for.
         command : `redbot.core.commands.Command`, optional
             The command ran.
+
+        Keyword Arguments
+        -----------------
+        check_permissions : `bool`
+            If ``True``, this method will also check whether the bot can send embeds
+            in the given channel and if it can't, it will return ``False`` regardless of
+            the bot's embed settings.
 
         Returns
         -------
@@ -1237,6 +1246,9 @@ class Red(
             if (user_setting := await self._config.user(user).embeds()) is not None:
                 return user_setting
         else:
+            if not channel.permissions_for(channel.guild.me).embed_links:
+                return False
+
             if (channel_setting := await self._config.channel(channel).embeds()) is not None:
                 return channel_setting
 

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -239,9 +239,9 @@ class Context(DPYContext):
         bool:
             :code:`True` if an embed is requested
         """
-        if self.guild and not self.channel.permissions_for(self.guild.me).embed_links:
-            return False
-        return await self.bot.embed_requested(self.channel, self.author, command=self.command)
+        return await self.bot.embed_requested(
+            self.channel, self.author, command=self.command, check_permissions=True
+        )
 
     async def maybe_send_embed(self, message: str) -> discord.Message:
         """

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -358,7 +358,7 @@ class RedHelpFormatter(HelpFormatterABC):
             grp = cast(commands.Group, command)
             subcommands = await self.get_group_help_mapping(ctx, grp, help_settings=help_settings)
 
-        if await ctx.embed_requested():
+        if await self.embed_requested(ctx):
             emb = {"embed": {"title": "", "description": ""}, "footer": {"text": ""}, "fields": []}
 
             if description:
@@ -539,7 +539,7 @@ class RedHelpFormatter(HelpFormatterABC):
         description = obj.format_help_for_context(ctx)
         tagline = (help_settings.tagline) or self.get_default_tagline(ctx)
 
-        if await ctx.embed_requested():
+        if await self.embed_requested(ctx):
             emb = {"embed": {"title": "", "description": ""}, "footer": {"text": ""}, "fields": []}
 
             emb["footer"]["text"] = tagline
@@ -606,7 +606,7 @@ class RedHelpFormatter(HelpFormatterABC):
         description = ctx.bot.description or ""
         tagline = (help_settings.tagline) or self.get_default_tagline(ctx)
 
-        if await ctx.embed_requested():
+        if await self.embed_requested(ctx):
 
             emb = {"embed": {"title": "", "description": ""}, "footer": {"text": ""}, "fields": []}
 
@@ -705,6 +705,11 @@ class RedHelpFormatter(HelpFormatterABC):
             else:
                 yield obj
 
+    async def embed_requested(self, ctx: Context) -> bool:
+        return await ctx.bot.embed_requested(
+            channel=ctx.channel, user=ctx.author, command=red_help, check_permissions=True
+        )
+
     async def command_not_found(self, ctx, help_for, help_settings: HelpSettings):
         """
         Sends an error, fuzzy help, or stays quiet based on settings
@@ -717,7 +722,7 @@ class RedHelpFormatter(HelpFormatterABC):
             ),
             min_score=75,
         )
-        use_embeds = await ctx.embed_requested()
+        use_embeds = await self.embed_requested(ctx)
         if fuzzy_commands:
             ret = await format_fuzzy_results(ctx, fuzzy_commands, embed=use_embeds)
             if use_embeds:
@@ -751,7 +756,7 @@ class RedHelpFormatter(HelpFormatterABC):
         ret = _("Command *{command_name}* has no subcommand named *{not_found}*.").format(
             command_name=command.qualified_name, not_found=not_found[0]
         )
-        if await ctx.embed_requested():
+        if await self.embed_requested(ctx):
             ret = discord.Embed(color=(await ctx.embed_color()), description=ret)
             ret.set_author(
                 name=_("{ctx.me.display_name} Help Menu").format(ctx=ctx),


### PR DESCRIPTION
### Description of the changes
This makes embeds in help consistent regardless of whether it's sent because `[p]help` was used (`[p]help set`, `[p]help set prefix`) or because the command is command group (`[p]set`) or is missing required argument (`[p]set prefix`).

This PR also adds a new keyword argument to `bot.embed_requested()` called `check_permissions`. When set to `True` (defaults to `False`), it will additionally check that the bot has permissions to send embeds in the given channel, same as `ctx.embed_requested()` does.