### PR TITLE
Include command-line arguments in debuginfo

### DIFF
--- a/redbot/core/_debuginfo.py
+++ b/redbot/core/_debuginfo.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import getpass
 import os
 import platform
+import re
 import sys
 from typing import Optional
 
@@ -143,6 +144,24 @@ class DebugInfo:
         parts = [f"Instance name: {instance_name}"]
 
         if self.bot is not None:
+            # sys.original_argv is available since 3.10 and shows the actual command line arguments
+            # rather than a Python-transformed version (i.e. with '-c' or path to `__main__.py`
+            # as first element). We could just not show the first argument for consistency
+            # but it can be useful.
+            cli_args = getattr(sys, "orig_argv", sys.argv).copy()
+            # best effort attempt to expunge a token argument
+            for idx, arg in enumerate(cli_args):
+                if not arg.startswith("--to"):
+                    continue
+                arg_name, sep, arg_value = arg.partition("=")
+                if arg_name not in ("--to", "--tok", "--toke", "--token"):
+                    continue
+                if sep:
+                    cli_args[idx] = f"{arg_name}{sep}[EXPUNGED]"
+                elif len(cli_args) > idx + 1:
+                    cli_args[idx + 1] = f"[EXPUNGED]"
+            parts.append(f"Command line arguments: {cli_args!r}")
+
             # This formatting is a bit ugly but this is a debug information command
             # and calling repr() on prefix strings ensures that the list isn't ambiguous.
             prefixes = ", ".join(map(repr, await self.bot._config.prefix()))

--- a/redbot/core/_debuginfo.py
+++ b/redbot/core/_debuginfo.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import getpass
 import os
 import platform
-import re
 import sys
 from typing import Optional
 


### PR DESCRIPTION
### Description of the changes

I thought it could be helpful in some cases, not sure how others feel about it. It is a bit better on Python 3.10 and higher as we can use `sys.orig_argv` there which is a more precise representation of arguments as received by the Python executable. Note that neither `sys.argv` nor `sys.orig_argv` is necessarily the same as what the user put in the command line, it's just that `sys.orig_argv` allows you to get more information and allows you to differ between some cases that you otherwise couldn't.

![image](https://github.com/Cog-Creators/Red-DiscordBot/assets/6032823/0d96a3c9-33bc-4f6e-b02c-11122949c786)

### Have the changes in this PR been tested?

Yes