### PR TITLE
Correction of annotations in Config related methods

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -5,16 +5,13 @@ import logging
 import pickle
 import weakref
 
-from collections import (
-    Awaitable,
-    MutableMapping
-)
-from contextlib import AbstractAsyncContextManager
-
 from typing import (
     Any,
+    Awaitable,
+    AsyncContextManager,
     Dict,
     Generator,
+    MutableMapping,
     Type,
     Optional,
     Tuple,
@@ -71,7 +68,9 @@ def get_latest_confs() -> Tuple["Config"]:
     return tuple(ret)
 
 
-class _ValueCtxManager(Awaitable[_T], AbstractAsyncContextManager[_T]):  # pylint: disable=duplicate-bases
+class _ValueCtxManager(
+    Awaitable[_T], AsyncContextManager[_T]
+):  # pylint: disable=duplicate-bases
     """Context manager implementation of config values.
 
     This class allows mutable config values to be both "get" and "set" from

--- a/redbot/core/drivers/__init__.py
+++ b/redbot/core/drivers/__init__.py
@@ -1,5 +1,5 @@
 import enum
-from typing import Optional, Type
+from typing import Any, Optional, Type
 
 from .. import data_manager
 from .base import IdentifierData, BaseDriver, ConfigCategory
@@ -78,7 +78,7 @@ def get_driver(
     storage_type: Optional[BackendType] = None,
     *,
     allow_old: bool = False,
-    **kwargs,
+    **kwargs: Any,
 ):
     """Get a driver instance.
 


### PR DESCRIPTION
### Description of the changes

Improve annotations in Config.

- When awaiting a `Value`/`Group`, this will no longer raises `_ValueCtxManager is not awaitable` (Due to invalid annotation of `__await__`)
  ![Error in capspam.py, compaining that ValueCtxManager is not awaitable](https://media.discordapp.net/attachments/133251234164375552/1019942427542425643/Code_-_Insiders_4LmQK5ZK50.gif)
- Correction of some invalid annotations
- Use method overload for `Config.get_conf` to either include `cog_instance` or `cog_name`, or raise an error if both are `None` (See comment below)

### Have the changes in this PR been tested?

Yes