### PR TITLE
Add a Postgres educational message for Postgres driver users

### DIFF
--- a/docs/install_guides/_includes/install-and-setup-red-unix.rst
+++ b/docs/install_guides/_includes/install-and-setup-red-unix.rst
@@ -13,6 +13,8 @@ To install without additional config backend support:
     python -m pip install -U Red-DiscordBot
 
 Or, to install with PostgreSQL support:
+
+
 .. attention:: The default JSON driver is faster in most scenarios, the PostgresSQL driver is
                 not properly optimized for SQL and data is stored in JSON format in a single row. It is
                 only recommended if you have a large number of servers or a large number of users and notice

--- a/docs/install_guides/_includes/install-and-setup-red-unix.rst
+++ b/docs/install_guides/_includes/install-and-setup-red-unix.rst
@@ -13,6 +13,11 @@ To install without additional config backend support:
     python -m pip install -U Red-DiscordBot
 
 Or, to install with PostgreSQL support:
+.. attention:: The default JSON driver is faster in most scenarios, the PostgresSQL driver is
+                not properly optimized for SQL and data is stored in JSON format in a single row. It is
+                only recommended if you have a large number of servers or a large number of users and notice
+                slowdowns while using the JSON driver, you will be actively hampering your bots performance
+                by using PostgresSQL instead of JSON unless your bot meets the single scenario mentioned above.
 
 .. prompt:: bash
     :prompts: (redenv) $

--- a/docs/install_guides/_includes/install-and-setup-red-unix.rst
+++ b/docs/install_guides/_includes/install-and-setup-red-unix.rst
@@ -2,7 +2,7 @@
 Installing Red
 --------------
 
-Choose one of the following commands to install Red.
+Choose **one** of the following commands to install Red.
 
 To install without additional config backend support:
 

--- a/docs/install_guides/windows.rst
+++ b/docs/install_guides/windows.rst
@@ -127,17 +127,17 @@ Installing Red
 .. attention:: You may need to restart your computer after installing dependencies
                for the PATH changes to take effect.
 
-Run **one** of the following set of commands, depending on what extras you want installed
+Choose **one** of the following commands to install Red.
 
-  * Normal installation:
+To install without additional config backend support:
 
-    .. prompt:: batch
-        :prompts: (redenv) C:\\>
+.. prompt:: batch
+    :prompts: (redenv) C:\\>
 
-        python -m pip install -U pip wheel
-        python -m pip install -U Red-DiscordBot
+    python -m pip install -U pip wheel
+    python -m pip install -U Red-DiscordBot
 
-  * With PostgreSQL support:
+Or, to install with PostgreSQL support:
 
 
 .. attention:: The default JSON driver is faster in most scenarios, the PostgresSQL driver is
@@ -146,12 +146,11 @@ Run **one** of the following set of commands, depending on what extras you want 
                 slowdowns while using the JSON driver, you will be actively hampering your bots performance
                 by using PostgresSQL instead of JSON unless your bot meets the single scenario mentioned above.
 
+.. prompt:: batch
+    :prompts: (redenv) C:\\>
 
-    .. prompt:: batch
-        :prompts: (redenv) C:\\>
-
-        python -m pip install -U pip wheel
-        python -m pip install -U Red-DiscordBot[postgres]
+    python -m pip install -U pip wheel
+    python -m pip install -U Red-DiscordBot[postgres]
 
 --------------------------
 Setting Up and Running Red

--- a/docs/install_guides/windows.rst
+++ b/docs/install_guides/windows.rst
@@ -138,7 +138,9 @@ Run **one** of the following set of commands, depending on what extras you want 
         python -m pip install -U Red-DiscordBot
 
   * With PostgreSQL support:
-    .. attention:: The default JSON driver is faster in most scenarios, the PostgresSQL driver is
+
+
+.. attention:: The default JSON driver is faster in most scenarios, the PostgresSQL driver is
                 not properly optimized for SQL and data is stored in JSON format in a single row. It is
                 only recommended if you have a large number of servers or a large number of users and notice
                 slowdowns while using the JSON driver, you will be actively hampering your bots performance

--- a/docs/install_guides/windows.rst
+++ b/docs/install_guides/windows.rst
@@ -138,6 +138,12 @@ Run **one** of the following set of commands, depending on what extras you want 
         python -m pip install -U Red-DiscordBot
 
   * With PostgreSQL support:
+    .. attention:: The default JSON driver is faster in most scenarios, the PostgresSQL driver is
+                not properly optimized for SQL and data is stored in JSON format in a single row. It is
+                only recommended if you have a large number of servers or a large number of users and notice
+                slowdowns while using the JSON driver, you will be actively hampering your bots performance
+                by using PostgresSQL instead of JSON unless your bot meets the single scenario mentioned above.
+
 
     .. prompt:: batch
         :prompts: (redenv) C:\\>

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -213,6 +213,7 @@ def init_events(bot, cli_flags):
 
         if driver_type == "Postgres":
             from redbot.setup import POSTGRES_DRIVER_WARNING
+
             rich_console.print(POSTGRES_DRIVER_WARNING)
 
         bot._red_ready.set()

--- a/redbot/core/events.py
+++ b/redbot/core/events.py
@@ -159,12 +159,13 @@ def init_events(bot, cli_flags):
         lang = await bot._config.locale()
         dpy_version = discord.__version__
 
+        driver_type = data_manager.storage_type()
         table_general_info = Table(show_edge=False, show_header=False, box=box.MINIMAL)
         table_general_info.add_row("Prefixes", ", ".join(prefixes))
         table_general_info.add_row("Language", lang)
         table_general_info.add_row("Red version", red_version)
         table_general_info.add_row("Discord.py version", dpy_version)
-        table_general_info.add_row("Storage type", data_manager.storage_type())
+        table_general_info.add_row("Storage type", driver_type)
 
         table_counts = Table(show_edge=False, show_header=False, box=box.MINIMAL)
         # String conversion is needed as Rich doesn't deal with ints
@@ -209,6 +210,10 @@ def init_events(bot, cli_flags):
             )
         if rich_outdated_message:
             rich_console.print(rich_outdated_message)
+
+        if driver_type == "Postgres":
+            from redbot.setup import POSTGRES_DRIVER_WARNING
+            rich_console.print(POSTGRES_DRIVER_WARNING)
 
         bot._red_ready.set()
         if outdated_red_message:


### PR DESCRIPTION
### Description of the changes
Show the Postgres educational message in the following scenarios:

- When a user tries to convert their driver to Postgres
  - Prompt them for confirmation in this case after displaying the message
- When a user tries to create an instance with the Postgres driver
  - Prompt them for confirmation in this case after displaying the message
- Add an attention tag to the docs where it mentions the Postgres extras
- Show the warning if a user is already running on a Postgres driver during the start-up sequence
- Prompts should not be shown in non-interactive more

### Have the changes in this PR been tested?
Partial:
- Tested the prompt when migrating
  -  ![image](https://user-images.githubusercontent.com/27962761/215476272-10baad48-5dfe-4f11-80ae-195d1dcad85a.png)
  -  ![image](https://user-images.githubusercontent.com/27962761/215476402-0bbb788c-c655-4fa1-9ce2-f3bb9c2371e3.png)
- Tested the prompt during the creation
  -  ![image](https://user-images.githubusercontent.com/27962761/215476530-218b0679-3f9d-470d-87a5-68c3f54d66bd.png)
- Tested the docs
  - ![image](https://user-images.githubusercontent.com/27962761/215476621-0399dd84-c363-4189-8cc3-49b6aea34dcc.png)
  - ![image](https://user-images.githubusercontent.com/27962761/215476683-4933b86f-382c-4a04-bc75-04369f390cf8.png)

Not tested:
- That the warning is shown at the start-up sequence for Postgres users
- Non-interactive mode to verify prompts are not displayed (Warning should still be shown)

