### PR TITLE
Handle delete_after in interaction error handling for followup

### DIFF
--- a/redbot/core/tree.py
+++ b/redbot/core/tree.py
@@ -251,7 +251,12 @@ class RedTree(CommandTree):
         if interaction.response.is_done():
             if interaction.is_expired():
                 return await interaction.channel.send(*args, **kwargs)
-            return await interaction.followup.send(*args, ephemeral=True, **kwargs)
+            delete_after = kwargs.pop("delete_after", None)
+            kwargs["wait"] = True
+            msg = await interaction.followup.send(*args, ephemeral=True, **kwargs)
+            if delete_after is not None:
+                await msg.delete(delay=delete_after)
+            return msg
         return await interaction.response.send_message(*args, ephemeral=True, **kwargs)
 
     @staticmethod


### PR DESCRIPTION
### Description of the changes

Alternative to #6158 - actually spawning a delete task for the webhook message. Please choose one or the other.

Closes #6158

### Have the changes in this PR been tested?

No
