### PR TITLE
[Core] Use the `discord.User` converter for the dm command to avoid accepting only the id of a user.

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -4059,8 +4059,14 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             - `[message]` - The message to dm to the user.
         """
 
-        if user.bot:
-            await ctx.send(_("Sorry, the user {} is a bot.").format(user))
+        if user.bot or not user.mutual_guilds:
+            await ctx.send(
+                _(
+                    "User is a bot, or user not found.. "
+                    "You can only send messages to people I share "
+                    "a server with."
+                )
+            )
             return
         prefixes = await ctx.bot.get_valid_prefixes()
         prefix = re.sub(rf"<@!?{ctx.me.id}>", f"@{ctx.me.name}".replace("\\", r"\\"), prefixes[0])

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -4046,7 +4046,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         async def convert(self, ctx: commands.Context, argument: str):
             if not self._get_id_match(argument) or re.match(r'<@!?([0-9]{15,20})>$', argument):
                 arg = argument
-                if arg[0] == '@':
+                if arg.startswith('@'):
                     # Remove first character
                     arg = arg[1:]
                 if not (len(arg) > 5 and arg[-5] == '#'):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -4042,9 +4042,20 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             await ctx.send(_("I'm unable to deliver your message. Sorry."))
 
+    class UserConverter_with_tag(commands.UserConverter):
+        async def convert(self, ctx: commands.Context, argument: str):
+            if not self._get_id_match(argument) or re.match(r'<@!?([0-9]{15,20})>$', argument):
+                arg = argument
+                if arg[0] == '@':
+                    # Remove first character
+                    arg = arg[1:]
+                if not (len(arg) > 5 and arg[-5] == '#'):
+                    raise commands.BadArgument("Please specify the user's tag or use its id, for this command.")
+            return await super().convert(ctx, argument)
+
     @commands.command()
     @checks.is_owner()
-    async def dm(self, ctx: commands.Context, user: discord.User, *, message: str):
+    async def dm(self, ctx: commands.Context, user: UserConverter_with_tag, *, message: str):
         """Sends a DM to a user.
 
         This command needs a user ID or user name to work.
@@ -4059,14 +4070,11 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             - `[message]` - The message to dm to the user.
         """
 
-        if user.bot or not user.mutual_guilds:
-            await ctx.send(
-                _(
-                    "User is a bot, or user not found.. "
-                    "You can only send messages to people I share "
-                    "a server with."
-                )
-            )
+        if user.bot:
+            await ctx.send(_("User is a bot, or user not found.. "))
+            return
+        if not user.mutual_guilds:
+            await ctx.send(_("You can only send messages to people I share a server with."))
             return
         prefixes = await ctx.bot.get_valid_prefixes()
         prefix = re.sub(rf"<@!?{ctx.me.id}>", f"@{ctx.me.name}".replace("\\", r"\\"), prefixes[0])

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -4073,20 +4073,20 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 await user.send(embed=e)
             except discord.HTTPException:
                 await ctx.send(
-                    _("Sorry, I couldn't deliver your message to {}").format(user)
+                    _("Sorry, I couldn't deliver your message to {}.").format(user)
                 )
             else:
-                await ctx.send(_("Message delivered to {}").format(user))
+                await ctx.send(_("Message delivered to {}.").format(user))
         else:
             response = "{}\nMessage:\n\n{}".format(description, message)
             try:
                 await user.send("{}\n{}".format(box(response), content))
             except discord.HTTPException:
                 await ctx.send(
-                    _("Sorry, I couldn't deliver your message to {}").format(user)
+                    _("Sorry, I couldn't deliver your message to {}.").format(user)
                 )
             else:
-                await ctx.send(_("Message delivered to {}").format(user))
+                await ctx.send(_("Message delivered to {}.").format(user))
 
     @commands.command(hidden=True)
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -4044,10 +4044,10 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
     @commands.command()
     @checks.is_owner()
-    async def dm(self, ctx: commands.Context, user_id: int, *, message: str):
+    async def dm(self, ctx: commands.Context, user: discord.User, *, message: str):
         """Sends a DM to a user.
 
-        This command needs a user ID to work.
+        This command needs a user ID or user name to work.
 
         To get a user ID, go to Discord's settings and open the 'Appearance' tab.
         Enable 'Developer Mode', then right click a user and click on 'Copy ID'.
@@ -4058,16 +4058,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         **Arguments:**
             - `[message]` - The message to dm to the user.
         """
-        destination = self.bot.get_user(user_id)
-        if destination is None or destination.bot:
-            await ctx.send(
-                _(
-                    "Invalid ID, user not found, or user is a bot. "
-                    "You can only send messages to people I share "
-                    "a server with."
-                )
-            )
-            return
 
         prefixes = await ctx.bot.get_valid_prefixes()
         prefix = re.sub(rf"<@!?{ctx.me.id}>", f"@{ctx.me.name}".replace("\\", r"\\"), prefixes[0])
@@ -4080,23 +4070,23 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             e.set_author(name=description, icon_url=ctx.bot.user.display_avatar)
 
             try:
-                await destination.send(embed=e)
+                await user.send(embed=e)
             except discord.HTTPException:
                 await ctx.send(
-                    _("Sorry, I couldn't deliver your message to {}").format(destination)
+                    _("Sorry, I couldn't deliver your message to {}").format(user)
                 )
             else:
-                await ctx.send(_("Message delivered to {}").format(destination))
+                await ctx.send(_("Message delivered to {}").format(user))
         else:
             response = "{}\nMessage:\n\n{}".format(description, message)
             try:
-                await destination.send("{}\n{}".format(box(response), content))
+                await user.send("{}\n{}".format(box(response), content))
             except discord.HTTPException:
                 await ctx.send(
-                    _("Sorry, I couldn't deliver your message to {}").format(destination)
+                    _("Sorry, I couldn't deliver your message to {}").format(user)
                 )
             else:
-                await ctx.send(_("Message delivered to {}").format(destination))
+                await ctx.send(_("Message delivered to {}").format(user))
 
     @commands.command(hidden=True)
     @checks.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -4059,6 +4059,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             - `[message]` - The message to dm to the user.
         """
 
+        if user.bot:
+            await ctx.send(_("Sorry, the user {} is a bot.").format(user))
+            return
         prefixes = await ctx.bot.get_valid_prefixes()
         prefix = re.sub(rf"<@!?{ctx.me.id}>", f"@{ctx.me.name}".replace("\\", r"\\"), prefixes[0])
         description = _("Owner of {}").format(ctx.bot.user)


### PR DESCRIPTION

### Description of the changes

Hello,
Here is a PR to allow the dm command to use the `discord.User` converter to support usernames and mentions as valid command arguments.
We had talked about this quickly on the main Red server and you were not against the idea.
I know that the changes for dpy2 are more important. I didn't open a discussion because the change doesn't really require much thought and is just a minor change to a basic command.
Thanks in advance for your help,
AAA3A

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
