### PR TITLE
[3.4] Bump Red-Lavalink to version 0.9.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ install_requires =
     python-Levenshtein-wheels==0.13.2
     pytz==2021.1
     PyYAML==5.4.1
-    Red-Lavalink==0.9.0
+    Red-Lavalink==0.9.3
     rich==10.9.0
     schema==0.7.4
     six==1.16.0


### PR DESCRIPTION
### Description of the changes

Bumps Red-Lavalink 0.9.0 to a 0.9.3 maintenance release containing a missing FAULT exception severity which resulted in an unhandled exception that was in no way reported in Discord by the Audio cog, see Cog-Creators/Red-Lavalink#108 and the relevant backport of it to 0.9.x:
https://github.com/Cog-Creators/Red-Lavalink/commit/9526755c235946ef6dd3d7c0868e0ae91ee1a97e

### Have the changes in this PR been tested?

Yes
