### PR TITLE
Improved player restores - Restore current track and position, paused state, volume and requester.

### DIFF
--- a/redbot/cogs/audio/apis/interface.py
+++ b/redbot/cogs/audio/apis/interface.py
@@ -923,6 +923,8 @@ class AudioAPIInterface:
 
     async def autoplay(self, player: lavalink.Player, playlist_api: PlaylistWrapper):
         """Enqueue a random track."""
+        if not player.connected:
+            return
         autoplaylist = await self.config.guild(player.guild).autoplaylist()
         current_cache_level = CacheLevel(await self.config.cache_level())
         cache_enabled = CacheLevel.set_lavalink().is_subset(current_cache_level)
@@ -1004,7 +1006,9 @@ class AudioAPIInterface:
             if notify_channel_id:
                 await self.config.guild_from_id(
                     guild_id=player.guild.id
-                ).currently_auto_playing_in.set([notify_channel_id, player.channel.id])
+                ).currently_auto_playing_in.set(
+                    [notify_channel_id, player.channel.id, player.paused, player.volume]
+                )
             else:
                 await self.config.guild_from_id(
                     guild_id=player.guild.id

--- a/redbot/cogs/audio/core/__init__.py
+++ b/redbot/cogs/audio/core/__init__.py
@@ -117,6 +117,8 @@ class Audio(
         default_guild = dict(
             auto_play=False,
             currently_auto_playing_in=None,
+            last_known_vc_and_notify_channels=None,
+            last_known_track={},
             auto_deafen=True,
             autoplaylist=dict(
                 enabled=True,

--- a/redbot/cogs/audio/core/abc.py
+++ b/redbot/cogs/audio/core/abc.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from pathlib import Path
 from typing import (
+    Iterable,
     Set,
     TYPE_CHECKING,
     Any,
@@ -548,6 +549,10 @@ class MixinMeta(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    async def save_player_state(self) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
     async def get_lyrics_status(self, ctx: Context) -> bool:
         raise NotImplementedError()
 
@@ -573,4 +578,14 @@ class MixinMeta(ABC):
 
     @abstractmethod
     def can_join_and_speak(self, channel: discord.VoiceChannel) -> bool:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def update_guild_config(
+        self, *values: Dict[int, List[Tuple[str, Union[str, int, float, bool, None, dict, list]]]]
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def clean_up_guild_config(self, *keys: str, guild_ids: Optional[Iterable[int]] = None):
         raise NotImplementedError()

--- a/redbot/cogs/audio/core/commands/audioset.py
+++ b/redbot/cogs/audio/core/commands/audioset.py
@@ -1455,6 +1455,7 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
         """Restarts the lavalink connection."""
         async with ctx.typing():
             try:
+                await self.save_player_state()
                 await lavalink.close(self.bot)
                 self.lavalink_restart_connect(manual=True)
             except ProcessLookupError:

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -73,11 +73,14 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 await self.config.custom("EQUALIZER", ctx.guild.id).eq_bands.set(eq.bands)
             await player.stop()
             await player.disconnect()
-            await self.config.guild_from_id(guild_id=ctx.guild.id).currently_auto_playing_in.set(
-                []
-            )
             self._ll_guild_updates.discard(ctx.guild.id)
             await self.api_interface.persistent_queue_api.drop(ctx.guild.id)
+            await self.clean_up_guild_config(
+                "last_known_vc_and_notify_channels",
+                "last_known_track",
+                "currently_auto_playing_in",
+                guild_ids=[ctx.guild.id],
+            )
 
     @commands.command(name="now")
     @commands.guild_only()
@@ -608,11 +611,14 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
             player.store("requester", None)
             player.store("autoplay_notified", False)
             await player.stop()
-            await self.config.guild_from_id(guild_id=ctx.guild.id).currently_auto_playing_in.set(
-                []
-            )
             await self.send_embed_msg(ctx, title=_("Stopping..."))
             await self.api_interface.persistent_queue_api.drop(ctx.guild.id)
+            await self.clean_up_guild_config(
+                "last_known_vc_and_notify_channels",
+                "last_known_track",
+                "currently_auto_playing_in",
+                guild_ids=[ctx.guild.id],
+            )
 
     @commands.command(name="summon")
     @commands.guild_only()

--- a/redbot/cogs/audio/core/commands/llset.py
+++ b/redbot/cogs/audio/core/commands/llset.py
@@ -178,6 +178,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
                     ),
                 )
             try:
+                await self.save_player_state()
                 await lavalink.close(self.bot)
                 self.lavalink_restart_connect(manual=True)
             except ProcessLookupError:
@@ -718,6 +719,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
                 global_data["use_external_lavalink"] = False
 
             try:
+                await self.save_player_state()
                 await lavalink.close(self.bot)
                 self.lavalink_restart_connect(manual=True)
             except ProcessLookupError:

--- a/redbot/cogs/audio/core/events/dpy.py
+++ b/redbot/cogs/audio/core/events/dpy.py
@@ -430,12 +430,23 @@ class DpyEvents(MixinMeta, metaclass=CompositeMetaClass):
 
             lavalink.unregister_event_listener(self.lavalink_event_handler)
             lavalink.unregister_update_listener(self.lavalink_update_handler)
+            await self.save_player_state()
             await lavalink.close(self.bot)
             await self._close_database()
             if self.managed_node_controller is not None:
                 await self.managed_node_controller.shutdown()
 
             self.cog_cleaned_up = True
+
+    @commands.Cog.listener()
+    async def on_guild_remove(self, guild: discord.Guild) -> None:
+        await self.clean_up_guild_config(
+            "last_known_vc_and_notify_channels",
+            "last_known_track",
+            "currently_auto_playing_in",
+            guild_ids=[guild.id],
+        )
+        await self.api_interface.persistent_queue_api.drop(guild.id)
 
     @commands.Cog.listener()
     async def on_voice_state_update(

--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -42,9 +42,13 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
             await player.stop()
             await player.disconnect()
             if guild:
-                await self.config.guild_from_id(guild_id=guild.id).currently_auto_playing_in.set(
-                    []
+                await self.clean_up_guild_config(
+                    "last_known_vc_and_notify_channels",
+                    "last_known_track",
+                    "currently_auto_playing_in",
+                    guild_ids=[guild.id],
                 )
+                await self.api_interface.persistent_queue_api.drop(guild.id)
             return
         guild_id = self.rgetattr(guild, "id", None)
         if not guild:
@@ -139,7 +143,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
             notify_channel = player.fetch("notify_channel")
             if notify_channel and autoplay:
                 await self.config.guild_from_id(guild_id=guild_id).currently_auto_playing_in.set(
-                    [notify_channel, player.channel.id]
+                    [notify_channel, player.channel.id, player.paused, player.volume]
                 )
             else:
                 await self.config.guild_from_id(guild_id=guild_id).currently_auto_playing_in.set(
@@ -154,13 +158,16 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
             self.bot.dispatch("red_audio_queue_end", guild, prev_song, prev_requester)
             if guild_id:
                 await self.api_interface.persistent_queue_api.drop(guild_id)
-            if player.is_auto_playing or (
-                autoplay
-                and not player.queue
-                and player.fetch("playing_song") is not None
-                and self.playlist_api is not None
-                and self.api_interface is not None
-            ):
+            if (
+                player.is_auto_playing
+                or (
+                    autoplay
+                    and not player.queue
+                    and player.fetch("playing_song") is not None
+                    and self.playlist_api is not None
+                    and self.api_interface is not None
+                )
+            ) and player.connected:
                 notify_channel_id = player.fetch("notify_channel")
                 try:
                     await self.api_interface.autoplay(player, self.playlist_api)
@@ -234,9 +241,13 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                         "Queue ended for %s, Disconnecting bot due to configuration", guild_id
                     )
                     self.bot.dispatch("red_audio_audio_disconnect", guild)
-                    await self.config.guild_from_id(
-                        guild_id=guild_id
-                    ).currently_auto_playing_in.set([])
+                    await self.clean_up_guild_config(
+                        "last_known_vc_and_notify_channels",
+                        "last_known_track",
+                        "currently_auto_playing_in",
+                        guild_ids=[guild.id],
+                    )
+                    await self.api_interface.persistent_queue_api.drop(guild.id)
                     # let audio buffer run out on slower machines (GH-5158)
                     await asyncio.sleep(2)
                     await player.disconnect()
@@ -276,9 +287,13 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     await self.config.custom("EQUALIZER", guild_id).eq_bands.set(eq.bands)
                 await player.stop()
                 await player.disconnect()
-                await self.config.guild_from_id(guild_id=guild_id).currently_auto_playing_in.set(
-                    []
+                await self.clean_up_guild_config(
+                    "last_known_vc_and_notify_channels",
+                    "last_known_track",
+                    "currently_auto_playing_in",
+                    guild_ids=[guild_id],
                 )
+                await self.api_interface.persistent_queue_api.drop(guild_id)
                 self._ll_guild_updates.discard(guild_id)
                 self.bot.dispatch("red_audio_audio_disconnect", guild)
             if message_channel:
@@ -475,9 +490,13 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     player.store("autoplay_notified", False)
                     await player.stop()
                     await player.disconnect()
-                    await self.config.guild_from_id(
-                        guild_id=guild_id
-                    ).currently_auto_playing_in.set([])
+                    await self.clean_up_guild_config(
+                        "last_known_vc_and_notify_channels",
+                        "last_known_track",
+                        "currently_auto_playing_in",
+                        guild_ids=[guild_id],
+                    )
+                    await self.api_interface.persistent_queue_api.drop(guild_id)
                 else:
                     self.bot.dispatch("red_audio_audio_disconnect", guild)
                     ws_audio_log.info(
@@ -492,9 +511,13 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     player.store("autoplay_notified", False)
                     await player.stop()
                     await player.disconnect()
-                    await self.config.guild_from_id(
-                        guild_id=guild_id
-                    ).currently_auto_playing_in.set([])
+                    await self.clean_up_guild_config(
+                        "last_known_vc_and_notify_channels",
+                        "last_known_track",
+                        "currently_auto_playing_in",
+                        guild_ids=[guild_id],
+                    )
+                    await self.api_interface.persistent_queue_api.drop(guild_id)
             elif code in (42069,) and has_perm and player.current and player.is_playing:
                 player.store("resumes", player.fetch("resumes", 0) + 1)
                 await player.connect(deafen=deafen)
@@ -580,9 +603,13 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     player.store("autoplay_notified", False)
                     await player.stop()
                     await player.disconnect()
-                    await self.config.guild_from_id(
-                        guild_id=guild_id
-                    ).currently_auto_playing_in.set([])
+                    await self.clean_up_guild_config(
+                        "last_known_vc_and_notify_channels",
+                        "last_known_track",
+                        "currently_auto_playing_in",
+                        guild_ids=[guild_id],
+                    )
+                    await self.api_interface.persistent_queue_api.drop(guild_id)
             else:
                 if not player.paused and player.current:
                     player.store("resumes", player.fetch("resumes", 0) + 1)

--- a/redbot/cogs/audio/core/tasks/player.py
+++ b/redbot/cogs/audio/core/tasks/player.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Dict
 
 import lavalink
+from lavalink import NodeNotFound, PlayerNotFound
 from red_commons.logging import getLogger
 
 from redbot.core.i18n import Translator
@@ -46,35 +47,40 @@ class PlayerTasks(MixinMeta, metaclass=CompositeMetaClass):
                     stop_times.pop(sid, None)
                     pause_times.pop(sid, None)
                     try:
-                        player = lavalink.get_player(sid)
+                        await self.clean_up_guild_config(
+                            "last_known_vc_and_notify_channels",
+                            "last_known_track",
+                            "currently_auto_playing_in",
+                            guild_ids=[sid],
+                        )
                         await self.api_interface.persistent_queue_api.drop(sid)
+                        player = lavalink.get_player(sid)
                         player.store("autoplay_notified", False)
                         await player.stop()
                         await player.disconnect()
-                        await self.config.guild_from_id(
-                            guild_id=sid
-                        ).currently_auto_playing_in.set([])
                     except Exception as exc:
                         log.debug(
                             "Exception raised in Audio's emptydc_timer for %s.", sid, exc_info=exc
                         )
-
                 elif sid in stop_times and await self.config.guild(server_obj).emptydc_enabled():
                     emptydc_timer = await self.config.guild(server_obj).emptydc_timer()
                     if (time.time() - stop_times[sid]) >= emptydc_timer:
                         stop_times.pop(sid)
                         try:
-                            player = lavalink.get_player(sid)
+                            await self.clean_up_guild_config(
+                                "last_known_vc_and_notify_channels",
+                                "last_known_track",
+                                "currently_auto_playing_in",
+                                guild_ids=[sid],
+                            )
                             await self.api_interface.persistent_queue_api.drop(sid)
+                            player = lavalink.get_player(sid)
                             player.store("autoplay_notified", False)
                             await player.stop()
                             await player.disconnect()
-                            await self.config.guild_from_id(
-                                guild_id=sid
-                            ).currently_auto_playing_in.set([])
+                        except (PlayerNotFound, NodeNotFound):
+                            stop_times.pop(sid, None)
                         except Exception as exc:
-                            if "No such player for that guild" in str(exc):
-                                stop_times.pop(sid, None)
                             log.debug(
                                 "Exception raised in Audio's emptydc_timer for %s.",
                                 sid,
@@ -87,9 +93,9 @@ class PlayerTasks(MixinMeta, metaclass=CompositeMetaClass):
                     if (time.time() - pause_times.get(sid, 0)) >= emptypause_timer:
                         try:
                             await lavalink.get_player(sid).pause()
+                        except (PlayerNotFound, NodeNotFound):
+                            pause_times.pop(sid, None)
                         except Exception as exc:
-                            if "No such player for that guild" in str(exc):
-                                pause_times.pop(sid, None)
                             log.debug(
                                 "Exception raised in Audio's pausing for %s.", sid, exc_info=exc
                             )

--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -478,6 +478,7 @@ class ServerManager:
                             )
                             await lavalink.wait_until_ready(timeout=60, wait_if_no_node=60)
                         except asyncio.TimeoutError:
+                            await self.cog.save_player_state()
                             self.cog.lavalink_restart_connect(manual=True)
                             return  # lavalink_restart_connect will cause a new monitor task to be created.
                     except Exception as exc:


### PR DESCRIPTION
### Description of the changes

closes #5650

Requires Dpy2.0

### Have the changes in this PR been tested?
Yes


## What to test.

1. Start a song, run `[p]seek 60` 
2. Run `[p]audioset restart`
The player should resume playing at around the 60s mark
---
1. Start a song, run `[p]seek 60`, run `[p]pause` 
2. Run `[p]audioset restart`
The player should restore  at around the 60s mark but this time it will be paused
---

run the following commands while playing a song to test player restore:
`[p]audioset restart`
`[p]llset reset` 
`[p]llset external`
`[p]cog unload` + `[p]cog load`
`[p]cog reload`
`[p]shutdown` and start the bot back up

---

When a player is restored the following should be restored:
1 - the queue 
2 - the current track
3 - the volume 
4 - the paused state
5 - Original track requester should also be restored (before this PR when the player is restored the requester should change to the bot member)


supersedes #5360
resolves #5201

Filter and EQ state should be restored as part of https://github.com/Cog-Creators/Red-DiscordBot/pull/5668