### PR TITLE
Fix wrong extract location in Publish Release workflow

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Upload packaged distributions
         uses: actions/upload-artifact@v3
         with:
+          name: build-output
           path: ./dist
 
   release_to_pypi:
@@ -91,6 +92,9 @@ jobs:
     steps:
       - name: Download packaged distributions
         uses: actions/download-artifact@v3
+        with:
+          name: build-output
+          path: dist/
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
### Description of the changes

Fixes extract location of the package distributions in the artifact. Before this, they were extracted to `artifact/` directory, now they're correctly extracted to `dist/` directory.

### Have the changes in this PR been tested?

Yes

https://github.com/Cog-Creators/Red-Lavalink/actions/runs/4738515835