### PR TITLE
Fix typo in league of legends trivia list

### DIFF
--- a/redbot/cogs/trivia/data/lists/leagueoflegends.yaml
+++ b/redbot/cogs/trivia/data/lists/leagueoflegends.yaml
@@ -775,7 +775,7 @@ Who has a skill named "Relentless Assault"?:
 - Thresh
 Who has a skin released to celebrate the release of the League of Legends Mac client?:
 - Blitzcrank
-Who has a skin that a reference to Sesame Street characters?:
+Who has a skin that is a reference to Sesame Street characters?:
 - Nunu
 Who has a skin that is a reference to Elminster Aumar from Dungeons and Dragons?:
 - Ryze Whitebeard


### PR DESCRIPTION
### Description of the changes
Fixed typo in League of Legends trivia list, as indicated in brackets:
"Who has a skin that [is ]a reference to Sesame Street characters?"

### Have the changes in this PR been tested?
Yes