### PR TITLE
[3.4] Temporarily update Arch instructions

### DIFF
--- a/docs/install_guides/arch.rst
+++ b/docs/install_guides/arch.rst
@@ -14,7 +14,19 @@ Install the pre-requirements with pacman:
 
 .. prompt:: bash
 
-    sudo pacman -Syu python python-pip git jre11-openjdk-headless base-devel nano
+    sudo pacman -Syu git jre11-openjdk-headless base-devel nano
+
+On Arch Linux, Python 3.9 can be installed from the Arch User Repository (AUR) from the ``python39`` package.
+
+The manual build process is the Arch-supported install method for AUR packages. You can install ``python39`` package with the following commands:
+
+.. prompt:: bash
+
+    git clone https://aur.archlinux.org/python39.git /tmp/python39
+    cd /tmp/python39
+    makepkg -sicL
+    cd -
+    rm -rf /tmp/python39
 
 .. Include common instructions:
 


### PR DESCRIPTION
### Description of the changes
`python` package uses Python 3.10 which is not supported by Red 3.4 so this PR temporarily updates Arch instructions to use `python39` AUR package instead.

Tested here:
https://github.com/jack1142/Red-Install-Tests/runs/4674092571?check_suite_focus=true