### PR TITLE
Update enqueued track message to distinguish album from playlist

### DIFF
--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -383,6 +383,8 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 index = query.track_index
                 if query.start_time:
                     seek = query.start_time
+            if query.is_url:
+                playlist_url = query.uri
             try:
                 result, called_api = await self.api_interface.fetch_track(ctx, player, query)
             except TrackEnqueueError:
@@ -444,12 +446,12 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             async for track in AsyncIter(tracks):
                 if len(player.queue) >= 10000:
                     continue
-                query = Query.process_input(track, self.local_folder_current_path)
+                track_query = Query.process_input(track, self.local_folder_current_path)
                 if not await self.is_query_allowed(
                     self.config,
                     ctx,
-                    f"{track.title} {track.author} {track.uri} " f"{str(query)}",
-                    query_obj=query,
+                    f"{track.title} {track.author} {track.uri} " f"{str(track_query)}",
+                    query_obj=track_query,
                 ):
                     if IS_DEBUG:
                         log.debug("Query is not allowed in %r (%d)", ctx.guild.name, ctx.guild.id)
@@ -491,11 +493,12 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             playlist_name = escape(
                 playlist_data.name if playlist_data else _("No Title"), formatting=True
             )
+            title = _("Album Enqueued") if query.is_album else _("Playlist Enqueued")
             embed = discord.Embed(
-                description=bold(f"[{playlist_name}]({playlist_url})")
+                description=f"[{playlist_name}]({playlist_url})"
                 if playlist_url
                 else playlist_name,
-                title=_("Playlist Enqueued"),
+                title=title,
             )
             embed.set_footer(
                 text=_("Added {num} tracks to the queue.{maxlength_msg}").format(

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -493,7 +493,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             playlist_name = escape(
                 playlist_data.name if playlist_data else _("No Title"), formatting=True
             )
-            title = _("Album Enqueued") if query.is_album else _("Playlist Enqueued")
+            title = _("Playlist Enqueued") if not query.is_album else _("Album Enqueued")
             embed = discord.Embed(
                 description=f"[{playlist_name}]({playlist_url})"
                 if playlist_url

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -495,7 +495,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             )
             title = _("Playlist Enqueued") if not query.is_album else _("Album Enqueued")
             embed = discord.Embed(
-                description=f"[{playlist_name}]({playlist_url})"
+                description=bold(f"[{playlist_name}]({playlist_url})")
                 if playlist_url
                 else playlist_name,
                 title=title,


### PR DESCRIPTION
### Description of the changes
Pretty small change, all it does is check for if it's an album or playlist (the Query object was already providing this data) and display the correct type instead of always defaulting to saying a playlist was enqueued.

Also, while doing this I noticed playlist_url was set to None at the top of the function, but it was never changed to be the playlist url later, so I 'fixed' (was that intentional?) that as well.
