### PR TITLE
Remove Bank cog from labeler configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,11 +18,6 @@
   - redbot/core/bank.py
   # Docs
   - docs/framework_bank.rst
-"Category: Bank Cog":
-  # Source
-  - redbot/cogs/bank/*
-  # Docs
-  - docs/cog_guides/bank.rst
 "Category: Bot Core":
   # Source
   - redbot/*


### PR DESCRIPTION
Removes the Bank cog from the labeler configuration seeing as these directories/files no longer exist.