### PR TITLE
Make decorator combining in Requires more consistent

### DIFF
--- a/redbot/core/commands/requires.py
+++ b/redbot/core/commands/requires.py
@@ -705,7 +705,10 @@ def bot_has_permissions(**perms: bool):
 
     def decorator(func: "_CommandOrCoro") -> "_CommandOrCoro":
         if asyncio.iscoroutinefunction(func):
-            func.__requires_bot_perms__ = perms
+            if not hasattr(func, "__requires_bot_perms__"):
+                func.__requires_bot_perms__ = discord.Permissions.none()
+            _validate_perms_dict(perms)
+            func.__requires_bot_perms__.update(**perms)
         else:
             _validate_perms_dict(perms)
             func.requires.bot_perms.update(**perms)

--- a/redbot/core/commands/requires.py
+++ b/redbot/core/commands/requires.py
@@ -361,14 +361,20 @@ class Requires:
         def decorator(func: "_CommandOrCoro") -> "_CommandOrCoro":
             if inspect.iscoroutinefunction(func):
                 func.__requires_privilege_level__ = privilege_level
-                func.__requires_user_perms__ = user_perms
+                if user_perms is None:
+                    func.__requires_user_perms__ = None
+                else:
+                    if getattr(func, "__requires_user_perms__", None) is None:
+                        func.__requires_user_perms__ = discord.Permissions.none()
+                    func.__requires_user_perms__.update(**user_perms)
             else:
                 func.requires.privilege_level = privilege_level
                 if user_perms is None:
                     func.requires.user_perms = None
                 else:
                     _validate_perms_dict(user_perms)
-                    assert func.requires.user_perms is not None
+                    if func.requires.user_perms is None:
+                        func.requires.user_perms = discord.Permissions.none()
                     func.requires.user_perms.update(**user_perms)
             return func
 


### PR DESCRIPTION
### Description of the changes

This changes the behavior of decorators in `redbot.core.commands.requires` to be more consistent.
Specifically, this code:
```py
@commands.bot_has_permissions(embed_links=True)
@commands.bot_has_permissions(send_messages=True)
@commands.command()
async def somecom(ctx):
    ...


@commands.command()
@commands.bot_has_permissions(embed_links=True)
@commands.bot_has_permissions(send_messages=True)
async def anothercom(ctx):
    ...


print(somecom.requires.bot_perms)
print(anothercom.requires.bot_perms)
```
will now give the same result for both prints which it did not before.

### Have the changes in this PR been tested?

No