### PR TITLE
Prevent `/` being used in bot or server prefixes

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -138,7 +138,7 @@ async def _edit_prefix(red, prefix, no_prompt):
             if not prefixes:
                 print("You need to pass at least one prefix!")
                 continue
-            if prefix.startswith("/"):
+            if any(prefix.startswith("/") for prefix in prefixes):
                 print(
                     "Prefixes cannot start with '/', as it conflicts with Discord's slash commands."
                 )

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -138,7 +138,7 @@ async def _edit_prefix(red, prefix, no_prompt):
             if not prefixes:
                 print("You need to pass at least one prefix!")
                 continue
-            if "/" in prefix:
+            if prefix == "/":
                 print(
                     "'/' cannot be set as a prefix, as it conflicts with Discord's slash commands."
                 )

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -138,9 +138,9 @@ async def _edit_prefix(red, prefix, no_prompt):
             if not prefixes:
                 print("You need to pass at least one prefix!")
                 continue
-            if prefix == "/":
+            if prefix.startswith("/"):
                 print(
-                    "'/' cannot be set as a prefix, as it conflicts with Discord's slash commands."
+                    "Prefixes cannot start with '/', as it conflicts with Discord's slash commands."
                 )
                 continue
             prefixes = sorted(prefixes, reverse=True)

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -139,7 +139,9 @@ async def _edit_prefix(red, prefix, no_prompt):
                 print("You need to pass at least one prefix!")
                 continue
             if "/" in prefix:
-                print("'/' cannot be set as a prefix, as it conflicts with Discord's slash commands.")
+                print(
+                    "'/' cannot be set as a prefix, as it conflicts with Discord's slash commands."
+                )
                 continue
             prefixes = sorted(prefixes, reverse=True)
             await red._config.prefix.set(prefixes)

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -138,6 +138,9 @@ async def _edit_prefix(red, prefix, no_prompt):
             if not prefixes:
                 print("You need to pass at least one prefix!")
                 continue
+            if "/" in prefix:
+                print("'/' cannot be set as a prefix, as it conflicts with Discord's slash commands.")
+                continue
             prefixes = sorted(prefixes, reverse=True)
             await red._config.prefix.set(prefixes)
             print("Prefixes updated.\n")

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -70,6 +70,9 @@ async def interactive_config(red, token_set, prefix_set, *, print_header=True):
             if len(prefix) > 10:
                 if not confirm("Your prefix seems overly long. Are you sure that it's correct?"):
                     prefix = ""
+            if "/" in prefix:
+                print("'/' cannot be set as a prefix, as it conflicts with Discord's slash commands.")
+                prefix = ""
             if prefix:
                 await red._config.prefix.set([prefix])
 

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -70,9 +70,9 @@ async def interactive_config(red, token_set, prefix_set, *, print_header=True):
             if len(prefix) > 10:
                 if not confirm("Your prefix seems overly long. Are you sure that it's correct?"):
                     prefix = ""
-            if prefix == "/":
+            if prefix.startswith("/"):
                 print(
-                    "'/' cannot be set as a prefix, as it conflicts with Discord's slash commands."
+                    "Prefixes cannot start with '/', as it conflicts with Discord's slash commands."
                 )
                 prefix = ""
             if prefix:

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -70,7 +70,7 @@ async def interactive_config(red, token_set, prefix_set, *, print_header=True):
             if len(prefix) > 10:
                 if not confirm("Your prefix seems overly long. Are you sure that it's correct?"):
                     prefix = ""
-            if "/" in prefix:
+            if prefix == "/":
                 print(
                     "'/' cannot be set as a prefix, as it conflicts with Discord's slash commands."
                 )

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -71,7 +71,9 @@ async def interactive_config(red, token_set, prefix_set, *, print_header=True):
                 if not confirm("Your prefix seems overly long. Are you sure that it's correct?"):
                     prefix = ""
             if "/" in prefix:
-                print("'/' cannot be set as a prefix, as it conflicts with Discord's slash commands.")
+                print(
+                    "'/' cannot be set as a prefix, as it conflicts with Discord's slash commands."
+                )
                 prefix = ""
             if prefix:
                 await red._config.prefix.set([prefix])

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3515,6 +3515,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         **Arguments:**
             - `<prefixes...>` - The prefixes the bot will respond to globally.
         """
+        if "/" in prefixes:
+            await ctx.send(_("'/' cannot be set as a prefix, as it conflicts with Discord's slash commands."))
+            return
         if any(len(x) > MAX_PREFIX_LENGTH for x in prefixes):
             await ctx.send(
                 _(
@@ -3562,6 +3565,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         if not prefixes:
             await ctx.bot.set_prefixes(guild=ctx.guild, prefixes=[])
             await ctx.send(_("Server prefixes have been reset."))
+            return
+        if "/" in prefixes:
+            await ctx.send(_("'/' cannot be set as a prefix, as it conflicts with Discord's slash commands."))
             return
         if any(len(x) > MAX_PREFIX_LENGTH for x in prefixes):
             await ctx.send(_("You cannot have a prefix longer than 25 characters."))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3517,7 +3517,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """
         if any(p.startswith("/") for p in prefixes):
             await ctx.send(
-                _("'/' cannot be set as a prefix, as it conflicts with Discord's slash commands.")
+                _("Prefixes cannot start with '/', as it conflicts with Discord's slash commands.")
             )
             return
         if any(len(x) > MAX_PREFIX_LENGTH for x in prefixes):
@@ -3570,7 +3570,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             return
         if any(p.startswith("/") for p in prefixes):
             await ctx.send(
-                _("'/' cannot be set as a prefix, as it conflicts with Discord's slash commands.")
+                _("Prefixes cannot start with '/', as it conflicts with Discord's slash commands.")
             )
             return
         if any(len(x) > MAX_PREFIX_LENGTH for x in prefixes):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3515,7 +3515,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         **Arguments:**
             - `<prefixes...>` - The prefixes the bot will respond to globally.
         """
-        if "/" in prefixes:
+        if any(p.startswith("/") for p in prefixes):
             await ctx.send(
                 _("'/' cannot be set as a prefix, as it conflicts with Discord's slash commands.")
             )
@@ -3568,7 +3568,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             await ctx.bot.set_prefixes(guild=ctx.guild, prefixes=[])
             await ctx.send(_("Server prefixes have been reset."))
             return
-        if "/" in prefixes:
+        if any(p.startswith("/") for p in prefixes):
             await ctx.send(
                 _("'/' cannot be set as a prefix, as it conflicts with Discord's slash commands.")
             )

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3516,7 +3516,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             - `<prefixes...>` - The prefixes the bot will respond to globally.
         """
         if "/" in prefixes:
-            await ctx.send(_("'/' cannot be set as a prefix, as it conflicts with Discord's slash commands."))
+            await ctx.send(
+                _("'/' cannot be set as a prefix, as it conflicts with Discord's slash commands.")
+            )
             return
         if any(len(x) > MAX_PREFIX_LENGTH for x in prefixes):
             await ctx.send(
@@ -3567,7 +3569,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             await ctx.send(_("Server prefixes have been reset."))
             return
         if "/" in prefixes:
-            await ctx.send(_("'/' cannot be set as a prefix, as it conflicts with Discord's slash commands."))
+            await ctx.send(
+                _("'/' cannot be set as a prefix, as it conflicts with Discord's slash commands.")
+            )
             return
         if any(len(x) > MAX_PREFIX_LENGTH for x in prefixes):
             await ctx.send(_("You cannot have a prefix longer than 25 characters."))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3515,7 +3515,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         **Arguments:**
             - `<prefixes...>` - The prefixes the bot will respond to globally.
         """
-        if any(p.startswith("/") for p in prefixes):
+        if any(prefix.startswith("/") for prefix in prefixes):
             await ctx.send(
                 _("Prefixes cannot start with '/', as it conflicts with Discord's slash commands.")
             )
@@ -3568,7 +3568,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             await ctx.bot.set_prefixes(guild=ctx.guild, prefixes=[])
             await ctx.send(_("Server prefixes have been reset."))
             return
-        if any(p.startswith("/") for p in prefixes):
+        if any(prefix.startswith("/") for prefix in prefixes):
             await ctx.send(
                 _("Prefixes cannot start with '/', as it conflicts with Discord's slash commands.")
             )

--- a/redbot/core/settings_caches.py
+++ b/redbot/core/settings_caches.py
@@ -45,6 +45,10 @@ class PrefixManager:
         prefixes = prefixes or []
         if not isinstance(prefixes, list) and not all(isinstance(pfx, str) for pfx in prefixes):
             raise TypeError("Prefixes must be a list of strings")
+        if any(prefix.startswith("/") for prefix in prefixes):
+            raise ValueError(
+                "Prefixes cannot start with a slash ('/'), it conflicts with Discord's slash commands."
+            )
         prefixes = sorted(prefixes, reverse=True)
         if gid is None:
             if not prefixes:

--- a/redbot/core/settings_caches.py
+++ b/redbot/core/settings_caches.py
@@ -47,7 +47,7 @@ class PrefixManager:
             raise TypeError("Prefixes must be a list of strings")
         if any(prefix.startswith("/") for prefix in prefixes):
             raise ValueError(
-                "Prefixes cannot start with a slash ('/'), it conflicts with Discord's slash commands."
+                "Prefixes cannot start with '/', as it conflicts with Discord's slash commands."
             )
         prefixes = sorted(prefixes, reverse=True)
         if gid is None:


### PR DESCRIPTION
### Description of the changes

Prevents the use of "/" for the bot and guild's prefixes. 