### PR TITLE
Fix the bot starting when using --debuginfo

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -268,7 +268,7 @@ def _copy_data(data):
 def early_exit_runner(
     cli_flags: Namespace,
     func: Union[Callable[[], Awaitable[Any]], Callable[[Red, Namespace], Awaitable[Any]]],
-) -> None:
+) -> NoReturn:
     """
     This one exists to not log all the things like it's a full run of the bot.
     """
@@ -277,6 +277,7 @@ def early_exit_runner(
     try:
         if not cli_flags.instance_name:
             loop.run_until_complete(func())
+            sys.exit(ExitCodes.SHUTDOWN)
             return
 
         data_manager.load_basic_configuration(cli_flags.instance_name)
@@ -288,10 +289,12 @@ def early_exit_runner(
     except (KeyboardInterrupt, EOFError):
         print("Aborted!")
     finally:
-        loop.run_until_complete(asyncio.sleep(1))
+        # note: sleep is unnecessary since we're not making any network connections
         asyncio.set_event_loop(None)
         loop.stop()
         loop.close()
+
+    sys.exit(ExitCodes.SHUTDOWN)
 
 
 async def run_bot(red: Red, cli_flags: Namespace) -> None:


### PR DESCRIPTION
### Description of the changes

Regression from the combination of #5662 and #5673. Both of these together have resulted in `redbot --debuginfo` starting the bot even though it shouldn't.

### Have the changes in this PR been tested?

Yes
