### PR TITLE
Fix formatting in error message about already installed cog

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1447,7 +1447,7 @@ class Downloader(commands.Cog):
             message += (
                 _("\nSome cogs with these names are already installed from different repos: ")
                 if len(name_already_used) > 1
-                else _("\nCog with this name is already installed from a different repo.")
+                else _("\nCog with this name is already installed from a different repo: ")
             ) + humanize_list(name_already_used)
         correct_cogs, add_to_message = self._filter_incorrect_cogs(cogs)
         if add_to_message:


### PR DESCRIPTION
### Description of the changes

Adds a colon and a space to the end of the words when a cog is installed from another repo as the cog name is appended directly after the period with no space.

Example as is before this PR:
<img width="526" alt="Screen Shot 2022-01-04 at 4 19 33 PM" src="https://user-images.githubusercontent.com/20862007/148141433-b8ea539f-019d-453a-a555-76bd966051c3.png">
