### PR TITLE
Pin Temurin version on Windows until fixed version exists

### DIFF
--- a/docs/install_guides/windows.rst
+++ b/docs/install_guides/windows.rst
@@ -39,7 +39,7 @@ For Audio support, you should also run the following command before exiting:
 
 .. prompt:: powershell
 
-    choco upgrade temurin11 -y
+    choco upgrade temurin11 -y --version 11.0.14.10100
 
 
 From here, exit the prompt then continue onto `creating-venv-windows`.


### PR DESCRIPTION
### Description of the changes

Due to a bug in the current version of Temurin (11.0.15) in Windows, it is currently not working with Lavalink and an older version of it needs to be used.

The exact error reported in spring.log:
```
java.io.IOError: java.io.FileNotFoundException: Invalid file path
```

Relevant issue: https://bugs.openjdk.java.net/browse/JDK-8285445

This has been fixed in Oracle JDK 11.0.15.1 however OpenJDK has not made a release with that fix yet and as such Temurin does not have the fix either.

### Have the changes in this PR been tested?

Yes

https://github.com/jack1142/Red-Install-Tests/actions/runs/2418977499