### PR TITLE
Bump platformdirs to 3.x and remove the migration code for 2.x

### DIFF
--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -51,14 +51,6 @@ if _system_user:
         config_dir = appdir.site_data_path
 
 config_file = config_dir / "config.json"
-if not config_file.exists() and sys.platform == "darwin":
-    # backwards compatibility with the location given by appdirs 1.4.4 (replaced by platformdirs 2)
-    # which was the same as user_data_path
-    # https://platformdirs.readthedocs.io/en/stable/changelog.html#platformdirs-2-0-0
-    _old_config_location = appdir.user_data_path / "config.json"
-    if _old_config_location.exists():
-        config_dir.mkdir(parents=True, exist_ok=True)
-        _old_config_location.rename(config_file)
 
 
 def load_existing_config():

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -52,7 +52,7 @@ orjson==3.8.3
     # via -r base.in
 packaging==22.0
     # via -r base.in
-platformdirs==2.6.0
+platformdirs==3.2.0
     # via -r base.in
 psutil==5.9.4
     # via -r base.in


### PR DESCRIPTION
### Description of the changes

This code never existed in stable Red (3.4.x) and was only necessary because platformdirs 2.0 used a different path for `user_config_dir` than appdirs 1.x did. Apparently they decided that the previous way was actually the correct one so this being here will actively hurt us if we release it since we'll then have to deal with the migration when we inevitably will have to upgrade to platformdirs 3.x or newer.

See: https://github.com/platformdirs/platformdirs/compare/2.6.0...3.2.0#diff-c62b68d21c20415287fcac2ff0dd4a8e67ec181ee45fea497215143a885e4513

### Have the changes in this PR been tested?

No