### PR TITLE
[3.4] Update Visual Studio Build Tools to 2022 (#5702).

### DIFF
--- a/docs/install_guides/windows.rst
+++ b/docs/install_guides/windows.rst
@@ -30,7 +30,7 @@ Then run each of the following commands:
     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
     iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
     choco upgrade git --params "/GitOnlyOnPath /WindowsTerminal" -y
-    choco upgrade visualstudio2019-workload-vctools -y
+    choco upgrade visualstudio2022-workload-vctools -y
     choco upgrade python3 -y --version 3.9.13
 
 For Audio support, you should also run the following command before exiting:


### PR DESCRIPTION
(cherry picked from commit 22ede494621620add367e06bcc3980b092ce1324)

Co-authored-by: Jakub Kuczys <6032823+jack1142@users.noreply.github.com>
