### PR TITLE
Use `usage` attr to remove appended underscore for `from_` parameter in `[p]reorderpath`

### DIFF
--- a/docs/cog_guides/cog_manager_ui.rst
+++ b/docs/cog_guides/cog_manager_ui.rst
@@ -193,7 +193,7 @@ reorderpath
 
 .. code-block:: none
 
-    [p]reorderpath <from_> <to>
+    [p]reorderpath <from> <to>
 
 **Description**
 
@@ -221,7 +221,7 @@ have to put the 3rd path higher than the 2nd path, let's swap them! Type
 
 **Arguments**
 
-*   ``<from_>``: The index of the path you want to move.
+*   ``<from>``: The index of the path you want to move.
 *   ``<to>``: The location where you want to insert the path.
 
 .. _cogmanagerui-command-installpath:

--- a/redbot/core/cog_manager.py
+++ b/redbot/core/cog_manager.py
@@ -412,7 +412,7 @@ class CogManagerUI(commands.Cog):
         for page in pagify("\n\n".join(parts), ["\n", " "]):
             await ctx.send(page)
 
-    @commands.command()
+    @commands.command(usage="<from> <to>")
     @checks.is_owner()
     async def reorderpath(self, ctx: commands.Context, from_: positive_int, to: positive_int):
         """


### PR DESCRIPTION
### Description of the changes

Changes `from_` to `from` in `[p]reorderpath`'s usage attr as well as where it is displayed in the docs.

### Have the changes in this PR been tested?

Yes