### PR TITLE
Exclude `get_embed_color` member from Bot framework

### DIFF
--- a/docs/framework_bot.rst
+++ b/docs/framework_bot.rst
@@ -11,7 +11,7 @@ Red
 
 .. autoclass:: Red
     :members:
-    :exclude-members: get_context
+    :exclude-members: get_context, get_embed_color
 
     .. automethod:: register_rpc_handler
     .. automethod:: unregister_rpc_handler


### PR DESCRIPTION
### Description of the changes

Another instance where a method is repeated in the docs due to aliasing. This PR has prevented this duplicate in a similar fashion to the exclusion of `randomize_color` from the utils.embed automodule, where the American spelling "color" has been excluded. Not that it really matters though.

### Have the changes in this PR been tested?

Yes
