### PR TITLE
Switch the Publish Release workflow to use OpenID Connect

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -53,28 +53,53 @@ jobs:
               echo 'Continuing...'
           fi
 
-  release_to_pypi:
-    needs: release_information
-    environment: Release
-    name: Release to PyPI
+  build:
+    name: Build package
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.8'
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.pypi_token }}
-        run: |
-          python -m build
-          twine upload dist/*
+          python -m pip install --upgrade build twine
+
+      - name: Build
+        run: python -m build
+      - name: Check built distributions
+        run: python -m twine check dist/*
+
+      - name: Upload packaged distributions
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./dist
+
+  release_to_pypi:
+    needs:
+      - release_information
+      - build
+    environment: Release
+    name: Release to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Download packaged distributions
+        uses: actions/download-artifact@v3
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # This is already checked during the build.
+          verify-metadata: false
+          # Allow security-minded people to verify whether the files on PyPI
+          # were automatically uploaded by a CI script.
+          print-hash: true
 
   pr_dev_bump:
     permissions:


### PR DESCRIPTION
### Description of the changes

A more secure way (https://docs.pypi.org/trusted-publishers/#quick-background-publishing-with-openid-connect) of publishing releases to PyPI through the use of OpenID Connect (OIDC):
> PyPI's normal API tokens are long-lived, meaning that an attacker who compromises a package's release can use it until its legitimate user notices and manually revokes it. Similarly, uploading with a password means that an attacker can upload to any project associated with the account. Trusted publishing avoids both of these problems: the tokens minted expire automatically, and are scoped down to only the packages that they're authorized to upload to.

~~This is currently a draft due to this potentially *lowering* our current security model until https://github.com/pypi/warehouse/issues/13270 is resolved. Currently, the PyPI token is put inside the environment that needs to be manually approved which means that it prevents committers that aren't part of the admin core devs team from publishing releases. If we were to change to OIDC now, however, due to the aforementioned issue we would somewhat open ourselves to the potential of committers outside that team changing the workflow to not depend on the environment and publishing after such change. Once that issue is resolved, it will be possible to specify the environment that needs to be matched in order for PyPI to authorize minting the OIDC token.~~ This has now been implemented.

### Have the changes in this PR been tested?

No
