### PR TITLE
Ensure Nitro users can't make CCs that are too long

### DIFF
--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -95,6 +95,14 @@ class CommandObj:
 
             if msg.content.lower() == "exit()":
                 break
+            elif len(msg.content) > 2000:
+                await ctx.send(
+                    _(
+                        "The text response you're trying to create has more than 2000 characters.\n"
+                        "I cannot send messages that are longer than 2000 characters, please try again."
+                    )
+                )
+                continue
             else:
                 try:
                     this_args = ctx.cog.prepare_args(msg.content)
@@ -197,6 +205,8 @@ class CommandObj:
 
         if response:
             # test to raise
+            if len(response) > 2000:
+                raise ResponseTooLong()
             ctx.cog.prepare_args(response if isinstance(response, str) else response[0])
             ccinfo["response"] = response
 
@@ -380,7 +390,7 @@ class CustomCommands(commands.Cog):
                     command=f"{ctx.clean_prefix}customcom edit"
                 )
             )
-        except ResponseTooLong:
+        except ResponseTooLong:  # This isn't needed, however may be a good idea to keep this.
             await ctx.send(
                 _(
                     "The text response you're trying to create has more than 2000 characters.\n"
@@ -522,6 +532,13 @@ class CustomCommands(commands.Cog):
             await ctx.send(e.args[0])
         except CommandNotEdited:
             pass
+        except ResponseTooLong:
+            await ctx.send(
+                _(
+                    "The text response you're trying to create has more than 2000 characters.\n"
+                    "I cannot send messages that are longer than 2000 characters."
+                )
+            )
 
     @customcom.command(name="list")
     @checks.bot_has_permissions(add_reactions=True)

--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -130,7 +130,9 @@ class CommandObj:
         else:
             raise NotFound()
 
-    async def create(self, ctx: commands.Context, command: str, *, response: Union[str, List[str]]):
+    async def create(
+        self, ctx: commands.Context, command: str, *, response: Union[str, List[str]]
+    ):
         """Create a custom command"""
         # Check if this command is already registered as a customcommand
         if await self.db(ctx.guild).commands.get_raw(command, default=None):
@@ -379,10 +381,12 @@ class CustomCommands(commands.Cog):
                 )
             )
         except ResponseTooLong:
-            await ctx.send(_(
-                "The text response you're trying to create has more than 2000 characters.\n"
-                "I cannot send messages that are longer than 2000 characters."
-            ))
+            await ctx.send(
+                _(
+                    "The text response you're trying to create has more than 2000 characters.\n"
+                    "I cannot send messages that are longer than 2000 characters."
+                )
+            )
 
     @cc_create.command(name="simple")
     @checks.mod_or_permissions(administrator=True)
@@ -416,10 +420,12 @@ class CustomCommands(commands.Cog):
         except ArgParseError as e:
             await ctx.send(e.args[0])
         except ResponseTooLong:
-            await ctx.send(_(
-                "The text response you're trying to create has more than 2000 characters.\n"
-                "I cannot send messages that are longer than 2000 characters."
-            ))
+            await ctx.send(
+                _(
+                    "The text response you're trying to create has more than 2000 characters.\n"
+                    "I cannot send messages that are longer than 2000 characters."
+                )
+            )
 
     @customcom.command(name="cooldown")
     @checks.mod_or_permissions(administrator=True)


### PR DESCRIPTION
### Description of the changes

This PR solves an issue whereby users with Nitro could create custom commands that are over 2000 characters and therefor silently error out the bot when trying to call the newly created custom command.

Source: https://discord.com/channels/133049272517001216/387398816317440000/925955050621272146