### PR TITLE
[3.4] [Core] Changed prefix length to `40`. (#5476)

### DIFF
--- a/docs/cog_guides/core.rst
+++ b/docs/cog_guides/core.rst
@@ -3229,7 +3229,7 @@ Sets Red's server prefix(es).
 
     This is not additive. It will replace all current server prefixes.
 
-    You cannot have a prefix with more than 20 characters.
+    You cannot have a prefix with more than 25 characters.
 
 **Examples:**
     - ``[p]set serverprefix !``

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -100,7 +100,7 @@ _ = i18n.Translator("Core", __file__)
 
 TokenConverter = commands.get_dict_converter(delims=[" ", ",", ";"])
 
-MAX_PREFIX_LENGTH = 20
+MAX_PREFIX_LENGTH = 25
 
 
 class CoreLogic:
@@ -2703,7 +2703,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         if any(len(x) > MAX_PREFIX_LENGTH for x in prefixes):
             await ctx.send(
                 _(
-                    "Warning: A prefix is above the recommended length (20 characters).\n"
+                    "Warning: A prefix is above the recommended length (25 characters).\n"
                     "Do you want to continue?"
                 )
                 + " (yes/no)"
@@ -2733,7 +2733,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         Warning: This will override global prefixes, the bot will not respond to any global prefixes in this server.
             This is not additive. It will replace all current server prefixes.
-            A prefix cannot have more than 20 characters.
+            A prefix cannot have more than 25 characters.
 
         **Examples:**
             - `[p]set serverprefix !`
@@ -2749,7 +2749,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             await ctx.send(_("Server prefixes have been reset."))
             return
         if any(len(x) > MAX_PREFIX_LENGTH for x in prefixes):
-            await ctx.send(_("You cannot have a prefix longer than 20 characters."))
+            await ctx.send(_("You cannot have a prefix longer than 25 characters."))
             return
         prefixes = sorted(prefixes, reverse=True)
         await ctx.bot.set_prefixes(guild=ctx.guild, prefixes=prefixes)


### PR DESCRIPTION
* Update core_commands.py

* Docs yes facebook's metaverse

*jokes on me*

* meta

* forgot here

* Update core_commands.py

* Forgot here

* And forgot here
(cherry picked from commit b091f13df5b291dc483ed12023e69e600f09e938)

Co-authored-by: MAX <63972751+ltzmax@users.noreply.github.com>
