### PR TITLE
[Mod] Typo in unban command

### DIFF
--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -956,7 +956,7 @@ class KickBanMixin(MixinMeta):
                 except discord.HTTPException:
                     await ctx.send(
                         _(
-                            "Something went wrong when attempting to send that user"
+                            "Something went wrong when attempting to send that user "
                             "an invite. Here's the link so you can try: {invite_link}"
                         ).format(invite_link=invite.url)
                     )


### PR DESCRIPTION
### Description of the changes
Fix the typo in unban command if it reaches the HTTPException

before:
![before](https://user-images.githubusercontent.com/57430307/146484839-cab83dda-c424-4813-a40c-c13a17fc83d0.png)

after:
![after](https://user-images.githubusercontent.com/57430307/146484910-7a6e7773-5890-4296-a727-8cb3dcada424.png)
