### PR TITLE
Fix NoneType error and channelmute saying user is already muted

### DIFF
--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -1729,7 +1729,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
 
         if channel.id not in self._channel_mutes:
             self._channel_mutes[channel.id] = {}
-        current_mute = self._channel_mutes.get(channel.id) or None
+        current_mute = self._channel_mutes[channel.id].get(user.id)
 
         # Determine if this is voice mute -> channel mute upgrade
         is_mute_upgrade = (

--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -405,8 +405,6 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
                             self._unmute_tasks[task_name] = asyncio.create_task(
                                 self._auto_channel_unmute_user(guild_channel, mute_data)
                             )
-                        else:
-                            await self.config.channel_from_id(channel).clear()
 
         del multiple_mutes
 

--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -401,9 +401,12 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
                         log.debug(f"Creating task: {task_name}")
                         if task_name in self._unmute_tasks:
                             continue
-                        self._unmute_tasks[task_name] = asyncio.create_task(
-                            self._auto_channel_unmute_user(guild.get_channel(channel), mute_data)
-                        )
+                        if guild_channel := guild.get_channel(channel):
+                            self._unmute_tasks[task_name] = asyncio.create_task(
+                                self._auto_channel_unmute_user(guild_channel, mute_data)
+                            )
+                        else:
+                            await self.config.channel_from_id(channel).clear()
 
         del multiple_mutes
 
@@ -1726,7 +1729,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
 
         if channel.id not in self._channel_mutes:
             self._channel_mutes[channel.id] = {}
-        current_mute = self._channel_mutes.get(channel.id)
+        current_mute = self._channel_mutes.get(channel.id) or None
 
         # Determine if this is voice mute -> channel mute upgrade
         is_mute_upgrade = (


### PR DESCRIPTION
### Description of the changes
Fixes #6140 by first checking if the channel exists/is in the cache.

I have also found another issue wherein `channelmute` always errored with a "That user is already muted" error, I have fixed that in this PR as well.


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes, to the best of my ability
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
