### PR TITLE
Include vendored menus update for guild attribute

### DIFF
--- a/redbot/vendored/discord/ext/menus/__init__.py
+++ b/redbot/vendored/discord/ext/menus/__init__.py
@@ -702,7 +702,7 @@ class Menu(metaclass=_MenuMeta):
         self.ctx = ctx
         self._author_id = ctx.author.id
         channel = channel or ctx.channel
-        me = channel.guild.me if hasattr(channel, 'guild') else ctx.bot.user
+        me = channel.guild.me if getattr(channel, 'guild', None) else ctx.bot.user
         permissions = channel.permissions_for(me)
         self.__me = discord.Object(id=me.id)
         self._verify_permissions(ctx, channel, permissions)


### PR DESCRIPTION
See Rapptz/discord-ext-menus@8686b5d

### Description of the changes

Since dpy2, all channels have a guild attribute, breaking vendored menus in DMs. The
upstream commit cited above fixes this by switching from hasattr to getattr.

### Have the changes in this PR been tested?

Yes