### PR TITLE
Wait for two 'Started Launcher' lines before connecting to managed LL

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -313,12 +313,22 @@ class ServerManager:
 
     async def _wait_for_launcher(self) -> None:
         log.info("Waiting for Managed Lavalink node to be ready")
+        # Since Lavalink jar 3.4.0_1346, there are two "Started Launcher" lines logged
+        # before Lavalink is ready to receive requests.
+        started_line_seen = False
         for i in itertools.cycle(range(50)):
             line = await self._proc.stdout.readline()
             if _RE_READY_LINE.search(line):
-                self.ready.set()
-                log.info("Managed Lavalink node is ready to receive requests.")
-                break
+                if started_line_seen:
+                    self.ready.set()
+                    log.info("Managed Lavalink node is ready to receive requests.")
+                    break
+                else:
+                    log.debug(
+                        "Seen first 'Started Launcher' line from Managed Lavalink node."
+                        " Waiting for the second one..."
+                    )
+                    started_line_seen = True
             if _FAILED_TO_START.search(line):
                 raise ManagedLavalinkStartFailure(
                     f"Lavalink failed to start: {line.decode().strip()}"


### PR DESCRIPTION
### Description of the changes

With the new jar (3.4.0_1347), there's been a change to the spring boot configuration in Lavalink which results in it logging the "Started Launcher" message twice *before* it is actually ready to receive requests. This PR fixes an issue where we considered the internal LL jar to be ready after the first "Started Launcher" message which resulted in failed connect attempts:
![VirtualBoxVM_2022-06-04_23-12-02](https://user-images.githubusercontent.com/6032823/172027512-c7b8cd35-6c68-4cb4-8e10-08c84ab7b3ef.png)

### Have the changes in this PR been tested?

Yes