### PR TITLE
[cleanup] fix error in [p]cleanup spam command

### DIFF
--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -733,7 +733,7 @@ class Cleanup(commands.Cog):
         )
 
         to_delete.append(ctx.message)
-        await mass_purge(to_delete, ctx.channel, "Duplicate message cleanup")
+        await mass_purge(to_delete, ctx.channel, reason="Duplicate message cleanup")
         await self.send_optional_notification(len(to_delete), ctx.channel, subtract_invoking=True)
 
     @commands.group()


### PR DESCRIPTION
### Description of the changes

Hi, I saw last merged PR added reason feature in cleanup cmds, though `[p]cleanup duplicates` errors due to not using kw-only `reason` argument in `mass_purge` method. This PR fixes it from my testing locally.
Error being raised is:
```py
[ERROR] red: Exception in command 'cleanup duplicates'
Traceback (most recent call last):
  File "/home/ubuntu/redenv/lib/python3.9/site-packages/discord/ext/commands/core.py", line 190, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/ubuntu/redenv/lib/python3.9/site-packages/redbot/cogs/cleanup/cleanup.py", line 736, in cleanup_duplicates
    await mass_purge(to_delete, ctx.channel, "Duplicate message cleanup")
TypeError: mass_purge() takes 2 positional arguments but 3 were given
```
my discord is Emile#5674 if you wanna contact me in case.
P.S. thanks alot to red bot team for making this cool project. ❤️ 

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
