### PR TITLE
Add missing empty line in error output of Trivia unit test

### DIFF
--- a/tests/cogs/test_trivia.py
+++ b/tests/cogs/test_trivia.py
@@ -21,7 +21,7 @@ def test_trivia_lists():
                 problem_lists.append((l.stem, f"YAML error:\n{e!s}"))
 
     if problem_lists:
-        msg = ""
-        for name, error in problem_lists:
-            msg += f"- {name}:\n{textwrap.indent(error, '    ')}"
+        msg = "\n".join(
+            f"- {name}:\n{textwrap.indent(error, '    ')}" for name, error in problem_lists
+        )
         raise TypeError("The following lists contain errors:\n" + msg)


### PR DESCRIPTION
### Description of the changes

Very minor thing, the error message is missing an empty line between bullet points, here's an example:
```
TypeError: The following lists contain errors:
- starwars:
    YAML error:
    while scanning a simple key
      in "/home/runner/work/Red-SmileyBot/Red-SmileyBot/.tox/py38/lib/python3.8/site-packages/redbot/cogs/trivia/data/lists/starwars.yaml", line 395, column 1
    could not find expected ':'
      in "/home/runner/work/Red-SmileyBot/Red-SmileyBot/.tox/py38/lib/python3.8/site-packages/redbot/cogs/trivia/data/lists/starwars.yaml", line 396, column 1- disney:
    YAML error:
    while scanning a simple key
      in "/home/runner/work/Red-SmileyBot/Red-SmileyBot/.tox/py38/lib/python3.8/site-packages/redbot/cogs/trivia/data/lists/disney.yaml", line 1295, column 1
    could not find expected ':'
      in "/home/runner/work/Red-SmileyBot/Red-SmileyBot/.tox/py38/lib/python3.8/site-packages/redbot/cogs/trivia/data/lists/disney.yaml", line 1296, column 1
```
After fix it should look like this:
```
TypeError: The following lists contain errors:
- starwars:
    YAML error:
    while scanning a simple key
      in "/home/runner/work/Red-SmileyBot/Red-SmileyBot/.tox/py38/lib/python3.8/site-packages/redbot/cogs/trivia/data/lists/starwars.yaml", line 395, column 1
    could not find expected ':'
      in "/home/runner/work/Red-SmileyBot/Red-SmileyBot/.tox/py38/lib/python3.8/site-packages/redbot/cogs/trivia/data/lists/starwars.yaml", line 396, column 1
- disney:
    YAML error:
    while scanning a simple key
      in "/home/runner/work/Red-SmileyBot/Red-SmileyBot/.tox/py38/lib/python3.8/site-packages/redbot/cogs/trivia/data/lists/disney.yaml", line 1295, column 1
    could not find expected ':'
      in "/home/runner/work/Red-SmileyBot/Red-SmileyBot/.tox/py38/lib/python3.8/site-packages/redbot/cogs/trivia/data/lists/disney.yaml", line 1296, column 1
```

### Have the changes in this PR been tested?

No
