### PR TITLE
Add failed_cogs to install reqs method

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -457,7 +457,11 @@ class Downloader(commands.Cog):
             for req in reqs:
                 if not await repo.install_raw_requirements([req], self.LIB_PATH):
                     failed_reqs.append(req)
-        return tuple(failed_reqs)
+        failed_cogs = []
+        for cog in cogs:
+            if any(req in failed_reqs for cog_req in cog.requirements):
+                failed_cogs.append(cog)
+        return tuple(failed_reqs), tuple(failed_cogs)
 
     @staticmethod
     async def _delete_cog(target: Path) -> None:
@@ -722,7 +726,7 @@ class Downloader(commands.Cog):
                     continue
                 repos.add(cog.repo)
                 cogs.append(cog)
-            failed_reqs = await self._install_requirements(cogs)
+            failed_reqs, failed_cogs = await self._install_requirements(cogs)
             all_installed_libs: List[InstalledModule] = []
             all_failed_libs: List[Installable] = []
             for repo in repos:
@@ -738,6 +742,12 @@ class Downloader(commands.Cog):
                 if len(failed_reqs) > 1
                 else _("Failed to install the requirement: ")
             ) + humanize_list(tuple(map(inline, failed_reqs)))
+            if failed_cogs:
+                message += (
+                    _("Potentially problematic cogs:")
+                    if len(failed_cogs) > 1
+                    else _("Potentially problematic cog:")
+                ) + humanize_list(tuple(map(inline, failed_cogs)))
         if all_failed_libs:
             libnames = [lib.name for lib in failed_libs]
             message += (
@@ -834,13 +844,19 @@ class Downloader(commands.Cog):
                 if not cogs:
                     await self.send_pagified(ctx, message)
                     return
-                failed_reqs = await self._install_requirements(cogs)
+                failed_reqs, failed_cogs = await self._install_requirements(cogs)
                 if failed_reqs:
                     message += (
                         _("\nFailed to install requirements: ")
                         if len(failed_reqs) > 1
                         else _("\nFailed to install the requirement: ")
                     ) + humanize_list(tuple(map(inline, failed_reqs)))
+                    if failed_cogs:
+                        message += (
+                            _("Potentially problematic cogs:")
+                            if len(failed_cogs) > 1
+                            else _("Potentially problematic cog:")
+                        ) + humanize_list(tuple(map(inline, failed_cogs)))
                     await self.send_pagified(ctx, message)
                     return
 
@@ -1581,7 +1597,7 @@ class Downloader(commands.Cog):
         current_cog_versions: Iterable[InstalledModule],
     ) -> Tuple[Set[str], str]:
         current_cog_versions_map = {cog.name: cog for cog in current_cog_versions}
-        failed_reqs = await self._install_requirements(cogs_to_update)
+        failed_reqs, failed_cogs = await self._install_requirements(cogs_to_update)
         if failed_reqs:
             return (
                 set(),
@@ -1590,7 +1606,15 @@ class Downloader(commands.Cog):
                     if len(failed_reqs) > 1
                     else _("Failed to install the requirement: ")
                 )
-                + humanize_list(tuple(map(inline, failed_reqs))),
+                + humanize_list(tuple(map(inline, failed_reqs)))
+                + (
+                    _("Potentially problematic cogs:")
+                    if len(failed_cogs) > 1
+                    else _("Potentially problematic cog:")
+                    + humanize_list(tuple(map(inline, failed_cogs)))
+                )
+                if failed_cogs
+                else "",
             )
         installed_cogs, failed_cogs = await self._install_cogs(cogs_to_update)
         installed_libs, failed_libs = await self._reinstall_libraries(libs_to_update)


### PR DESCRIPTION
### Description of the changes

Adds failed_cogs to the install reqs method to be able to give a hint as to which cogs may have broken due to an error when installing/updating their requirements.
Since one requirement can be shared by many cogs, the exact cog it failed on is not really required.
Instead a list of potential culprits is provided to allow the user to investigate further.

This will close #5431 
### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Partially (I have tried installing a cog, not updating one)

<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
