### PR TITLE
[Admin] add reasoning to `addrole` & `removerole`.

### DIFF
--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -203,7 +203,7 @@ class Admin(commands.Cog):
             return
         try:
             reason = get_audit_reason(ctx.author)
-            await member.remove_roles(role)
+            await member.remove_roles(role, reason=reason)
         except discord.Forbidden:
             await ctx.send(_(GENERIC_FORBIDDEN))
         else:

--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -6,6 +6,7 @@ import discord
 from redbot.core import Config, checks, commands
 from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils.chat_formatting import box
+from redbot.core.utils.mod import get_audit_reason
 from redbot.core.utils.predicates import MessagePredicate
 
 from .announcer import Announcer
@@ -170,7 +171,8 @@ class Admin(commands.Cog):
             await ctx.send(_(NEED_MANAGE_ROLES))
             return
         try:
-            await member.add_roles(role)
+            reason = get_audit_reason(ctx.author)
+            await member.add_roles(role, reason=reason)
         except discord.Forbidden:
             await ctx.send(_(GENERIC_FORBIDDEN))
         else:
@@ -200,6 +202,7 @@ class Admin(commands.Cog):
             await ctx.send(_(NEED_MANAGE_ROLES))
             return
         try:
+            reason = get_audit_reason(ctx.author)
             await member.remove_roles(role)
         except discord.Forbidden:
             await ctx.send(_(GENERIC_FORBIDDEN))


### PR DESCRIPTION
### Description of the changes

This PR adds a command invocation reasoning to the `[p]addrole` & `[p]removerole` command respectively.


### Have the changes in this PR been tested?

Yes
