### PR TITLE
Updated excluded features

### DIFF
--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -422,6 +422,8 @@ class General(commands.Cog):
                 "NEW_THREAD_PERMISSIONS",
                 "TEXT_IN_VOICE_ENABLED",
                 "THREADS_ENABLED",
+                # available to evertyone sometime after forum channel release
+                "PRIVATE_THREADS",
             }
             custom_feature_names = {
                 "VANITY_URL": "Vanity URL",

--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -422,7 +422,7 @@ class General(commands.Cog):
                 "NEW_THREAD_PERMISSIONS",
                 "TEXT_IN_VOICE_ENABLED",
                 "THREADS_ENABLED",
-                # available to evertyone sometime after forum channel release
+                # available to everyone sometime after forum channel release
                 "PRIVATE_THREADS",
             }
             custom_feature_names = {


### PR DESCRIPTION
### Description of the changes

Add ``PRIVATE_THREADS`` to the excluded list of features, as this feature is now available to the public after being removed from T2 boosting

### Have the changes in this PR been tested?

Yes
