### PR TITLE
[Docs] Windows batch autostart docs

### DIFF
--- a/docs/autostart_windows.rst
+++ b/docs/autostart_windows.rst
@@ -1,0 +1,48 @@
+.. _autostart_windows:
+
+==============================================
+Setting up auto-restart using batch on Windows
+==============================================
+
+.. note:: This guide assumes that you already have a working Red instance.
+
+-----------------------
+Creating the batch file
+-----------------------
+
+Create a new text document anywhere you want to. This file will be used to launch the bot, so you may want to put it somewhere convenient, like Documents or Desktop.
+
+Open that document in Notepad, and paste the following text in it:
+
+.. code-block:: batch
+    
+    @ECHO OFF
+    :RED
+    CALL "%userprofile%\redenv\Scripts\activate.bat"
+    python -O -m redbot <your instance name>
+
+    IF %ERRORLEVEL% NEQ 0 (
+        ECHO Restarting Red...
+        GOTO RED
+    )
+
+Replace ``<your instance name>`` with the instance name of your bot.
+If you created your VENV at a location other than the recommended one, replace ``%userprofile%\redenv\Scripts\activate.bat`` with the path to your VENV.
+
+Click "File", "Save as". Change the dropdown "Save as type" to "All Files (*.*)". Set the filename to ``start_redbot.bat``, and click save.
+
+There should now be a new file in the location you created the text document in. You can delete that text document as it is no longer needed.
+You can now use the ``start_redbot.bat`` batch file to launch Red by double clicking it.
+This script will automatically restart red when the ``[p]restart`` command is used or when the bot shuts down abnormally.
+
+-------------------------
+Launch the bot on startup
+-------------------------
+
+Create a shortcut of your ``start_redbot.bat`` file.
+
+Open the "Run" dialogue box using Windows Key + R.
+
+Enter ``shell:startup`` if you want the bot to launch only when the current user logs in, or ``shell:common startup`` if you want the bot to launch when any user logs in.
+
+Drag the shortcut into the folder that is opened. The bot will now launch on startup.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,8 +16,9 @@ Welcome to Red - Discord Bot's documentation!
     bot_application_guide
     update_red
     about_venv
-    autostart_systemd
+    autostart_windows
     autostart_mac
+    autostart_systemd
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
### Description of the changes
Documents the `?winautorestart` batch script more formally, and includes instructions for setting up autostart using the Startup folder.

Supersedes #3893 and #4081
Unblocks #3182

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
