### PR TITLE
Make it possible to set slowmode in stage/voice channels

### DIFF
--- a/redbot/cogs/mod/slowmode.py
+++ b/redbot/cogs/mod/slowmode.py
@@ -30,9 +30,6 @@ class Slowmode(MixinMeta):
         Interval can be anything from 0 seconds to 6 hours.
         Use without parameters to disable.
         """
-        if not isinstance(ctx.channel, (discord.TextChannel, discord.Thread)):
-            await ctx.send(_("Slowmode can only be set in text channels and threads."))
-            return
         seconds = interval.total_seconds()
         await ctx.channel.edit(slowmode_delay=seconds)
         if seconds > 0:


### PR DESCRIPTION
### Description of the changes

The check was added in #5709 (https://github.com/Cog-Creators/Red-DiscordBot/pull/5709/commits/f351e5903e254ed0be724d506dc52e11ec24856c) but it is no longer necessary now that d.py 2.2.0 has added the `slowmode_delay` argument to the `edit()` method of those objects.

### Have the changes in this PR been tested?

No
