### PR TITLE
[Audio] Update Lavalink.jar build

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 _ = Translator("Audio", pathlib.Path(__file__))
 log = getLogger("red.Audio.manager")
 JAR_VERSION: Final[str] = "3.4.0"
-JAR_BUILD: Final[int] = 1275
+JAR_BUILD: Final[int] = 1347
 LAVALINK_DOWNLOAD_URL: Final[str] = (
     "https://github.com/Cog-Creators/Lavalink-Jars/releases/download/"
     f"{JAR_VERSION}_{JAR_BUILD}/"


### PR DESCRIPTION
### Description of the changes

Updates the Lavalink.jar for audio.

Fix for plain word yt searching with [p]play or [p]search (https://github.com/devoxin/walkyst-lavaplayer/tree/arb)
Age restricted tracks work without any additional keys or setup needing to be supplied... for now. Enjoy it while it lasts. (https://github.com/devoxin/walkyst-lavaplayer/tree/arb)
Slightly better handling of some 1006 close codes (https://github.com/freyacodes/Lavalink/pull/648)

### Have the changes in this PR been tested?
Yes (on the Lavalink.jar side only, haven't tested Red grabbing the published jar with this change)

Resolves #5710 


