### PR TITLE
Add automodule reference for the caching module

### DIFF
--- a/docs/framework_utils.rst
+++ b/docs/framework_utils.rst
@@ -73,3 +73,9 @@ Common Filters
 
 .. automodule:: redbot.core.utils.common_filters
     :members:
+    
+Caching
+=======
+
+.. automodule:: redbot.core.utils.caching
+    :members:

--- a/redbot/core/utils/caching.py
+++ b/redbot/core/utils/caching.py
@@ -17,6 +17,12 @@ class LRUDict:
     def __init__(self, *keyval_pairs: Sequence[Iterable[Any]], size: int):
         self.size = size
         self._dict = collections.OrderedDict(*keyval_pairs)
+   
+    def __len__(self):
+        return len(self._dict)
+    
+    def __bool__(self):
+        return len(self._dict)
 
     def __contains__(self, key):
         if key in self._dict:

--- a/redbot/core/utils/caching.py
+++ b/redbot/core/utils/caching.py
@@ -22,7 +22,7 @@ class LRUDict:
         return len(self._dict)
 
     def __bool__(self):
-        return len(self._dict)
+        return bool(self._dict)
 
     def __contains__(self, key):
         if key in self._dict:

--- a/redbot/core/utils/caching.py
+++ b/redbot/core/utils/caching.py
@@ -1,17 +1,20 @@
 import collections
+from typing import Any, Iterable, Sequence
 
 
 class LRUDict:
     """
-    dict with LRU-eviction and max-size
+    Dictionary with LRU-eviction and maximum-size, intended for caching.
 
-    This is intended for caching, it may not behave how you want otherwise
-
-    This uses collections.OrderedDict under the hood, but does not directly expose
-    all of it's methods (intentional)
+    Attributes
+    ----------
+    keyval_pairs : Sequence[Iterable[Any]]
+        A sequence of key value pairs to instantiate the dictionary.
+    size : int
+        The maximum size of the dictionary at any given time.
     """
 
-    def __init__(self, *keyval_pairs, size):
+    def __init__(self, *keyval_pairs: Sequence[Iterable[Any]], size: int):
         self.size = size
         self._dict = collections.OrderedDict(*keyval_pairs)
 

--- a/redbot/core/utils/caching.py
+++ b/redbot/core/utils/caching.py
@@ -17,10 +17,10 @@ class LRUDict:
     def __init__(self, *keyval_pairs: Sequence[Iterable[Any]], size: int):
         self.size = size
         self._dict = collections.OrderedDict(*keyval_pairs)
-   
+
     def __len__(self):
         return len(self._dict)
-    
+
     def __bool__(self):
         return len(self._dict)
 


### PR DESCRIPTION
### Description of the changes

Alike with #5641, this time for the caching module.
Also adds `__len__()` and `__bool__()` methods to the LRU Dict which inherit from `collections.OrderedDict`.
Entries in the utils framework between this PR and that of antispam may conflict as they both append to the end of the file.

### Have the changes in this PR been tested?

Yes