### PR TITLE
Add a way to include where a command is disabled in disabled message

### DIFF
--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -481,10 +481,11 @@ class Command(CogCommandMixin, DPYCommand):
 
         if not self.enabled:
             disabled_message = await ctx.bot._config.disabled_command_msg()
-            disabled_message.replace("{command}", ctx.invoked_with).replace(
-                "{origin}", _("globally")
+            raise DisabledCommand(
+                disabled_message.replace("{command}", ctx.invoked_with).replace(
+                    "{origin}", _("globally")
+                )
             )
-            raise DisabledCommand(disabled_message)
 
         if not await self.can_run(ctx, change_permission_state=True):
             raise CheckFailure(f"The check functions for command {self.qualified_name} failed.")
@@ -1095,10 +1096,11 @@ def get_command_disabler(guild: discord.Guild) -> Callable[["Context"], Awaitabl
         async def disabler(ctx: "Context") -> bool:
             if ctx.guild is not None and ctx.guild.id == guild.id:
                 disabled_msg = await ctx.bot._config.disabled_command_msg()
-                disabled_msg.replace("{command}", ctx.invoked_with).replace(
-                    "{origin}", _("in this server")
+                raise DisabledCommand(
+                    disabled_msg.replace("{command}", ctx.invoked_with).replace(
+                        "{origin}", _("in this server")
+                    )
                 )
-                raise DisabledCommand(disabled_msg)
             return True
 
         __command_disablers[guild.id] = disabler

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -480,7 +480,11 @@ class Command(CogCommandMixin, DPYCommand):
         ctx.command = self
 
         if not self.enabled:
-            raise DisabledCommand(f"{self.name} command is disabled")
+            disabled_message = await ctx.bot._config.disabled_command_msg()
+            disabled_message.replace("{command}", ctx.invoked_with).replace(
+                "{origin}", _("globally")
+            )
+            raise DisabledCommand(disabled_message)
 
         if not await self.can_run(ctx, change_permission_state=True):
             raise CheckFailure(f"The check functions for command {self.qualified_name} failed.")
@@ -1090,7 +1094,11 @@ def get_command_disabler(guild: discord.Guild) -> Callable[["Context"], Awaitabl
 
         async def disabler(ctx: "Context") -> bool:
             if ctx.guild is not None and ctx.guild.id == guild.id:
-                raise DisabledCommand()
+                disabled_msg = await ctx.bot._config.disabled_command_msg()
+                disabled_msg.replace("{command}", ctx.invoked_with).replace(
+                    "{origin}", _("in this server")
+                )
+                raise DisabledCommand(disabled_msg)
             return True
 
         __command_disablers[guild.id] = disabler

--- a/redbot/core/commands/requires.py
+++ b/redbot/core/commands/requires.py
@@ -518,10 +518,11 @@ class Requires:
             cog = ctx.cog
             if cog and await ctx.bot.cog_disabled_in_guild(cog, ctx.guild):
                 disabled_msg = await ctx.bot._config.disabled_command_msg()
-                disabled_msg = disabled_msg.replace("{command}", ctx.invoked_with).replace(
-                    "{origin}", _("in this server")
+                raise discord.ext.commands.DisabledCommand(
+                    disabled_msg.replace("{command}", ctx.invoked_with).replace(
+                        "{origin}", _("in this server")
+                    )
                 )
-                raise discord.ext.commands.DisabledCommand(disabled_msg)
 
         bot_perms = ctx.channel.permissions_for(bot_user)
         if not (bot_perms.administrator or bot_perms >= self.bot_perms):

--- a/redbot/core/commands/requires.py
+++ b/redbot/core/commands/requires.py
@@ -29,6 +29,7 @@ import discord
 
 from discord.ext.commands import check
 from .errors import BotMissingPermissions
+from ..i18n import Translator
 
 if TYPE_CHECKING:
     from .commands import Command
@@ -61,6 +62,8 @@ __all__ = [
     "PermStateTransitions",
     "PermStateAllowedStates",
 ]
+
+_ = Translator("commands.requires", __file__)
 
 _T = TypeVar("_T")
 GlobalPermissionModel = Union[
@@ -514,7 +517,11 @@ class Requires:
             bot_user = ctx.guild.me
             cog = ctx.cog
             if cog and await ctx.bot.cog_disabled_in_guild(cog, ctx.guild):
-                raise discord.ext.commands.DisabledCommand()
+                disabled_msg = await ctx.bot._config.disabled_command_msg()
+                disabled_msg = disabled_msg.replace("{command}", ctx.invoked_with).replace(
+                    "{origin}", _("in this server")
+                )
+                raise discord.ext.commands.DisabledCommand(disabled_msg)
 
         bot_perms = ctx.channel.permissions_for(bot_user)
         if not (bot_perms.administrator or bot_perms >= self.bot_perms):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -5051,10 +5051,11 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         Leave blank to send nothing.
 
         To include the command name in the message, include the `{command}` placeholder.
+        To include where the command is disabled, include the `{origin}` placeholder.
 
         **Examples:**
             - `[p]command disabledmsg This command is disabled`
-            - `[p]command disabledmsg {command} is disabled`
+            - `[p]command disabledmsg {command} is disabled {origin}`
             - `[p]command disabledmsg` - Sends nothing when a disabled command is attempted.
 
         **Arguments:**

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -229,9 +229,8 @@ def init_events(bot, cli_flags):
         elif isinstance(error, commands.UserInputError):
             await ctx.send_help()
         elif isinstance(error, commands.DisabledCommand):
-            disabled_message = await bot._config.disabled_command_msg()
-            if disabled_message:
-                await ctx.send(disabled_message.replace("{command}", ctx.invoked_with))
+            if error.args:
+                await ctx.send(error.args[0])
         elif isinstance(error, commands.CommandInvokeError):
             log.exception(
                 "Exception in command '{}'".format(ctx.command.qualified_name),


### PR DESCRIPTION
### Description of the changes
By using `{origin}` placeholder in the command `[p]command disabledmsg`, it will show where the command is disabled.
So `globally` for global, and `in this server` if it's in the current guild.

There's a cleaner way of doing it with #5552 than currently though.