### PR TITLE
Fix PR titles made by prepare/publish release workflows

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Automated Crowdin downstream
-          title: "[i18n] Automated Crowdin downstream"
+          title: "[${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}][i18n] Automated Crowdin downstream"
           body: |
             This is an automated PR that is part of Prepare Release automated workflow (2 out of 2).
             Please ensure that there are no errors or invalid files are in the PR.
@@ -101,13 +101,19 @@ jobs:
             );
             return await script({github, context});
 
+      - name: Extract Semver
+        id: semver_parser
+        uses: booxmedialtd/ws-action-parse-semver@v1.4.7
+        with:
+          input_string: ${{ steps.bump_version_stable.outputs.new_version }}
+
       - name: Create Pull Request
         id: cpr_bump_stable
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Version bump to ${{ steps.bump_version_stable.outputs.new_version }}
-          title: Version bump to ${{ steps.bump_version_stable.outputs.new_version }}
+          commit-message: "[${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}] Version bump to ${{ steps.bump_version_stable.outputs.new_version }}"
+          title: "[${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}] Version bump to ${{ steps.bump_version_stable.outputs.new_version }}"
           body: |
             This is an automated PR that is part of Prepare Release automated workflow (1 out of 2).
             Please ensure that there are no errors or invalid files are in the PR.

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -120,13 +120,19 @@ jobs:
             );
             return await script({github, context});
 
+      - name: Extract Semver
+        id: semver_parser
+        uses: booxmedialtd/ws-action-parse-semver@v1.4.7
+        with:
+          input_string: ${{ steps.bump_version_stable.outputs.new_version }}
+
       - name: Create Pull Request
         id: cpr_bump_dev
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Version bump to ${{ steps.bump_version_dev.outputs.new_version }}
-          title: Version bump to ${{ steps.bump_version_dev.outputs.new_version }}
+          commit-message: "[${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}]Version bump to ${{ steps.bump_version_dev.outputs.new_version }}"
+          title: "[${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}]Version bump to ${{ steps.bump_version_dev.outputs.new_version }}"
           body: |
             This is an automated PR.
             Please ensure that there are no errors or invalid files are in the PR.


### PR DESCRIPTION
### Description of the changes
We have added an action in the .github/workflow/prepare_release.yml and .github/workflow/publish_release.yml files to display the PR title with the major and minor version prefix. This PR is from the issue #5766.


### Have the changes in this PR been tested?

Yes