### PR TITLE
[3.4] Update Python versions in install instructions

### DIFF
--- a/docs/install_guides/_includes/install-python-pyenv.rst
+++ b/docs/install_guides/_includes/install-python-pyenv.rst
@@ -10,7 +10,7 @@ virtual environment.
 
 .. prompt:: bash
 
-    CONFIGURE_OPTS=--enable-optimizations pyenv install 3.9.13 -v
+    CONFIGURE_OPTS=--enable-optimizations pyenv install 3.9.16 -v
 
 This may take a long time to complete, depending on your hardware. For some machines (such as
 Raspberry Pis and micro-tier VPSes), it may take over an hour; in this case, you may wish to remove
@@ -22,6 +22,6 @@ After that is finished, run:
 
 .. prompt:: bash
 
-    pyenv global 3.9.13
+    pyenv global 3.9.16
 
 Pyenv is now installed and your system should be configured to run Python 3.9.

--- a/docs/install_guides/_includes/install-python38-pyenv.rst
+++ b/docs/install_guides/_includes/install-python38-pyenv.rst
@@ -10,7 +10,7 @@ virtual environment.
 
 .. prompt:: bash
 
-    CONFIGURE_OPTS=--enable-optimizations pyenv install 3.8.12 -v
+    CONFIGURE_OPTS=--enable-optimizations pyenv install 3.8.16 -v
 
 This may take a long time to complete, depending on your hardware. For some machines (such as
 Raspberry Pis and micro-tier VPSes), it may take over an hour; in this case, you may wish to remove
@@ -22,6 +22,6 @@ After that is finished, run:
 
 .. prompt:: bash
 
-    pyenv global 3.8.12
+    pyenv global 3.8.16
 
 Pyenv is now installed and your system should be configured to run Python 3.8.

--- a/docs/install_guides/windows.rst
+++ b/docs/install_guides/windows.rst
@@ -31,7 +31,7 @@ Then run each of the following commands:
     iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
     choco upgrade git --params "/GitOnlyOnPath /WindowsTerminal" -y
     choco upgrade visualstudio2022-workload-vctools -y
-    choco upgrade python3 -y --version 3.9.13
+    choco upgrade python39 -y
 
 For Audio support, you should also run the following command before exiting:
 


### PR DESCRIPTION
### Description of the changes

Bumps Python micro versions in Windows and pyenv install instructions. In a similar vein to what was done in #5611 on V3/develop, Windows install instructions now use the `python39` package instead of the `python3` package with `--version` flag.

### Have the changes in this PR been tested?

Yes

Test run of updated install instructions:
- macOS x86_64: https://github.com/Jackenmen/Red-Install-Tests/actions/runs/3852138418
- everything else: https://cirrus-ci.com/build/6186892673155072
