### PR TITLE
[3.4] Bump Red-Lavalink version to 0.9.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ install_requires =
     python-Levenshtein-wheels==0.13.2
     pytz==2021.1
     PyYAML==5.4.1
-    Red-Lavalink==0.9.3
+    Red-Lavalink==0.9.4
     rich==10.9.0
     schema==0.7.4
     six==1.16.0


### PR DESCRIPTION
### Description of the changes

Bumps version of Red-Lavalink to 0.9.4.

### Have the changes in this PR been tested?

Yes

Well, sort of. I tested #131 which is what will basically be RLL 0.9.4. However, I couldn't test that this change works since RLL 0.9.4 is not available yet.
