### PR TITLE
[Installation] Enabling no-prompt setup when PostgreSQL is used as the backend

### DIFF
--- a/redbot/core/drivers/json.py
+++ b/redbot/core/drivers/json.py
@@ -97,7 +97,7 @@ class JsonDriver(BaseDriver):
         return
 
     @staticmethod
-    def get_config_details() -> Dict[str, Any]:
+    def get_config_details(interactive: bool) -> Dict[str, Any]:
         # No driver-specific configuration needed
         return {}
 

--- a/redbot/core/drivers/postgres/postgres.py
+++ b/redbot/core/drivers/postgres/postgres.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 from typing import Optional, Any, AsyncIterator, Tuple, Union, Callable, List
 
+
 try:
     # pylint: disable=import-error
     import asyncpg
@@ -55,7 +56,17 @@ class PostgresDriver(BaseDriver):
             await cls._pool.close()
 
     @staticmethod
-    def get_config_details():
+    def get_config_details(interactive: bool):
+
+        if not interactive:
+            return {
+                "host": None,
+                "port": None,
+                "user": None,
+                "password": None,
+                "database": None,
+            }
+
         unixmsg = (
             ""
             if sys.platform == "win32"

--- a/redbot/core/drivers/postgres/postgres.py
+++ b/redbot/core/drivers/postgres/postgres.py
@@ -4,7 +4,6 @@ import sys
 from pathlib import Path
 from typing import Optional, Any, AsyncIterator, Tuple, Union, Callable, List
 
-
 try:
     # pylint: disable=import-error
     import asyncpg

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -212,7 +212,7 @@ def basic_setup(
 
     default_dirs["STORAGE_TYPE"] = storage_type.value
     driver_cls = drivers.get_driver_class(storage_type)
-    default_dirs["STORAGE_DETAILS"] = driver_cls.get_config_details()
+    default_dirs["STORAGE_DETAILS"] = driver_cls.get_config_details(interactive)
 
     if name in instance_data:
         if overwrite_existing_instance:
@@ -407,7 +407,9 @@ async def remove_instance_interaction() -> None:
         "Choose a backend type for the new instance."
         " If this option is omitted, you will be asked for this."
         " Defaults to JSON in non-interactive mode.\n"
-        "Note: Choosing PostgreSQL will prevent the setup from being completely non-interactive."
+        "Note: Choosing PostgreSQL with the non-interactive flag\n"
+        "will use either the enivronmental variables if set \n "
+        "or the default values.\n"
     ),
 )
 @click.option(


### PR DESCRIPTION
### Description of the changes

This change enables the use of PostgreSQL as the backend using environmental variables or default variables when using the `--no-prompt` flag. 

### Reason for this change

Due to the use of `getpass` in the PostgreSQL prompts, it prevents you from bypassing the password prompt and letting the application use environmental variables in Docker environments. 

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->

`redbot-setup` run with changes:
```
(.venv) @xn4p4lm ➜ /workspaces/Red-DiscordBot (V3/develop) $ redbot-setup --no-prompt --instance-name test --backend postgres
Your basic configuration has been saved.
(.venv) @xn4p4lm ➜ /workspaces/Red-DiscordBot (V3/develop) $
``` 

`tox` output:
```
_________________________________________________________ summary __________________________________________________________
  py38: commands succeeded
  py39: commands succeeded
  py310: commands succeeded
  py311: commands succeeded
  docs: commands succeeded
  style: commands succeeded
  congratulations :)
```

