### PR TITLE
Add serverlock warning to `[p]invite`

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -62,6 +62,7 @@ from .utils.chat_formatting import (
     humanize_timedelta,
     inline,
     pagify,
+    warning,
 )
 from .commands import CommandConverter, CogConverter
 from .commands.requires import PrivilegeLevel
@@ -1477,6 +1478,14 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         **Example:**
             - `[p]invite`
         """
+        message = await self.bot.get_invite_url()
+        if (admin := self.bot.get_cog("Admin")) and await admin.config.serverlocked():
+            message += "\n\n" + warning(
+                _(
+                    "This bot is currently **serverlocked**, meaning that it is locked "
+                    "to its current servers and will leave any server it joins."
+                )
+            )
         try:
             await ctx.author.send(await self.bot.get_invite_url())
             await ctx.tick()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1487,7 +1487,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 )
             )
         try:
-            await ctx.author.send(await self.bot.get_invite_url())
+            await ctx.author.send(message)
             await ctx.tick()
         except discord.errors.Forbidden:
             await ctx.send(


### PR DESCRIPTION
### Description of the changes

Adds a warning to the `[p]invite` command message if the bot is serverlocked.

### Have the changes in this PR been tested?

No
