### PR TITLE
Use bot embed colour in [p]dm command

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -4089,7 +4089,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         description = _("Owner of {}").format(ctx.bot.user)
         content = _("You can reply to this message with {}contact").format(prefix)
         if await ctx.embed_requested():
-            e = discord.Embed(colour=discord.Colour.red(), description=message)
+            e = discord.Embed(colour=await ctx.embed_colour(), description=message)
 
             e.set_footer(text=content)
             e.set_author(name=description, icon_url=ctx.bot.user.display_avatar)


### PR DESCRIPTION
### Description of the changes

Makes [p]dm use the bot's configured embed colour instead of strictly red.

### Have the changes in this PR been tested?

Yes
