### PR TITLE
Fix flaky CI caused by flake8's flakiness (GitHub migration)

### DIFF
--- a/.github/workflows/lint_python.yaml
+++ b/.github/workflows/lint_python.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
-      - run: "python -m pip install git+https://github.com/pycqa/pyflakes@1911c20#egg=pyflakes git+https://github.com/pycqa/pycodestyle@d219c68#egg=pycodestyle git+https://gitlab.com/pycqa/flake8@3.7.9#egg=flake8"
+      - run: "python -m pip install git+https://github.com/pycqa/pyflakes@1911c20#egg=pyflakes git+https://github.com/pycqa/pycodestyle@d219c68#egg=pycodestyle git+https://github.com/pycqa/flake8@3.7.9#egg=flake8"
         name: Install Flake8
       - run: "python -m flake8 . --count --select=E9,F7,F82 --show-source"
         name: Flake8 Linting


### PR DESCRIPTION
### Description of the changes

Flake8's GitLab mirror (mirror since the move to GitHub earlier this year) has been removed which breaks our CI.

### Have the changes in this PR been tested?

Yes
