### PR TITLE
Update Track stuck error message and detect when a track is stuck so that it can be skipped.

### DIFF
--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -311,7 +311,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                             colour=await self.bot.get_embed_color(message_channel),
                             title=_("Track Stuck"),
                             description=_(
-                                "Playback of the song has stopped due to an unexpected error.\n{error}"
+                                "Playback of the song was unable to continue.\n{error}"
                             ).format(error=description),
                         )
                     else:

--- a/redbot/cogs/audio/core/tasks/lavalink.py
+++ b/redbot/cogs/audio/core/tasks/lavalink.py
@@ -45,6 +45,7 @@ class LavalinkTasks(MixinMeta, metaclass=CompositeMetaClass):
                 await self.managed_node_controller.shutdown()
                 await asyncio.sleep(5)
         await lavalink.close(self.bot)
+        is_managed = False
         while retry_count < max_retries:
             configs = await self.config.all()
             external = configs["use_external_lavalink"]
@@ -62,6 +63,7 @@ class LavalinkTasks(MixinMeta, metaclass=CompositeMetaClass):
                     # timeout is the same as ServerManager.timeout -
                     # 60s in case of ServerManager(self.config, timeout=60)
                     await self.managed_node_controller.wait_until_ready()
+                    is_managed = True
                 except asyncio.TimeoutError:
                     if self.managed_node_controller is not None:
                         await self.managed_node_controller.shutdown()
@@ -110,6 +112,7 @@ class LavalinkTasks(MixinMeta, metaclass=CompositeMetaClass):
                     timeout=timeout,
                     resume_key=f"Red-Core-Audio-{self.bot.user.id}-{data_manager.instance_name}",
                     secured=secured,
+                    is_managed=is_managed,
                 )
             except lavalink.AbortingNodeConnection:
                 await lavalink.close(self.bot)

--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -458,8 +458,11 @@ class ServerManager:
                     if not psutil.pid_exists(self._node_pid):
                         raise NoProcessFound
                     try:
-                        node = lavalink.get_all_nodes()[0]
-                        if node.ready:
+                        lavalink.get_all_nodes()[0]
+                        node = next(
+                            (node for node in lavalink.get_all_nodes() if node.is_managed), None
+                        )
+                        if node and node.ready:
                             # Hoping this throws an exception which will then trigger a restart
                             await node._ws.ping()
                             backoff = ExponentialBackoff(

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ install_requires =
     pytz==2021.1
     PyYAML==5.4.1
     Red-Commons==1.0.0
-    Red-Lavalink==0.11.0rc0
+    Red-Lavalink @ git+https://github.com/Cog-Creators/Red-Lavalink@refs/pull/118/merge#egg=Red-Lavalink
     rich==10.9.0
     schema==0.7.4
     six==1.16.0


### PR DESCRIPTION
### Description of the changes

Updated Track stuck message - Changed from 
`Playback of the song has stopped due to an unexpected error.\n{error}`
to 
`Playback of the song was unable to continue.\n{error}`


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->



### Test cases
- Start playback and pause for 30s.
- Start playback then Disconnect player and wait 30s
- Start playback and run the stop command and wait for 30s
- Leave it on autoplay for 24/7 and monitor the bot messages for Track stuck messages


Needs the following 2 prs to be merged so this one can be installed:
https://github.com/Cog-Creators/Red-DiscordBot/pull/5631
https://github.com/Cog-Creators/Red-DiscordBot/pull/5629

Alternatively use https://github.com/Cog-Creators/Red-DiscordBot/pull/5640