### PR TITLE
Exclude `files_from_attatch` member from Tunnel automodule

### DIFF
--- a/docs/framework_utils.rst
+++ b/docs/framework_utils.rst
@@ -67,6 +67,7 @@ Tunnel
 
 .. automodule:: redbot.core.utils.tunnel
     :members: Tunnel
+    :exclude-members: files_from_attatch
 
 Common Filters
 ==============


### PR DESCRIPTION
### Description of the changes

Excludes the `files_from_attatch` member from Tunnel automodule, as this "alias" doesn't need to be documented aswell.

### Have the changes in this PR been tested?

Yes
