### PR TITLE
add port conflict resolution

### DIFF
--- a/redbot/cogs/audio/core/__init__.py
+++ b/redbot/cogs/audio/core/__init__.py
@@ -65,6 +65,7 @@ class Audio(
         self.skip_votes = {}
         self.play_lock = {}
         self.antispam: Dict[int, Dict[str, AntiSpam]] = defaultdict(lambda: defaultdict(AntiSpam))
+        self._runtime_external_node = False
 
         self.lavalink_connect_task = None
         self._restore_task = None

--- a/redbot/cogs/audio/core/abc.py
+++ b/redbot/cogs/audio/core/abc.py
@@ -66,6 +66,8 @@ class MixinMeta(ABC):
     _disconnected_players: MutableMapping[int, bool]
     global_api_user: MutableMapping[str, Any]
 
+    _runtime_external_node: bool
+
     cog_cleaned_up: bool
     lavalink_connection_aborted: bool
 

--- a/redbot/cogs/audio/core/commands/audioset.py
+++ b/redbot/cogs/audio/core/commands/audioset.py
@@ -1113,6 +1113,8 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
             lavalink_version=lavalink.__version__,
             use_external_lavalink=_("Enabled")
             if global_data["use_external_lavalink"]
+            else _("Enabled (Temporary)")
+            if self._runtime_external_node
             else _("Disabled"),
         )
         if (

--- a/redbot/cogs/audio/errors.py
+++ b/redbot/cogs/audio/errors.py
@@ -31,6 +31,10 @@ class ManagedLavalinkStartFailure(ManagedLavalinkNodeException):
     """Exception thrown when a managed Lavalink node fails to start"""
 
 
+class PortAlreadyInUse(ManagedLavalinkStartFailure):
+    """Exception thrown when a managed Lavalink node fails to start due to a port conflict"""
+
+
 class ManagedLavalinkPreviouslyShutdownException(ManagedLavalinkNodeException):
     """Exception thrown when a managed Lavalink node already has been shutdown"""
 


### PR DESCRIPTION
### Description of the changes
Reimplement port handling, audio will automatically connect to any available node in the host machine upon a port conflict.

#### To test
Scenario 1
- Start a Bot or Lavalink node with default settings
- Start a second/first bot with managed node - observe the port conflict and audio will connect to the first node

Scenario 2
- Start an external node with a different password (edit application.yaml) but using the default port
  - Alternatively, Start a bot, change the password with `[p]llset config token`, keep port 2333
- Start a bot with managed node - Audio should connect to the first node even though the password isn't the default.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->

Closes #2843