### PR TITLE
Drop openSUSE Leap 15.2, add openSUSE Leap 15.4

### DIFF
--- a/docs/install_guides/opensuse-leap-15.rst
+++ b/docs/install_guides/opensuse-leap-15.rst
@@ -1,7 +1,7 @@
 .. _install-opensuse-leap-15:
 
 =====================================
-Installing Red on openSUSE Leap 15.2+
+Installing Red on openSUSE Leap 15.3+
 =====================================
 
 .. include:: _includes/supported-arch-x64+aarch64.rst
@@ -12,42 +12,13 @@ Installing Red on openSUSE Leap 15.2+
 Installing the pre-requirements
 -------------------------------
 
-We recommend installing a community package to get Python 3.9 on openSUSE Leap 15.2+. This package will
-be installed to the ``/opt`` directory.
-
-First, add the Opt-Python community repository:
+openSUSE Leap 15.3+ has all required dependencies available in official repositories. Install them
+with zypper:
 
 .. prompt:: bash
 
-    source /etc/os-release
-    sudo zypper -n ar -f https://download.opensuse.org/repositories/home:/Rotkraut:/Opt-Python/openSUSE_Leap_${VERSION_ID}/ Opt-Python
-    sudo zypper -n --gpg-auto-import-keys ref
-
-Now install the pre-requirements with zypper:
-
-.. prompt:: bash
-
-    sudo zypper -n install opt-python39 opt-python39-setuptools git-core java-11-openjdk-headless nano
+    sudo zypper -n install python39-base python39-pip git-core java-11-openjdk-headless nano
     sudo zypper -n install -t pattern devel_basis
-
-Since Python is now installed to ``/opt/python``, we should add it to PATH. You can add a file in
-``/etc/profile.d/`` to do this:
-
-.. prompt:: bash
-
-    echo 'export PATH="/opt/python/bin:$PATH"' | sudo tee /etc/profile.d/opt-python.sh
-    source /etc/profile.d/opt-python.sh
-
-Now, bootstrap pip with ensurepip:
-
-.. prompt:: bash
-
-    sudo /opt/python/bin/python3.9 -m ensurepip --altinstall
-
-.. note::
-
-    After this command, a warning about running pip as root might be printed.
-    For this specific command, this warning can be safely ignored.
 
 .. Include common instructions:
 

--- a/docs/version_guarantees.rst
+++ b/docs/version_guarantees.rst
@@ -64,7 +64,6 @@ Debian 10 Buster                   x86-64, aarch64, armv7l   2022-08-14 (`End of
 Debian 11 Bullseye                 x86-64, aarch64, armv7l   ~2024-09 (`End of life <https://wiki.debian.org/DebianReleases#Production_Releases>`__)
 Fedora Linux 35                    x86-64, aarch64           2022-11-15 (`End of Life <https://docs.fedoraproject.org/en-US/releases/lifecycle/#_maintenance_schedule>`__)
 Fedora Linux 36                    x86-64, aarch64           2023-05-16 (`End of Life <https://docs.fedoraproject.org/en-US/releases/lifecycle/#_maintenance_schedule>`__)
-openSUSE Leap 15.2                 x86-64, aarch64           2021-12-31 (`end of maintenance life cycle <https://en.opensuse.org/Lifetime#openSUSE_Leap>`__)
 openSUSE Leap 15.3                 x86-64, aarch64           2022-11-30 (`end of maintenance life cycle <https://en.opensuse.org/Lifetime#openSUSE_Leap>`__)
 openSUSE Leap 15.4                 x86-64, aarch64           2023-11-30 (`end of maintenance life cycle <https://en.opensuse.org/Lifetime#openSUSE_Leap>`__)
 openSUSE Tumbleweed                x86-64, aarch64           forever (support is only provided for an up-to-date system)

--- a/docs/version_guarantees.rst
+++ b/docs/version_guarantees.rst
@@ -66,6 +66,7 @@ Fedora Linux 35                    x86-64, aarch64           2022-11-15 (`End of
 Fedora Linux 36                    x86-64, aarch64           2023-05-16 (`End of Life <https://docs.fedoraproject.org/en-US/releases/lifecycle/#_maintenance_schedule>`__)
 openSUSE Leap 15.2                 x86-64, aarch64           2021-12-31 (`end of maintenance life cycle <https://en.opensuse.org/Lifetime#openSUSE_Leap>`__)
 openSUSE Leap 15.3                 x86-64, aarch64           2022-11-30 (`end of maintenance life cycle <https://en.opensuse.org/Lifetime#openSUSE_Leap>`__)
+openSUSE Leap 15.4                 x86-64, aarch64           2023-11-30 (`end of maintenance life cycle <https://en.opensuse.org/Lifetime#openSUSE_Leap>`__)
 openSUSE Tumbleweed                x86-64, aarch64           forever (support is only provided for an up-to-date system)
 Oracle Linux 8                     x86-64, aarch64           2029-07-31 (`End of Premier Support <https://www.oracle.com/us/support/library/elsp-lifetime-069338.pdf>`__)
 Raspberry Pi OS (Legacy) 10        armv7l                    2022-08-14 (`End of life for Debian 10 <https://wiki.debian.org/DebianReleases#Production_Releases>`__)


### PR DESCRIPTION
### Description of the changes

Missed this before 3.4.17... It simplifies the installation process a lot as Leap 15.3+ has python 3.9 in its official repositories and we no longer have to use a somewhat problematic Opt-Python community repository.
I have added openSUSE Leap 15.4 to the list of EOL dates as well.

This change has been split from #5611.

### Have the changes in this PR been tested?

Yes

openSUSE Leap 15.3: https://cirrus-ci.com/task/6679555246129152
openSUSE Leap 15.4: https://cirrus-ci.com/task/4638861664976896