### PR TITLE
Add Lavalink version parsing

### DIFF
--- a/redbot/cogs/audio/core/commands/audioset.py
+++ b/redbot/cogs/audio/core/commands/audioset.py
@@ -1118,10 +1118,10 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
         if (
             is_owner
             and not global_data["use_external_lavalink"]
-            and self.managed_node_controller.ll_build
+            and self.managed_node_controller.ll_version
         ):
             msg += _(
-                "Lavalink build:         [{llbuild}]\n"
+                "Lavalink version:       [{llversion}]\n"
                 "Lavalink branch:        [{llbranch}]\n"
                 "Release date:           [{build_time}]\n"
                 "Lavaplayer version:     [{lavaplayer}]\n"
@@ -1131,7 +1131,7 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
                 "Max Heapsize:           [{xmx}]\n"
             ).format(
                 build_time=self.managed_node_controller.build_time,
-                llbuild=self.managed_node_controller.ll_build,
+                llversion=self.managed_node_controller.ll_version,
                 llbranch=self.managed_node_controller.ll_branch,
                 lavaplayer=self.managed_node_controller.lavaplayer,
                 jvm=self.managed_node_controller.jvm,

--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -62,7 +62,7 @@ LAVALINK_JAR_FILE: Final[pathlib.Path] = LAVALINK_DOWNLOAD_DIR / "Lavalink.jar"
 LAVALINK_APP_YML: Final[pathlib.Path] = LAVALINK_DOWNLOAD_DIR / "application.yml"
 
 _FAILED_TO_START: Final[Pattern] = re.compile(rb"Web server failed to start\. (.*)")
-_RE_BUILD_LINE: Final[Pattern] = re.compile(rb"Build:\s+(?P<build>\d+)")
+_RE_BUILD_LINE: Final[Pattern] = re.compile(rb"^Build:\s+(?P<build>\d+)$", re.MULTILINE)
 
 # Version regexes
 #
@@ -104,10 +104,14 @@ _RE_JAVA_VERSION_LINE_223: Final[Pattern] = re.compile(
     r'version "(?P<major>\d+)(?:\.(?P<minor>\d+))?(?:\.\d+)*(\-[a-zA-Z0-9]+)?"'
 )
 
-LAVALINK_BRANCH_LINE: Final[Pattern] = re.compile(rb"Branch\s+(?P<branch>[\w\-\d_.]+)")
-LAVALINK_JAVA_LINE: Final[Pattern] = re.compile(rb"JVM:\s+(?P<jvm>\d+[.\d+]*)")
-LAVALINK_LAVAPLAYER_LINE: Final[Pattern] = re.compile(rb"Lavaplayer\s+(?P<lavaplayer>\d+[.\d+]*)")
-LAVALINK_BUILD_TIME_LINE: Final[Pattern] = re.compile(rb"Build time:\s+(?P<build_time>\d+[.\d+]*)")
+LAVALINK_BRANCH_LINE: Final[Pattern] = re.compile(rb"^Branch\s+(?P<branch>\S+)$", re.MULTILINE)
+LAVALINK_JAVA_LINE: Final[Pattern] = re.compile(rb"^JVM:\s+(?P<jvm>\S+)$", re.MULTILINE)
+LAVALINK_LAVAPLAYER_LINE: Final[Pattern] = re.compile(
+    rb"^Lavaplayer\s+(?P<lavaplayer>\S+)$", re.MULTILINE
+)
+LAVALINK_BUILD_TIME_LINE: Final[Pattern] = re.compile(
+    rb"^Build time:\s+(?P<build_time>\d+[.\d+]*).*$", re.MULTILINE
+)
 
 
 class ServerManager:


### PR DESCRIPTION
### Description of the changes

Since Lavalink 3.5-rc4, the output of Lavalink's `--version` no longer contains a build number as it doesn't make as much sense with their new build system. Therefore, we'll be switching to full version parsing and comparison of those instead.

To support both the older and newer jars, this PR adds two new classes for representing versions:
- `LavalinkOldVersion` represents versions older than 3.5-rc4 (or more specifically, versions that contain a build number in the `--version`'s output).
    - When compared with another instance of this class, the build number is used for comparison
    - When compared with an instance of `LavalinkVersion`, an instance of `LavalinkOldVersion` is always considered to be older
    - This class only keeps the raw version string and doesn't try to parse it - this improves compatibility with some of the jars that have `commithash-SNAPSHOT` as their version
- `LavalinkVersion` represents version 3.5-rc4 and newer (or more specifically, versions that do not contain a build number in the `--version`'s output).
    - When compared with another instance of this class, all of its fields are compared
    - When compared with an instance of `LavalinkOldVersion`, an instance of `LavalinkVersion` is always considered to be newer
    - The version format contains a Red-specific field for the (currently unlikely) scenario where we would have to build LL before upstream and need a way to discern our version from the upstream version

### Have the changes in this PR been tested?

Yes

Comparison tests were done on this ordered list of versions:
```
versions = [
    LavalinkVersion(3, 4),
    LavalinkVersion(3, 5, rc=1),
    LavalinkVersion(3, 5, rc=2),
    LavalinkVersion(3, 5, rc=3),
    LavalinkVersion(3, 5, rc=3, red=1),
    LavalinkVersion(3, 5, rc=3, red=2),
    LavalinkVersion(3, 5),
    LavalinkVersion(3, 5, red=1),
    LavalinkVersion(3, 5, red=2),
    LavalinkVersion(3, 5, 1),
]
```
