### PR TITLE
Fix formatting breaking with nested formatting utils in help

### DIFF
--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -578,7 +578,7 @@ class RedHelpFormatter(HelpFormatterABC):
                 )
                 for i, page in enumerate(pagify(command_text, page_length=500, shorten_by=0)):
                     if i == 0:
-                        title = f"{underline(bold(_('Commands:')), escape_formatting=False)}"
+                        title = underline(bold(_("Commands:")), escape_formatting=False)
                     else:
                         title = f"{underline(bold(_('Commands: (continued)')), escape_formatting=False)}"
                     field = EmbedField(title, page, False)
@@ -632,7 +632,7 @@ class RedHelpFormatter(HelpFormatterABC):
                 if cog_name:
                     title = f"{underline(bold(cog_name), escape_formatting=False)}:"
                 else:
-                    title = f"{underline(bold(_('No Category:')), escape_formatting=False)}"
+                    title = underline(bold(_("No Category:")), escape_formatting=False)
 
                 def shorten_line(a_line: str) -> str:
                     if len(a_line) < 70:  # embed max width needs to be lower

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -401,9 +401,11 @@ class RedHelpFormatter(HelpFormatterABC):
                 )
                 for i, page in enumerate(pagify(subtext, page_length=500, shorten_by=0)):
                     if i == 0:
-                        title = bold(underline(_("Subcommands:")))
+                        title = bold(underline(_("Subcommands:")), escape_formatting=False)
                     else:
-                        title = bold(underline(_("Subcommands: (continued)")))
+                        title = bold(
+                            underline(_("Subcommands: (continued)")), escape_formatting=False
+                        )
                     field = EmbedField(title, page, False)
                     emb["fields"].append(field)
 
@@ -576,9 +578,9 @@ class RedHelpFormatter(HelpFormatterABC):
                 )
                 for i, page in enumerate(pagify(command_text, page_length=500, shorten_by=0)):
                     if i == 0:
-                        title = f"{underline(bold(_('Commands:')))}"
+                        title = f"{underline(bold(_('Commands:')), escape_formatting=False)}"
                     else:
-                        title = f"{underline(bold(_('Commands: (continued)')))}"
+                        title = f"{underline(bold(_('Commands: (continued)')), escape_formatting=False)}"
                     field = EmbedField(title, page, False)
                     emb["fields"].append(field)
 
@@ -628,9 +630,9 @@ class RedHelpFormatter(HelpFormatterABC):
             for cog_name, data in coms:
 
                 if cog_name:
-                    title = f"{underline(bold(cog_name))}:"
+                    title = f"{underline(bold(cog_name), escape_formatting=False)}:"
                 else:
-                    title = f"{underline(bold(_('No Category:')))}"
+                    title = f"{underline(bold(_('No Category:')), escape_formatting=False)}"
 
                 def shorten_line(a_line: str) -> str:
                     if len(a_line) < 70:  # embed max width needs to be lower

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -632,7 +632,7 @@ class RedHelpFormatter(HelpFormatterABC):
             for cog_name, data in coms:
 
                 if cog_name:
-                    title = f"{underline(bold(cog_name), escape_formatting=False)}:"
+                    title = underline(bold(f"{cog_name}:"), escape_formatting=False)
                 else:
                     title = underline(bold(_("No Category:")), escape_formatting=False)
 

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -403,8 +403,8 @@ class RedHelpFormatter(HelpFormatterABC):
                     if i == 0:
                         title = bold(underline(_("Subcommands:")), escape_formatting=False)
                     else:
-                        title = bold(
-                            underline(_("Subcommands: (continued)")), escape_formatting=False
+                        title = bold(underline(_("Subcommands:")), escape_formatting=False) + _(
+                            " (continued)"
                         )
                     field = EmbedField(title, page, False)
                     emb["fields"].append(field)
@@ -580,7 +580,9 @@ class RedHelpFormatter(HelpFormatterABC):
                     if i == 0:
                         title = underline(bold(_("Commands:")), escape_formatting=False)
                     else:
-                        title = f"{underline(bold(_('Commands: (continued)')), escape_formatting=False)}"
+                        title = underline(bold(_("Commands:")), escape_formatting=False) + _(
+                            " (continued)"
+                        )
                     field = EmbedField(title, page, False)
                     emb["fields"].append(field)
 


### PR DESCRIPTION
### Description of the changes

This PR is a simple fix to the broken formatting in the help command because of the nested formatters.

Fixes #5581

Before:
![image](https://user-images.githubusercontent.com/79806064/156928479-8dc1f503-2811-445b-803f-a6bffc4fb1f1.png)

After:
![image](https://user-images.githubusercontent.com/79806064/156928589-d643463e-883d-4cc9-a0fb-adff1ba96215.png)

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
