### PR TITLE
[Core] Add `--unload-cogs` cli flag.

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1140,11 +1140,8 @@ class Red(
             if self._cli_flags.load_cogs:
                 packages.update(dict.fromkeys(self._cli_flags.load_cogs))
             if self._cli_flags.unload_cogs:
-                for x in self._cli_flags.unload_cogs:
-                    if x not in self._cli_flags.unload_cogs:
-                        self._cli_flags.unload_cogs.remove(x)
-                        continue
-                    del packages[x]
+                for package in self._cli_flags.unload_cogs:
+                    packages.pop(package, None)
 
         system_changed = False
         machine = platform.machine()

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1140,9 +1140,8 @@ class Red(
             if self._cli_flags.load_cogs:
                 packages.update(dict.fromkeys(self._cli_flags.load_cogs))
             if self._cli_flags.unload_cogs:
-                for x in self._cli_flags.unload_cogs:
-                    if x in self._cli_flags.unload_cogs:
-                        del packages[x]
+                for package in self._cli_flags.unload_cogs:
+                    packages.pop(package, None)
 
         system_changed = False
         machine = platform.machine()
@@ -1174,7 +1173,7 @@ class Red(
             # Load permissions first, for security reasons
             try:
                 packages.move_to_end("permissions", last=False)
-            except ValueError:
+            except KeyError:
                 pass
 
             to_remove = []

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1203,7 +1203,7 @@ class Red(
             for package in to_remove:
                 del packages[package]
         if packages:
-            log.info("Loaded packages: " + ", ".join(packages.keys()))
+            log.info("Loaded packages: " + ", ".join(packages))
         else:
             log.info("No packages were loaded.")
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1140,6 +1140,10 @@ class Red(
             if self._cli_flags.load_cogs:
                 packages.extend(self._cli_flags.load_cogs)
 
+            if self._cli_flags.unload_cogs:
+                self._cli_flags.unload_cogs = [x for x in self._cli_flags.unload_cogs if x in packages]
+                packages.remove(*self._cli_flags.unload_cogs)
+
         system_changed = False
         machine = platform.machine()
         system = platform.system()

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1140,8 +1140,9 @@ class Red(
             if self._cli_flags.load_cogs:
                 packages.update(dict.fromkeys(self._cli_flags.load_cogs))
             if self._cli_flags.unload_cogs:
-                for package in self._cli_flags.unload_cogs:
-                    packages.pop(package, None)
+                for x in self._cli_flags.unload_cogs:
+                    if x in self._cli_flags.unload_cogs:
+                        del packages[x]
 
         system_changed = False
         machine = platform.machine()
@@ -1172,12 +1173,9 @@ class Red(
         if packages:
             # Load permissions first, for security reasons
             try:
-                del packages["permissions"]
+                packages.move_to_end("permissions", last=False)
             except ValueError:
                 pass
-            else:
-                packages["permissions"] = None
-                packages.move_to_end("permissions", last=False)
 
             to_remove = []
             log.info("Loading packages...")

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1141,8 +1141,11 @@ class Red(
                 packages.extend(self._cli_flags.load_cogs)
 
             if self._cli_flags.unload_cogs:
-                self._cli_flags.unload_cogs = [x for x in self._cli_flags.unload_cogs if x in packages]
-                packages.remove(*self._cli_flags.unload_cogs)
+                for x in self._cli_flags.unload_cogs:
+                    if x not in self._cli_flags.unload_cogs:
+                        self._cli_flags.unload_cogs.remove(x)
+                        continue
+                    packages.remove(x)
 
         system_changed = False
         machine = platform.machine()
@@ -1202,8 +1205,10 @@ class Red(
                     to_remove.append(package)
             for package in to_remove:
                 packages.remove(package)
-            if packages:
-                log.info("Loaded packages: " + ", ".join(packages))
+        if packages:
+            log.info("Loaded packages: " + ", ".join(packages))
+        else:
+            log.info("No packages were loaded.")
 
         if self.rpc_enabled:
             await self.rpc.initialize(self.rpc_port)

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -186,6 +186,12 @@ def parse_cli_flags(args):
         "Can be used with the --no-cogs flag to load these cogs exclusively.",
     )
     parser.add_argument(
+        "--unload-cogs",
+        type=str,
+        nargs="+",
+        help="Force unloading specified cogs."
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Makes Red quit with code 0 just before the "

--- a/redbot/core/cli.py
+++ b/redbot/core/cli.py
@@ -186,10 +186,7 @@ def parse_cli_flags(args):
         "Can be used with the --no-cogs flag to load these cogs exclusively.",
     )
     parser.add_argument(
-        "--unload-cogs",
-        type=str,
-        nargs="+",
-        help="Force unloading specified cogs."
+        "--unload-cogs", type=str, nargs="+", help="Force unloading specified cogs."
     )
     parser.add_argument(
         "--dry-run",


### PR DESCRIPTION
### Description of the changes

Hello,
Following issue #5796 on this repo, this PR allows to add a cli command line argument that prevents all the cogs mentioned from being loaded at Red startup.
As explained in the related issue, users sometimes want to unload a single cog that is causing problems, without having to quote all the other cogs to be loaded.
I don't know if it's better to allow `--load-cogs` to add the packages anyway.
The code was tested under the development version of Red 3.5 and under the latest commit of dpy2 with a patch file. The agument was used or not, with a valid or invalid package name and with `--no-cogs` and `load-cogs` arguments.
I guess there is some documentation somewhere that I need to change. Where is it?
Thank you in advance,
AAA3A

Fixes #5796 

### Have the changes in this PR been tested?

Yes
