### PR TITLE
[3.4] Fix 'Red._app_info' attribute error

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1327,12 +1327,13 @@ class RedBase(
         str
             Invite URL.
         """
+        app_info = await self.application_info()
         data = await self._config.all()
         commands_scope = data["invite_commands_scope"]
         scopes = ("bot", "applications.commands") if commands_scope else None
         perms_int = data["invite_perm"]
         permissions = discord.Permissions(perms_int)
-        return discord.utils.oauth_url(self._app_info.id, permissions, scopes=scopes)
+        return discord.utils.oauth_url(app_info.id, permissions, scopes=scopes)
 
     async def is_invite_url_public(self) -> bool:
         """


### PR DESCRIPTION
### Description of the changes
Slipped through the cracks when backporting changes to 3.4.
```
[2021-12-31 06:33:11] [ERROR] aiohttp-json-rpc.server: 'Red' object has no attribute '_app_info'
Traceback (most recent call last):
  File "/home/ubuntu/.redenv/lib/python3.8/site-packages/aiohttp_json_rpc/rpc.py", line 316, in _handle_rpc_msg
    result = await http_request.methods[msg.data['method']](
  File "/home/ubuntu/.redenv/lib/python3.8/site-packages/aiohttp_json_rpc/rpc.py", line 146, in __call__
    return await self.method(**method_params)
  File "/home/ubuntu/.local/share/Red-DiscordBot/data/palmbotv3/cogs/CogManager/cogs/dashboard/rpc/utils.py", line 11, in rpccheckwrapped
    return await func(self, *args, **kwargs)
  File "/home/ubuntu/.local/share/Red-DiscordBot/data/palmbotv3/cogs/CogManager/cogs/dashboard/baserpc.py", line 144, in get_variables
    self.invite_url = await core._invite_url()
  File "/home/ubuntu/.redenv/lib/python3.8/site-packages/redbot/core/core_commands.py", line 363, in _invite_url
    return await self.bot.get_invite_url()
  File "/home/ubuntu/.redenv/lib/python3.8/site-packages/redbot/core/bot.py", line 1335, in get_invite_url
    return discord.utils.oauth_url(self._app_info.id, permissions, scopes=scopes)
AttributeError: 'Red' object has no attribute '_app_info'
```