### PR TITLE
[Audio] Don't escape formatting on Playlist Enqueued message

### DIFF
--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -493,7 +493,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             )
             title = _("Playlist Enqueued") if not query.is_album else _("Album Enqueued")
             embed = discord.Embed(
-                description=bold(f"[{playlist_name}]({playlist_url})")
+                description=bold(f"[{playlist_name}]({playlist_url})", False)
                 if playlist_url
                 else playlist_name,
                 title=title,


### PR DESCRIPTION
### Description of the changes

Use `[p]play https://soundcloud.com/aikaterna/sets/p5-1`

Before:
![1](https://user-images.githubusercontent.com/20862007/232362704-543fa1f7-1c3d-45a4-86ee-933a106760c5.png)

After:
![2](https://user-images.githubusercontent.com/20862007/232362723-4f141a4e-5077-4006-8c22-a8f981d54d0c.png)


### Have the changes in this PR been tested?

Yes

