### PR TITLE
Add typechecking to config from_id methods

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -956,7 +956,15 @@ class Config(metaclass=ConfigMeta):
         `Group <redbot.core.config.Group>`
             The guild's Group object.
 
+        Raises
+        ------
+        TypeError
+            If the given guild_id parameter is not of type int
         """
+        if not isinstance(guild_id, int):
+            raise TypeError(
+                f"`guild_id` should be of type `int`, not {guild_id.__class__.__name__}"
+            )
         return self._get_base_group(self.GUILD, str(guild_id))
 
     def guild(self, guild: discord.Guild) -> Group:
@@ -990,7 +998,15 @@ class Config(metaclass=ConfigMeta):
         `Group <redbot.core.config.Group>`
             The channel's Group object.
 
+        Raises
+        ------
+        TypeError
+            If the given channel_id parameter is not of type int
         """
+        if not isinstance(channel_id, int):
+            raise TypeError(
+                f"`channel_id` should be of type `int`, not {channel_id.__class__.__name__}"
+            )
         return self._get_base_group(self.CHANNEL, str(channel_id))
 
     def channel(self, channel: discord.abc.GuildChannel) -> Group:
@@ -1024,7 +1040,13 @@ class Config(metaclass=ConfigMeta):
         `Group <redbot.core.config.Group>`
             The role's Group object.
 
+        Raises
+        ------
+        TypeError
+            If the given role_id parameter is not of type int
         """
+        if not isinstance(role_id, int):
+            raise TypeError(f"`role_id` should be of type `int`, not {role_id.__class__.__name__}")
         return self._get_base_group(self.ROLE, str(role_id))
 
     def role(self, role: discord.Role) -> Group:
@@ -1056,7 +1078,13 @@ class Config(metaclass=ConfigMeta):
         `Group <redbot.core.config.Group>`
             The user's Group object.
 
+        Raises
+        ------
+        TypeError
+            If the given user_id parameter is not of type int
         """
+        if not isinstance(user_id, int):
+            raise TypeError(f"`user_id` should be of type `int`, not {user_id.__class__.__name__}")
         return self._get_base_group(self.USER, str(user_id))
 
     def user(self, user: discord.abc.User) -> Group:
@@ -1090,7 +1118,21 @@ class Config(metaclass=ConfigMeta):
         `Group <redbot.core.config.Group>`
             The member's Group object.
 
+        Raises
+        ------
+        TypeError
+            If the given guild_id or member_id parameter is not of type int
         """
+        if not isinstance(guild_id, int):
+            raise TypeError(
+                f"`guild_id` should be of type `int`, not {guild_id.__class__.__name__}"
+            )
+
+        if not isinstance(member_id, int):
+            raise TypeError(
+                f"`member_id` should be of type `int`, not {member_id.__class__.__name__}"
+            )
+
         return self._get_base_group(self.MEMBER, str(guild_id), str(member_id))
 
     def member(self, member: discord.Member) -> Group:

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -961,7 +961,7 @@ class Config(metaclass=ConfigMeta):
         TypeError
             If the given guild_id parameter is not of type int
         """
-        if not isinstance(guild_id, int):
+        if type(guild_id) is not int:
             raise TypeError(
                 f"`guild_id` should be of type `int`, not {guild_id.__class__.__name__}"
             )
@@ -1003,7 +1003,7 @@ class Config(metaclass=ConfigMeta):
         TypeError
             If the given channel_id parameter is not of type int
         """
-        if not isinstance(channel_id, int):
+        if type(channel_id) is not int:
             raise TypeError(
                 f"`channel_id` should be of type `int`, not {channel_id.__class__.__name__}"
             )
@@ -1045,7 +1045,7 @@ class Config(metaclass=ConfigMeta):
         TypeError
             If the given role_id parameter is not of type int
         """
-        if not isinstance(role_id, int):
+        if type(role_id) is not int:
             raise TypeError(f"`role_id` should be of type `int`, not {role_id.__class__.__name__}")
         return self._get_base_group(self.ROLE, str(role_id))
 
@@ -1083,7 +1083,7 @@ class Config(metaclass=ConfigMeta):
         TypeError
             If the given user_id parameter is not of type int
         """
-        if not isinstance(user_id, int):
+        if type(user_id) is not int:
             raise TypeError(f"`user_id` should be of type `int`, not {user_id.__class__.__name__}")
         return self._get_base_group(self.USER, str(user_id))
 
@@ -1123,12 +1123,12 @@ class Config(metaclass=ConfigMeta):
         TypeError
             If the given guild_id or member_id parameter is not of type int
         """
-        if not isinstance(guild_id, int):
+        if type(guild_id) is not int:
             raise TypeError(
                 f"`guild_id` should be of type `int`, not {guild_id.__class__.__name__}"
             )
 
-        if not isinstance(member_id, int):
+        if type(member_id) is not int:
             raise TypeError(
                 f"`member_id` should be of type `int`, not {member_id.__class__.__name__}"
             )

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -962,9 +962,7 @@ class Config(metaclass=ConfigMeta):
             If the given guild_id parameter is not of type int
         """
         if type(guild_id) is not int:
-            raise TypeError(
-                f"guild_id should be of type int, not {guild_id.__class__.__name__}"
-            )
+            raise TypeError(f"guild_id should be of type int, not {guild_id.__class__.__name__}")
         return self._get_base_group(self.GUILD, str(guild_id))
 
     def guild(self, guild: discord.Guild) -> Group:
@@ -1124,14 +1122,10 @@ class Config(metaclass=ConfigMeta):
             If the given guild_id or member_id parameter is not of type int
         """
         if type(guild_id) is not int:
-            raise TypeError(
-                f"guild_id should be of type int, not {guild_id.__class__.__name__}"
-            )
+            raise TypeError(f"guild_id should be of type int, not {guild_id.__class__.__name__}")
 
         if type(member_id) is not int:
-            raise TypeError(
-                f"member_id should be of type int, not {member_id.__class__.__name__}"
-            )
+            raise TypeError(f"member_id should be of type int, not {member_id.__class__.__name__}")
 
         return self._get_base_group(self.MEMBER, str(guild_id), str(member_id))
 

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -963,7 +963,7 @@ class Config(metaclass=ConfigMeta):
         """
         if type(guild_id) is not int:
             raise TypeError(
-                f"`guild_id` should be of type `int`, not {guild_id.__class__.__name__}"
+                f"guild_id should be of type int, not {guild_id.__class__.__name__}"
             )
         return self._get_base_group(self.GUILD, str(guild_id))
 
@@ -1005,7 +1005,7 @@ class Config(metaclass=ConfigMeta):
         """
         if type(channel_id) is not int:
             raise TypeError(
-                f"`channel_id` should be of type `int`, not {channel_id.__class__.__name__}"
+                f"channel_id should be of type int, not {channel_id.__class__.__name__}"
             )
         return self._get_base_group(self.CHANNEL, str(channel_id))
 
@@ -1046,7 +1046,7 @@ class Config(metaclass=ConfigMeta):
             If the given role_id parameter is not of type int
         """
         if type(role_id) is not int:
-            raise TypeError(f"`role_id` should be of type `int`, not {role_id.__class__.__name__}")
+            raise TypeError(f"role_id should be of type int, not {role_id.__class__.__name__}")
         return self._get_base_group(self.ROLE, str(role_id))
 
     def role(self, role: discord.Role) -> Group:
@@ -1084,7 +1084,7 @@ class Config(metaclass=ConfigMeta):
             If the given user_id parameter is not of type int
         """
         if type(user_id) is not int:
-            raise TypeError(f"`user_id` should be of type `int`, not {user_id.__class__.__name__}")
+            raise TypeError(f"user_id should be of type int, not {user_id.__class__.__name__}")
         return self._get_base_group(self.USER, str(user_id))
 
     def user(self, user: discord.abc.User) -> Group:
@@ -1125,12 +1125,12 @@ class Config(metaclass=ConfigMeta):
         """
         if type(guild_id) is not int:
             raise TypeError(
-                f"`guild_id` should be of type `int`, not {guild_id.__class__.__name__}"
+                f"guild_id should be of type int, not {guild_id.__class__.__name__}"
             )
 
         if type(member_id) is not int:
             raise TypeError(
-                f"`member_id` should be of type `int`, not {member_id.__class__.__name__}"
+                f"member_id should be of type int, not {member_id.__class__.__name__}"
             )
 
         return self._get_base_group(self.MEMBER, str(guild_id), str(member_id))


### PR DESCRIPTION
### Description of the changes
This PR is a redo for #5462

This PR adds type checking for the parameters of *_from_id(s) methods in config in order to ensure config files do not break in case parameters are not of type `int`.

If I've made any sort of mistakes, please correct me as this is my first PR and I would be happy to receive constructive criticism

Fixes #5459
