### PR TITLE
Switch from low-level loop.create_task and asyncio.ensure_future

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -493,7 +493,7 @@ def red_exception_handler(red, red_task: asyncio.Future):
     except Exception as exc:
         log.critical("The main bot task didn't handle an exception and has crashed", exc_info=exc)
         log.warning("Attempting to die as gracefully as possible...")
-        red.loop.create_task(shutdown_handler(red))
+        asyncio.create_task(shutdown_handler(red))
 
 
 def main():

--- a/redbot/cogs/admin/announcer.py
+++ b/redbot/cogs/admin/announcer.py
@@ -30,7 +30,7 @@ class Announcer:
         """
         if self.active is None:
             self.active = True
-            self.ctx.bot.loop.create_task(self.announcer())
+            asyncio.create_task(self.announcer())
 
     def cancel(self):
         """

--- a/redbot/cogs/audio/core/events/dpy.py
+++ b/redbot/cogs/audio/core/events/dpy.py
@@ -230,9 +230,7 @@ class DpyEvents(MixinMeta, metaclass=CompositeMetaClass):
         if not self.cog_cleaned_up:
             self.bot.dispatch("red_audio_unload", self)
             self.session.detach()
-            asyncio.create_task(self._close_database()).add_done_callback(
-                task_callback_trace
-            )
+            asyncio.create_task(self._close_database()).add_done_callback(task_callback_trace)
             if self.player_automated_timer_task:
                 self.player_automated_timer_task.cancel()
 
@@ -247,9 +245,7 @@ class DpyEvents(MixinMeta, metaclass=CompositeMetaClass):
 
             lavalink.unregister_event_listener(self.lavalink_event_handler)
             lavalink.unregister_update_listener(self.lavalink_update_handler)
-            asyncio.create_task(lavalink.close(self.bot)).add_done_callback(
-                task_callback_trace
-            )
+            asyncio.create_task(lavalink.close(self.bot)).add_done_callback(task_callback_trace)
             if self.player_manager is not None:
                 asyncio.create_task(self.player_manager.shutdown()).add_done_callback(
                     task_callback_trace

--- a/redbot/cogs/audio/core/events/dpy.py
+++ b/redbot/cogs/audio/core/events/dpy.py
@@ -230,7 +230,7 @@ class DpyEvents(MixinMeta, metaclass=CompositeMetaClass):
         if not self.cog_cleaned_up:
             self.bot.dispatch("red_audio_unload", self)
             self.session.detach()
-            self.bot.loop.create_task(self._close_database()).add_done_callback(
+            asyncio.create_task(self._close_database()).add_done_callback(
                 task_callback_trace
             )
             if self.player_automated_timer_task:
@@ -247,11 +247,11 @@ class DpyEvents(MixinMeta, metaclass=CompositeMetaClass):
 
             lavalink.unregister_event_listener(self.lavalink_event_handler)
             lavalink.unregister_update_listener(self.lavalink_update_handler)
-            self.bot.loop.create_task(lavalink.close(self.bot)).add_done_callback(
+            asyncio.create_task(lavalink.close(self.bot)).add_done_callback(
                 task_callback_trace
             )
             if self.player_manager is not None:
-                self.bot.loop.create_task(self.player_manager.shutdown()).add_done_callback(
+                asyncio.create_task(self.player_manager.shutdown()).add_done_callback(
                     task_callback_trace
                 )
 

--- a/redbot/cogs/audio/core/tasks/lavalink.py
+++ b/redbot/cogs/audio/core/tasks/lavalink.py
@@ -28,7 +28,7 @@ class LavalinkTasks(MixinMeta, metaclass=CompositeMetaClass):
         self._restore_task = None
         lavalink.register_event_listener(self.lavalink_event_handler)
         lavalink.register_update_listener(self.lavalink_update_handler)
-        self.lavalink_connect_task = self.bot.loop.create_task(self.lavalink_attempt_connect())
+        self.lavalink_connect_task = asyncio.create_task(self.lavalink_attempt_connect())
         self.lavalink_connect_task.add_done_callback(task_callback_debug)
 
     async def lavalink_attempt_connect(self, timeout: int = 50) -> None:

--- a/redbot/cogs/audio/core/tasks/startup.py
+++ b/redbot/cogs/audio/core/tasks/startup.py
@@ -29,7 +29,7 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
         # If it waits for ready in startup, we cause a deadlock during initial load
         # as initial load happens before the bot can ever be ready.
         lavalink.set_logging_level(self.bot._cli_flags.logging_level)
-        self.cog_init_task = self.bot.loop.create_task(self.initialize())
+        self.cog_init_task = asyncio.create_task(self.initialize())
         self.cog_init_task.add_done_callback(task_callback_debug)
 
     async def initialize(self) -> None:
@@ -53,7 +53,7 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
             await self.api_interface.persistent_queue_api.delete_scheduled()
             await self._build_bundled_playlist()
             self.lavalink_restart_connect()
-            self.player_automated_timer_task = self.bot.loop.create_task(
+            self.player_automated_timer_task = asyncio.create_task(
                 self.player_automated_timer()
             )
             self.player_automated_timer_task.add_done_callback(task_callback_debug)

--- a/redbot/cogs/audio/core/tasks/startup.py
+++ b/redbot/cogs/audio/core/tasks/startup.py
@@ -53,9 +53,7 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
             await self.api_interface.persistent_queue_api.delete_scheduled()
             await self._build_bundled_playlist()
             self.lavalink_restart_connect()
-            self.player_automated_timer_task = asyncio.create_task(
-                self.player_automated_timer()
-            )
+            self.player_automated_timer_task = asyncio.create_task(self.player_automated_timer())
             self.player_automated_timer_task.add_done_callback(task_callback_debug)
         except Exception as exc:
             log.critical("Audio failed to start up, please report this issue.", exc_info=exc)

--- a/redbot/cogs/audio/core/utilities/miscellaneous.py
+++ b/redbot/cogs/audio/core/utilities/miscellaneous.py
@@ -35,7 +35,7 @@ class MiscellaneousUtilities(MixinMeta, metaclass=CompositeMetaClass):
         self, message: discord.Message, emoji: MutableMapping = None
     ) -> asyncio.Task:
         """Non blocking version of clear_react."""
-        task = self.bot.loop.create_task(self.clear_react(message, emoji))
+        task = asyncio.create_task(self.clear_react(message, emoji))
         task.add_done_callback(task_callback_trace)
         return task
 

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -154,9 +154,7 @@ class Mod(
                             "Ignored guilds and channels have been moved. "
                             "Please use {command} to migrate the old settings."
                         ).format(command=inline("[p]moveignoredchannels"))
-                        asyncio.create_task(
-                            send_to_owners_with_prefix_replaced(self.bot, msg)
-                        )
+                        asyncio.create_task(send_to_owners_with_prefix_replaced(self.bot, msg))
                         break
             await self.config.version.set("1.1.0")
         if await self.config.version() < "1.2.0":

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -144,7 +144,7 @@ class Mod(
                         "Ignored guilds and channels have been moved. "
                         "Please use {command} to migrate the old settings."
                     ).format(command=inline("[p]moveignoredchannels"))
-                    self.bot.loop.create_task(send_to_owners_with_prefix_replaced(self.bot, msg))
+                    asyncio.create_task(send_to_owners_with_prefix_replaced(self.bot, msg))
                     message_sent = True
                     break
             if message_sent is False:
@@ -154,7 +154,7 @@ class Mod(
                             "Ignored guilds and channels have been moved. "
                             "Please use {command} to migrate the old settings."
                         ).format(command=inline("[p]moveignoredchannels"))
-                        self.bot.loop.create_task(
+                        asyncio.create_task(
                             send_to_owners_with_prefix_replaced(self.bot, msg)
                         )
                         break
@@ -166,7 +166,7 @@ class Mod(
                         "Delete delay settings have been moved. "
                         "Please use {command} to migrate the old settings."
                     ).format(command=inline("[p]movedeletedelay"))
-                    self.bot.loop.create_task(send_to_owners_with_prefix_replaced(self.bot, msg))
+                    asyncio.create_task(send_to_owners_with_prefix_replaced(self.bot, msg))
                     break
             await self.config.version.set("1.2.0")
         if await self.config.version() < "1.3.0":

--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -108,7 +108,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
         # to wait for a guild to finish channel unmutes before
         # checking for manual overwrites
 
-        self._init_task = self.bot.loop.create_task(self._initialize())
+        self._init_task = asyncio.create_task(self._initialize())
 
     async def red_delete_data_for_user(
         self,

--- a/redbot/cogs/permissions/permissions.py
+++ b/redbot/cogs/permissions/permissions.py
@@ -819,7 +819,7 @@ class Permissions(commands.Cog):
                     cog_or_command.deny_to(model_id, guild_id=guild_id)
 
     def cog_unload(self) -> None:
-        self.bot.loop.create_task(self._unload_all_rules())
+        asyncio.create_task(self._unload_all_rules())
 
     async def _unload_all_rules(self) -> None:
         """Unload all rules set by this cog.

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -80,7 +80,7 @@ class Streams(commands.Cog):
         self.yt_cid_pattern = re.compile("^UC[-_A-Za-z0-9]{21}[AQgw]$")
 
         self._ready_event: asyncio.Event = asyncio.Event()
-        self._init_task: asyncio.Task = self.bot.loop.create_task(self.initialize())
+        self._init_task: asyncio.Task = asyncio.create_task(self.initialize())
 
     async def red_delete_data_for_user(self, **kwargs):
         """ Nothing to delete """
@@ -100,7 +100,7 @@ class Streams(commands.Cog):
             await self.move_api_keys()
             await self.get_twitch_bearer_token()
             self.streams = await self.load_streams()
-            self.task = self.bot.loop.create_task(self._stream_alerts())
+            self.task = asyncio.create_task(self._stream_alerts())
         except Exception as error:
             log.exception("Failed to initialize Streams cog:", exc_info=error)
 

--- a/redbot/cogs/trivia/session.py
+++ b/redbot/cogs/trivia/session.py
@@ -103,8 +103,7 @@ class TriviaSession:
 
         """
         session = cls(ctx, question_list, settings)
-        loop = ctx.bot.loop
-        session._task = loop.create_task(session.run())
+        session._task = asyncio.create_task(session.run())
         session._task.add_done_callback(session._error_handler)
         return session
 

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -47,7 +47,7 @@ class Warnings(commands.Cog):
         self.config.register_guild(**self.default_guild)
         self.config.register_member(**self.default_member)
         self.bot = bot
-        self.registration_task = self.bot.loop.create_task(self.register_warningtype())
+        self.registration_task = asyncio.create_task(self.register_warningtype())
 
     async def red_delete_data_for_user(
         self,

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1082,7 +1082,7 @@ class Red(
             if any(LIB_PATH.iterdir()):
                 shutil.rmtree(str(LIB_PATH))
                 LIB_PATH.mkdir()
-                self.loop.create_task(
+                asyncio.create_task(
                     send_to_owners_with_prefix_replaced(
                         self,
                         "We detected a change in minor Python version"
@@ -1117,7 +1117,7 @@ class Red(
             system_changed = True
 
         if system_changed and not python_version_changed:
-            self.loop.create_task(
+            asyncio.create_task(
                 send_to_owners_with_prefix_replaced(
                     self,
                     "We detected a possible change in machine's operating system"

--- a/redbot/core/utils/menus.py
+++ b/redbot/core/utils/menus.py
@@ -90,8 +90,8 @@ async def menu(
     try:
         predicates = ReactionPredicate.with_emojis(tuple(controls.keys()), message, ctx.author)
         tasks = [
-            asyncio.ensure_future(ctx.bot.wait_for("reaction_add", check=predicates)),
-            asyncio.ensure_future(ctx.bot.wait_for("reaction_remove", check=predicates)),
+            asyncio.create_task(ctx.bot.wait_for("reaction_add", check=predicates)),
+            asyncio.create_task(ctx.bot.wait_for("reaction_remove", check=predicates)),
         ]
         done, pending = await asyncio.wait(
             tasks, timeout=timeout, return_when=asyncio.FIRST_COMPLETED


### PR DESCRIPTION
### Description of the changes

Replaces usage of `loop.create_task()` and `asyncio.ensure_future()` with `asyncio.create_task()`
There's only a single occurrence of `loop.create_task()` left in a place where it actually is needed.

### Have the changes in this PR been tested?

Yes