### PR TITLE
[stable-docs] Split openSUSE Leap 15.2/15.3+ to support 15.4

### DIFF
--- a/docs/install_guides/index.rst
+++ b/docs/install_guides/index.rst
@@ -22,6 +22,7 @@ we recommend **Ubuntu 22.04 LTS**.
    debian-10
    debian-11
    fedora
+   opensuse-leap-152
    opensuse-leap-15
    opensuse-tumbleweed
    oracle-linux-8

--- a/docs/install_guides/opensuse-leap-15.rst
+++ b/docs/install_guides/opensuse-leap-15.rst
@@ -1,7 +1,7 @@
 .. _install-opensuse-leap-15:
 
 =====================================
-Installing Red on openSUSE Leap 15.2+
+Installing Red on openSUSE Leap 15.3+
 =====================================
 
 .. include:: _includes/linux-preamble.rst
@@ -10,42 +10,13 @@ Installing Red on openSUSE Leap 15.2+
 Installing the pre-requirements
 -------------------------------
 
-We recommend installing a community package to get Python 3.9 on openSUSE Leap 15.2+. This package will
-be installed to the ``/opt`` directory.
-
-First, add the Opt-Python community repository:
+openSUSE Leap 15.3+ has all required dependencies available in official repositories. Install them
+with zypper:
 
 .. prompt:: bash
 
-    source /etc/os-release
-    sudo zypper -n ar -f https://download.opensuse.org/repositories/home:/Rotkraut:/Opt-Python/openSUSE_Leap_${VERSION_ID}/ Opt-Python
-    sudo zypper -n --gpg-auto-import-keys ref
-
-Now install the pre-requirements with zypper:
-
-.. prompt:: bash
-
-    sudo zypper -n install opt-python39 opt-python39-setuptools git-core java-11-openjdk-headless nano
+    sudo zypper -n install python39-base python39-pip git-core java-11-openjdk-headless nano
     sudo zypper -n install -t pattern devel_basis
-
-Since Python is now installed to ``/opt/python``, we should add it to PATH. You can add a file in
-``/etc/profile.d/`` to do this:
-
-.. prompt:: bash
-
-    echo 'export PATH="/opt/python/bin:$PATH"' | sudo tee /etc/profile.d/opt-python.sh
-    source /etc/profile.d/opt-python.sh
-
-Now, bootstrap pip with ensurepip:
-
-.. prompt:: bash
-
-    sudo /opt/python/bin/python3.9 -m ensurepip --altinstall
-
-.. note::
-
-    After this command, a warning about running pip as root might be printed.
-    For this specific command, this warning can be safely ignored.
 
 .. Include common instructions:
 

--- a/docs/install_guides/opensuse-leap-152.rst
+++ b/docs/install_guides/opensuse-leap-152.rst
@@ -1,0 +1,53 @@
+.. _install-opensuse-leap-15-2:
+
+====================================
+Installing Red on openSUSE Leap 15.2
+====================================
+
+.. include:: _includes/linux-preamble.rst
+
+-------------------------------
+Installing the pre-requirements
+-------------------------------
+
+We recommend installing a community package to get Python 3.9 on openSUSE Leap 15.2. This package will
+be installed to the ``/opt`` directory.
+
+First, add the Opt-Python community repository:
+
+.. prompt:: bash
+
+    sudo zypper -n ar -f https://download.opensuse.org/repositories/home:/Rotkraut:/Opt-Python/openSUSE_Leap_15.2/ Opt-Python
+    sudo zypper -n --gpg-auto-import-keys ref
+
+Now install the pre-requirements with zypper:
+
+.. prompt:: bash
+
+    sudo zypper -n install opt-python39 opt-python39-setuptools git-core java-11-openjdk-headless nano
+    sudo zypper -n install -t pattern devel_basis
+
+Since Python is now installed to ``/opt/python``, we should add it to PATH. You can add a file in
+``/etc/profile.d/`` to do this:
+
+.. prompt:: bash
+
+    echo 'export PATH="/opt/python/bin:$PATH"' | sudo tee /etc/profile.d/opt-python.sh
+    source /etc/profile.d/opt-python.sh
+
+Now, bootstrap pip with ensurepip:
+
+.. prompt:: bash
+
+    sudo /opt/python/bin/python3.9 -m ensurepip --altinstall
+
+.. note::
+
+    After this command, a warning about running pip as root might be printed.
+    For this specific command, this warning can be safely ignored.
+
+.. Include common instructions:
+
+.. include:: _includes/create-env-with-venv.rst
+
+.. include:: _includes/install-and-setup-red-unix.rst


### PR DESCRIPTION
### Description of the changes

Trying out a way to publish fixes to our `stable` documentation without having to release a new version of Red.
In this case, our openSUSE Leap 15.2+ instructions, as I've recently found out, do not work with the latest openSUSE Leap 15.4. This is also a good opportunity to give simpler instructions for installing Python 3.9 for openSUSE Leap 15.3 and above since I forgot to drop support for openSUSE Leap 15.2 when releasing 3.4.17 and as such we have to keep those old, more complicated instructions for now.

The way this would get auto-published to our `stable` documentation is by using a `stable` branch for this documentation. This causes RTD to use that instead of the latest tag. The 
added maintenance is ensuring that we remove this branch before making another release so that the documentation gets properly updated to use that tag.

### Have the changes in this PR been tested?

Yes

openSUSE Leap 15.2: https://cirrus-ci.com/task/6229240977817600
openSUSE Leap 15.3: https://cirrus-ci.com/task/4821866094264320
openSUSE Leap 15.4: https://cirrus-ci.com/task/5947766001106944