### PR TITLE
[3.4] [Audio] Update application.yml for new Lavalink.jar

### DIFF
--- a/redbot/cogs/audio/data/application.yml
+++ b/redbot/cogs/audio/data/application.yml
@@ -39,10 +39,13 @@ sentry:
 
 logging:
   file:
-    max-history: 7
-    max-size: 1GB
-  path: ./logs/
+    path: ./logs/
 
   level:
     root: INFO
     lavalink: INFO
+
+  logback:
+    rollingpolicy:
+      max-history: 7
+      max-file-size: 1GB


### PR DESCRIPTION
### Description of the changes
We will be using a new Lavalink.jar on build 1350 and later that includes a Spring Boot version update from 2.1.8 to 2.6.6. In this version change, some of the logging functions have changed so they have been moved to their new designation.

### Have the changes in this PR been tested?
Yes, I installed a copy of Red with this file from a GH repo and Red started up, it replaced my old application.yml with this file and then the newer Lavalink.jar started to create log files again.