### PR TITLE
Use backtracking resolver in pip-compile

### DIFF
--- a/.github/workflows/scripts/compile_requirements.py
+++ b/.github/workflows/scripts/compile_requirements.py
@@ -18,6 +18,7 @@ def pip_compile(name: str) -> None:
             "piptools",
             "compile",
             "--upgrade",
+            "--resolver=backtracking",
             "--verbose",
             f"{name}.in",
             "--output-file",


### PR DESCRIPTION
### Description of the changes

Seems that our current set of dependencies cannot be resolved without a backtracking resolver. This will eventually become the default so let's just start using it now.

### Have the changes in this PR been tested?

Yes

You can see the successful run here: https://github.com/Jackenmen/Red-DiscordBot/actions/runs/5246241248
And the relevant failure with the legacy resolver here: https://github.com/Cog-Creators/Red-DiscordBot/actions/runs/5246079647/jobs/9474415297