### PR TITLE
Bump RLL to 0.11.0rc1

### DIFF
--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -657,7 +657,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
             if not self._player_check(ctx):
                 player = await lavalink.connect(
                     ctx.author.voice.channel,
-                    deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
+                    self_deaf=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
                 player.store("notify_channel", ctx.channel.id)
             else:
@@ -675,7 +675,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     )
                 await player.move_to(
                     ctx.author.voice.channel,
-                    deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
+                    self_deaf=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
             await ctx.tick()
         except AttributeError:

--- a/redbot/cogs/audio/core/commands/player.py
+++ b/redbot/cogs/audio/core/commands/player.py
@@ -85,7 +85,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     )
                 await lavalink.connect(
                     ctx.author.voice.channel,
-                    deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
+                    self_deaf=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
             except AttributeError:
                 return await self.send_embed_msg(
@@ -193,7 +193,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     )
                 await lavalink.connect(
                     ctx.author.voice.channel,
-                    deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
+                    self_deaf=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
             except AttributeError:
                 return await self.send_embed_msg(
@@ -456,7 +456,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     )
                 await lavalink.connect(
                     ctx.author.voice.channel,
-                    deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
+                    self_deaf=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
             except AttributeError:
                 return await self.send_embed_msg(
@@ -572,7 +572,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     )
                 await lavalink.connect(
                     ctx.author.voice.channel,
-                    deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
+                    self_deaf=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
             except AttributeError:
                 return await self.send_embed_msg(
@@ -697,7 +697,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     )
                 await lavalink.connect(
                     ctx.author.voice.channel,
-                    deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
+                    self_deaf=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
             except AttributeError:
                 return await self.send_embed_msg(

--- a/redbot/cogs/audio/core/commands/queue.py
+++ b/redbot/cogs/audio/core/commands/queue.py
@@ -345,7 +345,7 @@ class QueueCommands(MixinMeta, metaclass=CompositeMetaClass):
                 )
             player = await lavalink.connect(
                 ctx.author.voice.channel,
-                deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
+                self_deaf=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
             )
             player.store("notify_channel", ctx.channel.id)
         except AttributeError:

--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -90,7 +90,11 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     self._ws_resume[guild_id].set()
 
                 await self._websocket_closed_handler(
-                    guild=guild, player=player, extra=extra, deafen=deafen, disconnect=disconnect
+                    guild=guild,
+                    player=player,
+                    extra=extra,
+                    self_deaf=deafen,
+                    disconnect=disconnect,
                 )
             except Exception as exc:
                 log.debug(
@@ -335,7 +339,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
         guild: discord.Guild,
         player: lavalink.Player,
         extra: Dict,
-        deafen: bool,
+        self_deaf: bool,
         disconnect: bool,
     ) -> None:
         guild_id = guild.id
@@ -415,7 +419,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
 
                 if has_perm and player.current and player.is_playing:
                     player.store("resumes", player.fetch("resumes", 0) + 1)
-                    await player.connect(deafen=deafen)
+                    await player.connect(self_deaf=self_deaf)
                     await player.resume(player.current, start=player.position, replace=True)
                     ws_audio_log.info(
                         "Voice websocket reconnected Reason: Error code %s & Currently playing",
@@ -429,7 +433,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     )
                 elif has_perm and player.paused and player.current:
                     player.store("resumes", player.fetch("resumes", 0) + 1)
-                    await player.connect(deafen=deafen)
+                    await player.connect(self_deaf=self_deaf)
                     await player.resume(
                         player.current, start=player.position, replace=True, pause=True
                     )
@@ -445,7 +449,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     )
                 elif has_perm and (not disconnect) and (not player.is_playing):
                     player.store("resumes", player.fetch("resumes", 0) + 1)
-                    await player.connect(deafen=deafen)
+                    await player.connect(self_deaf=self_deaf)
                     ws_audio_log.info(
                         "Voice websocket reconnected "
                         "Reason: Error code %s & Not playing, but auto disconnect disabled",
@@ -497,7 +501,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     ).currently_auto_playing_in.set([])
             elif code in (42069,) and has_perm and player.current and player.is_playing:
                 player.store("resumes", player.fetch("resumes", 0) + 1)
-                await player.connect(deafen=deafen)
+                await player.connect(self_deaf=self_deaf)
                 await player.resume(player.current, start=player.position, replace=True)
                 ws_audio_log.info("Player resumed - Reason: Error code %s & %s", code, reason)
                 ws_audio_log.debug(
@@ -514,7 +518,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                 )
                 await asyncio.sleep(delay)
                 if has_perm and player.current and player.is_playing:
-                    await player.connect(deafen=deafen)
+                    await player.connect(self_deaf=self_deaf)
                     await player.resume(player.current, start=player.position, replace=True)
                     ws_audio_log.info(
                         "Voice websocket reconnected Reason: Error code %s & Player is active",
@@ -528,7 +532,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     )
                 elif has_perm and player.paused and player.current:
                     player.store("resumes", player.fetch("resumes", 0) + 1)
-                    await player.connect(deafen=deafen)
+                    await player.connect(self_deaf=self_deaf)
                     await player.resume(
                         player.current, start=player.position, replace=True, pause=True
                     )
@@ -544,7 +548,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                     )
                 elif has_perm and (not disconnect) and (not player.is_playing):
                     player.store("resumes", player.fetch("resumes", 0) + 1)
-                    await player.connect(deafen=deafen)
+                    await player.connect(self_deaf=self_deaf)
                     ws_audio_log.info(
                         "Voice websocket reconnected "
                         "to channel %s in guild: %s | "

--- a/redbot/cogs/audio/core/tasks/startup.py
+++ b/redbot/cogs/audio/core/tasks/startup.py
@@ -138,7 +138,7 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
                             if not (perms.connect and perms.speak):
                                 vc = None
                                 break
-                            player = await lavalink.connect(vc, deafen=auto_deafen)
+                            player = await lavalink.connect(vc, self_deaf=auto_deafen)
                             player.store("notify_channel", notify_channel_id)
                             break
                         except NodeNotFound:
@@ -222,7 +222,7 @@ class StartUpTasks(MixinMeta, metaclass=CompositeMetaClass):
                         if not (perms.connect and perms.speak):
                             vc = None
                             break
-                        player = await lavalink.connect(vc, deafen=auto_deafen)
+                        player = await lavalink.connect(vc, self_deaf=auto_deafen)
                         player.store("notify_channel", notify_channel_id)
                         break
                     except NodeNotFound:

--- a/redbot/cogs/audio/core/utilities/formatting.py
+++ b/redbot/cogs/audio/core/utilities/formatting.py
@@ -100,7 +100,7 @@ class FormattingUtilities(MixinMeta, metaclass=CompositeMetaClass):
             try:
                 await lavalink.connect(
                     ctx.author.voice.channel,
-                    deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
+                    self_deaf=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
             except AttributeError:
                 return await self.send_embed_msg(ctx, title=_("Connect to a voice channel first."))

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -711,7 +711,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             ):
                 await player.move_to(
                     user_channel,
-                    deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
+                    self_deaf=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
                 return True
         else:

--- a/redbot/cogs/audio/core/utilities/playlists.py
+++ b/redbot/cogs/audio/core/utilities/playlists.py
@@ -545,7 +545,7 @@ class PlaylistUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     return False
                 await lavalink.connect(
                     ctx.author.voice.channel,
-                    deafen=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
+                    self_deaf=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
             except NodeNotFound:
                 await self.send_embed_msg(

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ install_requires =
     pytz==2021.1
     PyYAML==5.4.1
     Red-Commons==1.0.0
-    Red-Lavalink==0.11.0rc1
+    Red-Lavalink @ git+https://github.com/Cog-Creators/Red-Lavalink@refs/pull/127/merge
     rich==10.9.0
     schema==0.7.4
     six==1.16.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ install_requires =
     pytz==2021.1
     PyYAML==5.4.1
     Red-Commons==1.0.0
-    Red-Lavalink==0.11.0rc0
+    Red-Lavalink==0.11.0rc1
     rich==10.9.0
     schema==0.7.4
     six==1.16.0


### PR DESCRIPTION
### Description of the changes

This PR comes down to replacing the usage of `deafen` kwarg with `self_deaf` which is what it's getting renamed to in RLL 0.11.0rc1 (once it's released), see: Cog-Creators/Red-Lavalink#127

### Have the changes in this PR been tested?

No
