### PR TITLE
[3.4] [Modlog] Make `modlogset cases` docstring less vague (#5352)

### DIFF
--- a/docs/cog_guides/modlog.rst
+++ b/docs/cog_guides/modlog.rst
@@ -120,11 +120,14 @@ modlogset cases
 
 **Description**
 
-Enable or disable case creation for a mod action.
+Enable or disable case creation for a mod action, like disabling warnings, enabling bans, etc.
 
-**Arguments**
+**Examples:**
+    - ``[p]modlogset cases kick`` - Enables/disables modlog messages for kicks.
+    - ``[p]modlogset cases ban`` - Enables/disables modlog messages for bans.
 
-* ``[action]``: The action to enable or disable case creation for.
+**Arguments:**
+    - ``[action]`` - The type of mod action to be enabled/disabled for case creation.
 
 .. _modlog-command-modlogset-modlog:
 

--- a/redbot/cogs/modlog/modlog.py
+++ b/redbot/cogs/modlog/modlog.py
@@ -72,7 +72,11 @@ class ModLog(commands.Cog):
     @modlogset.command(name="cases")
     @commands.guild_only()
     async def set_cases(self, ctx: commands.Context, action: str = None):
-        """Enable or disable case creation for a mod action."""
+        """
+        Enable or disable case creation for a mod action.
+        An action can be enabling or disabling specific cases. (Ban, kick, mute, etc.)
+        Example: `[p]modlogset cases kick enabled`
+        """
         guild = ctx.guild
 
         if action is None:  # No args given


### PR DESCRIPTION
(cherry picked from commit 6cda937ec232bca570999d28dc40b9e0ee88f7fe)
