### PR TITLE
Hide diffs for .po files by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,7 @@
 
 # include commit/tag information in `.git_archive_info.txt` when packing with git-archive
 .git_archive_info.txt export-subst
+
+# hide diffs for .po files by default
+# https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
+*.po linguist-generated


### PR DESCRIPTION
### Description of the changes

I found out about this the other day and thought that `.po` files in our repository would be a great use case for this. This should make looking at diffs easier when one of the commits in the given range is changing `.po` files.

### Have the changes in this PR been tested?

Yes
