### PR TITLE
[3.4] Update supported OSes (add Alma Linux, RPi OS 11, drop EOL OSes) (#5440)

### DIFF
--- a/docs/install_guides/alma-linux-8.rst
+++ b/docs/install_guides/alma-linux-8.rst
@@ -1,0 +1,7 @@
+.. _install-alma-linux-8:
+
+====================================
+Installing Red on Alma Linux 8.4-8.x
+====================================
+
+.. include:: _includes/install-guide-rhel-derivatives.rst

--- a/docs/install_guides/centos-8.rst
+++ b/docs/install_guides/centos-8.rst
@@ -1,7 +1,0 @@
-.. _install-centos-8:
-
-=============================
-Installing Red on CentOS 8.4+
-=============================
-
-.. include:: _includes/install-guide-rhel-derivatives.rst

--- a/docs/install_guides/fedora.rst
+++ b/docs/install_guides/fedora.rst
@@ -10,7 +10,7 @@ Installing Red on Fedora Linux
 Installing the pre-requirements
 -------------------------------
 
-Fedora Linux 33 and above has all required packages available in official repositories. Install
+Fedora Linux 34 and above has all required packages available in official repositories. Install
 them with dnf:
 
 .. prompt:: bash

--- a/docs/install_guides/index.rst
+++ b/docs/install_guides/index.rst
@@ -13,9 +13,9 @@ we recommend **Ubuntu 20.04 LTS**.
 
    windows
    mac
+   alma-linux-8
    arch
    centos-7
-   centos-8
    centos-stream-8
    debian-10
    debian-11
@@ -24,6 +24,7 @@ we recommend **Ubuntu 20.04 LTS**.
    opensuse-tumbleweed
    oracle-linux-8
    raspberry-pi-os-10
+   raspberry-pi-os-11
    rhel-8
    rocky-linux-8
    ubuntu-1804

--- a/docs/install_guides/raspberry-pi-os-10.rst
+++ b/docs/install_guides/raspberry-pi-os-10.rst
@@ -1,8 +1,28 @@
 .. _install-raspberry-pi-os-10:
 
-=================================
-Installing Red on Raspberry Pi OS
-=================================
+====================================================
+Installing Red on Raspberry Pi OS (Legacy) 10 Buster
+====================================================
+
+.. note::
+
+    While we do provide support and install instructions for running Red
+    on Raspberry Pi OS (Legacy) 10 Buster, we highly recommend installing/upgrading to
+    the new version - Raspberry Pi OS 11 Bullseye.
+
+    If you're not sure what version you are using,
+    you can check your version of Raspberry Pi OS by running:
+
+    .. prompt:: bash
+
+        lsb_release -a
+
+    If you're running Bullseye already, read `install-raspberry-pi-os-11` document instead.
+
+    If you're using Buster, please consider upgrading to Bullseye if possible.
+    You can read
+    `the post about Bullseye release from Raspberry Pi Foundation <https://www.raspberrypi.com/news/raspberry-pi-os-debian-bullseye/>`__
+    to learn how you can install/upgrade to the new version.
 
 .. include:: _includes/linux-preamble.rst
 

--- a/docs/install_guides/raspberry-pi-os-11.rst
+++ b/docs/install_guides/raspberry-pi-os-11.rst
@@ -1,0 +1,40 @@
+.. _install-raspberry-pi-os-11:
+
+=============================================
+Installing Red on Raspberry Pi OS 11 Bullseye
+=============================================
+
+.. note::
+
+    This guide can only be used with Raspberry Pi OS 11 Bullseye,
+    it will not work with any older (e.g. Raspberry Pi OS 10 Buster)
+    or newer (e.g. Raspberry Pi OS 12 Bookworm) releases.
+    You can check your version of Raspberry Pi OS by running:
+
+    .. prompt:: bash
+
+        lsb_release -a
+
+    If you're not running Bullseye, you should read
+    `the post about Bullseye release from Raspberry Pi Foundation <https://www.raspberrypi.com/news/raspberry-pi-os-debian-bullseye/>`__
+    to learn how you can install/upgrade to the new version.
+
+.. include:: _includes/linux-preamble.rst
+
+-------------------------------
+Installing the pre-requirements
+-------------------------------
+
+Raspberry Pi OS "Bullseye" has all required packages available in official repositories. Install them
+with apt:
+
+.. prompt:: bash
+
+    sudo apt update
+    sudo apt -y install python3 python3-dev python3-venv python3-pip git openjdk-11-jre-headless build-essential nano
+
+.. Include common instructions:
+
+.. include:: _includes/create-env-with-venv.rst
+
+.. include:: _includes/install-and-setup-red-unix.rst


### PR DESCRIPTION
* Drop Fedora 33

By the time we release, it's going to reach EOL.

* Drop Raspberry Pi OS 10, add support for 11

* Bring RPi OS 10 back

* Add Alma Linux 8

* Fix-up RHEL EOL dates

* Add '(Legacy)' to Raspberry Pi OS 10

* Drop CentOS 8.
(cherry picked from commit d1df27bc14157267f1da12d5eb627fb041af8346)

Co-authored-by: jack1142 <6032823+jack1142@users.noreply.github.com>
