### PR TITLE
Make mentions of x86-64-v2 accurate for AMD

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,7 +53,7 @@ Read before updating
 
 #. Red 3.5 comes with breaking changes for cog developers. Look at `Backward incompatible changes in Red 3.5 document <incompatible-changes-3.5>` and `Developer changelog <important-350-2>` for full details.
 #. Fedora 35 and Debian 10 (Buster) are no longer supported as they have already reached their end of life.
-#. On x86-64 systems, we now require that the CPU supports x86-64-v2 instruction set. This roughly translates to us dropping support for x86-64 CPUs that have been released before 2009.
+#. On x86-64 systems, we now require that the CPU supports x86-64-v2 instruction set. This roughly translates to us dropping support for Intel CPUs that have been released before 2009 and AMD CPUs that have been released before 2012.
 
 .. _important-350-1:
 
@@ -64,7 +64,7 @@ Breaking Changes
 ****************
 
 - **Core** - The bot will no longer launch without an owner set (:issue:`4926`)
-- **Core - OS support** - On x86-64 systems, we now require that the CPU supports x86-64-v2 instruction set. This roughly translates to us dropping support for x86-64 CPUs that have been released before 2009 (:issue:`6100`)
+- **Core - OS support** - On x86-64 systems, we now require that the CPU supports x86-64-v2 instruction set. This roughly translates to us dropping support for Intel CPUs that have been released before 2009 and AMD CPUs that have been released before 2012 (:issue:`6100`)
 
 Additions
 *********

--- a/docs/incompatible_changes/3.5.rst
+++ b/docs/incompatible_changes/3.5.rst
@@ -49,7 +49,8 @@ x86-64 CPUs are now only supported if they support x86-64-v2 instruction set
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 On x86-64 systems, we now require that your CPU supports x86-64-v2 instruction set.
-This roughly translates to us dropping support for x86-64 CPUs that have been released before 2009.
+This roughly translates to us dropping support for Intel CPUs that have been released before 2009
+and AMD CPUs that have been releasesd before 2012.
 
 This has been mostly dictated by one of our dependencies but some Linux distributions
 are already dropping support for it in their latest versions as well.

--- a/docs/version_guarantees.rst
+++ b/docs/version_guarantees.rst
@@ -38,7 +38,8 @@ their end-of-life date.
     The meaning of architecture names:
 
     - **x86-64** (also known as amd64) refers to computers running a 64-bit version of the operating system
-      on standard Intel and AMD 64-bit processors supporting x86-64-v2 instruction set (post-2008 hardware).
+      on standard Intel and AMD 64-bit processors supporting x86-64-v2 instruction set
+      (post-2008 Intel processors and post-2011 AMD processors).
     - **aarch64** (also known as arm64) refers to computers running an ARM 64-bit version of the operating system
       on 64-bit ARM processors (ARMv8-A and ARMv9-A) such as Apple M1 devices or Raspberry Pi computers
       (Raspberry Pi 3B and above, excluding Pi Zero (W/WH) model).


### PR DESCRIPTION
### Description of the changes

I wrongly assumed that Intel and AMD would have supported these extensions at roughly the same time... x86-64-v2 roughly translates to Intel Nehalem-era processors (Nov 2008) and AMD Bulldozer-era processors (Oct 2011)

### Have the changes in this PR been tested?

Yes
