### PR TITLE
Add checks submodule to redbot.core.app_commands

### DIFF
--- a/redbot/core/app_commands/__init__.py
+++ b/redbot/core/app_commands/__init__.py
@@ -60,6 +60,8 @@ from discord.app_commands import (
     rename as rename,
 )
 
+from . import checks as checks
+
 __all__ = (
     "AllChannels",
     "AppCommand",
@@ -112,4 +114,5 @@ __all__ = (
     "guilds",
     "locale_str",
     "rename",
+    "checks",
 )

--- a/redbot/core/app_commands/checks.py
+++ b/redbot/core/app_commands/checks.py
@@ -1,0 +1,25 @@
+########## SENSITIVE SECTION WARNING ###########
+################################################
+# Any edits of any of the exported names       #
+# may result in a breaking change.             #
+# Ensure no names are removed without warning. #
+################################################
+
+### DEP-WARN: Check this *every* discord.py update
+from discord.app_commands.checks import (
+    bot_has_permissions,
+    cooldown,
+    dynamic_cooldown,
+    has_any_role,
+    has_role,
+    has_permissions,
+)
+
+__all__ = (
+    "bot_has_permissions",
+    "cooldown",
+    "dynamic_cooldown",
+    "has_any_role",
+    "has_role",
+    "has_permissions",
+)

--- a/tests/core/test_app_commands.py
+++ b/tests/core/test_app_commands.py
@@ -21,3 +21,14 @@ def test_dpy_app_commands_reexports():
             "redbot.core.app_commands is missing these names from discord.app_commands: "
             + ", ".join(missing_attrs)
         )
+
+
+def test_dpy_app_commands_checks_reexports():
+    dpy_attrs = set(dpy_app_commands.checks.__all__)
+    missing_attrs = dpy_attrs - set(app_commands.checks.__dict__.keys())
+
+    if missing_attrs:
+        pytest.fail(
+            "redbot.core.app_commands.checks is missing these names from discord.app_commands: "
+            + ", ".join(missing_attrs)
+        )


### PR DESCRIPTION
### Description of the changes

I missed that `checks` is part of the public API of app_commands package when working on #6006.

### Have the changes in this PR been tested?

Yes
