### PR TITLE
Bump Red-Lavalink to stable 0.11.0

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -15,7 +15,7 @@ python-dateutil
 PyYAML
 rapidfuzz
 Red-Commons
-Red-Lavalink>=0.11.0rc1
+Red-Lavalink
 rich
 schema
 typing_extensions

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -74,7 +74,7 @@ red-commons==1.0.0
     # via
     #   -r base.in
     #   red-lavalink
-red-lavalink==0.11.0rc1
+red-lavalink==0.11.0
     # via -r base.in
 rich==12.6.0
     # via -r base.in


### PR DESCRIPTION
### Description of the changes

Red-Lavalink 0.11.0 is functionally equivalent to 0.11.0rc1, it's just that it can be considered as a final release rather than just a release candidate.

### Have the changes in this PR been tested?

No
