### PR TITLE
[3.4] [Audio] Update Lavalink.jar build

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -24,7 +24,7 @@ from .utils import task_callback
 _ = Translator("Audio", pathlib.Path(__file__))
 log = logging.getLogger("red.Audio.manager")
 JAR_VERSION: Final[str] = "3.4.0"
-JAR_BUILD: Final[int] = 1347
+JAR_BUILD: Final[int] = 1350
 LAVALINK_DOWNLOAD_URL: Final[str] = (
     "https://github.com/Cog-Creators/Lavalink-Jars/releases/download/"
     f"{JAR_VERSION}_{JAR_BUILD}/"


### PR DESCRIPTION
### Description of the changes
This changes audio's manager to download and use build 1350 of our Lavalink.jars.


### Have the changes in this PR been tested?
No, I PRed this without explicitly testing this change.
