### PR TITLE
Add global prefixes to debuginfo

### DIFF
--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -17,7 +17,7 @@ import sys
 from argparse import Namespace
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Awaitable, Callable, NoReturn, Union
+from typing import Any, Awaitable, Callable, NoReturn, Optional, Union
 
 import discord
 import rich
@@ -62,9 +62,9 @@ def list_instances():
         sys.exit(ExitCodes.SHUTDOWN)
 
 
-async def debug_info(*args: Any) -> None:
+async def debug_info(red: Optional[Red] = None, *args: Any) -> None:
     """Shows debug information useful for debugging."""
-    print(await DebugInfo().get_text())
+    print(await DebugInfo(red).get_cli_text())
 
 
 async def edit_instance(red, cli_flags):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -4688,7 +4688,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """Shows debug information useful for debugging."""
         from redbot.core._debuginfo import DebugInfo
 
-        await ctx.send(await DebugInfo(self.bot).get_text())
+        await ctx.send(await DebugInfo(self.bot).get_command_text())
 
     # You may ask why this command is owner-only,
     # cause after all it could be quite useful to guild owners!


### PR DESCRIPTION
### Description of the changes

This can be useful information when querying the debug information from the CLI (`redbot --debuginfo instance_name`).

### Have the changes in this PR been tested?

Yes
