### PR TITLE
Revert ``mock`` and ``mockmsg`` back to a guild_only state

### DIFF
--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -359,9 +359,10 @@ class Dev(commands.Cog):
         else:
             await ctx.send(_("The REPL session in this channel is now paused."))
 
+    @commands.guild_only()
     @commands.command()
     @checks.is_owner()
-    async def mock(self, ctx, user: discord.User, *, command):
+    async def mock(self, ctx, user: discord.Member, *, command):
         """Mock another user invoking a command.
 
         The prefix must not be entered.
@@ -372,9 +373,10 @@ class Dev(commands.Cog):
 
         ctx.bot.dispatch("message", msg)
 
+    @commands.guild_only()
     @commands.command(name="mockmsg")
     @checks.is_owner()
-    async def mock_msg(self, ctx, user: discord.User, *, content: str = ""):
+    async def mock_msg(self, ctx, user: discord.Member, *, content: str = ""):
         """Dispatch a message event as if it were sent by a different user.
 
         Current message is used as a base (including attachments, embeds, etc.),


### PR DESCRIPTION
### Description of the changes
Closes #5923 
Mock seems rarely used outside of guild contexts. This changes ``mock`` and ``mockmsg`` to be guild only 

### Have the changes in this PR been tested?
Yes