### PR TITLE
[Mod] Hide config migration commands

### DIFF
--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -172,7 +172,7 @@ class Mod(
                         guild_data["mention_spam"]["ban"] = current_state
             await self.config.version.set("1.3.0")
 
-    @commands.command()
+    @commands.command(hidden=True)
     @commands.is_owner()
     async def moveignoredchannels(self, ctx: commands.Context) -> None:
         """Move ignored channels and servers to core"""
@@ -186,7 +186,7 @@ class Mod(
             await self.config.channel_from_id(channel_id).clear()
         await ctx.send(_("Ignored channels and guilds restored."))
 
-    @commands.command()
+    @commands.command(hidden=True)
     @commands.is_owner()
     async def movedeletedelay(self, ctx: commands.Context) -> None:
         """


### PR DESCRIPTION
### Description of the changes
`[p]movedeletedelay` and `[p]moveignoredchannels` are owner only commands which migrate Mod's config to a newer schema that should only be run when the owner is told to do so. Because other similar commands (ie `[p]cog reinstallreqs`, `[p]modlogset fixcasetypes`) are hidden, and the fact that the Red versions which would use the old schema are likely no longer usable, this PR hides these two commands.


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
