### PR TITLE
Use absolute path to `which` to avoid aliases

### DIFF
--- a/docs/autostart_systemd.rst
+++ b/docs/autostart_systemd.rst
@@ -26,7 +26,7 @@ Next, your python :code:`path` can be fetched with the following commands:
 
     # If redbot is installed in a venv
     $ source ~/redenv/bin/activate
-    (redenv) $ which python
+    (redenv) $ /usr/bin/which python
 
     # If redbot is installed in a pyenv virtualenv
     $ pyenv shell <virtualenv_name>


### PR DESCRIPTION
### Description of the changes
Some OSes (RHEL derivatives) ship with a shell configuration containing an alias for `which` command:
```
alias which='(alias; declare -f) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot'
```

This causes the output of it to contain `~` instead of `/home/username` *which* makes it a path unsuitable for passing to the service manager.
Using absolute path `/usr/bin/which` will bypass the alias *which* will allow the command to show full path without any substitutions.