### PR TITLE
Fix Tunnel.message_forwarder's handling of >2000 strings

### DIFF
--- a/redbot/core/utils/tunnel.py
+++ b/redbot/core/utils/tunnel.py
@@ -128,10 +128,7 @@ class Tunnel(metaclass=TunnelMeta):
         if content:
             for page in pagify(content):
                 rets.append(await destination.send(page, files=files, embed=embed))
-                if files:
-                    del files
-                if embed:
-                    del embed
+                files = embed = None
         elif embed or files:
             rets.append(await destination.send(files=files, embed=embed))
         return rets


### PR DESCRIPTION
### Description of the changes

Fixes bad usage of `del` in `Tunnel.message_forwarder` that can result in `UnboundLocalError`.

### How to reproduce?

Run the eval command with the below code and a file attached:
```py
from redbot.core.utils.tunnel import Tunnel

await Tunnel.message_forwarder(
    destination=ctx, content="A"*4000, files=[await message.attachments[0].to_file()]
)
```
See output:
```
Traceback (most recent call last):
  File "/home/ubuntu/red-venv/lib/python3.8/site-packages/redbot/core/dev_commands.py", line 206, in _eval
    result = await func()
  File "<string>", line 5, in func
  File "/home/ubuntu/red-venv/lib/python3.8/site-packages/redbot/core/utils/tunnel.py", line 126, in message_forwarder
    rets.append(await destination.send(page, files=files, embed=embed))
UnboundLocalError: local variable 'files' referenced before assignment
```

### Have the changes in this PR been tested?

No
