### PR TITLE
Get rid of localized guild feature list in serverinfo

### DIFF
--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -414,14 +414,26 @@ class General(commands.Cog):
                 inline=False,
             )
 
+            excluded_features = {
+                # available to everyone since forum channels private beta
+                "THREE_DAY_THREAD_ARCHIVE",
+                "SEVEN_DAY_THREAD_ARCHIVE",
+                # rolled out to everyone already
+                "NEW_THREAD_PERMISSIONS",
+                "TEXT_IN_VOICE_ENABLED",
+                "THREADS_ENABLED",
+            }
             custom_feature_names = {
-                "TEXT_IN_VOICE_ENABLED": "Text in Voice enabled",
                 "VANITY_URL": "Vanity URL",
                 "VIP_REGIONS": "VIP regions",
             }
+            features = sorted(guild.features)
+            if "COMMUNITY" in features:
+                features.remove("NEWS")
             feature_names = [
                 custom_feature_names.get(feature, " ".join(feature.split("_")).capitalize())
-                for feature in sorted(guild.features)
+                for feature in features
+                if feature not in excluded_features
             ]
             if guild.features:
                 data.add_field(
@@ -430,6 +442,7 @@ class General(commands.Cog):
                         f"\N{WHITE HEAVY CHECK MARK} {feature}" for feature in feature_names
                     ),
                 )
+
             if guild.premium_tier != 0:
                 nitro_boost = _(
                     "Tier {boostlevel} with {nitroboosters} boosts\n"

--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -352,37 +352,6 @@ class General(commands.Cog):
                 "highest": _("4 - Highest"),
             }
 
-            features = {
-                "ANIMATED_ICON": _("Animated Icon"),
-                "ANIMATED_BANNER": _("Animated Banner"),
-                "BANNER": _("Banner"),
-                "COMMERCE": _("Commerce"),
-                "COMMUNITY": _("Community"),
-                "DISCOVERABLE": _("Discoverable"),
-                "FEATURABLE": _("Featurable"),
-                "INVITE_SPLASH": _("Splash Invite"),
-                "MEMBER_VERIFICATION_GATE_ENABLED": _("Membership Screening enabled"),
-                "MONETIZATION_ENABLED": _("Monetization Enabled"),
-                "MORE_STICKERS": _("More Stickers"),
-                "NEWS": _("News"),
-                "PARTNERED": _("Partnered"),
-                "PREVIEW_ENABLED": _("Preview Enabled"),
-                "PRIVATE_THREADS": _("Private Threads"),
-                "ROLE_ICON": _("Role Icon"),
-                "SEVEN_DAY_THREAD_ARCHIVE": _("Seven Day Thread Archive"),
-                "THREE_DAY_THREAD_ARCHIVE": _("Three Day Thread Archive"),
-                "TICKETED_EVENTS_ENABLED": _("Ticketed Events Enabled"),
-                "VERIFIED": _("Verified"),
-                "VANITY_URL": _("Vanity URL"),
-                "VIP_REGIONS": _("VIP Regions"),
-                "WELCOME_SCREEN_ENABLED": _("Welcome Screen Enabled"),
-            }
-            guild_features_list = [
-                f"\N{WHITE HEAVY CHECK MARK} {name}"
-                for feature, name in features.items()
-                if feature in guild.features
-            ]
-
             joined_on = _(
                 "{bot_name} joined this server on {bot_join}. That's over {since_join} days ago!"
             ).format(
@@ -444,8 +413,14 @@ class General(commands.Cog):
                 ),
                 inline=False,
             )
-            if guild_features_list:
-                data.add_field(name=_("Server features:"), value="\n".join(guild_features_list))
+
+            if guild.features:
+                data.add_field(
+                    name=_("Server features:"),
+                    value="\n".join(
+                        f"\N{WHITE HEAVY CHECK MARK} {feature}" for feature in guild.features
+                    ),
+                )
             if guild.premium_tier != 0:
                 nitro_boost = _(
                     "Tier {boostlevel} with {nitroboosters} boosts\n"

--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -414,11 +414,20 @@ class General(commands.Cog):
                 inline=False,
             )
 
+            custom_feature_names = {
+                "TEXT_IN_VOICE_ENABLED": "Text in Voice enabled",
+                "VANITY_URL": "Vanity URL",
+                "VIP_REGIONS": "VIP regions",
+            }
+            feature_names = [
+                custom_feature_names.get(feature, " ".join(feature.split("_")).capitalize())
+                for feature in sorted(guild.features)
+            ]
             if guild.features:
                 data.add_field(
                     name=_("Server features:"),
                     value="\n".join(
-                        f"\N{WHITE HEAVY CHECK MARK} {feature}" for feature in guild.features
+                        f"\N{WHITE HEAVY CHECK MARK} {feature}" for feature in feature_names
                     ),
                 )
             if guild.premium_tier != 0:


### PR DESCRIPTION
### Description of the changes

An attempt at lowering the requirement for constant maintenance of the guild feature list. This PR makes it so that instead of maintaining a guild features list, we show the guild features as given to us by the API. Mostly. I've made 3 exceptions where the automatic casing didn't really make sense to me.

Before:
![image](https://user-images.githubusercontent.com/6032823/184562006-19a1d8c1-668f-4e38-9d24-f233f7c90acd.png)

After:
![image](https://user-images.githubusercontent.com/6032823/184561972-030ad22c-1795-42f9-a793-c846d6a5524a.png)

As can be seen on the screenshots, this PR makes `[p]serverinfo 1` show more features than before but to me, it kind of seems like an upside... Feel free to comment if you disagree.

### Have the changes in this PR been tested?

Yes
