### PR TITLE
show RolePaydayAmounts in showsettings command

### DIFF
--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -816,15 +816,20 @@ class Economy(commands.Cog):
         """
         Shows the current economy settings
         """
+        roles = ""
         guild = ctx.guild
         if await bank.is_global():
             conf = self.config
         else:
             conf = self.config.guild(guild)
+            for role in guild.roles:
+                rolepayday = await self.config.role(role).PAYDAY_CREDITS()
+                if rolepayday:
+                    roles += f"{role}: {rolepayday}\n"
         await ctx.send(
             box(
                 _(
-                    "----Economy Settings---\n"
+                    "---Economy Settings---\n"
                     "Minimum slot bid: {slot_min}\n"
                     "Maximum slot bid: {slot_max}\n"
                     "Slot cooldown: {slot_time}\n"
@@ -843,6 +848,13 @@ class Economy(commands.Cog):
                 )
             )
         )
+        if roles:
+            await ctx.send(
+                box(
+                    f"---Role Payday Amounts---\n"
+                    f"{roles}"
+                )
+            )
 
     @economyset.command()
     async def slotmin(self, ctx: commands.Context, bid: positive_int):

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -845,12 +845,7 @@ class Economy(commands.Cog):
             )
         )
         if roles:
-            await ctx.send(
-                box(
-                    f"---Role Payday Amounts---\n"
-                    f"{roles}"
-                )
-            )
+            await ctx.send(box(f"---Role Payday Amounts---\n{roles}"))
 
     @economyset.command()
     async def slotmin(self, ctx: commands.Context, bid: positive_int):

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -8,8 +8,6 @@ from typing import cast, Iterable, Union, Literal
 
 import discord
 
-from redbot.cogs.bank import is_owner_if_bank_global
-from redbot.cogs.mod.converters import RawUserIds
 from redbot.core import Config, bank, commands, errors, checks
 from redbot.core.commands.converter import TimedeltaConverter
 from redbot.core.bot import Red
@@ -240,7 +238,7 @@ class Economy(commands.Cog):
             )
         )
 
-    @is_owner_if_bank_global()
+    @bank.is_owner_if_bank_global()
     @checks.admin_or_permissions(manage_guild=True)
     @_bank.command(name="set")
     async def _set(self, ctx: commands.Context, to: discord.Member, creds: SetParser):
@@ -290,151 +288,6 @@ class Economy(commands.Cog):
             await ctx.send(str(e))
         else:
             await ctx.send(msg)
-
-    @is_owner_if_bank_global()
-    @checks.guildowner_or_permissions(administrator=True)
-    @_bank.command()
-    async def reset(self, ctx, confirmation: bool = False):
-        """Delete all bank accounts.
-
-        Examples:
-            - `[p]bank reset` - Did not confirm. Shows the help message.
-            - `[p]bank reset yes`
-
-        **Arguments**
-
-        - `<confirmation>` This will default to false unless specified.
-        """
-        if confirmation is False:
-            await ctx.send(
-                _(
-                    "This will delete all bank accounts for {scope}.\nIf you're sure, type "
-                    "`{prefix}bank reset yes`"
-                ).format(
-                    scope=self.bot.user.name if await bank.is_global() else _("this server"),
-                    prefix=ctx.clean_prefix,
-                )
-            )
-        else:
-            await bank.wipe_bank(guild=ctx.guild)
-            await ctx.send(
-                _("All bank accounts for {scope} have been deleted.").format(
-                    scope=self.bot.user.name if await bank.is_global() else _("this server")
-                )
-            )
-
-    @is_owner_if_bank_global()
-    @checks.admin_or_permissions(manage_guild=True)
-    @_bank.group(name="prune")
-    async def _prune(self, ctx):
-        """Base command for pruning bank accounts."""
-        pass
-
-    @_prune.command(name="server", aliases=["guild", "local"])
-    @commands.guild_only()
-    @checks.guildowner()
-    async def _local(self, ctx, confirmation: bool = False):
-        """Prune bank accounts for users no longer in the server.
-
-        Cannot be used with a global bank. See `[p]bank prune global`.
-
-        Examples:
-            - `[p]bank prune server` - Did not confirm. Shows the help message.
-            - `[p]bank prune server yes`
-
-        **Arguments**
-
-        - `<confirmation>` This will default to false unless specified.
-        """
-        global_bank = await bank.is_global()
-        if global_bank is True:
-            return await ctx.send(_("This command cannot be used with a global bank."))
-
-        if confirmation is False:
-            await ctx.send(
-                _(
-                    "This will delete all bank accounts for users no longer in this server."
-                    "\nIf you're sure, type "
-                    "`{prefix}bank prune local yes`"
-                ).format(prefix=ctx.clean_prefix)
-            )
-        else:
-            await bank.bank_prune(self.bot, guild=ctx.guild)
-            await ctx.send(
-                _("Bank accounts for users no longer in this server have been deleted.")
-            )
-
-    @_prune.command(name="global")
-    @checks.is_owner()
-    async def _global(self, ctx, confirmation: bool = False):
-        """Prune bank accounts for users who no longer share a server with the bot.
-
-        Cannot be used without a global bank. See `[p]bank prune server`.
-
-        Examples:
-            - `[p]bank prune global` - Did not confirm. Shows the help message.
-            - `[p]bank prune global yes`
-
-        **Arguments**
-
-        - `<confirmation>` This will default to false unless specified.
-        """
-        global_bank = await bank.is_global()
-        if global_bank is False:
-            return await ctx.send(_("This command cannot be used with a local bank."))
-
-        if confirmation is False:
-            await ctx.send(
-                _(
-                    "This will delete all bank accounts for users "
-                    "who no longer share a server with the bot."
-                    "\nIf you're sure, type `{prefix}bank prune global yes`"
-                ).format(prefix=ctx.clean_prefix)
-            )
-        else:
-            await bank.bank_prune(self.bot)
-            await ctx.send(
-                _(
-                    "Bank accounts for users who "
-                    "no longer share a server with the bot have been pruned."
-                )
-            )
-
-    @_prune.command(usage="<user> [confirmation=False]")
-    async def user(
-        self, ctx, member_or_id: Union[discord.Member, RawUserIds], confirmation: bool = False
-    ):
-        """Delete the bank account of a specified user.
-
-        Examples:
-            - `[p]bank prune user @TwentySix` - Did not confirm. Shows the help message.
-            - `[p]bank prune user @TwentySix yes`
-
-        **Arguments**
-
-        - `<user>` The user to delete the bank of. Takes mentions, names, and user ids.
-        - `<confirmation>` This will default to false unless specified.
-        """
-        if ctx.guild is None and not await bank.is_global():
-            return await ctx.send(_("This command cannot be used in DMs with a local bank."))
-        try:
-            name = member_or_id.display_name
-            uid = member_or_id.id
-        except AttributeError:
-            name = member_or_id
-            uid = member_or_id
-
-        if confirmation is False:
-            await ctx.send(
-                _(
-                    "This will delete {name}'s bank account."
-                    "\nIf you're sure, type "
-                    "`{prefix}bank prune user {id} yes`"
-                ).format(prefix=ctx.clean_prefix, id=uid, name=name)
-            )
-        else:
-            await bank.bank_prune(self.bot, guild=ctx.guild, user_id=uid)
-            await ctx.send(_("The bank account for {name} has been pruned.").format(name=name))
 
     @guild_only_check()
     @commands.command()
@@ -805,7 +658,7 @@ class Economy(commands.Cog):
         )
 
     @guild_only_check()
-    @is_owner_if_bank_global()
+    @bank.is_owner_if_bank_global()
     @checks.admin_or_permissions(manage_guild=True)
     @commands.group()
     async def economyset(self, ctx: commands.Context):
@@ -829,7 +682,7 @@ class Economy(commands.Cog):
         await ctx.send(
             box(
                 _(
-                    "---Economy Settings---\n"
+                    "----Economy Settings---\n"
                     "Minimum slot bid: {slot_min}\n"
                     "Maximum slot bid: {slot_max}\n"
                     "Slot cooldown: {slot_time}\n"
@@ -1045,34 +898,6 @@ class Economy(commands.Cog):
                         num=humanize_number(creds), currency=credits_name, role_name=role.name
                     )
                 )
-
-    @economyset.command()
-    async def registeramount(self, ctx: commands.Context, creds: int):
-        """Set the initial balance for new bank accounts.
-
-        Example:
-            - `[p]economyset registeramount 5000`
-
-        **Arguments**
-
-        - `<creds>` The new initial balance amount. Default is 0.
-        """
-        guild = ctx.guild
-        max_balance = await bank.get_max_balance(ctx.guild)
-        credits_name = await bank.get_currency_name(guild)
-        try:
-            await bank.set_default_balance(creds, guild)
-        except ValueError:
-            return await ctx.send(
-                _("Amount must be greater than or equal to zero and less than {maxbal}.").format(
-                    maxbal=humanize_number(max_balance)
-                )
-            )
-        await ctx.send(
-            _("Registering an account will now give {num} {currency}.").format(
-                num=humanize_number(creds), currency=credits_name
-            )
-        )
 
     # What would I ever do without stackoverflow?
     @staticmethod

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -835,16 +835,12 @@ class Economy(commands.Cog):
                     "Slot cooldown: {slot_time}\n"
                     "Payday amount: {payday_amount}\n"
                     "Payday cooldown: {payday_time}\n"
-                    "Amount given at account registration: {register_amount}\n"
-                    "Maximum allowed balance: {maximum_bal}"
                 ).format(
                     slot_min=humanize_number(await conf.SLOT_MIN()),
                     slot_max=humanize_number(await conf.SLOT_MAX()),
                     slot_time=humanize_number(await conf.SLOT_TIME()),
                     payday_time=humanize_number(await conf.PAYDAY_TIME()),
                     payday_amount=humanize_number(await conf.PAYDAY_CREDITS()),
-                    register_amount=humanize_number(await bank.get_default_balance(guild)),
-                    maximum_bal=humanize_number(await bank.get_max_balance(guild)),
                 )
             )
         )


### PR DESCRIPTION
If bank is not global, running the "[p]economyset showsettings" command will display all current roles that are associated with a payday amount

kept added logic to a minimum and did my best to maintain the style used

### Description of the changes
iterate through guild roles if bank isnt global and log the ones associated to a role to string object. display after main settings if exists