### PR TITLE
Ignore d.py's |coro| substitution in Sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -251,3 +251,21 @@ doctest_test_doctest_blocks = ""
 # Autodoc options
 autodoc_default_options = {"show-inheritance": True}
 autodoc_typehints = "none"
+
+
+from docutils import nodes
+from sphinx.transforms import SphinxTransform
+
+
+# d.py's |coro| substitution leaks into our docs because we don't replace some of the docstrings
+class IgnoreCoroSubstitution(SphinxTransform):
+    default_priority = 210
+
+    def apply(self, **kwargs) -> None:
+        for ref in self.document.traverse(nodes.substitution_reference):
+            if ref["refname"] == "coro":
+                ref.replace_self(nodes.Text("", ""))
+
+
+def setup(app):
+    app.add_transform(IgnoreCoroSubstitution)


### PR DESCRIPTION
### Description of the changes

When we don't define our own docstring for an async method that we override in a subclass of one of d.py's classes, docs build can fail due to lack of `|coro|` substitution in our Sphinx's configuration.

Here's a (fabricated) example where this issue can be seen:
https://github.com/jack1142/Red-DiscordBot/commit/72464622f59427a00e82366d29e6b1e093e8c928
https://github.com/jack1142/Red-DiscordBot/runs/5770231801?check_suite_focus=true

### Have the changes in this PR been tested?

Yes