### PR TITLE
[3.4] Pin tox to <4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
         - name: Install tox
           run: |
             python -m pip install --upgrade pip
-            pip install tox
+            pip install "tox<4"
         - name: Tox test
           env:
             TOXENV: ${{ matrix.tox_env }}
@@ -82,7 +82,7 @@ jobs:
         - name: Install tox
           run: |
             python -m pip install --upgrade pip
-            pip install tox
+            pip install "tox<4"
         - name: Tox test
           env:
             TOXENV: postgres

--- a/tools/dev-requirements.txt
+++ b/tools/dev-requirements.txt
@@ -1,3 +1,3 @@
 packaging
-tox
+tox<4
 -e .[dev]


### PR DESCRIPTION
### Description of the changes

On V3/develop we pinned tox to <4 in #5924 and later made appropriate changes so that tox 4 works and unpinned it in #5611. Here we simply just pin tox to <4 without any other changes as that's the simplest solution for a maintenance branch.

### Have the changes in this PR been tested?

Yes