### PR TITLE
[CustomCom] Fix [p]cc cooldown docstring & docs

### DIFF
--- a/docs/cog_guides/customcommands.rst
+++ b/docs/cog_guides/customcommands.rst
@@ -80,8 +80,8 @@ Examples:
 **Arguments:**
 
 - ``<command>`` The custom command to check or set the cooldown.
-- ``<cooldown>`` The number of seconds to wait before allowing the command to be invoked again. If omitted, will instead return the current cooldown settings.
-- ``<per>`` The group to apply the cooldown on. Defaults to per member. Valid choices are server, guild, user, and member.
+- ``[cooldown]`` The number of seconds to wait before allowing the command to be invoked again. If omitted, will instead return the current cooldown settings.
+- ``[per]`` The group to apply the cooldown on. Defaults to per member. Valid choices are server / guild, user / member, and channel.
 
 .. _customcommands-command-customcom-create:
 

--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -454,8 +454,8 @@ class CustomCommands(commands.Cog):
         **Arguments:**
 
         - `<command>` The custom command to check or set the cooldown.
-        - `<cooldown>` The number of seconds to wait before allowing the command to be invoked again. If omitted, will instead return the current cooldown settings.
-        - `<per>` The group to apply the cooldown on. Defaults to per member. Valid choices are server, guild, user, and member.
+        - `[cooldown]` The number of seconds to wait before allowing the command to be invoked again. If omitted, will instead return the current cooldown settings.
+        - `[per]` The group to apply the cooldown on. Defaults to per member. Valid choices are server / guild, user / member, and channel.
         """
         if cooldown is None:
             try:


### PR DESCRIPTION
### Description of the changes
As pointed out in advanced-testing, the `[p]cc cooldown` docstring had some inaccuracies. This PR updates the docstring to align with the actual functionality of the command.


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
