### PR TITLE
[Core] fix error in `[p]ignore list`

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -5357,7 +5357,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                     category_channels.append(channel.category)
             if await self.bot._ignored_cache.get_ignored_channel(channel, check_category=False):
                 channels.append(channel)
-        for channel in ctx.guild.forum_channels:
+        for channel in ctx.guild.forums:
             if channel.category and channel.category not in category_channels:
                 if await self.bot._ignored_cache.get_ignored_channel(channel.category):
                     category_channels.append(channel.category)


### PR DESCRIPTION
### Description of the changes

Hi,

I observed that in dev version of redbot, when I use `[p]ignore list` command, it errors because `guild` object does not have `forum_channels` attribute but instead it is `forums` as per discord.py 2.x documentation. This PR fixes that issue.
After I applied the changes locally, the said comamnd works as expected.

The traceback received currently:
```py
Exception in command 'ignore list'
Traceback (most recent call last):
  File "/home/ubuntu/redenv/lib/python3.9/site-packages/discord/ext/commands/core.py", line 229, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/ubuntu/redenv/lib/python3.9/site-packages/redbot/core/core_commands.py", line 5233, in ignore_list
    for page in pagify(await self.count_ignored(ctx)):
  File "/home/ubuntu/redenv/lib/python3.9/site-packages/redbot/core/core_commands.py", line 5360, in count_ignored
    for channel in ctx.guild.forum_channels:
AttributeError: 'Guild' object has no attribute 'forum_channels'
```

Thank you for reading and g'day.


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
