### PR TITLE
Allow send_interactive to upload a file containing all content

### DIFF
--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -192,10 +192,11 @@ class Context(DPYContext):
                     "Type `more` to continue or `file` to upload all contents as a file."
                     "".format(is_are, n_remaining, plural)
                 )
+                pred = MessagePredicate.lower_contained_in(("more", "file"), self)
                 try:
                     resp = await self.bot.wait_for(
                         "message",
-                        check=MessagePredicate.lower_contained_in(("more", "file"), self),
+                        check=pred,
                         timeout=timeout,
                     )
                 except asyncio.TimeoutError:
@@ -211,7 +212,7 @@ class Context(DPYContext):
                         # or channel is a DM
                         with contextlib.suppress(discord.HTTPException):
                             await query.delete()
-                    if resp.content == "file":
+                    if pred.result == 1:
                         await self.send(file=text_to_file("".join(messages)))
                         break
         return ret

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -361,7 +361,6 @@ if TYPE_CHECKING or os.getenv("BUILDING_DOCS", False):
         def me(self) -> discord.Member:
             ...
 
-
 else:
     GuildContext = Context
     DMContext = Context

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -4,13 +4,12 @@ import asyncio
 import contextlib
 import os
 import re
-from io import StringIO
 from typing import Iterable, List, Union, Optional, TYPE_CHECKING
 import discord
 from discord.ext.commands import Context as DPYContext
 
 from .requires import PermState
-from ..utils.chat_formatting import box
+from ..utils.chat_formatting import box, text_to_file
 from ..utils.predicates import MessagePredicate
 from ..utils import can_user_react_in, common_filters
 
@@ -213,10 +212,7 @@ class Context(DPYContext):
                         with contextlib.suppress(discord.HTTPException):
                             await query.delete()
                     if resp.content == "file":
-                        msg = StringIO()
-                        msg.write("".join(i for i in messages))
-                        msg.seek(0)
-                        await self.send(file=discord.File(msg, filename="file.txt"))
+                        await self.send(file=text_to_file("".join(messages)))
                         break
         return ret
 

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -150,7 +150,11 @@ class Context(DPYContext):
             return True
 
     async def send_interactive(
-        self, messages: Iterable[str], box_lang: str = None, timeout: int = 15
+        self,
+        messages: Iterable[str],
+        box_lang: str = None,
+        timeout: int = 15,
+        join_character: str = "",
     ) -> List[discord.Message]:
         """Send multiple messages interactively.
 
@@ -168,6 +172,9 @@ class Context(DPYContext):
         timeout : int
             How long the user has to respond to the prompt before it times out.
             After timing out, the bot deletes its prompt message.
+        join_character : str
+            The character used to join all the messages when the file output
+            is selected.
 
         """
         messages = tuple(messages)
@@ -213,7 +220,7 @@ class Context(DPYContext):
                         with contextlib.suppress(discord.HTTPException):
                             await query.delete()
                     if pred.result == 1:
-                        await self.send(file=text_to_file("".join(messages)))
+                        await self.send(file=text_to_file(join_character.join(messages)))
                         break
         return ret
 
@@ -353,6 +360,7 @@ if TYPE_CHECKING or os.getenv("BUILDING_DOCS", False):
         @property
         def me(self) -> discord.Member:
             ...
+
 
 else:
     GuildContext = Context


### PR DESCRIPTION
### Description of the changes

This allows `send_interactive` to optionally upload a file containing all content in the next message when `file` is said instead of `more`. This resolves #5901. 

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
