### PR TITLE
Suppress stderr in `_get_version()`

### DIFF
--- a/redbot/_version.py
+++ b/redbot/_version.py
@@ -7,7 +7,9 @@ def _get_version(*, ignore_installed: bool = False) -> str:
 
         path = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
         output = subprocess.check_output(
-            ("git", "describe", "--tags", "--long", "--dirty"), cwd=path
+            ("git", "describe", "--tags", "--long", "--dirty"),
+            stderr=subprocess.DEVNULL,
+            cwd=path,
         )
         _, count, commit, *dirty = output.decode("utf-8").strip().split("-", 3)
         dirty_suffix = f".{dirty[0]}" if dirty else ""


### PR DESCRIPTION
### Description of the changes

Regression from #5664 that I believe can be seen when installing with `python -m pip install -U git+https://github.com/Cog-Creators/Red-DiscordBot.git`.

I have not tested this and don't even know if the example given above is one that allows for the reproduction of this but the problem that has been reported with this should be fixed.

### Have the changes in this PR been tested?

No
