### PR TITLE
Avoid potential memory leak in Filter cog

### DIFF
--- a/redbot/cogs/filter/filter.py
+++ b/redbot/cogs/filter/filter.py
@@ -348,10 +348,10 @@ class Filter(commands.Cog):
 
     def invalidate_cache(self, guild: discord.Guild, channel: discord.TextChannel = None):
         """ Invalidate a cached pattern"""
-        self.pattern_cache.pop((guild, channel), None)
+        self.pattern_cache.pop((guild.id, channel.id), None)
         if channel is None:
             for keyset in list(self.pattern_cache.keys()):  # cast needed, no remove
-                if guild in keyset:
+                if guild.id == keyset[0]:
                     self.pattern_cache.pop(keyset, None)
 
     async def add_to_filter(
@@ -408,7 +408,7 @@ class Filter(commands.Cog):
         hits: Set[str] = set()
 
         try:
-            pattern = self.pattern_cache[(guild, channel)]
+            pattern = self.pattern_cache[(guild.id, channel.id)]
         except KeyError:
             word_list = set(await self.config.guild(guild).filter())
             if channel:
@@ -421,7 +421,7 @@ class Filter(commands.Cog):
             else:
                 pattern = None
 
-            self.pattern_cache[(guild, channel)] = pattern
+            self.pattern_cache[(guild.id, channel.id)] = pattern
 
         if pattern:
             hits |= set(pattern.findall(text))

--- a/redbot/cogs/filter/filter.py
+++ b/redbot/cogs/filter/filter.py
@@ -2,7 +2,7 @@ import asyncio
 import discord
 import re
 from datetime import timezone
-from typing import Union, Set, Literal
+from typing import Union, Set, Literal, Optional
 
 from redbot.core import checks, Config, modlog, commands
 from redbot.core.bot import Red
@@ -346,9 +346,11 @@ class Filter(commands.Cog):
         else:
             await ctx.send(_("Names and nicknames will now be filtered."))
 
-    def invalidate_cache(self, guild: discord.Guild, channel: discord.TextChannel = None):
+    def invalidate_cache(
+        self, guild: discord.Guild, channel: Optional[discord.TextChannel] = None
+    ) -> None:
         """ Invalidate a cached pattern"""
-        self.pattern_cache.pop((guild.id, channel.id), None)
+        self.pattern_cache.pop((guild.id, channel and channel.id), None)
         if channel is None:
             for keyset in list(self.pattern_cache.keys()):  # cast needed, no remove
                 if guild.id == keyset[0]:
@@ -408,7 +410,7 @@ class Filter(commands.Cog):
         hits: Set[str] = set()
 
         try:
-            pattern = self.pattern_cache[(guild.id, channel.id)]
+            pattern = self.pattern_cache[(guild.id, channel and channel.id)]
         except KeyError:
             word_list = set(await self.config.guild(guild).filter())
             if channel:
@@ -421,7 +423,7 @@ class Filter(commands.Cog):
             else:
                 pattern = None
 
-            self.pattern_cache[(guild.id, channel.id)] = pattern
+            self.pattern_cache[(guild.id, channel and channel.id)] = pattern
 
         if pattern:
             hits |= set(pattern.findall(text))


### PR DESCRIPTION
### Description of the changes
Replaces a `(guild, channel)` key with `(guild.id, channel.id)` to ensure that the cog doesn't prevent the garbage collector from removing stale Guild and TextChannel objects.