### PR TITLE
Fix the handling of PartialMessageable channels

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -825,9 +825,8 @@ class Red(
         # We do not consider messages with PartialMessageable channel as eligible.
         # See `process_commands()` for our handling of it.
 
-        # 27-03-2023: Addendum, Fetching the channel here is gonna cost us some API calls.
-        # But so far seems like the better solution.
-        # On hybrid commands this may in a very rare scenario cause a timeout. But that's assuming the worst
+        # 27-03-2023: Addendum, DMs won't run into the same issues that guild partials will,
+        # so we can safely continue to execute the command.
         if (
             isinstance(channel, discord.PartialMessageable)
             and channel.type is not discord.ChannelType.private

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -828,7 +828,10 @@ class Red(
         # 27-03-2023: Addendum, Fetching the channel here is gonna cost us some API calls.
         # But so far seems like the better solution.
         # On hybrid commands this may in a very rare scenario cause a timeout. But that's assuming the worst
-        if isinstance(channel, discord.PartialMessageable):
+        if (
+            isinstance(channel, discord.PartialMessageable)
+            and channel.type is not discord.ChannelType.private
+        ):
             try:
                 channel = await self.get_or_fetch_channel(channel.id)
             except discord.DiscordException:
@@ -1646,7 +1649,11 @@ class Red(
                             ctx.prefix = m
                         break
 
-            if ctx.invoked_with and isinstance(message.channel, discord.PartialMessageable):
+            if (
+                ctx.invoked_with
+                and isinstance(message.channel, discord.PartialMessageable)
+                and message.channel.type is not discord.ChannelType.private
+            ):
                 log.warning(
                     "Discarded a command message (ID: %s) with PartialMessageable channel: %r",
                     message.id,

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1647,15 +1647,11 @@ class Red(
                         break
 
             if ctx.invoked_with and isinstance(message.channel, discord.PartialMessageable):
-                try:
-                    channel = await self.get_or_fetch_channel(message.channel.id)
-                    ctx.channel = message.channel = channel
-                except discord.DiscordException:
-                    log.warning(
-                        "Discarded a command message (ID: %s) with PartialMessageable channel: %r",
-                        message.id,
-                        message.channel,
-                    )
+                log.warning(
+                    "Discarded a command message (ID: %s) with PartialMessageable channel: %r",
+                    message.id,
+                    message.channel,
+                )
             else:
                 await self.invoke(ctx)
         else:

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1034,6 +1034,37 @@ class Red(
             return member
         return await guild.fetch_member(member_id)
 
+    async def get_or_fetch_channel(
+        self, channel_id: int
+    ) -> Union[discord.abc.GuildChannel, discord.abc.PrivateChannel, discord.Thread]:
+        """
+        Retrieves a channel based on their ID.
+
+
+        .. warning::
+
+            This method may make an API call if the channel is not found in the bot cache. For general usage, consider ``bot.get_channel`` instead.
+
+        Parameters
+        -----------
+        channel_id: int
+            The ID of the channel that should be retrieved.
+
+        Raises
+        -------
+        Errors
+            Please refer to `discord.Client.fetch_channel`.
+
+        Returns
+        --------
+        Union[discord.abc.GuildChannel, discord.abc.PrivateChannel, discord.Thread]
+            The channel requested.
+        """
+
+        if (channel := self.get_channel(channel_id)) is not None:
+            return channel
+        return await self.fetch_channel(channel_id)
+
     get_embed_colour = get_embed_color
 
     # start config migrations

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -832,10 +832,7 @@ class Red(
             isinstance(channel, discord.PartialMessageable)
             and channel.type is not discord.ChannelType.private
         ):
-            try:
-                channel = await self.get_or_fetch_channel(channel.id)
-            except discord.DiscordException:
-                return False
+            return False
 
         if guild:
             assert isinstance(channel, (discord.TextChannel, discord.VoiceChannel, discord.Thread))

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1040,37 +1040,6 @@ class Red(
             return member
         return await guild.fetch_member(member_id)
 
-    async def get_or_fetch_channel(
-        self, channel_id: int
-    ) -> Union[discord.abc.GuildChannel, discord.abc.PrivateChannel, discord.Thread]:
-        """
-        Retrieves a channel based on their ID.
-
-
-        .. warning::
-
-            This method may make an API call if the channel is not found in the bot cache. For general usage, consider ``bot.get_channel`` instead.
-
-        Parameters
-        -----------
-        channel_id: int
-            The ID of the channel that should be retrieved.
-
-        Raises
-        -------
-        Errors
-            Please refer to `discord.Client.fetch_channel`.
-
-        Returns
-        --------
-        Union[discord.abc.GuildChannel, discord.abc.PrivateChannel, discord.Thread]
-            The channel requested.
-        """
-
-        if (channel := self.get_channel(channel_id)) is not None:
-            return channel
-        return await self.fetch_channel(channel_id)
-
     get_embed_colour = get_embed_color
 
     # start config migrations


### PR DESCRIPTION
### Description of the changes
Closes #5995.

~~This PR adds in a new public function that works in a similar vain such as ``get_or_fetch_user/member``. Which looks for a channel in the cache and if it isn't found tries to retrieve it from Discord.~~
This is initially added to resolve the issues found in #5995, where a ``PartialChannel`` doesn't resolve permissions which we (I think) require for some command handling.


### Have the changes in this PR been tested?
Yes*~Ish*
