### PR TITLE
Add explicit type checking for *_from_id(s) methods (#5459)

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -957,6 +957,8 @@ class Config(metaclass=ConfigMeta):
             The guild's Group object.
 
         """
+        if not isinstance(guild_id, int):
+            raise TypeError(f"Guild id must be of type int, not `{type(guild_id)}`.")
         return self._get_base_group(self.GUILD, str(guild_id))
 
     def guild(self, guild: discord.Guild) -> Group:
@@ -991,6 +993,8 @@ class Config(metaclass=ConfigMeta):
             The channel's Group object.
 
         """
+        if not isinstance(channel_id, int):
+            raise TypeError(f"Channel id must be of type int, not `{type(channel_id)}`.")
         return self._get_base_group(self.CHANNEL, str(channel_id))
 
     def channel(self, channel: discord.abc.GuildChannel) -> Group:
@@ -1025,6 +1029,8 @@ class Config(metaclass=ConfigMeta):
             The role's Group object.
 
         """
+        if not isinstance(role_id, int):
+            raise TypeError(f"Role id must be of type int, not `{type(role_id)}`.")
         return self._get_base_group(self.ROLE, str(role_id))
 
     def role(self, role: discord.Role) -> Group:
@@ -1057,6 +1063,8 @@ class Config(metaclass=ConfigMeta):
             The user's Group object.
 
         """
+        if not isinstance(user_id, int):
+            raise TypeError(f"User id must be of type int, not `{type(user_id)}`.")
         return self._get_base_group(self.USER, str(user_id))
 
     def user(self, user: discord.abc.User) -> Group:
@@ -1091,6 +1099,11 @@ class Config(metaclass=ConfigMeta):
             The member's Group object.
 
         """
+        if not isinstance(guild_id, int):
+            raise TypeError(f"Guild id must be of type int, not `{type(guild_id)}`.")
+        elif not isinstance(member_id, int):
+            raise TypeError(f"Member id must be of type int, not `{type(member_id)}`.") 
+        #raising errors separately to be clear and concise about which parameter is of wrong type
         return self._get_base_group(self.MEMBER, str(guild_id), str(member_id))
 
     def member(self, member: discord.Member) -> Group:

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -955,7 +955,7 @@ class Config(metaclass=ConfigMeta):
         -------
         `Group <redbot.core.config.Group>`
             The guild's Group object.
-            
+
         Raises
         ------
         TypeError
@@ -1001,7 +1001,7 @@ class Config(metaclass=ConfigMeta):
         ------
         TypeError
             If the given channel_id parameter is not of type int
-            
+
         """
         if not isinstance(channel_id, int):
             raise TypeError(f"Channel id must be of type int, not `{type(channel_id)}`.")
@@ -1042,7 +1042,7 @@ class Config(metaclass=ConfigMeta):
         ------
         TypeError
             If the given role_id parameter is not of type int
-            
+
         """
         if not isinstance(role_id, int):
             raise TypeError(f"Role id must be of type int, not `{type(role_id)}`.")
@@ -1081,7 +1081,7 @@ class Config(metaclass=ConfigMeta):
         ------
         TypeError
             If the given user_id parameter is not of type int
-            
+
         """
         if not isinstance(user_id, int):
             raise TypeError(f"User id must be of type int, not `{type(user_id)}`.")
@@ -1122,13 +1122,13 @@ class Config(metaclass=ConfigMeta):
         ------
         TypeError
             If the given member_id/guild_id parameter is not of type int
-            
+
         """
         if not isinstance(guild_id, int):
             raise TypeError(f"Guild id must be of type int, not `{type(guild_id)}`.")
         elif not isinstance(member_id, int):
-            raise TypeError(f"Member id must be of type int, not `{type(member_id)}`.") 
-        #raising errors separately to be clear and concise about which parameter is of wrong type
+            raise TypeError(f"Member id must be of type int, not `{type(member_id)}`.")
+        # raising errors separately to be clear and concise about which parameter is of wrong type
         return self._get_base_group(self.MEMBER, str(guild_id), str(member_id))
 
     def member(self, member: discord.Member) -> Group:

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -955,6 +955,11 @@ class Config(metaclass=ConfigMeta):
         -------
         `Group <redbot.core.config.Group>`
             The guild's Group object.
+            
+        Raises
+        ------
+        TypeError
+            If the given guild_id parameter is not of type int
 
         """
         if not isinstance(guild_id, int):
@@ -992,6 +997,11 @@ class Config(metaclass=ConfigMeta):
         `Group <redbot.core.config.Group>`
             The channel's Group object.
 
+        Raises
+        ------
+        TypeError
+            If the given channel_id parameter is not of type int
+            
         """
         if not isinstance(channel_id, int):
             raise TypeError(f"Channel id must be of type int, not `{type(channel_id)}`.")
@@ -1028,6 +1038,11 @@ class Config(metaclass=ConfigMeta):
         `Group <redbot.core.config.Group>`
             The role's Group object.
 
+        Raises
+        ------
+        TypeError
+            If the given role_id parameter is not of type int
+            
         """
         if not isinstance(role_id, int):
             raise TypeError(f"Role id must be of type int, not `{type(role_id)}`.")
@@ -1062,6 +1077,11 @@ class Config(metaclass=ConfigMeta):
         `Group <redbot.core.config.Group>`
             The user's Group object.
 
+        Raises
+        ------
+        TypeError
+            If the given user_id parameter is not of type int
+            
         """
         if not isinstance(user_id, int):
             raise TypeError(f"User id must be of type int, not `{type(user_id)}`.")
@@ -1098,6 +1118,11 @@ class Config(metaclass=ConfigMeta):
         `Group <redbot.core.config.Group>`
             The member's Group object.
 
+        Raises
+        ------
+        TypeError
+            If the given member_id/guild_id parameter is not of type int
+            
         """
         if not isinstance(guild_id, int):
             raise TypeError(f"Guild id must be of type int, not `{type(guild_id)}`.")


### PR DESCRIPTION
### Description of the changes

This PR adds type checking for the parameters of *_from_id(s) methods in config in order to ensure config files do not break incase parameters are not of type `int`.

If I've made any sort of mistakes, please correct me as this is my first PR and i would be happy to recieve constructive criticism

Fixes #5459