### PR TITLE
Escape Discord's formatting in `[p]servers` command

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1653,7 +1653,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         Note: This command is interactive.
         """
         guilds = sorted(self.bot.guilds, key=lambda s: s.name.lower())
-        msg = "\n".join(f"{discord.utils.escape_markdown(guild.name)} (`{guild.id}`)\n" for guild in guilds)
+        msg = "\n".join(
+            f"{discord.utils.escape_markdown(guild.name)} (`{guild.id}`)\n" for guild in guilds
+        )
 
         pages = list(pagify(msg, ["\n"], page_length=1000))
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1653,7 +1653,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         Note: This command is interactive.
         """
         guilds = sorted(self.bot.guilds, key=lambda s: s.name.lower())
-        msg = "\n".join(f"{guild.name} (`{guild.id}`)\n" for guild in guilds)
+        msg = "\n".join(f"{discord.utils.escape_markdown(guild.name)} (`{guild.id}`)\n" for guild in guilds)
 
         pages = list(pagify(msg, ["\n"], page_length=1000))
 


### PR DESCRIPTION
### Description of the changes

Escape Discord's formatting when special names are included in guild names, in the `[p]servers` command.
Closes #5696.

### Have the changes in this PR been tested?

Yes
