### PR TITLE
Bump dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,7 @@ click==8.1.3
     # via -r base.in
 contextlib2==21.6.0
     # via schema
-discord-py==2.2.2
+discord-py==2.2.3
     # via
     #   -r base.in
     #   red-lavalink
@@ -50,11 +50,11 @@ multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-orjson==3.8.10
+orjson==3.8.11
     # via -r base.in
 packaging==23.1
     # via -r base.in
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via -r base.in
 psutil==5.9.5
     # via -r base.in
@@ -78,7 +78,7 @@ red-commons==1.0.0
     #   red-lavalink
 red-lavalink==0.11.0
     # via -r base.in
-rich==13.3.4
+rich==13.3.5
     # via -r base.in
 schema==0.7.5
     # via -r base.in
@@ -88,7 +88,7 @@ typing-extensions==4.5.0
     # via
     #   -r base.in
     #   rich
-yarl==1.9.1
+yarl==1.9.2
     # via
     #   -r base.in
     #   aiohttp

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 aiodns==3.0.0
     # via -r base.in
-aiohttp==3.8.3
+aiohttp==3.8.4
     # via
     #   -r base.in
     #   aiohttp-json-rpc
@@ -10,24 +10,22 @@ aiohttp-json-rpc==0.13.3
     # via -r base.in
 aiosignal==1.3.1
     # via aiohttp
-apsw==3.40.0.0
+apsw==3.41.2.0
     # via -r base.in
 async-timeout==4.0.2
     # via aiohttp
-attrs==22.2.0
+attrs==23.1.0
     # via aiohttp
-babel==2.11.0
+babel==2.12.1
     # via -r base.in
 brotli==1.0.9
     # via -r base.in
 cffi==1.15.1
     # via pycares
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via aiohttp
 click==8.1.3
     # via -r base.in
-commonmark==0.9.1
-    # via rich
 contextlib2==21.6.0
     # via schema
 discord-py==2.2.2
@@ -40,35 +38,39 @@ frozenlist==1.3.3
     #   aiosignal
 idna==3.4
     # via yarl
-importlib-metadata==5.2.0
+importlib-metadata==6.6.0
     # via markdown
-markdown==3.4.1
+markdown==3.4.3
     # via -r base.in
+markdown-it-py==2.2.0
+    # via rich
+mdurl==0.1.2
+    # via markdown-it-py
 multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-orjson==3.8.3
+orjson==3.8.10
     # via -r base.in
-packaging==22.0
+packaging==23.1
     # via -r base.in
 platformdirs==3.2.0
     # via -r base.in
-psutil==5.9.4
+psutil==5.9.5
     # via -r base.in
 pycares==4.3.0
     # via aiodns
 pycparser==2.21
     # via cffi
-pygments==2.13.0
+pygments==2.15.1
     # via rich
 python-dateutil==2.8.2
     # via -r base.in
-pytz==2022.7
+pytz==2023.3
     # via babel
 pyyaml==6.0
     # via -r base.in
-rapidfuzz==2.13.7
+rapidfuzz==3.0.0
     # via -r base.in
 red-commons==1.0.0
     # via
@@ -76,21 +78,21 @@ red-commons==1.0.0
     #   red-lavalink
 red-lavalink==0.11.0
     # via -r base.in
-rich==12.6.0
+rich==13.3.4
     # via -r base.in
 schema==0.7.5
     # via -r base.in
 six==1.16.0
     # via python-dateutil
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   -r base.in
     #   rich
-yarl==1.8.2
+yarl==1.9.1
     # via
     #   -r base.in
     #   aiohttp
-zipp==3.11.0
+zipp==3.15.0
     # via importlib-metadata
 colorama==0.4.6; sys_platform == "win32"
     # via click

--- a/requirements/extra-doc.txt
+++ b/requirements/extra-doc.txt
@@ -1,37 +1,41 @@
-alabaster==0.7.12
+alabaster==0.7.13
     # via sphinx
 certifi==2022.12.7
     # via requests
-docutils==0.17.1
+docutils==0.18.1
     # via
     #   sphinx
+    #   sphinx-prompt
     #   sphinx-rtd-theme
 imagesize==1.4.1
     # via sphinx
 jinja2==3.1.2
     # via sphinx
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
-requests==2.28.1
+requests==2.28.2
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.3.0
+sphinx==6.1.3
     # via
     #   -r extra-doc.in
     #   sphinx-prompt
     #   sphinx-rtd-theme
+    #   sphinxcontrib-jquery
     #   sphinxcontrib-trio
-sphinx-prompt==1.5.0
+sphinx-prompt==1.6.0
     # via -r extra-doc.in
-sphinx-rtd-theme==1.1.1
+sphinx-rtd-theme==1.2.0
     # via -r extra-doc.in
-sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
+sphinxcontrib-jquery==4.1
+    # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==1.0.3
@@ -40,5 +44,5 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sphinxcontrib-trio==1.1.2
     # via -r extra-doc.in
-urllib3==1.26.13
+urllib3==1.26.15
     # via requests

--- a/requirements/extra-doc.txt
+++ b/requirements/extra-doc.txt
@@ -13,11 +13,11 @@ jinja2==3.1.2
     # via sphinx
 markupsafe==2.1.2
     # via jinja2
-requests==2.28.2
+requests==2.29.0
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==6.1.3
+sphinx==6.2.1
     # via
     #   -r extra-doc.in
     #   sphinx-prompt

--- a/requirements/extra-test.txt
+++ b/requirements/extra-test.txt
@@ -1,27 +1,27 @@
-astroid==2.12.13
+astroid==2.15.3
     # via pylint
 dill==0.3.6
     # via pylint
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via pytest
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
-isort==5.11.4
+isort==5.12.0
     # via pylint
-lazy-object-proxy==1.8.0
+lazy-object-proxy==1.9.0
     # via astroid
 mccabe==0.7.0
     # via pylint
 pluggy==1.0.0
     # via pytest
-pylint==2.15.9
+pylint==2.17.2
     # via -r extra-test.in
-pytest==7.2.0
+pytest==7.3.1
     # via
     #   -r extra-test.in
     #   pytest-asyncio
     #   pytest-mock
-pytest-asyncio==0.20.3
+pytest-asyncio==0.21.0
     # via -r extra-test.in
 pytest-mock==3.10.0
     # via -r extra-test.in
@@ -29,7 +29,7 @@ tomli==2.0.1
     # via
     #   pylint
     #   pytest
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
-wrapt==1.14.1
+wrapt==1.15.0
     # via astroid

--- a/requirements/extra-test.txt
+++ b/requirements/extra-test.txt
@@ -1,4 +1,4 @@
-astroid==2.15.3
+astroid==2.15.4
     # via pylint
 dill==0.3.6
     # via pylint
@@ -14,7 +14,7 @@ mccabe==0.7.0
     # via pylint
 pluggy==1.0.0
     # via pytest
-pylint==2.17.2
+pylint==2.17.3
     # via -r extra-test.in
 pytest==7.3.1
     # via
@@ -29,7 +29,7 @@ tomli==2.0.1
     # via
     #   pylint
     #   pytest
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via pylint
 wrapt==1.15.0
     # via astroid


### PR DESCRIPTION
### Description of the changes

A preliminary check didn't reveal any issues with these dep bumps. platformdirs bump (#6098) and Black style bump (#6099). Leaving this PR as a draft until I have time to read through the changes in the dependencies more closely.

Not much happened with breaking changes but here's a list of base deps that had *some* breaking changes that are at least notable:
- charset_normalizer 3.0.0 - https://github.com/Ousret/charset_normalizer/blob/master/CHANGELOG.md
- rapidfuzz 3.0.0 - https://maxbachmann.github.io/RapidFuzz/changelog_link.html 

### Have the changes in this PR been tested?

No
