### PR TITLE
Various updates to geography trivia

### DIFF
--- a/redbot/cogs/trivia/data/lists/geography.yaml
+++ b/redbot/cogs/trivia/data/lists/geography.yaml
@@ -1,4 +1,4 @@
-AUTHOR: Kreusada#0518
+AUTHOR: Kreusada
 What is Earth's largest continent?:
 - Asia
 What country accounts for more than half of the western coastline of South America?:

--- a/redbot/cogs/trivia/data/lists/geography.yaml
+++ b/redbot/cogs/trivia/data/lists/geography.yaml
@@ -79,7 +79,9 @@ What ocean is home to 75% of the Earth's volcanoes?:
 - Pacific 
 - Pacific Ocean
 What is the largest city in the world based on surface area?:
-- Sermersooq
+- New York
+- New York City
+- NYC
 What is the only major city located on two continents?:
 - Istanbul
 What is the coldest sea on Earth?:
@@ -127,8 +129,6 @@ What is the smallest country in South America?:
 - Suriname
 What is the capital of Nigeria?:
 - Abuja
-Which country is NOT part of the Scaninavian Peninsula?:
-- Denmark
 What is the capital of Turkey?:
 - Ankara
 Lake Titicaca sits on the border between what two nations?:
@@ -151,13 +151,12 @@ What country borders the Caspian Sea, Persian Gulf, and Gulf of Oman?:
 Which U.S. state has the most miles of rivers?:
 - Alaska
 What is the capital of Costa Rica?:
+- San José
 - San Jose
 What is the earliest known walled city?:
 - Jericho
 What is the oldest city in India?:
 - Varanasi
-Which U.S. state has the largest aquifer?:
-- Nebraska
 What is the primary mountain range in Iran?:
 - Zagros 
 - Zagros Mountains
@@ -199,7 +198,8 @@ What is the largest UK city without a professional football team?:
 Which European city had the most tourists in 2019?:
 - London
 With the highest cost of living, which city is currently the most expensive in the world?:
-- Singapore
+- Tel Aviv
+- Tel-Aviv
 What is the only city in the United Kingdom to begin with the letter R?:
 - Ripon
 What is the biggest city in Africa by population?:
@@ -209,4 +209,4 @@ In which city would you find Leonardo Da Vinci's Mona Lisa?:
 What is the world's northernmost capital city?:
 - Reykjavik
 How many underground tube stations are there in London?:
-- 270
+- 272


### PR DESCRIPTION
### Description of the changes

Since it has been almost 2 years since this trivia was first created, I thought to look back through the questions and correct any answers that had been outdated. Some questions have also been removed due to "unpinpointable" answers or invalidity. 

- Tel-Aviv is now the most expensive city to live in, in the world. Previously, it was Singapore.
- New York City is the largest city in the world by surface area, not Sermersooq.
- There are now 272 underground tube stations in London, since the additions of both "Battersea Power Station" and "Nine Elms" stations to the Northern Line on the 20th of September, 2021.

### Have the changes in this PR been tested?

Yes
