### PR TITLE
Properly handle missing schemas/tables in PostgreSQL driver

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,3 +91,13 @@ jobs:
             PGPASSWORD: postgres
             PGPORT: 5432
           run: tox
+        - name: Verify no errors in PostgreSQL logs.
+          run: |
+            logs="$(docker logs "${{ job.services.postgresql.id }}" 2>&1)"
+            echo "---- PostgreSQL logs ----"
+            echo "$logs"
+            echo "---- PostgreSQL logs ----"
+            error_count="$(echo "$logs" | { grep -c 'ERROR: ' || true; })"
+            if [[ $error_count -gt 0 ]]; then
+              exit 1
+            fi

--- a/redbot/core/drivers/postgres/ddl.sql
+++ b/redbot/core/drivers/postgres/ddl.sql
@@ -140,6 +140,8 @@ CREATE OR REPLACE FUNCTION
     missing_pkey_columns text;
 
   BEGIN
+    PERFORM red_config.maybe_create_table(id_data);
+
     IF num_missing_pkeys <= 0 THEN
       -- No missing primary keys: we're getting all or part of a document.
       EXECUTE format(

--- a/redbot/core/drivers/postgres/ddl.sql
+++ b/redbot/core/drivers/postgres/ddl.sql
@@ -140,8 +140,6 @@ CREATE OR REPLACE FUNCTION
     missing_pkey_columns text;
 
   BEGIN
-    PERFORM red_config.maybe_create_table(id_data);
-
     IF num_missing_pkeys <= 0 THEN
       -- No missing primary keys: we're getting all or part of a document.
       EXECUTE format(

--- a/redbot/core/drivers/postgres/postgres.py
+++ b/redbot/core/drivers/postgres/postgres.py
@@ -137,14 +137,11 @@ class PostgresDriver(BaseDriver):
         }
 
     async def get(self, identifier_data: IdentifierData):
-        try:
-            result = await self._execute(
-                "SELECT red_config.get($1)",
-                encode_identifier_data(identifier_data),
-                method=self._pool.fetchval,
-            )
-        except asyncpg.UndefinedTableError:
-            raise KeyError from None
+        result = await self._execute(
+            "SELECT red_config.get($1)",
+            encode_identifier_data(identifier_data),
+            method=self._pool.fetchval,
+        )
 
         if result is None:
             # The result is None both when postgres yields no results, or when it yields a NULL row
@@ -163,12 +160,7 @@ class PostgresDriver(BaseDriver):
             raise errors.CannotSetSubfield
 
     async def clear(self, identifier_data: IdentifierData):
-        try:
-            await self._execute(
-                "SELECT red_config.clear($1)", encode_identifier_data(identifier_data)
-            )
-        except asyncpg.UndefinedTableError:
-            pass
+        await self._execute("SELECT red_config.clear($1)", encode_identifier_data(identifier_data))
 
     async def inc(
         self, identifier_data: IdentifierData, value: Union[int, float], default: Union[int, float]

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -669,3 +669,61 @@ async def test_config_custom_get_raw_with_default_on_whole_scope(config):
 
     group = config.custom("TEST")
     assert await group.get_raw(default=True) is True
+
+
+@pytest.mark.parametrize(
+    "pkeys,raw_args,to_set",
+    (
+        # no config data for (cog_name, cog_id) is present
+        ((), (), None),
+        ((1,), (), None),
+        ((1, 2), (), None),
+        ((1, 2, 3), (), None),
+        ((1, 2, 3), ("key1",), None),
+        ((1, 2, 3), ("key1", "key2"), None),
+        # config data for (cog_name, cog_id) is present but scope does not exist
+        ((), (), ()),
+        ((1,), (), ()),
+        ((1, 2), (), ()),
+        ((1, 2, 3), (), ()),
+        ((1, 2, 3), ("key1",), ()),
+        ((1, 2, 3), ("key1", "key2"), ()),
+        # the scope exists with no records
+        ((1,), (), ("1",)),
+        ((1, 2), (), ("1",)),
+        ((1, 2, 3), (), ("1",)),
+        ((1, 2, 3), ("key1",), ("1",)),
+        ((1, 2, 3), ("key1", "key2"), ("1",)),
+        # scope with partial primary key (1,) exists
+        ((1, 2), (), ("1", "2")),
+        ((1, 2, 3), (), ("1", "2")),
+        ((1, 2, 3), ("key1",), ("1", "2")),
+        ((1, 2, 3), ("key1", "key2"), ("1", "2")),
+        # scope with partial primary key (1, 2) exists
+        ((1, 2, 3), (), ("1", "2", "3")),
+        ((1, 2, 3), ("key1",), ("1", "2", "3")),
+        ((1, 2, 3), ("key1", "key2"), ("1", "2", "3")),
+        # scope with full primary key (1, 2, 3)
+        ((1, 2, 3), ("key1",), ("1", "2", "3", "key1")),
+        ((1, 2, 3), ("key1", "key2"), ("1", "2", "3", "key1")),
+        # scope with full primary key (1, 2, 3) and a group named "key1" exists
+        ((1, 2, 3), ("key1", "key2"), ("1", "2", "3", "key1", "key2")),
+    ),
+)
+@pytest.mark.asyncio
+async def test_config_custom_clear_identifiers_that_do_not_exist(config, pkeys, raw_args, to_set):
+    config.init_custom("TEST", 3)
+    config.register_custom("TEST")
+
+    group = config.custom("TEST", *pkeys)
+    if to_set is not None:
+        data = {}
+        partial = data
+        for key in to_set:
+            partial[key] = {}
+            partial = partial[key]
+        scope = config.custom("TEST")
+        await scope.set(data)
+        # Clear needed to be able to differ between missing config data and missing scope data
+        await scope.clear_raw(*to_set)
+    await group.clear_raw(*raw_args)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -660,3 +660,12 @@ async def test_config_custom_partial_pkeys_set(config, pkeys, raw_args, result):
     group = config.custom("TEST", *pkeys)
     await group.set_raw(*raw_args, value=result)
     assert await group.get_raw(*raw_args) == result
+
+
+@pytest.mark.asyncio
+async def test_config_custom_get_raw_with_default_on_whole_scope(config):
+    config.init_custom("TEST", 3)
+    config.register_custom("TEST")
+
+    group = config.custom("TEST")
+    assert await group.get_raw(default=True) is True


### PR DESCRIPTION
### Description of the changes

- Fixes #3983
    - The driver worked as designed however, we've decided that it would be better if we revised this design to avoid executing erroneous SQL queries
    - I've also added additional verification step in the PostgreSQL tests job to make sure we don't suppress any such errors
- Fixes an edge case in the PostgreSQL driver that could occur when trying to clear the whole Config scope when there's no config data for `(cog_name, cog_id)` pair:
```
.tox/postgres/lib/python3.8/site-packages/redbot/core/config.py:386: in clear_raw
    await self.driver.clear(identifier_data)
.tox/postgres/lib/python3.8/site-packages/redbot/core/drivers/postgres/postgres.py:167: in clear
    await self._execute(
.tox/postgres/lib/python3.8/site-packages/redbot/core/drivers/postgres/postgres.py:237: in _execute
    return await method(query, *args)
.tox/postgres/lib/python3.8/site-packages/asyncpg/pool.py:530: in execute
    return await con.execute(query, *args, timeout=timeout)
.tox/postgres/lib/python3.8/site-packages/asyncpg/connection.py:317: in execute
    _, status, _ = await self._execute(
.tox/postgres/lib/python3.8/site-packages/asyncpg/connection.py:1639: in _execute
    result, _ = await self.__execute(
.tox/postgres/lib/python3.8/site-packages/asyncpg/connection.py:1664: in __execute
    return await self._do_execute(
.tox/postgres/lib/python3.8/site-packages/asyncpg/connection.py:1711: in _do_execute
    result = await executor(stmt, None)
asyncpg.exceptions.InvalidSchemaNameError: schema "PyTest.32127" does not exist
```
- Adds more tests for getting and clearing data on custom config scopes with partial identifiers

### Have the changes in this PR been tested?

Yes

Proof that the added tests can fail:
https://github.com/jack1142/Red-DiscordBot/actions/runs/3162818621/jobs/5149778704#step:6:58