### PR TITLE
Clarify requirements for delisting an approved cog

### DIFF
--- a/docs/guide_cog_creators.rst
+++ b/docs/guide_cog_creators.rst
@@ -196,7 +196,7 @@ Other Details
 - QA reserves the right to revoke these roles and all privileges if you are found to be in gross negligence, malicious intent, or reckless abandonment of your repository.
 - Cogs must be functionally working to the quality of an approved cog on the latest minor version of Red to be listed on the Red Index. Cogs that are not updated within 1 month of initial breakage will be delisted from the index until they are updated. Examples of potential breakage include, but are not limited to:
 
-  - A dependency with an unlocked version receiving a breaking update
+  - A dependency without version constraints receiving a breaking update
   - An API changing the schema of its endpoints
   - Red itself releasing a new minor version
 

--- a/docs/guide_cog_creators.rst
+++ b/docs/guide_cog_creators.rst
@@ -94,8 +94,6 @@ Any Cog Creator that does not follow these requirements will have their repo rem
   - If that's not possible, don't break anything in core or any other cog with your code.
   - If you have to use private methods, lock the cog to specific Red versions you can guarantee it works on without breaking anything using the ``min_bot_version`` and ``max_bot_version`` keys in that cog's ``info.json`` file.
 
-- Cog Creators must keep their cogs up-to-date with core Red or be delisted until cogs meet Red API changes. Repositories must be kept up to date with the latest version of Red within 3 months of its release.
-
 .. _recommendations-for-cog-creators:
 
 --------------------------------
@@ -196,7 +194,12 @@ Other Details
 - The reviewer of your application has the final word.
 - Hidden cogs will not be explicitly reviewed, however they are not allowed to contain malicious or ToS breaking code.
 - QA reserves the right to revoke these roles and all privileges if you are found to be in gross negligence, malicious intent, or reckless abandonment of your repository.
-- If a Cog Creator's repository is not maintained and kept up to date, that repo will be removed from the approved repo listings until such issues are addressed.
+- Cogs must be functionally working to the quality of an approved cog on the latest minor version of Red to be listed on the Red Index. Cogs that are not updated within 1 month of initial breakage will be delisted from the index until they are updated. Examples of potential breakage include, but are not limited to:
+
+  - A dependency with an unlocked version receiving a breaking update
+  - An API changing the schema of its endpoints
+  - Red itself releasing a new minor version
+
 - Only 1 person is allowed to be the Cog Creator for a particular repo. Multiple people are allowed to maintain the repo, however the "main" owner (and the Cog Creator) is responsible for any code on the repo.
 - The Cog Creator status for a repo can be transferred to another user if the Cog Creator requests it.
 - An approved Cog Creator can ask QA to add additional repos they have created to the approved pool.


### PR DESCRIPTION
### Description of the changes
Applies the policy change from https://github.com/Cog-Creators/Red-Policies/pull/12 to the user-facing docs. Namely, this includes:
  - Reducing the time before delisting to 1 month (down from 3 months)
  - Clarifying that delisting happens on specific cogs, not entire repositories
  - Clarifying the criteria for delisting a cog with examples of causes.
  
I chose to remove the references to delisting *within* the CC requirements, since it isn't a requirement of a cog, rather this policy expects all of *those* requirements to be satisfied, and having it be recursive seemed yucky. I did not touch the header at the top of the requirements that states that 
> Any Cog Creator that does not follow these requirements will have their repo removed from approved listings and may have their Cog Creator status revoked.

as I think we still probably need more than just 
> QA reserves the right to revoke these roles and all privileges if you are found to be in gross negligence, malicious intent, or reckless abandonment of your repository.

under "other details", but I'm open to changing the language.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
