### PR TITLE
Add data_manager.instance_name() public API

### DIFF
--- a/redbot/cogs/audio/core/tasks/lavalink.py
+++ b/redbot/cogs/audio/core/tasks/lavalink.py
@@ -108,7 +108,7 @@ class LavalinkTasks(MixinMeta, metaclass=CompositeMetaClass):
                     password=password,
                     port=port,
                     timeout=timeout,
-                    resume_key=f"Red-Core-Audio-{self.bot.user.id}-{data_manager.instance_name}",
+                    resume_key=f"Red-Core-Audio-{self.bot.user.id}-{data_manager.instance_name()}",
                     secured=secured,
                 )
             except lavalink.AbortingNodeConnection:

--- a/redbot/core/_debuginfo.py
+++ b/redbot/core/_debuginfo.py
@@ -131,13 +131,14 @@ class DebugInfo:
         )
 
     async def _get_red_vars_section(self) -> DebugInfoSection:
-        if data_manager.instance_name is None:
+        instance_name = data_manager.instance_name()
+        if instance_name is None:
             return DebugInfoSection(
                 "Red variables",
                 f"Metadata file: {data_manager.config_file}",
             )
 
-        parts = [f"Instance name: {data_manager.instance_name}"]
+        parts = [f"Instance name: {instance_name}"]
         if self.bot is not None:
             owners = []
             for uid in self.bot.owner_ids:

--- a/redbot/core/data_manager.py
+++ b/redbot/core/data_manager.py
@@ -18,16 +18,17 @@ __all__ = (
     "core_data_path",
     "bundled_data_path",
     "data_path",
+    "instance_name",
     "metadata_file",
-    "storage_details",
     "storage_type",
+    "storage_details",
 )
 
 log = logging.getLogger("red.data_manager")
 
 basic_config = None
 
-instance_name = None
+_instance_name = None
 
 basic_config_default: Dict[str, Any] = {
     "DATA_PATH": None,
@@ -106,8 +107,8 @@ def load_basic_configuration(instance_name_: str):
         redbot setup.
     """
     global basic_config
-    global instance_name
-    instance_name = instance_name_
+    global _instance_name
+    _instance_name = instance_name_
 
     try:
         with config_file.open(encoding="utf-8") as fs:
@@ -119,7 +120,7 @@ def load_basic_configuration(instance_name_: str):
         )
         sys.exit(ExitCodes.CONFIGURATION_ERROR)
     try:
-        basic_config = config[instance_name]
+        basic_config = config[_instance_name]
     except KeyError:
         print(
             "Instance with this name doesn't exist."
@@ -232,6 +233,17 @@ def data_path() -> Path:
         Storage type.
     """
     return _base_data_path()
+
+
+def instance_name() -> str:
+    """Gets instance's name.
+
+    Returns
+    -------
+    str
+        Instance name.
+    """
+    return _instance_name
 
 
 def metadata_file() -> Path:

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -217,7 +217,7 @@ async def create_backup(dest: Path = Path.home()) -> Optional[Path]:
 
     dest.mkdir(parents=True, exist_ok=True)
     timestr = datetime.utcnow().strftime("%Y-%m-%dT%H-%M-%S")
-    backup_fpath = dest / f"redv3_{data_manager.instance_name}_{timestr}.tar.gz"
+    backup_fpath = dest / f"redv3_{data_manager.instance_name()}_{timestr}.tar.gz"
 
     to_backup = []
     exclusions = [
@@ -242,7 +242,7 @@ async def create_backup(dest: Path = Path.home()) -> Optional[Path]:
         json.dump(repo_output, fs, indent=4)
     instance_file = data_path / "instance.json"
     with instance_file.open("w") as fs:
-        json.dump({data_manager.instance_name: data_manager.basic_config}, fs, indent=4)
+        json.dump({data_manager.instance_name(): data_manager.basic_config}, fs, indent=4)
     for f in data_path.glob("**/*"):
         if not any(ex in str(f) for ex in exclusions) and f.is_file():
             to_backup.append(f)


### PR DESCRIPTION
### Description of the changes

Adds a new `data_manager.instance_name()` public API to replace the `instance_name` variable that was privatized in 3.5.0. This has been split out from #6023.

### Have the changes in this PR been tested?

No
