### PR TITLE
Fix an incorrect comparison in audio

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -250,7 +250,7 @@ class ServerManager:
         invalid = None
         if match and (
             (int(match.group(1)) * 1024 ** (2 if match.group(2).lower() == "m" else 3))
-            < (meta := get_max_allocation_size(self._java_exc))[0]
+            <= (meta := get_max_allocation_size(self._java_exc))[0]
         ):
             command_args.append(f"-Xmx{java_xmx}")
         elif meta[0] is not None:


### PR DESCRIPTION
Signed-off-by: Draper <27962761+Drapersniper@users.noreply.github.com>

### Description of the changes

Fix an issue with `Managed Lavalink node RAM allocation ignored due to system limitations, please fix this by setting the correct value with 'ff-llset heapsize'.` being logged unintentionally.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
