### PR TITLE
Add necessary None checks to Core's usage of `Requires.privilege_level`

### DIFF
--- a/redbot/cogs/warnings/helpers.py
+++ b/redbot/cogs/warnings/helpers.py
@@ -55,7 +55,8 @@ async def create_and_invoke_context(
         await realctx.bot.invoke(fctx)
     except (commands.CheckFailure, commands.CommandOnCooldown):
         # reinvoke bypasses checks and we don't want to run bot owner only commands here
-        if fctx.command.requires.privilege_level < PrivilegeLevel.BOT_OWNER:
+        privilege_level = fctx.command.requires.privilege_level
+        if privilege_level is None or privilege_level < PrivilegeLevel.BOT_OWNER:
             await fctx.reinvoke()
 
 
@@ -71,7 +72,8 @@ def get_command_from_input(bot, userinput: str):
     if com is None:
         return None, _("I could not find a command from that input!")
 
-    if com.requires.privilege_level >= PrivilegeLevel.BOT_OWNER:
+    privilege_level = com.requires.privilege_level
+    if privilege_level is not None and privilege_level >= PrivilegeLevel.BOT_OWNER:
         return (
             None,
             _("That command requires bot owner. I can't allow you to use that for an action"),

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -4984,9 +4984,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             )
             return
 
-        if command.requires.privilege_level > await PrivilegeLevel.from_ctx(ctx):
-            await ctx.send(_("You are not allowed to disable that command."))
-            return
+        if command.requires.privilege_level is not None:
+            if command.requires.privilege_level > await PrivilegeLevel.from_ctx(ctx):
+                await ctx.send(_("You are not allowed to disable that command."))
+                return
 
         async with ctx.bot._config.guild(ctx.guild).disabled_commands() as disabled_commands:
             if command.qualified_name not in disabled_commands:
@@ -5055,9 +5056,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         **Arguments:**
             - `<command>` - The command to enable for the current server.
         """
-        if command.requires.privilege_level > await PrivilegeLevel.from_ctx(ctx):
-            await ctx.send(_("You are not allowed to enable that command."))
-            return
+        if command.requires.privilege_level is not None:
+            if command.requires.privilege_level > await PrivilegeLevel.from_ctx(ctx):
+                await ctx.send(_("You are not allowed to enable that command."))
+                return
 
         async with ctx.bot._config.guild(ctx.guild).disabled_commands() as disabled_commands:
             with contextlib.suppress(ValueError):


### PR DESCRIPTION
Related Issue: https://sentry.io/share/issue/bf896b87103549b2b9b113c496d2493f/

This happens when someone is trying to disable a command that has user permission requirements set but not a Red PrivilegeLevel. (PrivilegeLevel.NONE was fine though)