### PR TITLE
[3.4] Bump minimum Fedora version to 35 (#5701)

### DIFF
--- a/docs/install_guides/fedora.rst
+++ b/docs/install_guides/fedora.rst
@@ -10,7 +10,7 @@ Installing Red on Fedora Linux
 Installing the pre-requirements
 -------------------------------
 
-Fedora Linux 34 and above has all required packages available in official repositories. Install
+Fedora Linux 35 and above has all required packages available in official repositories. Install
 them with dnf:
 
 .. prompt:: bash


### PR DESCRIPTION
* Drop Fedora Linux 34.
(cherry picked from commit 9cdcf07773f90073563cb3822c6bc05fd2a22330)

Co-authored-by: Jakub Kuczys <6032823+jack1142@users.noreply.github.com>
