### PR TITLE
Add Ubuntu 22.04 install guide

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -282,7 +282,7 @@ If you want to do it, follow these steps.
 2. **Install Linux**
 
   Most of the VPS providers have tools for installing Linux automatically. If
-  you're a beginner, we recommend **Ubuntu 20.04 LTS**.
+  you're a beginner, we recommend **Ubuntu 22.04 LTS**.
 
   For Raspberry Pi users, just install `Raspbian
   <https://www.raspberrypi.org/software/>`_ on a micro-SD card.

--- a/docs/install_guides/index.rst
+++ b/docs/install_guides/index.rst
@@ -6,7 +6,7 @@ Installing Red
 The list below shows the installation guides available based on the operating system being used.
 
 If you want to host Red on a VPS and are unsure what operating system you should choose,
-we recommend **Ubuntu 20.04 LTS**.
+we recommend **Ubuntu 22.04 LTS**.
 
 .. toctree::
    :maxdepth: 1
@@ -30,4 +30,5 @@ we recommend **Ubuntu 20.04 LTS**.
    rocky-linux-8
    ubuntu-1804
    ubuntu-2004
+   ubuntu-2204
    ubuntu-non-lts

--- a/docs/install_guides/ubuntu-2204.rst
+++ b/docs/install_guides/ubuntu-2204.rst
@@ -1,0 +1,31 @@
+.. _install-ubuntu-2204:
+
+==================================
+Installing Red on Ubuntu 22.04 LTS
+==================================
+
+.. include:: _includes/linux-preamble.rst
+
+-------------------------------
+Installing the pre-requirements
+-------------------------------
+
+We recommend adding the ``deadsnakes`` ppa to install Python 3.9:
+
+.. prompt:: bash
+
+    sudo apt update
+    sudo apt -y install software-properties-common
+    sudo add-apt-repository -y ppa:deadsnakes/ppa
+
+Now install the pre-requirements with apt:
+
+.. prompt:: bash
+
+    sudo apt -y install python3.9 python3.9-dev python3.9-venv python3-pip git openjdk-11-jre-headless build-essential nano
+
+.. Include common instructions:
+
+.. include:: _includes/create-env-with-venv.rst
+
+.. include:: _includes/install-and-setup-red-unix.rst

--- a/docs/install_guides/ubuntu-2204.rst
+++ b/docs/install_guides/ubuntu-2204.rst
@@ -4,6 +4,8 @@
 Installing Red on Ubuntu 22.04 LTS
 ==================================
 
+.. include:: _includes/supported-arch-x64+aarch64.rst
+
 .. include:: _includes/linux-preamble.rst
 
 -------------------------------

--- a/docs/version_guarantees.rst
+++ b/docs/version_guarantees.rst
@@ -76,6 +76,7 @@ Rocky Linux 8                      x86-64, aarch64           2029-05-31 (`end-of
 Ubuntu 18.04 LTS                   x86-64, aarch64           2023-04-30 (`End of Standard Support <https://wiki.ubuntu.com/Releases#Current>`__)
 Ubuntu 20.04 LTS                   x86-64, aarch64           2025-04-30 (`End of Standard Support <https://wiki.ubuntu.com/Releases#Current>`__)
 Ubuntu 21.10                       x86-64, aarch64           2022-07-31 (`End of Standard Support <https://wiki.ubuntu.com/Releases#Current>`__)
+Ubuntu 22.04 LTS                   x86-64, aarch64           2027-04-30 (`End of Standard Support <https://wiki.ubuntu.com/Releases#Current>`__)
 ================================   =======================   ============================================================
 
 ====================


### PR DESCRIPTION
### Description of the changes

Adds Ubuntu 22.04 to the install guides and declares it as the new recommendation.
These docs will eventually be updated to not use deadsnakes repository but that can't happen until we add support for Python 3.10. This new install guide follows the new guideline I want to follow: not to use external repositories when not necessary, so git PPA is not being used here.

### Have the changes in this PR been tested?

No