### PR TITLE
Add support for playing Bandcamp music from custom domains

### DIFF
--- a/redbot/cogs/audio/core/abc.py
+++ b/redbot/cogs/audio/core/abc.py
@@ -568,6 +568,10 @@ class MixinMeta(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    async def scrape_bandcamp_url(self, url: str) -> "Query":
+        raise NotImplementedError()
+
+    @abstractmethod
     async def self_deafen(self, player: lavalink.Player) -> None:
         raise NotImplementedError()
 

--- a/redbot/cogs/audio/core/commands/player.py
+++ b/redbot/cogs/audio/core/commands/player.py
@@ -47,11 +47,17 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
         if restrict and self.match_url(str(query)):
             valid_url = self.is_url_allowed(str(query))
             if not valid_url:
-                return await self.send_embed_msg(
-                    ctx,
-                    title=_("Unable To Play Tracks"),
-                    description=_("That URL is not allowed."),
-                )
+                # If it is a bandcamp page with a custom domain (not bandcamp.com),
+                # try and webscrape for the original bandcamp url and use that
+                bc_scrape_query = await self.scrape_bandcamp_url(str(query))
+                if bc_scrape_query is not None:
+                    query = bc_scrape_query
+                else:
+                    return await self.send_embed_msg(
+                        ctx,
+                        title=_("Unable To Play Tracks"),
+                        description=_("That URL is not allowed."),
+                    )
         elif not await self.is_query_allowed(self.config, ctx, f"{query}", query_obj=query):
             return await self.send_embed_msg(
                 ctx, title=_("Unable To Play Tracks"), description=_("That track is not allowed.")

--- a/redbot/cogs/audio/core/utilities/parsers.py
+++ b/redbot/cogs/audio/core/utilities/parsers.py
@@ -8,6 +8,7 @@ from red_commons.logging import getLogger
 
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
+from ...audio_dataclasses import Query
 
 log = getLogger("red.cogs.Audio.cog.Utilities.Parsing")
 
@@ -33,3 +34,26 @@ class ParsingUtilities(MixinMeta, metaclass=CompositeMetaClass):
                         return None
         except (KeyError, aiohttp.ClientConnectionError, aiohttp.ClientResponseError):
             return None
+
+    async def scrape_bandcamp_url(self, query: str) -> "Query":
+        # Try and webscrape for the original bandcamp url inside the custom domain's html body
+        try:
+            async with self.session.get(query) as response:
+                html = await response.text()
+                # Get the index of 'og:url"'
+                ind = html.index('og:url"')
+                # If found
+                if ind > -1:
+                    # Get the index of the closing tag
+                    end_ind = html.index(">", ind)
+                    if end_ind > -1:
+                        # Split '<meta property="og:url"' and 'content="<bandcamp url>">' using 're' library
+                        # and get the content side
+                        content = re.split(" +", html[ind:end_ind])[1]
+                        # Refine to get only the new bandcamp url
+                        bandcamp_url = content[content.index('"') + 1 : -1]
+                        # Recreate the query with the new url
+                        return Query.process_input(bandcamp_url, self.local_folder_current_path)
+        except Exception as e:
+            return None
+        return None

--- a/redbot/pytest/audio.py
+++ b/redbot/pytest/audio.py
@@ -1,0 +1,15 @@
+import pytest
+
+from redbot.cogs.audio import Audio
+from redbot.core import Config
+
+__all__ = ["audio"]
+
+
+@pytest.fixture()
+def audio(config, monkeypatch, red):
+    with monkeypatch.context() as m:
+        m.setattr(Config, "get_conf", lambda *args, **kwargs: config)
+
+        Audio._init(red)
+        return Audio

--- a/tests/cogs/test_audio.py
+++ b/tests/cogs/test_audio.py
@@ -1,0 +1,11 @@
+import pytest
+from redbot.pytest.audio import *
+
+
+@pytest.mark.asyncio
+async def test_command_play_bandcamp_custom_domain(audio, ctx):
+    url = f"https://jazzinbritain.co.uk/album/revisiting-tanglewood-63-the-early-tapes"
+
+    inv = await audio.scrape_bandcamp_url(url)
+
+    assert inv is not None

--- a/tests/cogs/test_audio.py
+++ b/tests/cogs/test_audio.py
@@ -3,8 +3,17 @@ from redbot.pytest.audio import *
 
 
 @pytest.mark.asyncio
-async def test_command_play_bandcamp_custom_domain(audio, ctx):
+async def test_command_play_bandcamp_custom_domain_album(audio, ctx):
     url = f"https://jazzinbritain.co.uk/album/revisiting-tanglewood-63-the-early-tapes"
+
+    inv = await audio.scrape_bandcamp_url(url)
+
+    assert inv is not None
+
+
+@pytest.mark.asyncio
+async def test_command_play_bandcamp_custom_domain_track(audio, ctx):
+    url = f"https://jazzinbritain.co.uk/track/fanfare"
 
     inv = await audio.scrape_bandcamp_url(url)
 


### PR DESCRIPTION
### Description of the changes

Previously unrecognizable to Red, this PR allows users to put in custom domain links of bandcamp pages and be able to play the track(s) listed on the page.

The audio cog will webscrape the HTML data of the unrecognized domain to find the original bandcamp url and use that url as the query, otherwise it will say it is not found.

Example:

From this page
```
https://jazzinbritain.co.uk/album/revisiting-tanglewood-63-the-early-tapes
```
we retrieve the bandcamp URL
```
https://jazzinbritain1.bandcamp.com/album/revisiting-tanglewood-63-the-early-tapes
```
and use that as the link to pull the music from.

### Have the changes in this PR been tested?

Without the unit tests I have added, it passes all of the tests. However, I am having problems trying to get my own test to run, but I think it might be more of a configuration issue on my end. I will write a comment below describing the issue.
