### PR TITLE
Shorten max page size in `[p]slash list` to account for box size

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2329,7 +2329,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 msg += diff + command_type.ljust(7) + " | " + name + "\n"
             msg += "\n"
 
-        pages = pagify(msg, delims=["\n\n", "\n"])
+        pages = pagify(msg, delims=["\n\n", "\n"], shorten_by=12)
         pages = [box(page, lang="diff") for page in pages]
         await menu(ctx, pages)
 


### PR DESCRIPTION
### Description of the changes

Hello,

If a bot has a lot of slash commands, as the page size only takes into account the formatting with the `py` language (`shorted_by=8`), the pages can be more than 2000 characters long and the sending of the message fails. This PR fixes this problem.

Thanks in advance,
AAA3A

```
Traceback (most recent call last):
  File "{USERPROFILE}\redenv\Lib\site-packages\discord\ext\commands\core.py", line 229, in wrapped
    ret = await coro(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "{USERPROFILE}\Documents\GitHub\Red-DiscordBot\redbot\core\core_commands.py", line 2334, in slash_list
    await menu(ctx, pages)
  File "{USERPROFILE}\Documents\GitHub\Red-DiscordBot\redbot\core\utils\menus.py", line 141, in menu
    await view.start(ctx)
  File "{USERPROFILE}\Documents\GitHub\Red-DiscordBot\redbot\core\utils\views.py", line 239, in start
    self.message = await ctx.send(**kwargs, ephemeral=ephemeral)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "{USERPROFILE}\Documents\GitHub\Red-DiscordBot\redbot\core\commands\context.py", line 91, in send
    return await super().send(content=content, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "{USERPROFILE}\redenv\Lib\site-packages\discord\ext\commands\context.py", line 1016, in send
    return await super().send(
           ^^^^^^^^^^^^^^^^^^^
  File "{USERPROFILE}\redenv\Lib\site-packages\discord\abc.py", line 1561, in send
    data = await state.http.send_message(channel.id, params=params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "{USERPROFILE}\redenv\Lib\site-packages\discord\http.py", line 744, in request
    raise HTTPException(response, data)
discord.errors.HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In content: Must be 2000 or fewer in length.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "{USERPROFILE}\redenv\Lib\site-packages\discord\ext\commands\bot.py", line 1350, in invoke
    await ctx.command.invoke(ctx)
  File "{USERPROFILE}\Documents\GitHub\Red-DiscordBot\redbot\core\commands\commands.py", line 791, in invoke
    await super().invoke(ctx)
  File "{USERPROFILE}\redenv\Lib\site-packages\discord\ext\commands\core.py", line 1642, in invoke
    await ctx.invoked_subcommand.invoke(ctx)
  File "{USERPROFILE}\redenv\Lib\site-packages\discord\ext\commands\core.py", line 1023, in invoke
    await injected(*ctx.args, **ctx.kwargs)  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "{USERPROFILE}\redenv\Lib\site-packages\discord\ext\commands\core.py", line 238, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In content: Must be 2000 or fewer in length.
```

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
