### PR TITLE
Fix for using redbot name --edit for changing name

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -222,7 +222,7 @@ def _edit_instance_name(old_name, new_name, confirm_overwrite, no_prompt):
                 " run this command with --overwrite-existing-instance flag."
             )
     elif not no_prompt and confirm("Would you like to change the instance name?", default=False):
-        name = get_name()
+        name = get_name("")
         if name in _get_instance_names():
             print(
                 "WARNING: An instance already exists with this name. "


### PR DESCRIPTION
### Description of the changes
Currently if you use `redbot <bot name> --edit` and choose `y` for `Would you like to change the instance name?: [y/N]`, it returns the user back to the command prompt with no changes. By using the imported `get_name` function from setup.py, it is expecting a str to be passed with the `name = get_name()` line. By passing a name with a len of 0, that is when setup.py can prompt the user for a new name.

Fixes #5545 