### PR TITLE
[3.4] Bump Python version in install guides to 3.9.13

### DIFF
--- a/docs/install_guides/_includes/install-python-pyenv.rst
+++ b/docs/install_guides/_includes/install-python-pyenv.rst
@@ -10,7 +10,7 @@ virtual environment.
 
 .. prompt:: bash
 
-    CONFIGURE_OPTS=--enable-optimizations pyenv install 3.9.9 -v
+    CONFIGURE_OPTS=--enable-optimizations pyenv install 3.9.13 -v
 
 This may take a long time to complete, depending on your hardware. For some machines (such as
 Raspberry Pis and micro-tier VPSes), it may take over an hour; in this case, you may wish to remove
@@ -22,6 +22,6 @@ After that is finished, run:
 
 .. prompt:: bash
 
-    pyenv global 3.9.9
+    pyenv global 3.9.13
 
 Pyenv is now installed and your system should be configured to run Python 3.9.

--- a/docs/install_guides/windows.rst
+++ b/docs/install_guides/windows.rst
@@ -31,7 +31,7 @@ Then run each of the following commands:
     iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
     choco upgrade git --params "/GitOnlyOnPath /WindowsTerminal" -y
     choco upgrade visualstudio2019-workload-vctools -y
-    choco upgrade python3 -y --version 3.9.9
+    choco upgrade python3 -y --version 3.9.13
 
 For Audio support, you should also run the following command before exiting:
 


### PR DESCRIPTION
### Description of the changes

What it says on the tin. Only doing this on the 3.4 branch because V3/develop should support Python 3.10 on the day of release.

### Have the changes in this PR been tested?

Yes

https://github.com/jack1142/Red-Install-Tests/actions/runs/2418977499