### PR TITLE
[redbot.core.tree] The kwarg `delete_after` doesn't exist in `discord.Interaction.followup.send`.

### DIFF
--- a/redbot/core/tree.py
+++ b/redbot/core/tree.py
@@ -321,7 +321,7 @@ class RedTree(CommandTree):
             msg = _("This command is on cooldown. Try again {relative_time}.").format(
                 relative_time=relative_time
             )
-            await self._send_from_interaction(interaction, msg, delete_after=error.retry_after)
+            await self._send_from_interaction(interaction, msg)
         elif isinstance(error, CheckFailure):
             await self._send_from_interaction(
                 interaction, _("You are not permitted to use this command.")

--- a/redbot/core/tree.py
+++ b/redbot/core/tree.py
@@ -251,7 +251,7 @@ class RedTree(CommandTree):
         if interaction.response.is_done():
             if interaction.is_expired():
                 return await interaction.channel.send(*args, **kwargs)
-            kwargs.pop("delete_after")
+            kwargs.pop("delete_after", None)
             return await interaction.followup.send(*args, ephemeral=True, **kwargs)
         return await interaction.response.send_message(*args, ephemeral=True, **kwargs)
 

--- a/redbot/core/tree.py
+++ b/redbot/core/tree.py
@@ -251,6 +251,7 @@ class RedTree(CommandTree):
         if interaction.response.is_done():
             if interaction.is_expired():
                 return await interaction.channel.send(*args, **kwargs)
+            kwargs.pop("delete_after")
             return await interaction.followup.send(*args, ephemeral=True, **kwargs)
         return await interaction.response.send_message(*args, ephemeral=True, **kwargs)
 
@@ -321,7 +322,7 @@ class RedTree(CommandTree):
             msg = _("This command is on cooldown. Try again {relative_time}.").format(
                 relative_time=relative_time
             )
-            await self._send_from_interaction(interaction, msg)
+            await self._send_from_interaction(interaction, msg, delete_after=error.retry_after)
         elif isinstance(error, CheckFailure):
             await self._send_from_interaction(
                 interaction, _("You are not permitted to use this command.")


### PR DESCRIPTION
### Description of the changes

Hello,

This PR fixes an error in the error handler for slash commands. It was reported by @Drapersniper in the main Red server (https://canary.discord.com/channels/133049272517001216/718148684629540905/1107334514302275615). The `delete_after` kwarg is used when the error is `redbot.core.app_commands.CommandOnCooldown`, but does not exist if `discord.Interaction.followup.send` is used to send the message, if the interaction has been answered but has not yet expired.
The simple removal of this kwarg for a slash command error in this one case was chosen.

Have a nice day,
AAA3A

Closes #6159

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
