### PR TITLE
Fix max heapsize calculation on 32-bit platforms

### DIFF
--- a/redbot/cogs/audio/utils.py
+++ b/redbot/cogs/audio/utils.py
@@ -27,7 +27,7 @@ def get_max_allocation_size(exec) -> Tuple[int, bool]:
         max_heap_allowed = psutil.virtual_memory().total
         thinks_is_64_bit = True
     else:
-        max_heap_allowed = 4 * 1024**3
+        max_heap_allowed = min(4 * 1024**3, psutil.virtual_memory().total)
         thinks_is_64_bit = False
     return max_heap_allowed, thinks_is_64_bit
 
@@ -36,7 +36,7 @@ def get_jar_ram_defaults() -> Tuple[str, str]:
     min_ram = 64 * 1024**2
     # We don't know the java executable at this stage - not worth the extra work required here
     max_allocation, is_64bit = get_max_allocation_size(sys.executable)
-    max_ram_allowed = max_allocation * 0.5 if is_64bit else max_allocation
+    max_ram_allowed = min(max_allocation, psutil.virtual_memory().total * 0.5)
     max_ram = max(min_ram, max_ram_allowed)
     size_name = ("", "K", "M", "G", "T")
     i = int(math.floor(math.log(min_ram, 1024)))


### PR DESCRIPTION
### Description of the changes

This fixes:
- `get_max_allocation_size()` potentially returning a number that is bigger than total available RAM on 32-bit platforms
- the max ram value returned by `get_jar_ram_defaults()` being more than half of the available memory on 32-bit platforms

Fixes #6137

### Have the changes in this PR been tested?

No
