### PR TITLE
[3.4] Drop openSUSE Leap 15.2, add openSUSE Leap 15.4 (#5777)

### DIFF
--- a/docs/install_guides/opensuse-leap-15.rst
+++ b/docs/install_guides/opensuse-leap-15.rst
@@ -1,7 +1,7 @@
 .. _install-opensuse-leap-15:
 
 =====================================
-Installing Red on openSUSE Leap 15.2+
+Installing Red on openSUSE Leap 15.3+
 =====================================
 
 .. include:: _includes/linux-preamble.rst
@@ -10,42 +10,13 @@ Installing Red on openSUSE Leap 15.2+
 Installing the pre-requirements
 -------------------------------
 
-We recommend installing a community package to get Python 3.9 on openSUSE Leap 15.2+. This package will
-be installed to the ``/opt`` directory.
-
-First, add the Opt-Python community repository:
+openSUSE Leap 15.3+ has all required dependencies available in official repositories. Install them
+with zypper:
 
 .. prompt:: bash
 
-    source /etc/os-release
-    sudo zypper -n ar -f https://download.opensuse.org/repositories/home:/Rotkraut:/Opt-Python/openSUSE_Leap_${VERSION_ID}/ Opt-Python
-    sudo zypper -n --gpg-auto-import-keys ref
-
-Now install the pre-requirements with zypper:
-
-.. prompt:: bash
-
-    sudo zypper -n install opt-python39 opt-python39-setuptools git-core java-11-openjdk-headless nano
+    sudo zypper -n install python39-base python39-pip git-core java-11-openjdk-headless nano
     sudo zypper -n install -t pattern devel_basis
-
-Since Python is now installed to ``/opt/python``, we should add it to PATH. You can add a file in
-``/etc/profile.d/`` to do this:
-
-.. prompt:: bash
-
-    echo 'export PATH="/opt/python/bin:$PATH"' | sudo tee /etc/profile.d/opt-python.sh
-    source /etc/profile.d/opt-python.sh
-
-Now, bootstrap pip with ensurepip:
-
-.. prompt:: bash
-
-    sudo /opt/python/bin/python3.9 -m ensurepip --altinstall
-
-.. note::
-
-    After this command, a warning about running pip as root might be printed.
-    For this specific command, this warning can be safely ignored.
 
 .. Include common instructions:
 


### PR DESCRIPTION
* Add openSUSE Leap 15.4 to list in version guarantees

* Drop openSUSE Leap 15.2
(cherry picked from commit 0cc964b87ce4a81f04506a1cf5970a5ada638145)

Co-authored-by: Jakub Kuczys <6032823+jack1142@users.noreply.github.com>
