### PR TITLE
[Core] Changed prefix length to `25`. 

### DIFF
--- a/docs/cog_guides/core.rst
+++ b/docs/cog_guides/core.rst
@@ -3651,7 +3651,7 @@ Sets Red's server prefix(es).
 
     This is not additive. It will replace all current server prefixes.
 
-    You cannot have a prefix with more than 40 characters.
+    You cannot have a prefix with more than 25 characters.
 
 **Examples:**
     - ``[p]set serverprefix !``

--- a/docs/cog_guides/core.rst
+++ b/docs/cog_guides/core.rst
@@ -3651,7 +3651,7 @@ Sets Red's server prefix(es).
 
     This is not additive. It will replace all current server prefixes.
 
-    You cannot have a prefix with more than 20 characters.
+    You cannot have a prefix with more than 40 characters.
 
 **Examples:**
     - ``[p]set serverprefix !``

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -102,7 +102,7 @@ _ = i18n.Translator("Core", __file__)
 
 TokenConverter = commands.get_dict_converter(delims=[" ", ",", ";"])
 
-MAX_PREFIX_LENGTH = 20
+MAX_PREFIX_LENGTH = 40
 
 
 class CoreLogic:

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3545,7 +3545,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         if any(len(x) > MAX_PREFIX_LENGTH for x in prefixes):
             await ctx.send(
                 _(
-                    "Warning: A prefix is above the recommended length (20 characters).\n"
+                    "Warning: A prefix is above the recommended length (40 characters).\n"
                     "Do you want to continue?"
                 )
                 + " (yes/no)"

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -102,7 +102,7 @@ _ = i18n.Translator("Core", __file__)
 
 TokenConverter = commands.get_dict_converter(delims=[" ", ",", ";"])
 
-MAX_PREFIX_LENGTH = 40
+MAX_PREFIX_LENGTH = 25
 
 
 class CoreLogic:
@@ -3545,7 +3545,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         if any(len(x) > MAX_PREFIX_LENGTH for x in prefixes):
             await ctx.send(
                 _(
-                    "Warning: A prefix is above the recommended length (40 characters).\n"
+                    "Warning: A prefix is above the recommended length (25 characters).\n"
                     "Do you want to continue?"
                 )
                 + " (yes/no)"
@@ -3591,7 +3591,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             await ctx.send(_("Server prefixes have been reset."))
             return
         if any(len(x) > MAX_PREFIX_LENGTH for x in prefixes):
-            await ctx.send(_("You cannot have a prefix longer than 40 characters."))
+            await ctx.send(_("You cannot have a prefix longer than 25 characters."))
             return
         prefixes = sorted(prefixes, reverse=True)
         await ctx.bot.set_prefixes(guild=ctx.guild, prefixes=prefixes)

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3575,7 +3575,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         Warning: This will override global prefixes, the bot will not respond to any global prefixes in this server.
             This is not additive. It will replace all current server prefixes.
-            A prefix cannot have more than 40 characters.
+            A prefix cannot have more than 25 characters.
 
         **Examples:**
             - `[p]set serverprefix !`

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3575,7 +3575,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         Warning: This will override global prefixes, the bot will not respond to any global prefixes in this server.
             This is not additive. It will replace all current server prefixes.
-            A prefix cannot have more than 20 characters.
+            A prefix cannot have more than 40 characters.
 
         **Examples:**
             - `[p]set serverprefix !`
@@ -3591,7 +3591,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             await ctx.send(_("Server prefixes have been reset."))
             return
         if any(len(x) > MAX_PREFIX_LENGTH for x in prefixes):
-            await ctx.send(_("You cannot have a prefix longer than 20 characters."))
+            await ctx.send(_("You cannot have a prefix longer than 40 characters."))
             return
         prefixes = sorted(prefixes, reverse=True)
         await ctx.bot.set_prefixes(guild=ctx.guild, prefixes=prefixes)


### PR DESCRIPTION
### Description of the changes

This PR changes the length from `20` to `40` so people can set their prefixes to bot mention (`"<@!12345678901234567890> "` - total of 25 characters) or a rendered bot mention (`"@AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA#1234 "` - total of 39 characters)