### PR TITLE
Add global checks to app commands

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -847,7 +847,7 @@ class Red(
         return True
 
     async def ignored_channel_or_guild(
-        self, ctx: Union[commands.Context, discord.Message]
+        self, ctx: Union[commands.Context, discord.Message, discord.Interaction]
     ) -> bool:
         """
         This checks if the bot is meant to be ignoring commands in a channel or guild,
@@ -857,7 +857,8 @@ class Red(
         ----------
         ctx :
             Context object of the command which needs to be checked prior to invoking
-            or a Message object which might be intended for use as a command.
+            or a Message object which might be intended for use as a command
+            or an Interaction object which might be intended for use with a command.
 
         Returns
         -------
@@ -867,20 +868,30 @@ class Red(
         Raises
         ------
         TypeError
-            ``ctx.channel`` is of `discord.PartialMessageable` type.
+            ``ctx.channel`` is a `discord.PartialMessageable` with a ``type`` other
+            than ``discord.ChannelType.private``
         """
+        if isinstance(ctx, discord.Interaction):
+            author = ctx.user
+        else:
+            author = ctx.author
+        
+        is_private = isinstance(ctx.channel, discord.abc.PrivateChannel)
         if isinstance(ctx.channel, discord.PartialMessageable):
-            raise TypeError("Can't check permissions for PartialMessageable.")
-        perms = ctx.channel.permissions_for(ctx.author)
+            if ctx.channel.type is not discord.ChannelType.private:
+                raise TypeError("Can't check permissions for non-private PartialMessageable.")
+            is_private = True
+        perms = ctx.channel.permissions_for(author)
         surpass_ignore = (
-            isinstance(ctx.channel, discord.abc.PrivateChannel)
+            is_private
             or perms.manage_guild
-            or await self.is_owner(ctx.author)
-            or await self.is_admin(ctx.author)
+            or await self.is_owner(author)
+            or await self.is_admin(author)
         )
         # guild-wide checks
         if surpass_ignore:
             return True
+
         guild_ignored = await self._ignored_cache.get_ignored_guild(ctx.guild)
         if guild_ignored:
             return False

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -875,7 +875,7 @@ class Red(
             author = ctx.user
         else:
             author = ctx.author
-        
+
         is_private = isinstance(ctx.channel, discord.abc.PrivateChannel)
         if isinstance(ctx.channel, discord.PartialMessageable):
             if ctx.channel.type is not discord.ChannelType.private:

--- a/redbot/core/tree.py
+++ b/redbot/core/tree.py
@@ -309,6 +309,22 @@ class RedTree(CommandTree):
         else:
             log.exception(type(error).__name__, exc_info=error)
 
+    async def interaction_check(self, interaction: discord.Interaction):
+        """Global checks for app commands."""
+        if interaction.user.bot:
+            return False
+
+        if interaction.guild:
+            if not (await self.client.ignored_channel_or_guild(interaction)):
+                await interaction.response.send_message("This channel or server is ignored.", ephemeral=True)
+                return False
+
+        if not (await self.client.allowed_by_whitelist_blacklist(interaction.user)):
+            await interaction.response.send_message("You are not permitted to use commands because of an allowlist or blocklist.", ephemeral=True)
+            return False
+        
+        return True
+
     # DEP-WARN
     def _remove_with_module(self, name: str, *args, **kwargs) -> None:
         """Handles cases where a module raises an exception in the loading process, but added commands to the tree.

--- a/redbot/core/tree.py
+++ b/redbot/core/tree.py
@@ -316,13 +316,18 @@ class RedTree(CommandTree):
 
         if interaction.guild:
             if not (await self.client.ignored_channel_or_guild(interaction)):
-                await interaction.response.send_message("This channel or server is ignored.", ephemeral=True)
+                await interaction.response.send_message(
+                    "This channel or server is ignored.", ephemeral=True
+                )
                 return False
 
         if not (await self.client.allowed_by_whitelist_blacklist(interaction.user)):
-            await interaction.response.send_message("You are not permitted to use commands because of an allowlist or blocklist.", ephemeral=True)
+            await interaction.response.send_message(
+                "You are not permitted to use commands because of an allowlist or blocklist.",
+                ephemeral=True,
+            )
             return False
-        
+
         return True
 
     # DEP-WARN


### PR DESCRIPTION
### Description of the changes
Adds checks for `[p]ignore`, `[p]allowlist`, and `[p]blocklist` to app commands.

Does *not* add checks for whether or not the bot has `send_messages` (or similar) permissions in the channel, since interacting via the `interaction` object does not require those permissions. These checks should still apply for hybrid commands, since those use the `commands` system of checks, so CCs coding specifically `app_command.command` commands should be able to account for this where necessary.

I opted to make the fail cases send an ephemeral message, as far as I know responding to an interaction does not count against the bot's rate limits, and it's just generally good practice to always respond to interactions if the bot is able to.

`ignored_channel_or_guild` was modified to accept an `Interaction` in addition to the `Message` and `Context` it already supported. It also has a (technically breaking) change to accept `PartialMessageable` objects if their `.type` is `discord.ChannelType.private`. It uses the same logic as for `PrivateChannel`s, allowing app commands used in DMs to not be caught by this filter.


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
