### PR TITLE
Restrict `[p]cleanupset notify` to guild only

### DIFF
--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -732,6 +732,7 @@ class Cleanup(commands.Cog):
         """Manage the settings for the cleanup command."""
         pass
 
+    @commands.guild_only()
     @cleanupset.command(name="notify")
     async def cleanupset_notify(self, ctx: commands.Context):
         """Toggle clean up notification settings.


### PR DESCRIPTION
Running `[p]cleanupset notify` in DMs raises an exception with Config seeing as a DM is not a guild. I don't feel that the hassle to add another setting per user for DM notifying is really necessary (imo), so just adding the `guild_only` decorator would fix this error.

![image](https://user-images.githubusercontent.com/67752638/145733209-9397b14b-ebf2-4eaf-931c-8fafffafa4d9.png)
