### PR TITLE
Update installation URLs for Homebrew and Chocolatey

### DIFF
--- a/docs/install_guides/mac.rst
+++ b/docs/install_guides/mac.rst
@@ -16,7 +16,7 @@ following, then press Enter:
 
 .. prompt:: bash
 
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 After the installation, install the required packages by pasting the commands and pressing enter,
 one-by-one:

--- a/docs/install_guides/windows.rst
+++ b/docs/install_guides/windows.rst
@@ -30,7 +30,7 @@ Then run each of the following commands:
 
     Set-ExecutionPolicy Bypass -Scope Process -Force
     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
-    iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+    iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
     choco upgrade git --params "/GitOnlyOnPath /WindowsTerminal" -y
     choco upgrade visualstudio2022-workload-vctools -y
     choco upgrade python3 -y --version 3.9.9


### PR DESCRIPTION
### Description of the changes

Since we made these instructions, the URLs changed. I doubt the old ones are likely to stop working but there's no reason not to follow upstream here.

### Have the changes in this PR been tested?

Yes

macOS: https://cirrus-ci.com/task/6191115761090560
Windows: https://cirrus-ci.com/task/5628165807669248