### PR TITLE
Reference how to reply in the `[p]contact` command with embed settings

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -4007,7 +4007,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 else:
                     e.set_author(name=description)
 
-                e.set_footer(text=footer)
+                e.set_footer(text="{}\n{}".format(footer, content))
 
                 try:
                     await destination.send(embed=e)


### PR DESCRIPTION
### Description of the changes

Closes #5528. References how an owner can reply to a user who contacted them via `[p]contact` when the contact message is sent as an embed.

![Image](https://user-images.githubusercontent.com/67752638/147992134-19e40615-3cfa-4279-a1a4-946fd5659869.png)
