### PR TITLE
Fix incorrect default argument value in `[p]streamalert twitch`

### DIFF
--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -303,7 +303,9 @@ class Streams(commands.Cog):
         self,
         ctx: commands.Context,
         channel_name: str,
-        discord_channel: Union[discord.TextChannel, discord.VoiceChannel] = None,
+        discord_channel: Union[
+            discord.TextChannel, discord.VoiceChannel
+        ] = commands.CurrentChannel,
     ):
         """Manage Twitch stream notifications."""
         await ctx.invoke(self.twitch_alert_channel, channel_name, discord_channel)


### PR DESCRIPTION
### Description of the changes

When updating to d.py 2.0.1, I've changed the default argument value in Streams cog to use the new `commands.CurrentChannel` (see commit: https://github.com/Cog-Creators/Red-DiscordBot/pull/5709/commits/3671cb0981489dd74a0a2fd153cd4a8ba480fba9). However, I've missed one of the commands while making the change.

### Have the changes in this PR been tested?

Yes