### PR TITLE
[3.4] Prepend emojis to better differentiate between `[p]canrun` responses (#5711)

### DIFF
--- a/redbot/cogs/permissions/permissions.py
+++ b/redbot/cogs/permissions/permissions.py
@@ -10,7 +10,7 @@ from schema import And, Or, Schema, SchemaError, Optional as UseOptional
 from redbot.core import checks, commands, config
 from redbot.core.bot import Red
 from redbot.core.i18n import Translator, cog_i18n
-from redbot.core.utils.chat_formatting import box
+from redbot.core.utils.chat_formatting import box, error, success
 from redbot.core.utils.menus import start_adding_reactions
 from redbot.core.utils.predicates import ReactionPredicate, MessagePredicate
 
@@ -264,9 +264,9 @@ class Permissions(commands.Cog):
                 can = False
 
             out = (
-                _("That user can run the specified command.")
+                success(_("That user can run the specified command."))
                 if can
-                else _("That user can not run the specified command.")
+                else error(_("That user can not run the specified command."))
             )
         await ctx.send(out)
 


### PR DESCRIPTION
* Add emojis to better differentiate between canrun responses

* Apply `success()`

Co-authored-by: Jakub Kuczys <6032823+jack1142@users.noreply.github.com>

* Apply `error()`

Co-authored-by: Jakub Kuczys <6032823+jack1142@users.noreply.github.com>

* add imports

(cherry picked from commit 1fd93241716c6b93c48edf48dde243746891e0a1)

Co-authored-by: Kreusada <67752638+Kreusada@users.noreply.github.com>
Co-authored-by: Jakub Kuczys <6032823+jack1142@users.noreply.github.com>
