### PR TITLE
Remove llsetup alias for llset

### DIFF
--- a/docs/changelog_3_4_0.rst
+++ b/docs/changelog_3_4_0.rst
@@ -1281,7 +1281,7 @@ Audio
 - Added ``[p]audioset restart``, allowing for Lavalink connection to be restarted (:issue:`4446`)
 - Added ``[p]audioset autodeafen``, allowing for bot to auto-deafen itself when entering voice channel (:issue:`4446`)
 - Added ``[p]audioset mycountrycode``, allowing Spotify search locale per user (:issue:`4446`)
-- Added ``[p]llsetup java``, allowing for a custom Java executable path (:issue:`4446`)
+- Added ``[p]llset java``, allowing for a custom Java executable path (:issue:`4446`)
 - Added ``[p]llset info`` to show Lavalink settings (:issue:`4527`)
 - Added ``[p]audioset logs`` to download Lavalink logs if the Lavalink server is set to internal (:issue:`4527`)
 

--- a/docs/cog_guides/audio.rst
+++ b/docs/cog_guides/audio.rst
@@ -3227,7 +3227,7 @@ Set the volume, 1% - 150%.
 Lavalink Setup Commands
 -----------------------
 
-``[p]llsetup`` group commands are used for advanced management of the connection to the Lavalink 
+``[p]llset`` group commands are used for advanced management of the connection to the Lavalink 
 server. The subcommands are dynamically available depending on whether Red is managing your 
 Lavalink node or if you are connecting to one you manage yourself, or a service that offers Lavalink
 nodes.
@@ -3235,11 +3235,11 @@ nodes.
 Commands specifically for managed Lavalink nodes can be found in :ref:`this section<managed-node-management-commands>`, 
 whilst commands for unmanaged Lavalink nodes can be found :ref:`here<unmanaged-node-management-commands>`.
 
-.. _audio-command-llsetup:
+.. _audio-command-llset:
 
-^^^^^^^
-llsetup
-^^^^^^^
+^^^^^
+llset
+^^^^^
 
 .. note:: |owner-lock|
 
@@ -3247,7 +3247,7 @@ llsetup
 
 .. code-block:: none
 
-    [p]llsetup 
+    [p]llset 
 
 **Description**
 
@@ -3258,18 +3258,18 @@ manage an unmanaged (external) or managed Lavalink node.
 
     You should not change any command settings in this group command unless you 
     have a valid reason to, e.g. been told by someone in the Red-Discord Bot support 
-    server to do so. Changing llsetup command settings have the potential to break 
+    server to do so. Changing llset command settings have the potential to break 
     Audio cog connection and playback if the wrong settings are used.
 
-""""""""""""""""
-llsetup external
-""""""""""""""""
+""""""""""""""
+llset external
+""""""""""""""
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup external
+    [p]llset external
 
 **Description**
 
@@ -3277,29 +3277,29 @@ Toggle using external Lavalink nodes - requires an existing external Lavalink no
 Audio to work, if enabled. This command disables the managed Lavalink server: if you do
 not have an external Lavalink node you will be unable to use Audio while this is enabled.
 
-""""""""""""
-llsetup info
-""""""""""""
+""""""""""
+llset info
+""""""""""
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup info
+    [p]llset info
 
 **Description**
 
 Display Lavalink connection settings.
 
-"""""""""""""
-llsetup reset
-"""""""""""""
+"""""""""""
+llset reset
+"""""""""""
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup reset
+    [p]llset reset
 
 **Description**
 
@@ -3311,17 +3311,17 @@ Reset all ``[p]llset`` changes back to their default values.
 Managed Node Management Commands
 --------------------------------
 
-.. _audio-command-llsetup-config:
+.. _audio-command-llset-config:
 
-^^^^^^^^^^^^^^
-llsetup config
-^^^^^^^^^^^^^^
+^^^^^^^^^^^^
+llset config
+^^^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup config
+    [p]llset config
 
 **Description**
 
@@ -3330,17 +3330,17 @@ Configure the managed Lavalink node runtime options.
 All settings under this group will likely cause Audio to malfunction if changed
 from their defaults, only change settings here if you have been advised to by #support.
 
-.. _audio-command-llsetup-config-bind:
+.. _audio-command-llset-config-bind:
 
-^^^^^^^^^^^^^^^^^^^
-llsetup config bind
-^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^
+llset config bind
+^^^^^^^^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup config bind [host=localhost]
+    [p]llset config bind [host=localhost]
 
 **Description**
 
@@ -3350,17 +3350,17 @@ Set the managed Lavalink node's binding IP address.
 
 * ``[host]``: The node's binding IP address, defaulting to "localhost".
 
-.. _audio-command-llsetup-config-port:
+.. _audio-command-llset-config-port:
 
-^^^^^^^^^^^^^^^^^^^
-llsetup config port
-^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^
+llset config port
+^^^^^^^^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup config port [port=2333]
+    [p]llset config port [port=2333]
 
 **Description**
 
@@ -3374,33 +3374,33 @@ you already have an application using port 2333 on this device.
 
 * ``[port]``: The node's connection port, defaulting to 2333.
 
-.. _audio-command-llsetup-config-server:
+.. _audio-command-llset-config-server:
 
-^^^^^^^^^^^^^^^^^^^^^
-llsetup config server
-^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^
+llset config server
+^^^^^^^^^^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup config server
+    [p]llset config server
 
 **Description**
 
 Configure the managed node authorization and connection settings.
 
-.. _audio-command-llsetup-config-server-buffer:
+.. _audio-command-llset-config-server-buffer:
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-llsetup config server buffer
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+llset config server buffer
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup config server buffer [milliseconds=400]
+    [p]llset config server buffer [milliseconds=400]
 
 **Description**
 
@@ -3412,17 +3412,17 @@ changing it can cause significant playback issues.
 
 * ``[milliseconds]`` - The buffer size, defaults to 400.
 
-.. _audio-command-llsetup-config-server-framebuffer:
+.. _audio-command-llset-config-server-framebuffer:
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-llsetup config server framebuffer
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+llset config server framebuffer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup config server framebuffer [milliseconds=1000]
+    [p]llset config server framebuffer [milliseconds=1000]
 
 **Description**
 
@@ -3434,17 +3434,17 @@ changing it can cause significant playback issues.
 
 * ``[milliseconds]`` - The framebuffer size, defaults to 1000.
 
-.. _audio-command-llsetup-config-source:
+.. _audio-command-llset-config-source:
 
-^^^^^^^^^^^^^^^^^^^^^
-llsetup config source 
-^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^
+llset config source 
+^^^^^^^^^^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup config source
+    [p]llset config source
 
 **Description**
 
@@ -3454,34 +3454,34 @@ By default, all sources are enabled, you should only use commands here to
 disable a specific source if you have been advised to, disabling sources
 without background knowledge can cause Audio to break.
 
-.. _audio-command-llsetup-config-source-bandcamp:
+.. _audio-command-llset-config-source-bandcamp:
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-llsetup config source bandcamp
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+llset config source bandcamp
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup config source bandcamp
+    [p]llset config source bandcamp
 
 **Description**
 
 Toggle Bandcamp source on or off. This toggle controls the playback
 of all Bandcamp related content.
 
-.. _audio-command-llsetup-config-source-http:
+.. _audio-command-llset-config-source-http:
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-llsetup config source http
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^
+llset config source http
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup config source http
+    [p]llset config source http
 
 **Description**
 
@@ -3489,17 +3489,17 @@ Toggle HTTP direct URL usage on or off. This source is used to
 allow playback from direct HTTP streams (this does not affect direct URL
 playback for the other sources).
 
-.. _audio-command-llsetup-config-source-local:
+.. _audio-command-llset-config-source-local:
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-llsetup config source local
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
+llset config source local
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup config source local
+    [p]llset config source local
 
 **Description**
 
@@ -3507,85 +3507,85 @@ Toggle local file usage on or off.
 This toggle controls the playback of all local track content,
 usually found inside the ``localtracks`` folder.
 
-.. _audio-command-llsetup-config-source-soundcloud:
+.. _audio-command-llset-config-source-soundcloud:
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-llsetup config source soundcloud
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+llset config source soundcloud
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup config source soundcloud
+    [p]llset config source soundcloud
 
 **Description**
 
 Toggle SoundCloud source on or off.
 This toggle controls the playback of all SoundCloud related content.
 
-.. _audio-command-llsetup-config-source-twitch:
+.. _audio-command-llset-config-source-twitch:
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-llsetup config source twitch
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+llset config source twitch
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup config source twitch
+    [p]llset config source twitch
 
 **Description**
 
 Toggle Twitch source on or off.
 This toggle controls the playback of all Twitch related content.
 
-.. _audio-command-llsetup-config-source-vimeo:
+.. _audio-command-llset-config-source-vimeo:
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-llsetup config source vimeo
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
+llset config source vimeo
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup config source vimeo
+    [p]llset config source vimeo
 
 **Description**
 
 Toggle Vimeo source on or off.
 This toggle controls the playback of all Vimeo related content.
 
-.. _audio-command-llsetup-config-source-youtube:
+.. _audio-command-llset-config-source-youtube:
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-llsetup config source youtube
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+llset config source youtube
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup config source youtube
+    [p]llset config source youtube
 
 **Description**
 
 Toggle YouTube source on or off (**this includes Spotify**).
 This toggle controls the playback of all YouTube and Spotify related content.
 
-.. _audio-command-llsetup-config-token:
+.. _audio-command-llset-config-token:
 
-^^^^^^^^^^^^^^^^^^^^
-llsetup config token
-^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^
+llset config token
+^^^^^^^^^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup config token [password=youshallnotpass]
+    [p]llset config token [password=youshallnotpass]
 
 **Description**
 
@@ -3597,17 +3597,17 @@ The value by default is ``youshallnotpass``.
 
 * ``[password]`` - The node's connection password, defaulting to ``youshallnotpass``.
 
-.. _audio-command-llsetup-heapsize:
+.. _audio-command-llset-heapsize:
 
-^^^^^^^^^^^^^^^^
-llsetup heapsize
-^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^
+llset heapsize
+^^^^^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup heapsize [size=3G]
+    [p]llset heapsize [size=3G]
 
 **Description**
 
@@ -3624,17 +3624,17 @@ node will always use this amount of RAM.
 
 * ``[size]`` - The node's maximum heap-size, defaulting to ``3G``.
 
-.. _audio-command-llsetup-java:
+.. _audio-command-llset-java:
 
-^^^^^^^^^^^^
-llsetup java
-^^^^^^^^^^^^
+^^^^^^^^^^
+llset java
+^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup java [javapath]
+    [p]llset java [javapath]
 
 **Description**
 
@@ -3650,17 +3650,17 @@ The current supported version is Java 11.
 
 * ``[java]`` - The java executable path, leave blank to reset it back to default.
 
-.. _audio-command-llsetup-yaml:
+.. _audio-command-llset-yaml:
 
-^^^^^^^^^^^^
-llsetup yaml
-^^^^^^^^^^^^
+^^^^^^^^^^
+llset yaml
+^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup yaml
+    [p]llset yaml
 
 **Description**
 
@@ -3676,17 +3676,17 @@ Unmanaged Node Management Commands
 
     A normal Red user should never have to use these commands unless they are :ref:`managing multiple Red bots with Audio<multibots>`.
 
-.. _audio-command-llsetup-host:
+.. _audio-command-llset-host:
 
-^^^^^^^^^^^^
-llsetup host
-^^^^^^^^^^^^
+^^^^^^^^^^
+llset host
+^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup host [host=localhost]
+    [p]llset host [host=localhost]
 
 **Description**
 
@@ -3697,17 +3697,17 @@ Audio will use to connect to an external Lavalink node.
 
 * ``[host]`` - The connection host, defaulting to "localhost".
 
-.. _audio-command-llsetup-password:
+.. _audio-command-llset-password:
 
-^^^^^^^^^^^^^^^^
-llsetup password
-^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^
+llset password
+^^^^^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup password [password=youshallnotpass]
+    [p]llset password [password=youshallnotpass]
 
 **Description**
 
@@ -3718,17 +3718,17 @@ Audio will use to connect to an external Lavalink node.
 
 * ``[password]`` - The connection password, defaulting to "youshallnotpass".
 
-.. _audio-command-llsetup-port:
+.. _audio-command-llset-port:
 
-^^^^^^^^^^^^
-llsetup port
-^^^^^^^^^^^^
+^^^^^^^^^^
+llset port
+^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup port [port=2333]
+    [p]llset port [port=2333]
 
 **Description**
 
@@ -3739,17 +3739,17 @@ Audio will use to connect to an external Lavalink node.
 
 * ``[password]`` - The connection password, defaulting to 2333.
 
-.. _audio-command-llsetup-secured:
+.. _audio-command-llset-secured:
 
-^^^^^^^^^^^^^^^
-llsetup secured
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^
+llset secured
+^^^^^^^^^^^^^
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]llsetup secured
+    [p]llset secured
 
 **Description**
 

--- a/redbot/cogs/audio/core/abc.py
+++ b/redbot/cogs/audio/core/abc.py
@@ -85,7 +85,7 @@ class MixinMeta(ABC):
     _disconnected_shard: Set[int]
 
     @abstractmethod
-    async def command_llsetup(self, ctx: commands.Context):
+    async def command_llset(self, ctx: commands.Context):
         raise NotImplementedError()
 
     @commands.command()

--- a/redbot/cogs/audio/core/commands/llset.py
+++ b/redbot/cogs/audio/core/commands/llset.py
@@ -30,7 +30,7 @@ _ = Translator("Audio", Path(__file__))
 
 
 class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
-    @commands.group(name="llsetup", aliases=["llset"])
+    @commands.group(name="llset", aliases=["llsetup"])
     @commands.is_owner()
     @commands.bot_has_permissions(embed_links=True)
     async def command_llsetup(self, ctx: commands.Context):

--- a/redbot/cogs/audio/core/commands/llset.py
+++ b/redbot/cogs/audio/core/commands/llset.py
@@ -33,7 +33,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
     @commands.group(name="llset")
     @commands.is_owner()
     @commands.bot_has_permissions(embed_links=True)
-    async def command_llsetup(self, ctx: commands.Context):
+    async def command_llset(self, ctx: commands.Context):
         """`Dangerous commands` Manage Lavalink node configuration settings.
 
         This command block holds all commands to manage an unmanaged (external) or managed Lavalink node.
@@ -43,9 +43,9 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
         All the commands in here have the potential to break the Audio cog.
         """
 
-    @command_llsetup.command(name="java")
+    @command_llset.command(name="java")
     @has_managed_server()
-    async def command_llsetup_java(self, ctx: commands.Context, *, java_path: str = "java"):
+    async def command_llset_java(self, ctx: commands.Context, *, java_path: str = "java"):
         """Change your Java executable path.
 
         This command shouldn't need to be used most of the time, and is only useful if the host machine has conflicting Java versions.
@@ -90,9 +90,9 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
                 ),
             )
 
-    @command_llsetup.command(name="heapsize", aliases=["hs", "ram", "memory"])
+    @command_llset.command(name="heapsize", aliases=["hs", "ram", "memory"])
     @has_managed_server()
-    async def command_llsetup_heapsize(self, ctx: commands.Context, size: str = MAX_JAVA_RAM):
+    async def command_llset_heapsize(self, ctx: commands.Context, size: str = MAX_JAVA_RAM):
         """Set the managed Lavalink node maximum heap-size.
 
         By default, this value is 50% of available RAM in the host machine represented by [1-1024][M|G] (256M, 256G for example)
@@ -152,8 +152,8 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
             ),
         )
 
-    @command_llsetup.command(name="unmanaged", aliases=["external"])
-    async def command_llsetup_external(self, ctx: commands.Context):
+    @command_llset.command(name="unmanaged", aliases=["external"])
+    async def command_llset_external(self, ctx: commands.Context):
         """Toggle using external Lavalink nodes - requires an existing external Lavalink node for Audio to work, if enabled.
 
         This command disables the managed Lavalink server, if you do not have an external Lavalink node you will be unable to use Audio while this is enabled.
@@ -189,9 +189,9 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
                     ),
                 )
 
-    @command_llsetup.command(name="host")
+    @command_llset.command(name="host")
     @has_unmanaged_server()
-    async def command_llsetup_host(
+    async def command_llset_host(
         self, ctx: commands.Context, host: str = DEFAULT_LAVALINK_SETTINGS["host"]
     ):
         """Set the Lavalink node host.
@@ -210,9 +210,9 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
             ),
         )
 
-    @command_llsetup.command(name="password", aliases=["pass", "token"])
+    @command_llset.command(name="password", aliases=["pass", "token"])
     @has_unmanaged_server()
-    async def command_llsetup_password(
+    async def command_llset_password(
         self, ctx: commands.Context, *, password: str = DEFAULT_LAVALINK_SETTINGS["password"]
     ):
         """Set the Lavalink node password.
@@ -234,9 +234,9 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
             ),
         )
 
-    @command_llsetup.command(name="port")
+    @command_llset.command(name="port")
     @has_unmanaged_server()
-    async def command_llsetup_wsport(
+    async def command_llset_wsport(
         self, ctx: commands.Context, port: int = DEFAULT_LAVALINK_SETTINGS["ws_port"]
     ):
         """Set the Lavalink node port.
@@ -263,9 +263,9 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
             ),
         )
 
-    @command_llsetup.command(name="secured", aliases=["wss"])
+    @command_llset.command(name="secured", aliases=["wss"])
     @has_unmanaged_server()
-    async def command_llsetup_secured(self, ctx: commands.Context):
+    async def command_llset_secured(self, ctx: commands.Context):
         """Set the Lavalink node connection to secured.
 
         This toggle sets the connection type to secured or unsecured when connecting to an external Lavalink node.
@@ -299,8 +299,8 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
                 secured_protocol=inline("wss://"),
             )
 
-    @command_llsetup.command(name="info", aliases=["settings"])
-    async def command_llsetup_info(self, ctx: commands.Context):
+    @command_llset.command(name="info", aliases=["settings"])
+    async def command_llset_info(self, ctx: commands.Context):
         """Display Lavalink connection settings."""
         configs = await self.config.all()
 
@@ -332,9 +332,9 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
         except discord.HTTPException:
             await ctx.send(_("I need to be able to DM you to send you this info."))
 
-    @command_llsetup.command(name="yaml", aliases=["yml"])
+    @command_llset.command(name="yaml", aliases=["yml"])
     @has_managed_server()
-    async def command_llsetup_yaml(self, ctx: commands.Context):
+    async def command_llset_yaml(self, ctx: commands.Context):
         """Uploads a copy of the application.yml file used by the managed Lavalink node."""
         configs = change_dict_naming_convention(await self.config.yaml.all())
         data = yaml.safe_dump(configs)
@@ -356,20 +356,20 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
         finally:
             temp_file.unlink()
 
-    @command_llsetup.group(name="config", aliases=["conf"])
+    @command_llset.group(name="config", aliases=["conf"])
     @has_managed_server()
-    async def command_llsetup_config(self, ctx: commands.Context):
+    async def command_llset_config(self, ctx: commands.Context):
         """Configure the managed Lavalink node runtime options.
 
         All settings under this group will likely cause Audio to malfunction if changed from their defaults, only change settings here if you have been advised to by support.
         """
 
-    @command_llsetup_config.group(name="server")
-    async def command_llsetup_config_server(self, ctx: commands.Context):
+    @command_llset_config.group(name="server")
+    async def command_llset_config_server(self, ctx: commands.Context):
         """Configure the managed node authorization and connection settings."""
 
-    @command_llsetup_config.command(name="bind", aliases=["host", "address"])
-    async def command_llsetup_config_host(
+    @command_llset_config.command(name="bind", aliases=["host", "address"])
+    async def command_llset_config_host(
         self, ctx: commands.Context, *, host: str = DEFAULT_LAVALINK_YAML["yaml__server__address"]
     ):
         """`Dangerous command` Set the managed Lavalink node's binding IP address.
@@ -389,8 +389,8 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
             ),
         )
 
-    @command_llsetup_config.command(name="token", aliases=["password", "pass"])
-    async def command_llsetup_config_token(
+    @command_llset_config.command(name="token", aliases=["password", "pass"])
+    async def command_llset_config_token(
         self,
         ctx: commands.Context,
         *,
@@ -415,8 +415,8 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
             ),
         )
 
-    @command_llsetup_config.command(name="port")
-    async def command_llsetup_config_port(
+    @command_llset_config.command(name="port")
+    async def command_llset_config_port(
         self, ctx: commands.Context, *, port: int = DEFAULT_LAVALINK_YAML["yaml__server__port"]
     ):
         """`Dangerous command` Set the managed Lavalink node's connection port.
@@ -446,15 +446,15 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
             ),
         )
 
-    @command_llsetup_config.group(name="source")
-    async def command_llsetup_config_source(self, ctx: commands.Context):
+    @command_llset_config.group(name="source")
+    async def command_llset_config_source(self, ctx: commands.Context):
         """`Dangerous command` Toggle audio sources on/off.
 
         By default, all sources are enabled, you should only use commands here to disable a specific source if you have been advised to, disabling sources without background knowledge can cause Audio to break.
         """
 
-    @command_llsetup_config_source.command(name="http")
-    async def command_llsetup_config_source_http(self, ctx: commands.Context):
+    @command_llset_config_source.command(name="http")
+    async def command_llset_config_source_http(self, ctx: commands.Context):
         """Toggle HTTP direct URL usage on or off.
 
         This source is used to allow playback from direct HTTP streams (this does not affect direct URL playback for the other sources).
@@ -480,8 +480,8 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
                 ).format(p=ctx.prefix, cmd=self.command_audioset_restart.qualified_name),
             )
 
-    @command_llsetup_config_source.command(name="bandcamp", aliases=["bc"])
-    async def command_llsetup_config_source_bandcamp(self, ctx: commands.Context):
+    @command_llset_config_source.command(name="bandcamp", aliases=["bc"])
+    async def command_llset_config_source_bandcamp(self, ctx: commands.Context):
         """Toggle Bandcamp source on or off.
 
         This toggle controls the playback of all Bandcamp related content.
@@ -507,8 +507,8 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
                 ).format(p=ctx.prefix, cmd=self.command_audioset_restart.qualified_name),
             )
 
-    @command_llsetup_config_source.command(name="local")
-    async def command_llsetup_config_source_local(self, ctx: commands.Context):
+    @command_llset_config_source.command(name="local")
+    async def command_llset_config_source_local(self, ctx: commands.Context):
         """Toggle local file usage on or off.
 
         This toggle controls the playback of all local track content, usually found inside the `localtracks` folder.
@@ -534,8 +534,8 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
                 ).format(p=ctx.prefix, cmd=self.command_audioset_restart.qualified_name),
             )
 
-    @command_llsetup_config_source.command(name="soundcloud", aliases=["sc"])
-    async def command_llsetup_config_source_soundcloud(self, ctx: commands.Context):
+    @command_llset_config_source.command(name="soundcloud", aliases=["sc"])
+    async def command_llset_config_source_soundcloud(self, ctx: commands.Context):
         """Toggle Soundcloud source on or off.
 
         This toggle controls the playback of all SoundCloud related content.
@@ -561,8 +561,8 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
                 ).format(p=ctx.prefix, cmd=self.command_audioset_restart.qualified_name),
             )
 
-    @command_llsetup_config_source.command(name="youtube", aliases=["yt"])
-    async def command_llsetup_config_source_youtube(self, ctx: commands.Context):
+    @command_llset_config_source.command(name="youtube", aliases=["yt"])
+    async def command_llset_config_source_youtube(self, ctx: commands.Context):
         """`Dangerous command` Toggle YouTube source on or off (this includes Spotify).
 
         This toggle controls the playback of all YouTube and Spotify related content.
@@ -588,8 +588,8 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
                 ).format(p=ctx.prefix, cmd=self.command_audioset_restart.qualified_name),
             )
 
-    @command_llsetup_config_source.command(name="twitch")
-    async def command_llsetup_config_source_twitch(self, ctx: commands.Context):
+    @command_llset_config_source.command(name="twitch")
+    async def command_llset_config_source_twitch(self, ctx: commands.Context):
         """Toggle Twitch source on or off.
 
         This toggle controls the playback of all Twitch related content.
@@ -615,8 +615,8 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
                 ).format(p=ctx.prefix, cmd=self.command_audioset_restart.qualified_name),
             )
 
-    @command_llsetup_config_source.command(name="vimeo")
-    async def command_llsetup_config_source_vimeo(self, ctx: commands.Context):
+    @command_llset_config_source.command(name="vimeo")
+    async def command_llset_config_source_vimeo(self, ctx: commands.Context):
         """Toggle Vimeo source on or off.
 
         This toggle controls the playback of all Vimeo related content.
@@ -642,8 +642,8 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
                 ).format(p=ctx.prefix, cmd=self.command_audioset_restart.qualified_name),
             )
 
-    @command_llsetup_config_server.command(name="framebuffer", aliases=["fb", "frame"])
-    async def command_llsetup_config_server_framebuffer(
+    @command_llset_config_server.command(name="framebuffer", aliases=["fb", "frame"])
+    async def command_llset_config_server_framebuffer(
         self,
         ctx: commands.Context,
         *,
@@ -673,8 +673,8 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
             ),
         )
 
-    @command_llsetup_config_server.command(name="buffer", aliases=["b"])
-    async def command_llsetup_config_server_buffer(
+    @command_llset_config_server.command(name="buffer", aliases=["b"])
+    async def command_llset_config_server_buffer(
         self,
         ctx: commands.Context,
         *,
@@ -704,8 +704,8 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
             ),
         )
 
-    @command_llsetup.command(name="reset")
-    async def command_llsetup_reset(self, ctx: commands.Context):
+    @command_llset.command(name="reset")
+    async def command_llset_reset(self, ctx: commands.Context):
         """Reset all `llset` changes back to their default values."""
         async with ctx.typing():
             async with self.config.all() as global_data:

--- a/redbot/cogs/audio/core/commands/llset.py
+++ b/redbot/cogs/audio/core/commands/llset.py
@@ -30,7 +30,7 @@ _ = Translator("Audio", Path(__file__))
 
 
 class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
-    @commands.group(name="llset", aliases=["llsetup"])
+    @commands.group(name="llset")
     @commands.is_owner()
     @commands.bot_has_permissions(embed_links=True)
     async def command_llsetup(self, ctx: commands.Context):

--- a/redbot/cogs/audio/core/commands/llset.py
+++ b/redbot/cogs/audio/core/commands/llset.py
@@ -152,7 +152,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
             ),
         )
 
-    @command_llsetup.command(name="external", aliases=["unmanaged"])
+    @command_llsetup.command(name="unmanaged", aliases=["external"])
     async def command_llsetup_external(self, ctx: commands.Context):
         """Toggle using external Lavalink nodes - requires an existing external Lavalink node for Audio to work, if enabled.
 

--- a/redbot/cogs/audio/core/commands/llset.py
+++ b/redbot/cogs/audio/core/commands/llset.py
@@ -152,7 +152,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
             ),
         )
 
-    @command_llset.command(name="unmanaged", aliases=["external"])
+    @command_llset.command(name="external", aliases=["unmanaged"])
     async def command_llset_external(self, ctx: commands.Context):
         """Toggle using external Lavalink nodes - requires an existing external Lavalink node for Audio to work, if enabled.
 

--- a/redbot/cogs/audio/core/events/dpy.py
+++ b/redbot/cogs/audio/core/events/dpy.py
@@ -75,92 +75,92 @@ HUMANIZED_PERM = {
 }
 
 DANGEROUS_COMMANDS = {
-    "command_llsetup_java": _(
+    "command_llset_java": _(
         "This command will change the executable path of Java, "
         "this is useful if you have multiple installations of Java and the default one is causing issues. "
         "Please don't change this unless you are certain that the Java version you are specifying is supported by Red. "
         "The default and supported version is currently Java 11."
     ),
-    "command_llsetup_heapsize": _(
+    "command_llset_heapsize": _(
         "This command will change the maximum RAM allocation for the managed Lavalink node, "
         "usually you will never have to change this, "
         "before considering changing it please consult our support team."
     ),
-    "command_llsetup_external": _(
+    "command_llset_external": _(
         "This command will disable the managed Lavalink node, "
         "if you toggle this command you must specify an external Lavalink node to connect to, "
         "if you do not do so Audio will stop working."
     ),
-    "command_llsetup_host": _(
+    "command_llset_host": _(
         "This command is used to specify the IP which will be used by Red to connect to an external Lavalink node. "
     ),
-    "command_llsetup_password": _(
+    "command_llset_password": _(
         "This command is used to specify the authentication password used by Red to connect to an "
         "external Lavalink node."
     ),
-    "command_llsetup_secured": _(
+    "command_llset_secured": _(
         "This command is used toggle between secured and unsecured connections to an external Lavalink node."
     ),
-    "command_llsetup_wsport": _(
+    "command_llset_wsport": _(
         "This command is used to specify the connection port used by Red to connect to an external Lavalink node."
     ),
-    "command_llsetup_config_host": _(
+    "command_llset_config_host": _(
         "This command specifies which network interface and IP the managed Lavalink node will bind to, "
         "by default this is 'localhost', "
         "only change this if you want the managed Lavalink node to bind to a specific IP/interface."
     ),
-    "command_llsetup_config_token": _(
+    "command_llset_config_token": _(
         "This command changes the authentication password required to connect to this managed node."
         "The default value is 'youshallnotpass'."
     ),
-    "command_llsetup_config_port": _(
+    "command_llset_config_port": _(
         "This command changes the connection port used to connect to this managed node, "
         "only change this if the default port '2333' is causing conflicts with existing applications."
     ),
-    "command_llsetup_config_source_http": _(
+    "command_llset_config_source_http": _(
         "This command toggles the support of direct url streams like Icecast or Shoutcast streams. "
         "An example is <http://ice1.somafm.com/gsclassic-128-mp3>; "
         "disabling this will make the bot unable to play any direct url steam content."
     ),
-    "command_llsetup_config_source_bandcamp": _(
+    "command_llset_config_source_bandcamp": _(
         "This command toggles the support of Bandcamp audio playback. "
         "An example is <http://deaddiskdrive.bandcamp.com/track/crystal-glass>; "
         "disabling this will make the bot unable to play any Bandcamp content",
     ),
-    "command_llsetup_config_source_local": _(
+    "command_llset_config_source_local": _(
         "This command toggles the support of local track audio playback. "
         "An example is `/mnt/data/my_super_funky_track.mp3`; "
         "disabling this will make the bot unable to play any local track content."
     ),
-    "command_llsetup_config_source_soundcloud": _(
+    "command_llset_config_source_soundcloud": _(
         "This command toggles the support of SoundCloud playback. "
         "An example is <https://soundcloud.com/user-103858850/tilla>; "
         "disabling this will make the bot unable to play any SoundCloud content."
     ),
-    "command_llsetup_config_source_youtube": _(
+    "command_llset_config_source_youtube": _(
         "This command toggles the support of YouTube playback (Spotify depends on YouTube). "
         "Disabling this will make the bot unable to play any YouTube content: "
         "this includes Spotify."
     ),
-    "command_llsetup_config_source_twitch": _(
+    "command_llset_config_source_twitch": _(
         "This command toggles the support of Twitch playback. "
         "An example of this is <https://twitch.tv/monstercat>; "
         "disabling this will make the bot unable to play any Twitch content."
     ),
-    "command_llsetup_config_source_vimeo": _(
+    "command_llset_config_source_vimeo": _(
         "This command toggles the support of Vimeo playback. "
         "An example of this is <https://vimeo.com/157743578>; "
         "disabling this will make the bot unable to play any Vimeo content."
     ),
-    "command_llsetup_config_server_framebuffer": _(
+    "command_llset_config_server_framebuffer": _(
         "This setting controls the managed node's framebuffer, "
         "do not change this unless instructed."
     ),
-    "command_llsetup_config_server_buffer": _(
+    "command_llset_config_server_buffer": _(
         "This setting controls the managed node's JDA-NAS buffer, "
         "do not change this unless instructed."
     ),
-    "command_llsetup_reset": _("This command will reset every setting changed by `[p]llset`."),
+    "command_llset_reset": _("This command will reset every setting changed by `[p]llset`."),
 }
 
 _ = _T
@@ -172,7 +172,7 @@ class DpyEvents(MixinMeta, metaclass=CompositeMetaClass):
         # check for unsupported arch
         # Check on this needs refactoring at a later date
         # so that we have a better way to handle the tasks
-        if self.command_llsetup in [ctx.command, ctx.command.root_parent]:
+        if self.command_llset in [ctx.command, ctx.command.root_parent]:
             pass
 
         elif self.lavalink_connect_task and self.lavalink_connect_task.cancelled():


### PR DESCRIPTION
### Description of the changes

Rename `llsetup` to `llset` and don't keep `llsetup` as an alias. Hopefully, this will avoid users from trending towards thinking that they must set up something on Lavalink to make it work initially.

### Have the changes in this PR been tested?
No