### PR TITLE
Support all Messageables in `bot.embed_requested()`

### DIFF
--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -543,8 +543,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
         if not reason:
             reason = _("No reason provided.")
 
-        # okay, this is some poor API to require PrivateChannel here...
-        if await self.bot.embed_requested(await user.create_dm(), user):
+        if await self.bot.embed_requested(user):
             em = discord.Embed(
                 title=title,
                 description=reason,

--- a/redbot/cogs/reports/reports.py
+++ b/redbot/cogs/reports/reports.py
@@ -193,7 +193,6 @@ class Reports(commands.Cog):
             return guild
 
     async def send_report(self, ctx: commands.Context, msg: discord.Message, guild: discord.Guild):
-
         author = guild.get_member(msg.author.id)
         report = msg.clean_content
 
@@ -207,7 +206,7 @@ class Reports(commands.Cog):
         ticket_number = await self.config.guild(guild).next_ticket()
         await self.config.guild(guild).next_ticket.set(ticket_number + 1)
 
-        if await self.bot.embed_requested(channel, author):
+        if await self.bot.embed_requested(channel):
             em = discord.Embed(description=report, colour=await ctx.embed_colour())
             em.set_author(
                 name=_("Report from {author}{maybe_nick}").format(

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1205,10 +1205,9 @@ class Red(
 
     async def embed_requested(
         self,
-        channel: Union[discord.abc.GuildChannel, discord.abc.PrivateChannel],
-        user: discord.abc.User,
-        command: Optional[commands.Command] = None,
+        channel: discord.abc.Messageable,
         *,
+        command: Optional[commands.Command] = None,
         check_permissions: bool = False,
     ) -> bool:
         """
@@ -1216,15 +1215,14 @@ class Red(
 
         Arguments
         ---------
-        channel : `discord.abc.GuildChannel` or `discord.abc.PrivateChannel`
-            The channel to check embed settings for.
-        user : `discord.abc.User`
-            The user to check embed settings for.
-        command : `redbot.core.commands.Command`, optional
-            The command ran.
+        channel : `discord.abc.Messageable`
+            The target messageable object to check embed settings for.
 
         Keyword Arguments
         -----------------
+        command : `redbot.core.commands.Command`, optional
+            The command ran.
+            This is auto-filled when ``channel`` is passed with command context.
         check_permissions : `bool`
             If ``True``, this method will also check whether the bot can send embeds
             in the given channel and if it can't, it will return ``False`` regardless of
@@ -1242,10 +1240,12 @@ class Red(
             scope = self._config.custom(COMMAND_SCOPE, command.qualified_name, guild_id)
             return await scope.embeds()
 
-        if isinstance(channel, discord.abc.PrivateChannel):
-            if (user_setting := await self._config.user(user).embeds()) is not None:
-                return user_setting
-        else:
+        # using dpy_commands.Context to keep the Messageable contract in full
+        if isinstance(channel, dpy_commands.Context):
+            command = command or channel.command
+            channel = channel.channel
+
+        if isinstance(channel, discord.TextChannel):
             if check_permissions and not channel.permissions_for(channel.guild.me).embed_links:
                 return False
 
@@ -1257,6 +1257,13 @@ class Red(
 
             if (guild_setting := await self._config.guild(channel.guild).embeds()) is not None:
                 return guild_setting
+        elif isinstance(channel, discord.GroupChannel):
+            # this only uses global settings
+            pass
+        else:
+            user = channel.recipient if isinstance(discord.DMChannel) else channel
+            if (user_setting := await self._config.user(user).embeds()) is not None:
+                return user_setting
 
         # XXX: maybe this should be checked before guild setting?
         if (global_command_setting := await get_command_setting(0)) is not None:

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1208,7 +1208,7 @@ class Red(
         channel: discord.abc.Messageable,
         *,
         command: Optional[commands.Command] = None,
-        check_permissions: bool = False,
+        check_permissions: bool = True,
     ) -> bool:
         """
         Determine if an embed is requested for a response.

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -231,17 +231,20 @@ class Context(DPYContext):
 
     async def embed_requested(self):
         """
-        Simple helper to call bot.embed_requested
-        with logic around if embed permissions are available
+        Short-hand for calling bot.embed_requested with permission checks.
+
+        Equivalent to:
+
+        .. code:: python
+
+            await ctx.bot.embed_requested(ctx, check_permissions=True)
 
         Returns
         -------
         bool:
             :code:`True` if an embed is requested
         """
-        return await self.bot.embed_requested(
-            self.channel, self.author, command=self.command, check_permissions=True
-        )
+        return await self.bot.embed_requested(self, check_permissions=True)
 
     async def maybe_send_embed(self, message: str) -> discord.Message:
         """

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -237,14 +237,14 @@ class Context(DPYContext):
 
         .. code:: python
 
-            await ctx.bot.embed_requested(ctx, check_permissions=True)
+            await ctx.bot.embed_requested(ctx)
 
         Returns
         -------
         bool:
             :code:`True` if an embed is requested
         """
-        return await self.bot.embed_requested(self, check_permissions=True)
+        return await self.bot.embed_requested(self)
 
     async def maybe_send_embed(self, message: str) -> discord.Message:
         """

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -717,9 +717,7 @@ class RedHelpFormatter(HelpFormatterABC):
                 yield obj
 
     async def embed_requested(self, ctx: Context) -> bool:
-        return await ctx.bot.embed_requested(
-            channel=ctx.channel, command=red_help, check_permissions=True
-        )
+        return await ctx.bot.embed_requested(channel=ctx.channel, command=red_help)
 
     async def command_not_found(self, ctx, help_for, help_settings: HelpSettings):
         """

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -718,7 +718,7 @@ class RedHelpFormatter(HelpFormatterABC):
 
     async def embed_requested(self, ctx: Context) -> bool:
         return await ctx.bot.embed_requested(
-            channel=ctx.channel, user=ctx.author, command=red_help, check_permissions=True
+            channel=ctx.channel, command=red_help, check_permissions=True
         )
 
     async def command_not_found(self, ctx, help_for, help_settings: HelpSettings):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3975,31 +3975,14 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         successful = False
 
         for destination in destinations:
-
             is_dm = isinstance(destination, discord.User)
-            send_embed = None
+            if not is_dm and not destination.permissions_for(destination.guild.me).send_messages:
+                continue
 
-            if is_dm:
-                send_embed = await ctx.bot._config.user(destination).embeds()
-            else:
-                if not destination.permissions_for(destination.guild.me).send_messages:
-                    continue
-                if destination.permissions_for(destination.guild.me).embed_links:
-                    send_embed = await ctx.bot._config.channel(destination).embeds()
-                    if send_embed is None:
-                        send_embed = await ctx.bot._config.guild(destination.guild).embeds()
-                else:
-                    send_embed = False
-
-            if send_embed is None:
-                send_embed = await ctx.bot._config.embeds()
-
-            if send_embed:
-
-                if not is_dm:
-                    color = await ctx.bot.get_embed_color(destination)
-                else:
-                    color = ctx.bot._color
+            if await ctx.bot.embed_requested(
+                destination, command=ctx.command, check_permissions=True
+            ):
+                color = await ctx.bot.get_embed_color(destination)
 
                 e = discord.Embed(colour=color, description=message)
                 if author.avatar_url:

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3979,9 +3979,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             if not is_dm and not destination.permissions_for(destination.guild.me).send_messages:
                 continue
 
-            if await ctx.bot.embed_requested(
-                destination, command=ctx.command, check_permissions=True
-            ):
+            if await ctx.bot.embed_requested(destination, command=ctx.command):
                 color = await ctx.bot.get_embed_color(destination)
 
                 e = discord.Embed(colour=color, description=message)

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -368,7 +368,7 @@ class Case:
         if not self.message:
             return
         try:
-            use_embed = await self.bot.embed_requested(self.message.channel, self.guild.me)
+            use_embed = await self.bot.embed_requested(self.message.channel)
             case_content = await self.message_content(use_embed)
             if use_embed:
                 await self.message.edit(embed=case_content)
@@ -986,7 +986,7 @@ async def create_case(
     bot.dispatch("modlog_case_create", case)
     try:
         mod_channel = await get_modlog_channel(case.guild)
-        use_embeds = await case.bot.embed_requested(mod_channel, case.guild.me)
+        use_embeds = await case.bot.embed_requested(mod_channel)
         case_content = await case.message_content(use_embeds)
         if use_embeds:
             msg = await mod_channel.send(embed=case_content)


### PR DESCRIPTION
### Description of the changes
`await User.create_dm()`, no more :)

This PR makes the following changes to the signature of `Red.embed_requested()`:
- `channel` parameter now accepts all kinds of `Messageable` objects
    - for `Context`, `Context.channel` is used and `command` is auto-filled with `Context.command`
    - for `GroupChannel`, only global settings are checked (bots can't send to group channels but it's part of the `Messageable` contract)
- `user` parameter has been removed
    - I know that if we instead just ignored the `user` param, we could avoid breakage but 3.5 seems like the right time to do this + there's a chance this results in more people using `command` so seems like a win to me :)
- `command` parameter has been made keyword-only
    - this makes it so that `bot.embed_requested(channel, user)` usage correctly starts raising errors
    - and it's a better choice for this parameter anyway

We *could* also do another breakage and have `check_permissions` default to True as it seems like a more sane default though I have not done this change for now. Opinions here would be very much welcome.