### PR TITLE
Suppress importlib 3.12 warning about load_module

### DIFF
--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -371,3 +371,12 @@ if not any(_re.match("^-(-debug|d+|-verbose|v+)$", i) for i in _sys.argv):
         module="discord",
         message="'audioop' is deprecated and slated for removal",
     )
+    # DEP-WARN - will need a fix before Python 3.12 support
+    #
+    # DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead
+    _warnings.filterwarnings(
+        "ignore",
+        category=DeprecationWarning,
+        module="importlib",
+        message=r"the load_module\(\) method is deprecated and slated for removal",
+    )


### PR DESCRIPTION
### Description of the changes

We don't want #support to be flooded with those. This will be properly addressed at later date as a part of cog manager refactoring that was originally planned for 3.5.0.

### Have the changes in this PR been tested?

Yes

