### PR TITLE
[Dev] Fix `__repr__()` errors in REPL when referencing an instance of a class & catch Exception

### DIFF
--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -204,7 +204,7 @@ class Dev(commands.Cog):
         try:
             with redirect_stdout(stdout):
                 result = await func()
-        except:
+        except Exception:
             printed = "{}{}".format(stdout.getvalue(), traceback.format_exc())
         else:
             printed = stdout.getvalue()
@@ -293,7 +293,7 @@ class Dev(commands.Cog):
                     else:
                         result = executor(code, env)
                     result = await self.maybe_await(result)
-            except:
+            except Exception:
                 value = stdout.getvalue()
                 msg = "{}{}".format(value, traceback.format_exc())
             else:
@@ -301,7 +301,7 @@ class Dev(commands.Cog):
                 if result is not None:
                     try:
                         msg = "{}{}".format(value, result)
-                    except:
+                    except Exception:
                         msg = "{}{}".format(value, traceback.format_exc())
                     env["_"] = result
                 elif value:

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -299,7 +299,10 @@ class Dev(commands.Cog):
             else:
                 value = stdout.getvalue()
                 if result is not None:
-                    msg = "{}{}".format(value, result)
+                    try:
+                        msg = "{}{}".format(value, result)
+                    except:
+                        msg = "{}{}".format(value, traceback.format_exc())
                     env["_"] = result
                 elif value:
                     msg = "{}".format(value)


### PR DESCRIPTION
### Description of the changes

I have noticed that when `__repr__()` is to raise an exception, the `[p]repl` command fails, and the exception is explicitly raised instead of being sent as a message in the session. However, this only happens when the instance is referenced (`object()`) and not when the `repr()` function is used (`repr(object())`).

Take the following code, for example:

```py
class A(object):
    def __repr__(self) -> str:
        raise Exception
```

If we were to type `A()`, Exception would be explicitly raised as a command error. However, typing `repr(A())` would behave as you would expect.

I discovered this with my own code in a REPL session:

```py
def __repr__(self) -> str:
    attrs = {n[1:]: getattr(self, n) for n in self.__slots__}
    join = ", ".join(f"{k}={v!r}" for k, v in attrs.items())
    return f"{self.__class__.__name__}({join})"
```

I had not included the `__slots__` definition within the class, hence why an AttributeError was raised when I typed "MyClass()". I was expecting this error to be printed in the session's channel, not to error the command.

### Have the changes in this PR been tested?

Yes, working