### PR TITLE
Use custom groups in config instead of a big list

### DIFF
--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -133,14 +133,13 @@ class Alias(commands.Cog):
             return
 
         if await self.config.entries():
-            async with self.config.entries() as global_alias_list:
-                for a in global_alias_list:
-                    await self.config.custom("Alias", None, a["name"]).command.set(a["command"])
-                    await self.config.custom("Alias", None, a["name"]).creator.set(a["creator"])
-                global_alias_list.clear()
+            async for a in self.config.entries():
+                await self.config.custom("Alias", None, a["name"]).command.set(a["command"])
+                await self.config.custom("Alias", None, a["name"]).creator.set(a["creator"])
+            await self.config.entries.clear()
 
         all_guild_aliases = await self.config.all_guilds()
-        for guild_id, guild_data in all_guild_aliases:
+        for guild_id, guild_data in all_guild_aliases.items():
             try:
                 for a in guild_data["entries"]:
                     await self.config.custom("Alias", guild_id, a["name"]).command.set(

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -12,7 +12,7 @@ from redbot.core.utils.chat_formatting import box, pagify
 from redbot.core.utils.menus import menu
 
 from redbot.core.bot import Red
-from .alias_entry import AliasEntry, AliasCache, ArgParseError
+from .alias_cache import AliasEntry, AliasCache, ArgParseError
 
 _ = Translator("Alias", __file__)
 

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -3,7 +3,7 @@ import logging
 from copy import copy
 from re import search
 from string import Formatter
-from typing import Dict, List, Literal
+from typing import List, Literal
 
 import discord
 from redbot.core import Config, commands, checks
@@ -47,6 +47,14 @@ class Alias(commands.Cog):
         self.bot = bot
         self.config = Config.get_conf(self, 8927348724)
 
+        default_alias = {
+            "command": None,
+            "creator": None,
+            "uses": 0,
+        }
+
+        self.config.init_custom("Alias", 2)
+        self.config.register_custom("Alias", **default_alias)
         self.config.register_global(entries=[], handled_string_creator=False)
         self.config.register_guild(entries=[])
         self._aliases: AliasCache = AliasCache(config=self.config, cache_enabled=True)

--- a/redbot/cogs/alias/alias_cache.py
+++ b/redbot/cogs/alias/alias_cache.py
@@ -1,4 +1,3 @@
-from ast import alias
 from typing import Tuple, Dict, Optional, List, Union
 from re import findall
 
@@ -152,17 +151,17 @@ class AliasCache:
                         return self._aliases[guild_id][alias_name]
         else:
             if guild:
-                alias_config = self.config.custom("Alias", guild.id, alias_name)
+                alias_config = self.config.custom("Alias", guild.id, alias_name).all()
                 alias = AliasEntry(
                     alias_name,
-                    await alias_config.command(),
-                    await alias_config.creator(),
+                    alias_config["command"],
+                    alias_config["creator"],
                     guild.id,
                 )
             else:
                 alias_config = self.config.custom("Alias", None, alias_name)
                 alias = AliasEntry(
-                    alias_name, await alias_config.command(), await alias_config.creator(), None
+                    alias_name, alias_config["command"], alias_config["creator"], None
                 )
             return alias
 

--- a/redbot/cogs/alias/alias_cache.py
+++ b/redbot/cogs/alias/alias_cache.py
@@ -143,7 +143,7 @@ class AliasCache:
 
         if self._cache_enabled:
             if alias_name in self._aliases[str(None)]:
-                return self._aliases[(None)][alias_name]
+                return self._aliases[str(None)][alias_name]
             if guild is not None:
                 guild_id = str(guild.id)
                 if guild_id in self._aliases:

--- a/redbot/pytest/alias.py
+++ b/redbot/pytest/alias.py
@@ -10,4 +10,6 @@ __all__ = ["alias"]
 def alias(config, monkeypatch):
     with monkeypatch.context() as m:
         m.setattr(Config, "get_conf", lambda *args, **kwargs: config)
-        return Alias(None)
+        cog = Alias(None)
+        cog._aliases._aliases = {"None": {}}
+        return

--- a/redbot/pytest/alias.py
+++ b/redbot/pytest/alias.py
@@ -12,4 +12,4 @@ def alias(config, monkeypatch):
         m.setattr(Config, "get_conf", lambda *args, **kwargs: config)
         cog = Alias(None)
         cog._aliases._aliases = {"None": {}}
-        return
+        return cog


### PR DESCRIPTION
### Description of the changes

Move aliases config from a list per guild to custom groups.
Additionally potentially change the cache structure to better fit the new config model.
Add a migration to migrate existing Alias Data to the new config forma.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
This closes #5242 