### PR TITLE
Fix _ValueCtxManager.__await__ typehint

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -9,6 +9,7 @@ from typing import (
     AsyncContextManager,
     Awaitable,
     Dict,
+    Generator,
     MutableMapping,
     Optional,
     Tuple,
@@ -96,7 +97,7 @@ class _ValueCtxManager(Awaitable[_T], AsyncContextManager[_T]):  # pylint: disab
         self.__acquire_lock = acquire_lock
         self.__lock = self.value_obj.get_lock()
 
-    def __await__(self) -> _T:
+    def __await__(self) -> Generator[Any, None, _T]:
         return self.coro.__await__()
 
     async def __aenter__(self) -> _T:


### PR DESCRIPTION
### Description of the changes

`_ValueCtxManager.__await__` had an incorrect typehint which made pyright believe the object wasn't awaitable.

### Have the changes in this PR been tested?

Yes
