### PR TITLE
Update the Lavalink version parsing and add tests for it

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -24,6 +24,8 @@
       - "!redbot/cogs/audio/**/locales/*"
   # Docs
   - docs/cog_guides/audio.rst
+  # Tests
+  - tests/cogs/audio/**/*
 "Category: Cogs - Bank": []  # historical label for a removed cog
 "Category: Cogs - Cleanup":
   # Source

--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -109,6 +109,9 @@ LAVALINK_VERSION_LINE_PRE35: Final[Pattern] = re.compile(
     rb"^Version:\s+(?P<version>\S+)$", re.MULTILINE | re.VERBOSE
 )
 # used for LL 3.5-rc4 and newer
+# This regex is limited to the realistic usage in the LL version number,
+# not everything that could be a part of it according to the spec.
+# We can easily release an update to this regex in the future if it ever becomes necessary.
 LAVALINK_VERSION_LINE: Final[Pattern] = re.compile(
     rb"""
     ^
@@ -117,9 +120,11 @@ LAVALINK_VERSION_LINE: Final[Pattern] = re.compile(
         (?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)
         # Before LL 3.6, when patch version == 0, it was stripped from the version string
         (?:\.(?P<patch>0|[1-9]\d*))?
-        (?:-rc(?P<rc>0|[1-9]\d*))?
-        # only used by our downstream Lavalink if we need to make a release before upstream
-        (?:_red(?P<red>[1-9]\d*))?
+        # Before LL 3.6, the dot in rc.N was optional
+        (?:-rc\.?(?P<rc>0|[1-9]\d*))?
+        # additional build metadata, can be used by our downstream Lavalink
+        # if we need to alter an upstream release
+        (?:\+red\.(?P<red>[1-9]\d*))?
     )
     $
     """,

--- a/tests/cogs/audio/test_manager.py
+++ b/tests/cogs/audio/test_manager.py
@@ -1,0 +1,76 @@
+import itertools
+
+import pytest
+
+from redbot.cogs.audio.manager import LavalinkOldVersion, LavalinkVersion
+
+
+ORDERED_VERSIONS = [
+    LavalinkOldVersion("3.3.2.3", build_number=1239),
+    LavalinkOldVersion("3.4.0", build_number=1275),
+    LavalinkOldVersion("3.4.0", build_number=1350),
+    # LavalinkVersion is always newer than LavalinkOldVersion
+    LavalinkVersion(3, 3),
+    LavalinkVersion(3, 4),
+    LavalinkVersion(3, 5, rc=1),
+    LavalinkVersion(3, 5, rc=2),
+    LavalinkVersion(3, 5, rc=3),
+    # version with `+red.N` build number is newer than an equivalent upstream version
+    LavalinkVersion(3, 5, rc=3, red=1),
+    LavalinkVersion(3, 5, rc=3, red=2),
+    # all RC versions (including ones with `+red.N`) are older than a stable version
+    LavalinkVersion(3, 5),
+    # version with `+red.N` build number is newer than an equivalent upstream version
+    LavalinkVersion(3, 5, red=1),
+    LavalinkVersion(3, 5, red=2),
+    # but newer version number without `+red.N` is still newer
+    LavalinkVersion(3, 5, 1),
+]
+
+
+@pytest.mark.parametrize(
+    "raw_version,raw_build_number,expected",
+    (
+        # 3-segment version number
+        ("3.4.0", "1350", LavalinkOldVersion("3.4.0", build_number=1350)),
+        # 4-segment version number
+        ("3.3.2.3", "1239", LavalinkOldVersion("3.3.2.3", build_number=1239)),
+        # 3-segment version number with 3-digit build number
+        ("3.3.1", "987", LavalinkOldVersion("3.3.1", build_number=987)),
+    ),
+)
+def test_old_ll_version_parsing(
+    raw_version: str, raw_build_number: str, expected: LavalinkOldVersion
+) -> None:
+    line = b"Version: %b\nBuild: %b" % (raw_version.encode(), raw_build_number.encode())
+    assert LavalinkOldVersion.from_version_output(line)
+
+
+@pytest.mark.parametrize(
+    "raw_version,expected",
+    (
+        # older version format that allowed stripped `.0` and no dot in `rc.4`, used until LL 3.6
+        ("3.5-rc4", LavalinkVersion(3, 5, rc=4)),
+        ("3.5", LavalinkVersion(3, 5)),
+        # newer version format
+        ("3.6.0-rc.1", LavalinkVersion(3, 6, 0, rc=1)),
+        # downstream RC version with `+red.N` suffix
+        ("3.7.5-rc.1+red.1", LavalinkVersion(3, 7, 5, rc=1, red=1)),
+        ("3.7.5-rc.1+red.123", LavalinkVersion(3, 7, 5, rc=1, red=123)),
+        # upstream stable version
+        ("3.7.5", LavalinkVersion(3, 7, 5)),
+        # downstream stable version with `+red.N` suffix
+        ("3.7.5+red.1", LavalinkVersion(3, 7, 5, red=1)),
+        ("3.7.5+red.123", LavalinkVersion(3, 7, 5, red=123)),
+    ),
+)
+def test_ll_version_parsing(raw_version: str, expected: LavalinkVersion) -> None:
+    line = b"Version: " + raw_version.encode()
+    assert LavalinkVersion.from_version_output(line)
+
+
+def test_ll_version_comparison() -> None:
+    it1, it2 = itertools.tee(ORDERED_VERSIONS)
+    next(it2, None)
+    for a, b in zip(it1, it2):
+        assert a < b


### PR DESCRIPTION
### Description of the changes

Updates the version format for downstream versions from `_red123` suffix to `+red.123` suffix per https://github.com/freyacodes/Lavalink/pull/867.

Additionally, it fixes an issue with the parsing for RC versions - I forgot that LL switched to the `rc.1` format per the semver spec.

To top it off, I added some unit tests since it's exactly the kind of code that we can reasonably test.

### Have the changes in this PR been tested?

Yes
