### PR TITLE
Add `brew shellenv` to shell profile in macOS install guide

### DIFF
--- a/docs/install_guides/mac.rst
+++ b/docs/install_guides/mac.rst
@@ -17,6 +17,9 @@ following, then press Enter:
 .. prompt:: bash
 
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    brew_location="$([ -n "$HOMEBREW_PREFIX" ] && echo "$HOMEBREW_PREFIX" || ([ "$(/usr/bin/uname -m)" = "arm64" ] && echo /opt/homebrew || echo /usr/local))/bin/brew"
+    printf '\neval "$(%s shellenv)"\n' "$brew_location" >> "$([ -n "$ZSH_VERSION" ] && echo ~/.zprofile || ([ -f ~/.bash_profile ] && echo ~/.bash_profile || echo ~/.profile))"
+    eval "$("$brew_location" shellenv)"
 
 After the installation, install the required packages by pasting the commands and pressing enter,
 one-by-one:
@@ -33,9 +36,8 @@ To fix this, you should run these commands:
 
 .. prompt:: bash
 
-    profile=$([ -n "$ZSH_VERSION" ] && echo ~/.zprofile || ([ -f ~/.bash_profile ] && echo ~/.bash_profile || echo ~/.profile))
-    echo 'export PATH="$(brew --prefix)/opt/python@3.11/bin:$PATH"' >> "$profile"
-    source "$profile"
+    echo 'export PATH="$(brew --prefix)/opt/python@3.11/bin:$PATH"' >> "$([ -n "$ZSH_VERSION" ] && echo ~/.zprofile || ([ -f ~/.bash_profile ] && echo ~/.bash_profile || echo ~/.profile))"
+    export PATH="$(brew --prefix)/opt/python@3.11/bin:$PATH"
 
 .. Include common instructions:
 


### PR DESCRIPTION
### Description of the changes

Fixes an issue with brew not being on PATH when installing it on Apple Silicon due to us not adding `brew shellenv` call to the shell profile file.

### Have the changes in this PR been tested?

Yes

Test run of updated install instructions:

- macOS x86_64: https://github.com/Jackenmen/Red-Install-Tests/actions/runs/4233301748
- everything else: https://cirrus-ci.com/build/4527527192952832