### PR TITLE
Clear the view in `[p]set api` after timeout

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3598,13 +3598,12 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         - `<service>` - The service you're adding tokens to.
         - `<tokens>` - Pairs of token keys and values. The key and value should be separated by one of ` `, `,`, or `;`.
         """
-        if service is None:  # Handled in order of missing operations
-            await ctx.send(_("Click the button below to set your keys."), view=SetApiView())
-        elif tokens is None:
-            await ctx.send(
-                _("Click the button below to set your keys."),
-                view=SetApiView(default_service=service),
-            )
+        if service is None or tokens is None:
+            view = SetApiView(default_service=service)
+            msg = await ctx.send(_("Click the button below to set your keys."), view=view)
+            await view.wait()
+            view.auth_button.disabled = True
+            await msg.edit(view=view)
         else:
             if ctx.bot_permissions.manage_messages:
                 await ctx.message.delete()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3602,8 +3602,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             view = SetApiView(default_service=service)
             msg = await ctx.send(_("Click the button below to set your keys."), view=view)
             await view.wait()
-            view.auth_button.disabled = True
-            await msg.edit(view=view)
+            await msg.edit(content=_("This API keys setup message has expired."), view=None)
         else:
             if ctx.bot_permissions.manage_messages:
                 await ctx.message.delete()


### PR DESCRIPTION

### Description of the changes

Hello,

This PR disables the "Set API token" button of the `redbot.core.utils.views.SetApiView` view after the 180 seconds timeout. The logic is in the `[p]set api` command and not in the View itself, as Trusty would rather have.

Thanks in advance,
AAA3A

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
