### PR TITLE
Fix help breaking when removing a command without removing its cog

### DIFF
--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -274,10 +274,7 @@ class RedHelpFormatter(HelpFormatterABC):
     async def get_cog_help_mapping(
         self, ctx: Context, obj: commands.Cog, help_settings: HelpSettings
     ):
-        if obj is None:
-            iterator = filter(lambda c: c.parent is None and c.cog is None, ctx.bot.commands)
-        else:
-            iterator = obj.get_commands()
+        iterator = filter(lambda c: c.parent is None and c.cog is obj, ctx.bot.commands)
         return {
             com.name: com
             async for com in self.help_filter_func(ctx, iterator, help_settings=help_settings)


### PR DESCRIPTION
### Description of the changes
#5354 introduced a bug in cogs which dynamically override commands from existing cogs. If a command is removed from the bot, but the cog is not removed, the updated logic would still attempt to display it in help. This would cause help to silently fail or to error, depending on OS. This PR reverts that change, as there is no good way to filter from the cog object itself while accounting for differences from the bot's command list.


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
