### PR TITLE
Add optional delay for [p]audioset dc

### DIFF
--- a/redbot/cogs/audio/core/__init__.py
+++ b/redbot/cogs/audio/core/__init__.py
@@ -133,6 +133,7 @@ class Audio(
             emptydc_timer=0,
             emptypause_enabled=False,
             emptypause_timer=0,
+            emptyqueuedc_timer=0,
             jukebox=False,
             jukebox_price=0,
             maxlength=0,

--- a/redbot/cogs/audio/core/commands/audioset.py
+++ b/redbot/cogs/audio/core/commands/audioset.py
@@ -614,23 +614,33 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
     @command_audioset.command(name="dc")
     @commands.guild_only()
     @commands.mod_or_permissions(manage_guild=True)
-    async def command_audioset_dc(self, ctx: commands.Context):
+    async def command_audioset_dc(self, ctx: commands.Context, seconds: int = 0):
         """Toggle the bot auto-disconnecting when done playing.
 
         This setting takes precedence over `[p]audioset emptydisconnect`.
+        Users can optionally specify a delay.
         """
+        if seconds < 0:
+            return await self.send_embed_msg(
+                ctx, title=_("Invalid Time"), description=_("Seconds can't be less than zero.")
+            )
 
         disconnect = await self.config.guild(ctx.guild).disconnect()
         autoplay = await self.config.guild(ctx.guild).auto_play()
         msg = ""
-        msg += _("Auto-disconnection at queue end: {true_or_false}.").format(
-            true_or_false=_("Enabled") if not disconnect else _("Disabled")
+        msg += _("Auto-disconnection at queue end: {true_or_false}").format(
+            true_or_false=_(f"Enabled with {seconds} second delay.")
+            if not disconnect
+            else _("Disabled")
         )
         if disconnect is not True and autoplay is True:
             msg += _("\nAuto-play has been disabled.")
             await self.config.guild(ctx.guild).auto_play.set(False)
 
         await self.config.guild(ctx.guild).disconnect.set(not disconnect)
+
+        if not disconnect:
+            await self.config.guild(ctx.guild).emptyqueuedc_timer.set(seconds)
 
         await self.send_embed_msg(ctx, title=_("Setting Changed"), description=msg)
 
@@ -960,12 +970,14 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
         data = await self.config.guild(ctx.guild).all()
 
         auto_deafen = _("Enabled") if data["auto_deafen"] else _("Disabled")
+        disconnect = data["disconnect"]
         dj_role_obj = ctx.guild.get_role(data["dj_role"])
         dj_enabled = data["dj_enabled"]
         emptydc_enabled = data["emptydc_enabled"]
         emptydc_timer = data["emptydc_timer"]
         emptypause_enabled = data["emptypause_enabled"]
         emptypause_timer = data["emptypause_timer"]
+        emptyqueuedc_timer = data["emptyqueuedc_timer"]
         jukebox = data["jukebox"]
         jukebox_price = data["jukebox_price"]
         thumbnail = data["thumbnail"]
@@ -1004,6 +1016,10 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
         if emptydc_enabled:
             msg += _("Disconnect timer: [{num_seconds}]\n").format(
                 num_seconds=self.get_time_string(emptydc_timer)
+            )
+        if disconnect:
+            msg += _("Empty queue disconnect timer: [{num_seconds}]\n").format(
+                num_seconds=self.get_time_string(emptyqueuedc_timer)
             )
         if emptypause_enabled:
             msg += _("Auto Pause timer: [{num_seconds}]\n").format(

--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -234,6 +234,8 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                 if notify_channel and notify and self._has_notify_perms(notify_channel):
                     await self.send_embed_msg(notify_channel, title=_("Queue ended."))
                 if disconnect:
+                    delay = guild_data["emptyqueuedc_timer"]
+                    await asyncio.sleep(delay)
                     log.debug(
                         "Queue ended for %s, Disconnecting bot due to configuration", guild_id
                     )


### PR DESCRIPTION
### Description of the changes
Closes #5350 
Gives users the option to specify a delay before the bot disconnects on an empty queue with `[p]audioset dc <delay>`


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->