### PR TITLE
[Trivia] Fix string interpolation in test errors

### DIFF
--- a/tests/cogs/test_trivia.py
+++ b/tests/cogs/test_trivia.py
@@ -26,7 +26,7 @@ def test_trivia_lists():
         except InvalidListError as exc:
             e = exc.__cause__
             if isinstance(e, SchemaError):
-                problem_lists.append((l.stem, f"SCHEMA error:\n{e!s}"))
+                problem_lists.append((l.stem, f"SCHEMA error:\n{format_schema_error(e)!s}"))
             else:
                 problem_lists.append((l.stem, f"YAML error:\n{e!s}"))
 

--- a/tests/cogs/test_trivia.py
+++ b/tests/cogs/test_trivia.py
@@ -26,7 +26,7 @@ def test_trivia_lists():
         except InvalidListError as exc:
             e = exc.__cause__
             if isinstance(e, SchemaError):
-                problem_lists.append((l.stem, f"SCHEMA error:\n{format_schema_error(e)!s}"))
+                problem_lists.append((l.stem, f"SCHEMA error:\n{format_schema_error(e)}"))
             else:
                 problem_lists.append((l.stem, f"YAML error:\n{e!s}"))
 


### PR DESCRIPTION
### Description of the changes
`test_trivia_lists` prints the value of `SchemaError` objects without running the object through `format_schema_error` first. This causes values that should be interpolated to be left as is, such as `{key}`. This PR fixes this issue, making the test output once again useful.

To test this PR, insert a new trivia file with valid YAML that does not follow the trivia file schema, and compare the outputs on the current build vs with this PR.


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
