### PR TITLE
Use Temurin 11 instead of discontinued AdoptOpenJDK on macOS

### DIFF
--- a/docs/install_guides/mac.rst
+++ b/docs/install_guides/mac.rst
@@ -25,7 +25,8 @@ one-by-one:
 
     brew install python@3.9
     brew install git
-    brew install --cask adoptopenjdk/openjdk/adoptopenjdk11
+    brew tap homebrew/cask-versions
+    brew install --cask temurin11
 
 By default, Python installed through Homebrew is not added to the load path.
 To fix this, you should run these commands:


### PR DESCRIPTION
### Description of the changes

This was missed when we swapped it out for Windows install guide.
Note that the latest version of Temurin 11 supports M1 natively and as such the Lavalink used with it needs to support M1 as well (the up-to-date version of our Lavalink build does support it).

### Have the changes in this PR been tested?

Yes

https://github.com/jack1142/Red-Install-Tests/actions/runs/2418977499