### PR TITLE
Fix short help in docstrings for core cogs and commands

### DIFF
--- a/docs/cog_guides/cog_manager_ui.rst
+++ b/docs/cog_guides/cog_manager_ui.rst
@@ -238,8 +238,10 @@ installpath
 
 **Description**
 
-Shows the install path, or sets a new one. If you want to set a new path, the
-same rules as for :ref:`addpath <cogmanagerui-command-addpath>` applies.
+Shows the install path, or sets a new one.
+
+If you want to set a new path, the same rules as for
+:ref:`addpath <cogmanagerui-command-addpath>` apply
 
 .. warning:: If you edit the install path, the cogs won't be transfered.
 

--- a/docs/cog_guides/economy.rst
+++ b/docs/cog_guides/economy.rst
@@ -204,7 +204,9 @@ economyset rolepaydayamount
 
 **Description**
 
-Set the amount earned each payday for a role. Setting to 0 will remove the custom payday for that role instead.
+Set the amount earned each payday for a role.
+
+Set to 0 will remove the custom payday for that role instead.
 
 Only available when not using a global bank.
 

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -853,6 +853,7 @@ class Economy(commands.Cog):
     @economyset.command()
     async def rolepaydayamount(self, ctx: commands.Context, role: discord.Role, creds: int):
         """Set the amount earned each payday for a role.
+
         Set to `0` to remove the payday amount you set for that role.
 
         Only available when not using a global bank.

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -156,6 +156,7 @@ class Warnings(commands.Cog):
     @commands.guild_only()
     async def warnchannel(self, ctx: commands.Context, channel: discord.TextChannel = None):
         """Set the channel where warnings should be sent to.
+
         Leave empty to use the channel `[p]warn` command was called in.
         """
         guild = ctx.guild
@@ -191,6 +192,7 @@ class Warnings(commands.Cog):
     @checks.guildowner_or_permissions(administrator=True)
     async def warnaction(self, ctx: commands.Context):
         """Manage automated actions for Warnings.
+
         Actions are essentially command macros. Any command can be run
         when the action is initially triggered, and/or when the action
         is lifted.
@@ -204,6 +206,7 @@ class Warnings(commands.Cog):
     @commands.guild_only()
     async def action_add(self, ctx: commands.Context, name: str, points: int):
         """Create an automated action.
+
         Duplicate action names are not allowed.
         """
         guild = ctx.guild
@@ -255,6 +258,7 @@ class Warnings(commands.Cog):
     @checks.guildowner_or_permissions(administrator=True)
     async def warnreason(self, ctx: commands.Context):
         """Manage warning reasons.
+
         Reasons must be given a name, description and points value. The
         name of the reason must be given when a user is warned.
         """
@@ -369,6 +373,7 @@ class Warnings(commands.Cog):
         reason: str,
     ):
         """Warn the user for the specified reason.
+
         `<points>` number of points the warning should be for. If no number is supplied
         1 point will be given. Pre-set warnings disregard this.
         `<reason>` is reason for the warning. This can be a registered reason,

--- a/redbot/core/cog_manager.py
+++ b/redbot/core/cog_manager.py
@@ -413,8 +413,9 @@ class CogManagerUI(commands.Cog):
     async def installpath(self, ctx: commands.Context, path: Path = None):
         """
         Returns the current install path or sets it if one is provided.
-            The provided path must be absolute or relative to the bot's
-            directory and it must already exist.
+
+        The provided path must be absolute or relative to the bot's
+        directory and it must already exist.
 
         No installed cogs will be transferred in the process.
         """


### PR DESCRIPTION
### Description of the changes

This PR fixes only part of the description of the `[p]warn` and `[p]warnaction` command appearing in the help command.

### Before:
![image](https://user-images.githubusercontent.com/79806064/147756527-c7d8c0f2-5dc2-47d7-b5fa-99d09981765f.png)
![image](https://user-images.githubusercontent.com/79806064/147756468-b995fd6e-e1ff-4588-b394-32d0c40fc8ac.png)

### After:
![image](https://user-images.githubusercontent.com/79806064/147756843-a4926c3a-93b9-498d-8150-9775f5012046.png)
![image](https://user-images.githubusercontent.com/79806064/147756876-62bc8d02-b17d-4bdb-b7cf-3da08c3509ee.png)
