### PR TITLE
Add `core/_debuginfo.py` to labeler configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,6 +22,7 @@
   # Source
   - redbot/*
   - redbot/core/__init__.py
+  - redbot/core/_debuginfo.py
   - redbot/core/_diagnoser.py
   - redbot/core/_sharedlibdeprecation.py
   - redbot/core/bot.py


### PR DESCRIPTION
### Description of the changes

I noticed that `redbot/core/_debuginfo.py` was not present in the labeler config, and probably should be.

### Have the changes in this PR been tested?

Yes