### PR TITLE
[Commands] Fix @commands.group(help=...) not setting the help attr

### DIFF
--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -999,6 +999,8 @@ def group(name=None, cls=Group, **attrs):
 
     Same interface as `discord.ext.commands.group`.
     """
+    attrs["help_override"] = attrs.pop("help", None)
+
     return dpy_command_deco(name, cls, **attrs)
 
 


### PR DESCRIPTION
### Description of the changes
Fixes #5838


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No - I tested that the issue is fixed in the basic case, however I have not tested for any side effects, nor do I know if there was any reason this line was deliberately omitted from the group deco.
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
