### PR TITLE
Add missing period which caused ignore list to fail

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -5236,7 +5236,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             if await self.bot._ignored_cache.get_ignored_channel(channel, check_category=False):
                 text_channels.append(channel)
         for thread in ctx.guild.threads:
-            if await self.bot_ignored_cache.get_ignored_channel(thread, check_category=False):
+            if await self.bot._ignored_cache.get_ignored_channel(thread, check_category=False):
                 threads.append(thread)
 
         cat_str = (


### PR DESCRIPTION

### Description of the changes

When testing 3.5 I tried to list all ignored channels and got an error which referenced `AttributeError: 'Core' object has no attribute 'bot_ignored_cache'` bot_ignored_cache is only mentioned here and appears to be a typo. I've tested this locally and it appears to have fixed the error as the ignore list now appears correctly.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
