### PR TITLE
[3.4] docs: fix typos (#5989)

### DIFF
--- a/docs/cog_guides/alias.rst
+++ b/docs/cog_guides/alias.rst
@@ -68,7 +68,7 @@ be replaced by the first argument of your alias:
     # this alias will execute the following command:
     [p]ban Slime#3160 7 Spam bot.
 
-For a more detailed explaination, read :ref:`this <alias-command-alias-add>`.
+For a more detailed explanation, read :ref:`this <alias-command-alias-add>`.
 
 .. _alias-commands:
 

--- a/docs/cog_guides/cog_manager_ui.rst
+++ b/docs/cog_guides/cog_manager_ui.rst
@@ -13,7 +13,7 @@ find detailed docs about usage and commands.
     included in the cogs paths and it cannot be unloaded. It contains needed
     commands for cog management.
 
-.. _cogmanaerui-usage:
+.. _cogmanagerui-usage:
 
 -----
 Usage
@@ -243,7 +243,7 @@ Shows the install path, or sets a new one.
 If you want to set a new path, the same rules as for
 :ref:`addpath <cogmanagerui-command-addpath>` apply
 
-.. warning:: If you edit the install path, the cogs won't be transfered.
+.. warning:: If you edit the install path, the cogs won't be transferred.
 
 **Arguments**
 

--- a/docs/cog_guides/core.rst
+++ b/docs/cog_guides/core.rst
@@ -971,7 +971,7 @@ embedset command server
 
 **Description**
 
-Sets a commmand's embed setting for the current server.
+Sets a command's embed setting for the current server.
 
 If set, this is used instead of the server default to determine whether or not to use embeds.
 

--- a/docs/framework_config.rst
+++ b/docs/framework_config.rst
@@ -128,7 +128,7 @@ Notice a few things in the above examples:
     self.config.<insert scope here, or nothing if global>.variable_name.set(new_value)
 
 It is also possible to use :code:`async with` syntax to get and set config
-values. When entering the statement, the config value is retreived, and on exit,
+values. When entering the statement, the config value is retrieved, and on exit,
 it is saved. This puts a safeguard on any code within the :code:`async with`
 block such that if it breaks from the block in any way (whether it be from
 :code:`return`, :code:`break`, :code:`continue` or an exception), the value will
@@ -262,7 +262,7 @@ Now let's see an example that uses multiple identifiers:
     from redbot.core import Config, commands, checks
 
 
-    class ChannelAccesss(commands.Cog):
+    class ChannelAccess(commands.Cog):
         def __init__(self):
             self.config = Config.get_conf(self, identifier=1234567890)
             default_access = {

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -20,7 +20,7 @@ window like this:
 
 .. image:: .resources/red-console.png
 
-.. _gettings-started-invite:
+.. _getting-started-invite:
 
 -------------------------
 Invite Red to your server

--- a/docs/install_guides/windows.rst
+++ b/docs/install_guides/windows.rst
@@ -50,7 +50,7 @@ Manually installing dependencies
 
 .. attention:: There are additional configuration steps required which are
                not documented for installing dependencies manually.
-               These dependencies are only listed seperately here for
+               These dependencies are only listed separately here for
                reference purposes.
 
 * `MSVC Build tools <https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019>`_

--- a/docs/prolog.txt
+++ b/docs/prolog.txt
@@ -1,5 +1,5 @@
 .. This file will be run at the beginning of all files.
-    You can add the subsitutions you need.
+    You can add the substitutions you need.
 
 .. this is a .txt so sphinx doesn't error because it's
     missing in the index

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -362,7 +362,7 @@ class Alias(commands.Cog):
         try:
             if await self._aliases.edit_alias(ctx, alias_name, command):
                 await ctx.send(
-                    _("The alias with the trigger `{name}` has been edited sucessfully.").format(
+                    _("The alias with the trigger `{name}` has been edited successfully.").format(
                         name=alias_name
                     )
                 )
@@ -395,7 +395,7 @@ class Alias(commands.Cog):
         try:
             if await self._aliases.edit_alias(ctx, alias_name, command, global_=True):
                 await ctx.send(
-                    _("The alias with the trigger `{name}` has been edited sucessfully.").format(
+                    _("The alias with the trigger `{name}` has been edited successfully.").format(
                         name=alias_name
                     )
                 )

--- a/redbot/cogs/audio/core/utilities/playlists.py
+++ b/redbot/cogs/audio/core/utilities/playlists.py
@@ -32,7 +32,7 @@ from ..cog_utils import CompositeMetaClass
 
 log = logging.getLogger("red.cogs.Audio.cog.Utilities.playlists")
 _ = Translator("Audio", Path(__file__))
-CURRATED_DATA = (
+CURATED_DATA = (
     "https://gist.githubusercontent.com/aikaterna/4b5de6c420cd6f12b83cb895ca2de16a/raw/json"
 )
 
@@ -263,9 +263,9 @@ class PlaylistUtilities(MixinMeta, metaclass=CompositeMetaClass):
             colour=await context.embed_colour(),
         )
         msg = await context.send(embed=embed)
-        avaliable_emojis = ReactionPredicate.NUMBER_EMOJIS[1:]
-        avaliable_emojis.append("🔟")
-        emojis = avaliable_emojis[: len(correct_scope_matches)]
+        available_emojis = ReactionPredicate.NUMBER_EMOJIS[1:]
+        available_emojis.append("🔟")
+        emojis = available_emojis[: len(correct_scope_matches)]
         emojis.append("\N{CROSS MARK}")
         start_adding_reactions(msg, emojis)
         pred = ReactionPredicate.with_emojis(emojis, msg, user=context.author)
@@ -688,7 +688,7 @@ class PlaylistUtilities(MixinMeta, metaclass=CompositeMetaClass):
     async def _get_bundled_playlist_tracks(self):
         async with aiohttp.ClientSession(json_serialize=json.dumps) as session:
             async with session.get(
-                CURRATED_DATA + f"?timestamp={int(time.time())}",
+                CURATED_DATA + f"?timestamp={int(time.time())}",
                 headers={"content-type": "application/json"},
             ) as response:
                 if response.status != 200:

--- a/redbot/cogs/mod/names.py
+++ b/redbot/cogs/mod/names.py
@@ -76,7 +76,7 @@ class ModInfo(MixinMeta):
                 if exc.status == 400:  # BAD REQUEST
                     await ctx.send(_("That nickname is invalid."))
                 else:
-                    await ctx.send(_("An unexpected error has occured."))
+                    await ctx.send(_("An unexpected error has occurred."))
             else:
                 await ctx.send(_("Done."))
 

--- a/redbot/cogs/mutes/converters.py
+++ b/redbot/cogs/mutes/converters.py
@@ -33,7 +33,7 @@ _ = i18n.Translator("Mutes", __file__)
 class MuteTime(Converter):
     """
     This will parse my defined multi response pattern and provide usable formats
-    to be used in multiple reponses
+    to be used in multiple responses
     """
 
     async def convert(

--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -393,7 +393,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
         for result in results:
             if not result:
                 continue
-            _mmeber, channel, reason = result
+            _member, channel, reason = result
             unmuted_channels.remove(channel)
         modlog_reason = _("Automatic unmute")
 
@@ -1524,7 +1524,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
             "user": user,
         }
         # TODO: This typing is ugly and should probably be an object on its own
-        # along with this entire method and some othe refactorization
+        # along with this entire method and some other refactorization
         # v1.0.0 is meant to look ugly right :')
         if permissions.administrator:
             ret["reason"] = _(MUTE_UNMUTE_ISSUES["is_admin"])

--- a/redbot/cogs/reports/reports.py
+++ b/redbot/cogs/reports/reports.py
@@ -34,7 +34,7 @@ class Reports(commands.Cog):
 
     default_report = {"report": {}}
 
-    # This can be made configureable later if it
+    # This can be made configurable later if it
     # becomes an issue.
     # Intervals should be a list of tuples in the form
     # (period: timedelta, max_frequency: int)

--- a/redbot/cogs/streams/streams.py
+++ b/redbot/cogs/streams/streams.py
@@ -855,7 +855,7 @@ class Streams(commands.Cog):
                                 await role.edit(mentionable=False)
                         await self.save_streams()
             except Exception as e:
-                log.error("An error has occured with Streams. Please report it.", exc_info=e)
+                log.error("An error has occurred with Streams. Please report it.", exc_info=e)
 
         if to_remove:
             for stream in to_remove:

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -196,7 +196,7 @@ class YoutubeStream(Stream):
         log.debug(f"livestreams for {self.name}: {self.livestreams}")
         log.debug(f"not_livestreams for {self.name}: {self.not_livestreams}")
         # This is technically redundant since we have the
-        # info from the RSS ... but incase you don't wanna deal with fully rewritting the
+        # info from the RSS ... but incase you don't wanna deal with fully rewriting the
         # code for this part, as this is only a 2 quota query.
         if self.livestreams:
             params = {
@@ -328,7 +328,7 @@ class TwitchStream(Stream):
     async def wait_for_rate_limit_reset(self) -> None:
         """Check rate limits in response header and ensure we're following them.
 
-        From python-twitch-client and adaptated to asyncio from Trusty-cogs:
+        From python-twitch-client and adapted to asyncio from Trusty-cogs:
         https://github.com/tsifrer/python-twitch-client/blob/master/twitch/helix/base.py
         https://github.com/TrustyJAID/Trusty-cogs/blob/master/twitch/twitch_api.py
         """

--- a/redbot/cogs/trivia/trivia.py
+++ b/redbot/cogs/trivia/trivia.py
@@ -153,7 +153,7 @@ class Trivia(commands.Cog):
             )
 
     @triviaset.command(name="usespoilers", usage="<true_or_false>")
-    async def trivaset_use_spoilers(self, ctx: commands.Context, enabled: bool):
+    async def triviaset_use_spoilers(self, ctx: commands.Context, enabled: bool):
         """Set if bot will display the answers in spoilers.
 
         If enabled, the bot will use spoilers to hide answers.
@@ -166,7 +166,7 @@ class Trivia(commands.Cog):
             await ctx.send(_("Alright, I won't use spoilers to hide answers anymore."))
 
     @triviaset.command(name="botplays", usage="<true_or_false>")
-    async def trivaset_bot_plays(self, ctx: commands.Context, enabled: bool):
+    async def triviaset_bot_plays(self, ctx: commands.Context, enabled: bool):
         """Set whether or not the bot gains points.
 
         If enabled, the bot will gain a point if no one guesses correctly.
@@ -179,7 +179,7 @@ class Trivia(commands.Cog):
             await ctx.send(_("Alright, I won't embarrass you at trivia anymore."))
 
     @triviaset.command(name="revealanswer", usage="<true_or_false>")
-    async def trivaset_reveal_answer(self, ctx: commands.Context, enabled: bool):
+    async def triviaset_reveal_answer(self, ctx: commands.Context, enabled: bool):
         """Set whether or not the answer is revealed.
 
         If enabled, the bot will reveal the answer if no one guesses correctly

--- a/redbot/core/_diagnoser.py
+++ b/redbot/core/_diagnoser.py
@@ -132,7 +132,7 @@ class DetailedGlobalCallOnceChecksMixin(IssueDiagnoserBase):
 
     # While the following 2 checks could show even more precise error message,
     # it would require a usage of private attribute rather than the public API
-    # which increases maintanance burden for not that big of benefit.
+    # which increases maintenance burden for not that big of benefit.
     async def _check_ignored_issues(self) -> CheckResult:
         label = _("Check if the channel and the server aren't set to be ignored")
         if await self.bot.ignored_channel_or_guild(self.message):
@@ -782,7 +782,7 @@ class RootDiagnosersMixin(
     async def _check_global_call_once_checks_issues(self) -> CheckResult:
         label = _("Global 'call once' checks")
         # To avoid running core's global checks twice, we just run them all regularly
-        # and if it turns out that invokation would end here, we go back and check each of
+        # and if it turns out that invocation would end here, we go back and check each of
         # core's global check individually to give more precise error message.
         try:
             can_run = await self.bot.can_run(self.ctx, call_once=True)

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -693,7 +693,7 @@ class RedBase(
 
         If given a member, this will additionally check guild lists
 
-        If omiting a user or member, you must provide a value for ``who_id``
+        If omitting a user or member, you must provide a value for ``who_id``
 
         You may also provide a value for ``guild_id`` in this case
 

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -481,7 +481,7 @@ class RedHelpFormatter(HelpFormatterABC):
         offset += len(embed_dict["embed"]["title"])
 
         # In order to only change the size of embeds when necessary for this rather
-        # than change the existing behavior for people uneffected by this
+        # than change the existing behavior for people unaffected by this
         # we're only modifying the page char limit should they be impacted.
         # We could consider changing this to always just subtract the offset,
         # But based on when this is being handled (very end of 3.2 release)
@@ -490,7 +490,7 @@ class RedHelpFormatter(HelpFormatterABC):
             # This is still necessary with the max interaction above
             # While we could subtract 100% of the time the offset from page_char_limit
             # the intent here is to shorten again
-            # *only* when necessary, by the exact neccessary amount
+            # *only* when necessary, by the exact necessary amount
             # To retain a visual match with prior behavior.
             page_char_limit = 5500 - offset
         elif page_char_limit < 250:

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -1309,7 +1309,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         self, ctx: commands.GuildContext, command: CommandConverter, enabled: bool = None
     ):
         """
-        Sets a commmand's embed setting for the current server.
+        Sets a command's embed setting for the current server.
 
         If set, this is used instead of the server default to determine whether or not to use embeds.
 

--- a/redbot/core/rpc.py
+++ b/redbot/core/rpc.py
@@ -163,7 +163,7 @@ class RPCMixin:
 
     def unregister_rpc_handler(self, method):
         """
-        Unregisters an RPC method handler.
+        Deregisters an RPC method handler.
 
         This will be called automatically for you on cog unload and will pass silently if the
         method is not previously registered.

--- a/redbot/core/settings_caches.py
+++ b/redbot/core/settings_caches.py
@@ -14,7 +14,7 @@ from .utils import AsyncIter
 class PrefixManager:
     def __init__(self, config: Config, cli_flags: Namespace):
         self._config: Config = config
-        self._global_prefix_overide: Optional[List[str]] = (
+        self._global_prefix_override: Optional[List[str]] = (
             sorted(cli_flags.prefix, reverse=True) or None
         )
         self._cached: Dict[Optional[int], List[str]] = {}
@@ -32,7 +32,7 @@ class PrefixManager:
                 if not ret:
                     ret = await self.get_prefixes(None)
             else:
-                ret = self._global_prefix_overide or (await self._config.prefix())
+                ret = self._global_prefix_override or (await self._config.prefix())
 
             self._cached[gid] = ret.copy()
 

--- a/redbot/core/utils/tunnel.py
+++ b/redbot/core/utils/tunnel.py
@@ -175,7 +175,7 @@ class Tunnel(metaclass=TunnelMeta):
 
     async def close_because_disabled(self, close_message: str):
         """
-        Sends a mesage to both ends of the tunnel that the tunnel is now closed.
+        Sends a message to both ends of the tunnel that the tunnel is now closed.
 
         Parameters
         ----------

--- a/redbot/vendored/discord/ext/menus/__init__.py
+++ b/redbot/vendored/discord/ext/menus/__init__.py
@@ -651,7 +651,7 @@ class Menu(metaclass=_MenuMeta):
         Handles reporting of errors while updating the menu from events.
         The default behaviour is to log the exception.
 
-        This may be overriden by subclasses.
+        This may be overridden by subclasses.
 
         Parameters
         ----------

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -101,7 +101,7 @@ async def test_bounded_gather():
         if isinstance(result, RuntimeError):
             num_failed += 1
         else:
-            assert result == i  # verify_permissions original orde
+            assert result == i  # verify_permissions original order
             assert 0 <= result < num_tasks
 
     assert 0 < status[1] <= num_concurrent


### PR DESCRIPTION
(cherry picked from commit a89a27cadf56b142892a02f8fbb0e0db06c51106)
