### PR TITLE
[Audio] Use more of the newer Managed/Unmanaged terminology

### DIFF
--- a/docs/cog_guides/audio.rst
+++ b/docs/cog_guides/audio.rst
@@ -376,7 +376,7 @@ necessary modifications.
 Firstly, stop all Red bots. For each bot using Audio:
 
 1. Start the bot.
-2. Run the command ``[p]llset external``.
+2. Run the command ``[p]llset unmanaged``.
 3. Stop the bot.
 
 Next, open a command prompt/terminal window. Navigate to ``<datapath>/cogs/Audio`` for any of your bot
@@ -806,7 +806,7 @@ Do not use quotes in these commands. For example, ``[p]llset host 192.168.10.101
 
 .. code-block:: none
 
-    [p]llset external
+    [p]llset unmanaged
     [p]llset host "yourlavalinkip"
     [p]llset port "port"
     [p]llset password "password"
@@ -3252,7 +3252,7 @@ llsetup
 **Description**
 
 Manage Lavalink node configuration settings. This command holds all commands to
-manage an unmanaged (external) or managed Lavalink node.
+manage an unmanaged (user-managed) or managed (bot-managed) Lavalink node.
 
 .. warning::
 
@@ -3271,11 +3271,18 @@ llsetup external
 
     [p]llsetup external
 
+or 
+
+.. code-block:: none
+
+    [p]llsetup unmanaged
+
 **Description**
 
-Toggle using external Lavalink nodes - requires an existing external Lavalink node for
-Audio to work, if enabled. This command disables the managed Lavalink server: if you do
-not have an external Lavalink node you will be unable to use Audio while this is enabled.
+Toggle using unmanaged (user-managed) Lavalink nodes - requires an existing Lavalink 
+node for Audio to work, if enabled. This command disables the managed (bot-managed) 
+Lavalink server: if you do not have an unmanaged Lavalink node available, you will be 
+unable to use Audio while this is enabled.
 
 """"""""""""
 llsetup info
@@ -3691,7 +3698,7 @@ llsetup host
 **Description**
 
 Set the Lavalink node host. This command sets the connection host which
-Audio will use to connect to an external Lavalink node.
+Audio will use to connect to an unmanaged Lavalink node.
 
 **Arguments**
 
@@ -3712,7 +3719,7 @@ llsetup password
 **Description**
 
 Set the Lavalink node password. This command sets the connection password which
-Audio will use to connect to an external Lavalink node.
+Audio will use to connect to an unmanaged Lavalink node.
 
 **Arguments**
 
@@ -3733,7 +3740,7 @@ llsetup port
 **Description**
 
 Set the Lavalink node port. This command sets the connection port which
-Audio will use to connect to an external Lavalink node.
+Audio will use to connect to an unmanaged Lavalink node.
 
 **Arguments**
 
@@ -3754,4 +3761,4 @@ llsetup secured
 **Description**
 
 Set the Lavalink node connection to secured. This toggle sets the connection type
-to secured or unsecured when connecting to an external Lavalink node.
+to secured or unsecured when connecting to an unmanaged Lavalink node.

--- a/docs/cog_guides/audio.rst
+++ b/docs/cog_guides/audio.rst
@@ -3281,7 +3281,7 @@ or
 
 Toggle using unmanaged (user-managed) Lavalink nodes - requires an existing Lavalink 
 node for Audio to work, if enabled. This command disables the managed (bot-managed) 
-Lavalink server: if you do not have an unmanaged Lavalink node available, you will be 
+Lavalink server: if you do not have an unmanaged Lavalink node set up, you will be 
 unable to use Audio while this is enabled.
 
 """"""""""

--- a/docs/cog_guides/audio.rst
+++ b/docs/cog_guides/audio.rst
@@ -3261,15 +3261,15 @@ manage an unmanaged (user-managed) or managed (bot-managed) Lavalink node.
     server to do so. Changing llset command settings have the potential to break 
     Audio cog connection and playback if the wrong settings are used.
 
-""""""""""""""
-llset external
-""""""""""""""
+"""""""""""""""
+llset unmanaged
+"""""""""""""""
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llset external
+    [p]llset unmanaged
 
 or 
 

--- a/redbot/cogs/audio/core/commands/llset.py
+++ b/redbot/cogs/audio/core/commands/llset.py
@@ -156,7 +156,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
     async def command_llset_unmanaged(self, ctx: commands.Context):
         """Toggle using external (unmanaged) Lavalink nodes - requires an existing Lavalink node for Audio to work, if enabled.
 
-        This command disables the managed Lavalink server. If you do not have another Lavalink node to access, you will be unable to use Audio while this is enabled.
+        This command disables the managed Lavalink server. If you do not have another Lavalink node set up, you will be unable to use Audio while this is enabled.
         """
         external = await self.config.use_external_lavalink()
         await self.config.use_external_lavalink.set(not external)

--- a/redbot/cogs/audio/core/commands/llset.py
+++ b/redbot/cogs/audio/core/commands/llset.py
@@ -164,7 +164,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
             if external:
                 embed = discord.Embed(
                     title=_("Setting Changed"),
-                    description=_("External Lavalink server: {true_or_false}.").format(
+                    description=_("Unmanaged Lavalink server: {true_or_false}.").format(
                         true_or_false=inline(_("Enabled") if not external else _("Disabled"))
                     ),
                 )
@@ -173,7 +173,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
                 await self.send_embed_msg(
                     ctx,
                     title=_("Setting Changed"),
-                    description=_("External Lavalink server: {true_or_false}.").format(
+                    description=_("Unmanaged Lavalink server: {true_or_false}.").format(
                         true_or_false=inline(_("Enabled") if not external else _("Disabled"))
                     ),
                 )
@@ -196,14 +196,14 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
     ):
         """Set the Lavalink node host.
 
-        This command sets the connection host which Audio will use to connect to an external Lavalink node.
+        This command sets the connection host which Audio will use to connect to an unmanaged Lavalink node.
         """
         await self.config.host.set(host)
         await self.send_embed_msg(
             ctx,
             title=_("Setting Changed"),
             description=_(
-                "External Lavalink node host set to {host}. "
+                "Unmanaged Lavalink node host set to {host}. "
                 "Run `{p}{cmd}` for it to take effect."
             ).format(
                 host=inline(host), p=ctx.prefix, cmd=self.command_audioset_restart.qualified_name
@@ -217,7 +217,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
     ):
         """Set the Lavalink node password.
 
-        This command sets the connection password which Audio will use to connect to an external Lavalink node.
+        This command sets the connection password which Audio will use to connect to an unmanaged Lavalink node.
         """
 
         await self.config.password.set(str(password))
@@ -225,7 +225,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
             ctx,
             title=_("Setting Changed"),
             description=_(
-                "External Lavalink node password set to {password}. "
+                "Unmanaged Lavalink node password set to {password}. "
                 "Run `{p}{cmd}` for it to take effect."
             ).format(
                 password=inline(password),
@@ -241,7 +241,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
     ):
         """Set the Lavalink node port.
 
-        This command sets the connection port which Audio will use to connect to an external Lavalink node.
+        This command sets the connection port which Audio will use to connect to an unmanaged Lavalink node.
         """
         if port < 0 or port > 65535:
             return await self.send_embed_msg(
@@ -254,7 +254,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
             ctx,
             title=_("Setting Changed"),
             description=_(
-                "External Lavalink node port set to {port}. "
+                "Unmanaged Lavalink node port set to {port}. "
                 "Run `{p}{cmd}` for it to take effect."
             ).format(
                 port=inline(str(port)),
@@ -268,7 +268,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
     async def command_llsetup_secured(self, ctx: commands.Context):
         """Set the Lavalink node connection to secured.
 
-        This toggle sets the connection type to secured or unsecured when connecting to an external Lavalink node.
+        This toggle sets the connection type to secured or unsecured when connecting to an unmanaged Lavalink node.
         """
         state = await self.config.secured_ws()
         await self.config.secured_ws.set(not state)
@@ -278,7 +278,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
                 ctx,
                 title=_("Setting Changed"),
                 description=_(
-                    "External Lavalink node will now connect using the secured {secured_protocol} protocol.\n\n"
+                    "Unmanaged Lavalink node will now connect using the secured {secured_protocol} protocol.\n\n"
                     "Run `{p}{cmd}` for it to take effect."
                 ).format(
                     p=ctx.prefix,
@@ -291,7 +291,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
                 ctx,
                 title=_("Setting Changed"),
                 description=_(
-                    "External Lavalink node will no longer connect using the secured "
+                    "Unmanaged Lavalink node will no longer connect using the secured "
                     "{secured_protocol} protocol and wil use {unsecured_protocol} instead .\n\n"
                     "Run `{p}{cmd}` for it to take effect."
                 ).format(p=ctx.prefix, cmd=self.command_audioset_restart.qualified_name),

--- a/redbot/cogs/audio/core/commands/llset.py
+++ b/redbot/cogs/audio/core/commands/llset.py
@@ -152,8 +152,8 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
             ),
         )
 
-    @command_llset.command(name="external", aliases=["unmanaged"])
-    async def command_llset_external(self, ctx: commands.Context):
+    @command_llset.command(name="unmanaged", aliases=["external"])
+    async def command_llset_unmanaged(self, ctx: commands.Context):
         """Toggle using external (unmanaged) Lavalink nodes - requires an existing Lavalink node for Audio to work, if enabled.
 
         This command disables the managed Lavalink server. If you do not have another Lavalink node to access, you will be unable to use Audio while this is enabled.

--- a/redbot/cogs/audio/core/commands/llset.py
+++ b/redbot/cogs/audio/core/commands/llset.py
@@ -154,9 +154,9 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
 
     @command_llsetup.command(name="external", aliases=["unmanaged"])
     async def command_llsetup_external(self, ctx: commands.Context):
-        """Toggle using external Lavalink nodes - requires an existing external Lavalink node for Audio to work, if enabled.
+        """Toggle using external (unmanaged) Lavalink nodes - requires an existing Lavalink node for Audio to work, if enabled.
 
-        This command disables the managed Lavalink server, if you do not have an external Lavalink node you will be unable to use Audio while this is enabled.
+        This command disables the managed Lavalink server. If you do not have another Lavalink node to access, you will be unable to use Audio while this is enabled.
         """
         external = await self.config.use_external_lavalink()
         await self.config.use_external_lavalink.set(not external)

--- a/redbot/cogs/audio/core/commands/llset.py
+++ b/redbot/cogs/audio/core/commands/llset.py
@@ -36,7 +36,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
     async def command_llsetup(self, ctx: commands.Context):
         """`Dangerous commands` Manage Lavalink node configuration settings.
 
-        This command block holds all commands to manage an unmanaged (external) or managed Lavalink node.
+        This command block holds all commands to configure an unmanaged (user maintained) or managed (bot maintained) Lavalink node.
 
         You should not mess with any command in here unless you have a valid reason to,
         i.e. been told by someone in the Red-Discord Bot support server to do so.

--- a/redbot/cogs/audio/core/events/dpy.py
+++ b/redbot/cogs/audio/core/events/dpy.py
@@ -86,7 +86,7 @@ DANGEROUS_COMMANDS = {
         "usually you will never have to change this, "
         "before considering changing it please consult our support team."
     ),
-    "command_llset_external": _(
+    "command_llset_unmanaged": _(
         "This command will disable the managed Lavalink node, "
         "if you toggle this command you must specify an external Lavalink node to connect to, "
         "if you do not do so Audio will stop working."


### PR DESCRIPTION
### Description of the changes
This PR holds a correction for #5944, where the change should have been Managed -> Unmanaged instead of Managed -> External.

Changed the wording in some llsetup commands' docstrings to try to be more consistent with this idea.

Kreusada and I had talked about fully changing the External/Internal wording to Unmanaged/Managed when working on Audio's docs previously. I had said I wanted to keep some of the old External wording to try to make the change a bit more transparent for users since we have been referring to them as external/internal for years, but I changed my mind a little on that and wanted to also provide the corresponding docs changes. Let me know if this should be a separate PR for docs.

### Have the changes in this PR been tested?
No, please double check the docs formatting.
