### PR TITLE
Allow force enabling app commands using flag in extras

### DIFF
--- a/docs/cog_guides/core.rst
+++ b/docs/cog_guides/core.rst
@@ -4168,7 +4168,14 @@ slash list
 **Description**
 
 List the slash commands the bot can see, and whether or not they are enabled.
+
 This command shows the state that will be changed to when ``[p]slash sync`` is run.
+Commands from the same cog are grouped, with the cog name as the header.
+
+The prefix denotes the state of the command:
+- Commands starting with ``- `` have not yet been enabled.
+- Commands starting with ``+ `` have been manually enabled.
+- Commands starting with ``++`` have been enabled by the cog author, and cannot be disabled.
 
 .. _core-command-slash-sync:
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1919,6 +1919,8 @@ class Red(
                 self.dispatch("command_add", subcommand)
                 if permissions_not_loaded:
                     subcommand.requires.ready_event.set()
+        if isinstance(command, (commands.HybridCommand, commands.HybridGroup)):
+            command.app_command.extras = command.extras
 
     def remove_command(self, name: str, /) -> Optional[commands.Command]:
         command = super().remove_command(name)

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2049,8 +2049,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         if existing is not None and existing.extras.get("red_force_enable", False):
             await ctx.send(
                 _(
-                    "That application command has been enabled by the cog author, "
-                    "and cannot be disabled. The cog must be unloaded to remove the command."
+                    "That application command has been set as required for the cog to function "
+                    "by the author, and cannot be disabled. "
+                    "The cog must be unloaded to remove the command."
                 )
             )
             return

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2214,13 +2214,27 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             module = command.module
             if "." in module:
                 module = module[: module.find(".")]
-            cog_commands[module].append((command.name, discord.AppCommandType.chat_input, True, command.extras.get("red_force_enable", False)))
+            cog_commands[module].append(
+                (
+                    command.name,
+                    discord.AppCommandType.chat_input,
+                    True,
+                    command.extras.get("red_force_enable", False),
+                )
+            )
             slash_command_names.add(command.name)
         for command in self.bot.tree._disabled_global_commands.values():
             module = command.module
             if "." in module:
                 module = module[: module.find(".")]
-            cog_commands[module].append((command.name, discord.AppCommandType.chat_input, False, command.extras.get("red_force_enable", False)))
+            cog_commands[module].append(
+                (
+                    command.name,
+                    discord.AppCommandType.chat_input,
+                    False,
+                    command.extras.get("red_force_enable", False),
+                )
+            )
         for key, command in self.bot.tree._context_menus.items():
             # Filter out guild context menus
             if key[1] is not None:
@@ -2228,7 +2242,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             module = command.module
             if "." in module:
                 module = module[: module.find(".")]
-            cog_commands[module].append((command.name, command.type, True, command.extras.get("red_force_enable", False)))
+            cog_commands[module].append(
+                (command.name, command.type, True, command.extras.get("red_force_enable", False))
+            )
             if command.type is discord.AppCommandType.message:
                 message_command_names.add(command.name)
             elif command.type is discord.AppCommandType.user:
@@ -2237,7 +2253,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             module = command.module
             if "." in module:
                 module = module[: module.find(".")]
-            cog_commands[module].append((command.name, command.type, False, command.extras.get("red_force_enable", False)))
+            cog_commands[module].append(
+                (command.name, command.type, False, command.extras.get("red_force_enable", False))
+            )
 
         # Commands added with evals will come from __main__, make them unknown instead
         if "__main__" in cog_commands:
@@ -2251,8 +2269,12 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         unknown_message = set(enabled_commands["message"]) - message_command_names
         unknown_user = set(enabled_commands["user"]) - user_command_names
 
-        unknown_slash = [(n, discord.AppCommandType.chat_input, True, False) for n in unknown_slash]
-        unknown_message = [(n, discord.AppCommandType.message, True, False) for n in unknown_message]
+        unknown_slash = [
+            (n, discord.AppCommandType.chat_input, True, False) for n in unknown_slash
+        ]
+        unknown_message = [
+            (n, discord.AppCommandType.message, True, False) for n in unknown_message
+        ]
         unknown_user = [(n, discord.AppCommandType.user, True, False) for n in unknown_user]
 
         cog_commands["(unknown)"].extend(unknown_slash)

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2045,11 +2045,21 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             await ctx.send(_("Command type must be one of `slash`, `message`, or `user`."))
             return
 
+        existing = self.bot.tree.get_command(command_name, type=raw_type)
+        if existing is not None and existing.extras.get("red_force_enable", False):
+            await ctx.send(
+                _(
+                    "That application command has been enabled by the cog author, "
+                    "and cannot be disabled. The cog must be unloaded to remove the command."
+                )
+            )
+            return
+
         current_settings = await self.bot.list_enabled_app_commands()
         current_settings = current_settings[command_type]
 
         if command_name not in current_settings:
-            await ctx.send(_("That application command is already disabled."))
+            await ctx.send(_("That application command is already disabled or does not exist."))
             return
 
         await self.bot.disable_app_command(command_name, raw_type)

--- a/redbot/core/tree.py
+++ b/redbot/core/tree.py
@@ -1,6 +1,7 @@
 import discord
 from discord.abc import Snowflake
 from discord.utils import MISSING
+from discord.ext.commands.hybrid import HybridAppCommand
 
 from .app_commands import (
     AppCommand,
@@ -61,6 +62,8 @@ class RedTree(CommandTree):
         Commands will be internally stored until enabled by ``[p]slash enable``.
         """
         # Allow guild specific commands to bypass the internals for development
+        if isinstance(command, HybridAppCommand):
+            command.extras = command.wrapped.extras
         if (
             guild is not MISSING
             or guilds is not MISSING

--- a/redbot/core/tree.py
+++ b/redbot/core/tree.py
@@ -61,7 +61,11 @@ class RedTree(CommandTree):
         Commands will be internally stored until enabled by ``[p]slash enable``.
         """
         # Allow guild specific commands to bypass the internals for development
-        if guild is not MISSING or guilds is not MISSING or command.extras.get("red_force_enable", False):
+        if (
+            guild is not MISSING
+            or guilds is not MISSING
+            or command.extras.get("red_force_enable", False)
+        ):
             return super().add_command(
                 command, *args, guild=guild, guilds=guilds, override=override, **kwargs
             )
@@ -193,7 +197,9 @@ class RedTree(CommandTree):
 
         # Remove commands
         for command, command_obj in self._global_commands.items():
-            if command not in enabled_commands["slash"] and not command_obj.extras.get("red_force_enable", False):
+            if command not in enabled_commands["slash"] and not command_obj.extras.get(
+                "red_force_enable", False
+            ):
                 to_remove_commands.append((command, discord.AppCommandType.chat_input))
 
         # Remove context

--- a/redbot/core/tree.py
+++ b/redbot/core/tree.py
@@ -61,7 +61,7 @@ class RedTree(CommandTree):
         Commands will be internally stored until enabled by ``[p]slash enable``.
         """
         # Allow guild specific commands to bypass the internals for development
-        if guild is not MISSING or guilds is not MISSING:
+        if guild is not MISSING or guilds is not MISSING or command.extras.get("red_force_enable", False):
             return super().add_command(
                 command, *args, guild=guild, guilds=guilds, override=override, **kwargs
             )
@@ -192,22 +192,25 @@ class RedTree(CommandTree):
                 to_add_context.append(key)
 
         # Remove commands
-        for command in self._global_commands:
-            if command not in enabled_commands["slash"]:
+        for command, command_obj in self._global_commands.items():
+            if command not in enabled_commands["slash"] and not command_obj.extras.get("red_force_enable", False):
                 to_remove_commands.append((command, discord.AppCommandType.chat_input))
 
         # Remove context
-        for command, guild_id, command_type in self._context_menus:
+        for key, command_obj in self._context_menus.items():
+            command, guild_id, command_type = key
             if guild_id is not None:
                 continue
             if (
                 discord.AppCommandType(command_type) is discord.AppCommandType.message
                 and command not in enabled_commands["message"]
+                and not command_obj.extras.get("red_force_enable", False)
             ):
                 to_remove_context.append((command, discord.AppCommandType.message))
             elif (
                 discord.AppCommandType(command_type) is discord.AppCommandType.user
                 and command not in enabled_commands["user"]
+                and not command_obj.extras.get("red_force_enable", False)
             ):
                 to_remove_context.append((command, discord.AppCommandType.user))
 

--- a/redbot/core/tree.py
+++ b/redbot/core/tree.py
@@ -1,7 +1,6 @@
 import discord
 from discord.abc import Snowflake
 from discord.utils import MISSING
-from discord.ext.commands.hybrid import HybridAppCommand
 
 from .app_commands import (
     AppCommand,
@@ -62,8 +61,6 @@ class RedTree(CommandTree):
         Commands will be internally stored until enabled by ``[p]slash enable``.
         """
         # Allow guild specific commands to bypass the internals for development
-        if isinstance(command, HybridAppCommand):
-            command.extras = command.wrapped.extras
         if (
             guild is not MISSING
             or guilds is not MISSING


### PR DESCRIPTION
### Description of the changes
Alternative to #6010

Unlike that PR, this PR does not subclass any of the `app_commands` objects to add kwargs to their constructors. Instead, it relies on the same data being passed via `Command.extras`, serving the same purpose once it is there. A list of differences in the two options are listed below.

| | #6010 | This PR |
| --- | --- | --- |
| Enabling a command | `@app_commands.command(`<br />`  red_force_enable=True`<br />`)` | `@app_commands.command(`<br />`  extras={"red_force_enable": True}`<br />`)` |
| Accessing the setting | `command.red_force_enable` | `command.extras.get(`<br />`  "red_force_enable",`<br />`  False`<br />`)` |
| Avoids subclassing? | No | Yes |

Still not certain how to approach the UX on `[p]slash disable`ing a force enabled cog, or displaying force enabled cogs in `[p]slash list`. The UX is, however, implemented the same on both this PR and #6010 from the perspective of a user.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
