### PR TITLE
Remove unused ConversionFailure

### DIFF
--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -43,7 +43,6 @@ from discord.ext.commands import (
     Greedy,
 )
 
-from .errors import ConversionFailure
 from .requires import PermState, PrivilegeLevel, Requires, PermStateAllowedStates
 from .. import app_commands
 from ..i18n import Translator

--- a/redbot/core/commands/errors.py
+++ b/redbot/core/commands/errors.py
@@ -4,21 +4,10 @@ import discord
 from discord.ext import commands
 
 __all__ = (
-    "ConversionFailure",
     "BotMissingPermissions",
     "UserFeedbackCheckFailure",
     "ArgParserFailure",
 )
-
-
-class ConversionFailure(commands.BadArgument):
-    """Raised when converting an argument fails."""
-
-    def __init__(self, converter, argument: str, param: inspect.Parameter, *args):
-        self.converter = converter
-        self.argument = argument
-        self.param = param
-        super().__init__(*args)
 
 
 class BotMissingPermissions(commands.CheckFailure):


### PR DESCRIPTION
### Description of the changes

I've apparently accidentally readded it to `__all__` in #6020? Weirdly enough, I didn't remove it in #5600 either... Us no longer wrapping `BadArgument` in `ConversionFailure` is already mentioned in the "Backwards incompatible changes in Red 3.5" document so there's no need to alter it?

Let me know if you think that it's fine to get this into 3.5 or if we should go with a standard deprecation warning on usage and remove it in 3.6, even though it's not used by anything at this point.

### Have the changes in this PR been tested?

No
