### PR TITLE
Show role payday amounts in `economyset showsettings`

### DIFF
--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -682,7 +682,7 @@ class Economy(commands.Cog):
         await ctx.send(
             box(
                 _(
-                    "----Economy Settings---\n"
+                    "---Economy Settings---\n"
                     "Minimum slot bid: {slot_min}\n"
                     "Maximum slot bid: {slot_max}\n"
                     "Slot cooldown: {slot_time}\n"

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -669,7 +669,7 @@ class Economy(commands.Cog):
         """
         Shows the current economy settings
         """
-        roles = ""
+        role_paydays = []
         guild = ctx.guild
         if await bank.is_global():
             conf = self.config
@@ -678,7 +678,7 @@ class Economy(commands.Cog):
             for role in guild.roles:
                 rolepayday = await self.config.role(role).PAYDAY_CREDITS()
                 if rolepayday:
-                    roles += f"{role}: {rolepayday}\n"
+                    role_paydays.append(f"{role}: {rolepayday}")
         await ctx.send(
             box(
                 _(
@@ -697,8 +697,8 @@ class Economy(commands.Cog):
                 )
             )
         )
-        if roles:
-            await ctx.send(box(f"---Role Payday Amounts---\n{roles}"))
+        if role_paydays:
+            await ctx.send(box(f"---Role Payday Amounts---\n{'\n'.join(role_paydays)}"))
 
     @economyset.command()
     async def slotmin(self, ctx: commands.Context, bid: positive_int):

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -698,7 +698,7 @@ class Economy(commands.Cog):
             )
         )
         if role_paydays:
-            await ctx.send(box(f"---Role Payday Amounts---\n{'\n'.join(role_paydays)}"))
+            await ctx.send(box(_("---Role Payday Amounts---\n") + "\n".join(role_paydays)))
 
     @economyset.command()
     async def slotmin(self, ctx: commands.Context, bid: positive_int):

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -669,11 +669,16 @@ class Economy(commands.Cog):
         """
         Shows the current economy settings
         """
+        roles = ""
         guild = ctx.guild
         if await bank.is_global():
             conf = self.config
         else:
             conf = self.config.guild(guild)
+            for role in guild.roles:
+                rolepayday = await self.config.role(role).PAYDAY_CREDITS()
+                if rolepayday:
+                    roles += f"{role}: {rolepayday}\n"
         await ctx.send(
             box(
                 _(
@@ -692,6 +697,8 @@ class Economy(commands.Cog):
                 )
             )
         )
+        if roles:
+            await ctx.send(box(f"---Role Payday Amounts---\n{roles}"))
 
     @economyset.command()
     async def slotmin(self, ctx: commands.Context, bid: positive_int):


### PR DESCRIPTION
If bank is not global, running the "[p]economyset showsettings" command will display all current roles that are associated with a payday role payday amount.

Fixes #5455