### PR TITLE
Change 'Managed' to 'External' in `[p]llset secured`'s output

### DIFF
--- a/redbot/cogs/audio/core/commands/llset.py
+++ b/redbot/cogs/audio/core/commands/llset.py
@@ -278,7 +278,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
                 ctx,
                 title=_("Setting Changed"),
                 description=_(
-                    "Managed Lavalink node will now connect using the secured {secured_protocol} protocol.\n\n"
+                    "External Lavalink node will now connect using the secured {secured_protocol} protocol.\n\n"
                     "Run `{p}{cmd}` for it to take effect."
                 ).format(
                     p=ctx.prefix,
@@ -291,7 +291,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
                 ctx,
                 title=_("Setting Changed"),
                 description=_(
-                    "Managed Lavalink node will no longer connect using the secured "
+                    "External Lavalink node will no longer connect using the secured "
                     "{secured_protocol} protocol and wil use {unsecured_protocol} instead .\n\n"
                     "Run `{p}{cmd}` for it to take effect."
                 ).format(p=ctx.prefix, cmd=self.command_audioset_restart.qualified_name),


### PR DESCRIPTION
### Description of the changes

A single-word fix in the output message of `[p]llset secured` that makes it correctly refer to External Lavalink node rather than Managed Lavalink node.

### Have the changes in this PR been tested?

Yes
