### PR TITLE
[3.4] [Modlog] Check if guild is unavailable (#5647)

### DIFF
--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -99,7 +99,7 @@ async def _init(bot: Red):
 
     async def on_member_ban(guild: discord.Guild, member: discord.Member):
 
-        if not guild.me.guild_permissions.view_audit_log:
+        if guild.unavailable or not guild.me.guild_permissions.view_audit_log:
             return
 
         try:
@@ -136,7 +136,7 @@ async def _init(bot: Red):
             await asyncio.sleep(300)
 
     async def on_member_unban(guild: discord.Guild, user: discord.User):
-        if not guild.me.guild_permissions.view_audit_log:
+        if guild.unavailable or not guild.me.guild_permissions.view_audit_log:
             return
 
         try:


### PR DESCRIPTION
fix for  AttributeError: 'NoneType' object has no attribute 'guild_permissions'
(cherry picked from commit 485e6837ca089f3a906e5222ce8a58a5e09ba6ba)

Co-authored-by: Candy <28566705+mina9999@users.noreply.github.com>
