### PR TITLE
Fix issues with channel unmutes for mute data from 3.4.x

### DIFF
--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -262,7 +262,6 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
         inside our tasks.
         """
         log.debug("Cleaning unmute tasks")
-        is_debug = log.getEffectiveLevel() <= logging.DEBUG
         for task_id in list(self._unmute_tasks.keys()):
             task = self._unmute_tasks[task_id]
 
@@ -273,9 +272,8 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
             if task.done():
                 try:
                     r = task.result()
-                except Exception:
-                    if is_debug:
-                        log.exception("Dead task when trying to unmute")
+                except Exception as exc:
+                    log.error("An unexpected error occurred in the unmute task", exc_info=exc)
                 self._unmute_tasks.pop(task_id, None)
 
     async def _handle_server_unmutes(self):

--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -1866,7 +1866,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
                 "channel": channel,
                 "reason": _(MUTE_UNMUTE_ISSUES["already_unmuted"]),
             }
-        if not current_mute["voice_mute"] and voice_mute:
+        if not current_mute.get("voice_mute", False) and voice_mute:
             return {
                 "success": False,
                 "channel": channel,


### PR DESCRIPTION
### Description of the changes

This one slipped through the cracks. Regression introduced by #5709 - this commit to be exact: https://github.com/Cog-Creators/Red-DiscordBot/pull/5709/commits/433b3ab019b5cf524c5c02e0c092a2029d77d276

I've made sure that we always log the errors during the task cleanup. I feel like it would be better if we had `add_done_callback()` on all unmute tasks instead of having to periodically clean them with `cleanup_tasks()` since it introduces a delay but for now, this is a lot simpler fix.

### Have the changes in this PR been tested?

Yes
