### PR TITLE
[General] Fix [p]lmgtfy URL generation

### DIFF
--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -220,7 +220,7 @@ class General(commands.Cog):
     async def lmgtfy(self, ctx, *, search_terms: str):
         """Create a lmgtfy link."""
         search_terms = escape(urllib.parse.quote_plus(search_terms), mass_mentions=True)
-        await ctx.send("https://lmgtfy.app/?q={}".format(search_terms))
+        await ctx.send("https://lmgtfy.app/?q={}&s=g".format(search_terms))
 
     @commands.command(hidden=True)
     @commands.guild_only()


### PR DESCRIPTION
### Description of the changes

This provides the `s` parameter with the value `g`, which redirects to Google instead of lmgtfy's own search engine which doesn't work anymore. 

Fixes #5908 

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
