### PR TITLE
Handle empty name case when splitting description field in help

### DIFF
--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -398,13 +398,18 @@ class RedHelpFormatter(HelpFormatterABC):
 
             command_help = command.format_help_for_context(ctx)
             if command_help:
-                splitted = command_help.split("\n\n")
-                name = splitted[0]
-                value = "\n\n".join(splitted[1:])
-                if not value:
-                    value = EMPTY_STRING
-                field = EmbedField(name[:250], value[:1024], False)
-                emb["fields"].append(field)
+                splitted = filter(None, command_help.split("\n\n"))
+                try:
+                    name = next(splitted)
+                except StopIteration:
+                    # all parts are empty
+                    pass
+                else:
+                    value = "\n\n".join(splitted)
+                    if not value:
+                        value = EMPTY_STRING
+                    field = EmbedField(name[:250], value[:1024], False)
+                    emb["fields"].append(field)
 
             if subcommands:
 
@@ -572,13 +577,18 @@ class RedHelpFormatter(HelpFormatterABC):
 
             emb["footer"]["text"] = tagline
             if description:
-                splitted = description.split("\n\n")
-                name = splitted[0]
-                value = "\n\n".join(splitted[1:])
-                if not value:
-                    value = EMPTY_STRING
-                field = EmbedField(name[:252], value[:1024], False)
-                emb["fields"].append(field)
+                splitted = filter(None, description.split("\n\n"))
+                try:
+                    name = next(splitted)
+                except StopIteration:
+                    # all parts are empty
+                    pass
+                else:
+                    value = "\n\n".join(splitted)
+                    if not value:
+                        value = EMPTY_STRING
+                    field = EmbedField(name[:252], value[:1024], False)
+                    emb["fields"].append(field)
 
             if coms:
 


### PR DESCRIPTION
### Description of the changes

Fixes an issue with how the string returned by `format_help_for_context()` gets splitted into name and value for the embed field in the help formatted.

The error can be reproduced with the following cog:
```py
class TestCog(commands.Cog):
    def format_help_for_context(self, ctx):
        return "\n\nlorem\nipsum"

    @commands.command()
    async def testcommand(self, ctx):
        await ctx.send("Hello!")


async def setup(bot):
    await bot.add_cog(TestCog())
```

### Have the changes in this PR been tested?

Yes