### PR TITLE
Ensure that registered Config defaults are serializable to JSON

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -1,5 +1,6 @@
 import asyncio
 import collections.abc
+import json
 import logging
 import pickle
 import weakref
@@ -807,7 +808,8 @@ class Config(metaclass=ConfigMeta):
         if key not in self._defaults:
             self._defaults[key] = {}
 
-        data = pickle.loads(pickle.dumps(kwargs, -1))
+        # this serves as a 'deep copy' and verification that the default is serializable to JSON
+        data = json.loads(json.dumps(kwargs))
 
         for k, v in data.items():
             to_add = self._get_defaults_dict(k, v)


### PR DESCRIPTION
### Description of the changes
Instead of pickle, let's use JSON here so that in addition to deep copying, we also verify that the value is JSON serializable. Might come with a very slight performance penalty but defaults are only registered on cog load so this does not matter.