### PR TITLE
Fix for using redbot name --edit for changing data location

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -270,7 +270,9 @@ def _edit_data_path(data, instance_name, data_path, copy_data, no_prompt):
             print("Can't copy data to non-empty location. Data location will remain unchanged.")
             data["DATA_PATH"] = data_manager.basic_config["DATA_PATH"]
     elif not no_prompt and confirm("Would you like to change the data location?", default=False):
-        data["DATA_PATH"] = get_data_dir(instance_name=instance_name, data_path=None, interactive=True)
+        data["DATA_PATH"] = get_data_dir(
+            instance_name=instance_name, data_path=None, interactive=True
+        )
         if confirm("Do you want to copy the data from old location?", default=True):
             if not _copy_data(data):
                 print("Can't copy the data to non-empty location.")

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -270,7 +270,7 @@ def _edit_data_path(data, instance_name, data_path, copy_data, no_prompt):
             print("Can't copy data to non-empty location. Data location will remain unchanged.")
             data["DATA_PATH"] = data_manager.basic_config["DATA_PATH"]
     elif not no_prompt and confirm("Would you like to change the data location?", default=False):
-        data["DATA_PATH"] = get_data_dir(instance_name)
+        data["DATA_PATH"] = get_data_dir(instance_name=instance_name, data_path=None, interactive=True)
         if confirm("Do you want to copy the data from old location?", default=True):
             if not _copy_data(data):
                 print("Can't copy the data to non-empty location.")


### PR DESCRIPTION
### Description of the changes
Currently if you use `redbot <bot name> --edit` and choose `y` for `Would you like to change the data location?: [y/N]`, it returns the user back to the command prompt with no changes. `get_data_dir` from setup.py is looking for all of the arguments needed before it will prompt the user for changing the data path.