### PR TITLE
Fix AttributeError from slash command tree

### DIFF
--- a/redbot/core/tree.py
+++ b/redbot/core/tree.py
@@ -81,7 +81,7 @@ class RedTree(CommandTree):
                 raise CommandAlreadyRegistered(name, None)
             if key in self._context_menus:
                 if not override:
-                    raise discord.errors.CommandAlreadyRegistered(name, None)
+                    raise CommandAlreadyRegistered(name, None)
                 del self._context_menus[key]
 
             self._disabled_context_menus[key] = command
@@ -97,10 +97,10 @@ class RedTree(CommandTree):
 
         # Handle cases where the command already is in the tree
         if not override and name in self._disabled_global_commands:
-            raise discord.errors.CommandAlreadyRegistered(name, None)
+            raise CommandAlreadyRegistered(name, None)
         if name in self._global_commands:
             if not override:
-                raise discord.errors.CommandAlreadyRegistered(name, None)
+                raise CommandAlreadyRegistered(name, None)
             del self._global_commands[name]
 
         self._disabled_global_commands[name] = root


### PR DESCRIPTION
### Description of the changes
Fix an AttributeError when adding a slash command that already exists.

Edits a few lines to use the imported CommandAlreadyRegistered exception instead of trying to use the non-existant one in discord.errors.

![image](https://cdn.discordapp.com/attachments/718148684629540905/1101235732271611975/image.png)


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
