### PR TITLE
Show serverlocked setting inside `[p]set showsettings`

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3842,7 +3842,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         locale = global_data["locale"]
         regional_format = global_data["regional_format"] or locale
         colour = discord.Colour(global_data["color"])
-        
+
         admin_cog = self.bot.get_cog("Admin")
         serverlocked = await admin_cog.config.serverlocked() if admin_cog else False
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3842,6 +3842,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         locale = global_data["locale"]
         regional_format = global_data["regional_format"] or locale
         colour = discord.Colour(global_data["color"])
+        
+        admin_cog = self.bot.get_cog("Admin")
+        serverlocked = await admin_cog.config.serverlocked() if admin_cog else False
 
         prefix_string = " ".join(prefixes)
         settings = _(
@@ -3850,7 +3853,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             "{guild_settings}"
             "Global locale: {locale}\n"
             "Global regional format: {regional_format}\n"
-            "Default embed colour: {colour}"
+            "Default embed colour: {colour}\n"
+            "Serverlocked: {serverlocked}"
         ).format(
             bot_name=ctx.bot.user.name,
             prefixes=prefix_string,
@@ -3858,6 +3862,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             locale=locale,
             regional_format=regional_format,
             colour=colour,
+            serverlocked=serverlocked,
         )
         for page in pagify(settings):
             await ctx.send(box(page))


### PR DESCRIPTION
### Description of the changes

Currently, there is no proper way to see whether the bot has been serverlocked or not. This PR adds a line which is displayed inside `[p]set showsettings`, to show whether the bot is serverlocked or not. It first checks whether the Admin cog is loaded (if not, then serverlock cannot function, so it will show as False), and then it accesses the cogs config to see whether serverlock is enabled.

![image](https://user-images.githubusercontent.com/67752638/236053449-bd6b2b92-6d00-41cd-8441-38dc5778ee9c.png)


### Have the changes in this PR been tested?

Yes
