### PR TITLE
Core - #5891 Recovering Server Prefixes

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3351,10 +3351,16 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     # -- End Set Ownernotifications Commands -- ###
 
     @_set.command(name="showsettings")
-    async def _set_showsettings(self, ctx: commands.Context):
+    async def _set_showsettings(
+        self, ctx: commands.Context, specified_guild: discord.Guild = None
+    ):
         """
-        Show the current settings for [botname].
+        Show the current settings for [botname]. Accepts optional guild parameter in case must recover prefix.
         """
+        if specified_guild is not None:
+            # override ctx.guild if a guild is provided as an argument
+            ctx.guild = specified_guild
+
         if ctx.guild:
             guild_data = await ctx.bot._config.guild(ctx.guild).all()
             guild = ctx.guild

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3351,19 +3351,16 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     # -- End Set Ownernotifications Commands -- ###
 
     @_set.command(name="showsettings")
-    async def _set_showsettings(
-        self, ctx: commands.Context, specified_guild: discord.Guild = None
-    ):
+    async def _set_showsettings(self, ctx: commands.Context, server: discord.Guild = None):
         """
-        Show the current settings for [botname]. Accepts optional guild parameter in case must recover prefix.
+        Show the current settings for [botname]. Accepts optional guild parameter if its prefix must be recovered.
         """
-        if specified_guild is not None:
-            # override ctx.guild if a guild is provided as an argument
-            ctx.guild = specified_guild
+        if server is None:
+            server = ctx.guild
 
-        if ctx.guild:
-            guild_data = await ctx.bot._config.guild(ctx.guild).all()
-            guild = ctx.guild
+        if server:
+            guild_data = await ctx.bot._config.guild(server).all()
+            guild = server
             admin_role_ids = guild_data["admin_role"]
             admin_role_names = [r.name for r in guild.roles if r.id in admin_role_ids]
             admin_roles_str = (
@@ -3373,9 +3370,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             mod_role_names = [r.name for r in guild.roles if r.id in mod_role_ids]
             mod_roles_str = humanize_list(mod_role_names) if mod_role_names else _("Not Set.")
 
-            guild_locale = await i18n.get_locale_from_guild(self.bot, ctx.guild)
+            guild_locale = await i18n.get_locale_from_guild(self.bot, server)
             guild_regional_format = (
-                await i18n.get_regional_format_from_guild(self.bot, ctx.guild) or guild_locale
+                await i18n.get_regional_format_from_guild(self.bot, server) or guild_locale
             )
 
             guild_settings = _(
@@ -3392,7 +3389,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             guild_settings = ""
 
-        prefixes = await ctx.bot._prefix_cache.get_prefixes(ctx.guild)
+        prefixes = await ctx.bot._prefix_cache.get_prefixes(server)
         global_data = await ctx.bot._config.all()
         locale = global_data["locale"]
         regional_format = global_data["regional_format"] or locale
@@ -3606,7 +3603,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @_set.command(name="serverprefix", aliases=["serverprefixes"])
     @checks.admin_or_permissions(manage_guild=True)
     async def _set_serverprefix(
-        self, ctx: commands.Context, specified_guild: Optional[discord.Guild], *prefixes: str
+        self, ctx: commands.Context, server: Optional[discord.Guild], *prefixes: str
     ):
         """
         Sets [botname]'s server prefix(es).
@@ -3620,17 +3617,16 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             - `[p]set serverprefix "! "` - Quotes are needed to use spaces in prefixes.
             - `[p]set serverprefix "@[botname] "` - This uses a mention as the prefix.
             - `[p]set serverprefix ! ? .` - Sets multiple prefixes.
-            - `[p]set serverprefix guild_name ? - Sets prefix for specified guild.
+            - `[p]set serverprefix "Red - Discord Bot" ? - Sets the prefix for a specific server. Quotes are needed to use spaces in the server name.
 
         **Arguments:**
             - `[prefixes...]` - The prefixes the bot will respond to on this server. Leave blank to clear server prefixes.
         """
-        if specified_guild is not None:
-            # prefer specified guild over ctx.guild when provided as argument
-            ctx.guild = specified_guild
+        if server is None:
+            server = ctx.guild
 
         if not prefixes:
-            await ctx.bot.set_prefixes(guild=ctx.guild, prefixes=[])
+            await ctx.bot.set_prefixes(guild=server, prefixes=[])
             await ctx.send(_("Server prefixes have been reset."))
             return
         if any(prefix.startswith("/") for prefix in prefixes):
@@ -3642,7 +3638,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             await ctx.send(_("You cannot have a prefix longer than 25 characters."))
             return
         prefixes = sorted(prefixes, reverse=True)
-        await ctx.bot.set_prefixes(guild=ctx.guild, prefixes=prefixes)
+        await ctx.bot.set_prefixes(guild=server, prefixes=prefixes)
         if len(prefixes) == 1:
             await ctx.send(_("Server prefix set."))
         else:

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3605,8 +3605,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
     @_set.command(name="serverprefix", aliases=["serverprefixes"])
     @checks.admin_or_permissions(manage_guild=True)
-    @commands.guild_only()
-    async def _set_serverprefix(self, ctx: commands.Context, *prefixes: str):
+    async def _set_serverprefix(
+        self, ctx: commands.Context, specified_guild: Optional[discord.Guild], *prefixes: str
+    ):
         """
         Sets [botname]'s server prefix(es).
 
@@ -3619,10 +3620,15 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             - `[p]set serverprefix "! "` - Quotes are needed to use spaces in prefixes.
             - `[p]set serverprefix "@[botname] "` - This uses a mention as the prefix.
             - `[p]set serverprefix ! ? .` - Sets multiple prefixes.
+            - `[p]set serverprefix guild_name ? - Sets prefix for specified guild.
 
         **Arguments:**
             - `[prefixes...]` - The prefixes the bot will respond to on this server. Leave blank to clear server prefixes.
         """
+        if specified_guild is not None:
+            # prefer specified guild over ctx.guild when provided as argument
+            ctx.guild = specified_guild
+
         if not prefixes:
             await ctx.bot.set_prefixes(guild=ctx.guild, prefixes=[])
             await ctx.send(_("Server prefixes have been reset."))


### PR DESCRIPTION
### Description of the changes
Resolves #5891 
Modifies [p]set showsettings to accept an optional [guild] parameter in case users forget server prefixes
Modifies [p]set serverprefix to have a typing.Optional [guild] parameter before the prefix(es). Now works in DMs to the bot.


### Have the changes in this PR been tested?
Yes