### PR TITLE
Bump dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ aiohttp-json-rpc==0.13.3
     # via -r base.in
 aiosignal==1.3.1
     # via aiohttp
-apsw==3.41.2.0
+apsw==3.42.0.0
     # via -r base.in
 async-timeout==4.0.2
     # via aiohttp
@@ -42,7 +42,7 @@ importlib-metadata==6.6.0
     # via markdown
 markdown==3.4.3
     # via -r base.in
-markdown-it-py==2.2.0
+markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
@@ -50,11 +50,11 @@ multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-orjson==3.8.12
+orjson==3.9.1
     # via -r base.in
 packaging==23.1
     # via -r base.in
-platformdirs==3.5.1
+platformdirs==3.5.3
     # via -r base.in
 psutil==5.9.5
     # via -r base.in
@@ -70,7 +70,7 @@ pytz==2023.3
     # via babel
 pyyaml==6.0
     # via -r base.in
-rapidfuzz==3.0.0
+rapidfuzz==3.1.1
     # via -r base.in
 red-commons==1.0.0
     # via
@@ -78,13 +78,13 @@ red-commons==1.0.0
     #   red-lavalink
 red-lavalink==0.11.0
     # via -r base.in
-rich==13.3.5
+rich==13.4.2
     # via -r base.in
 schema==0.7.5
     # via -r base.in
 six==1.16.0
     # via python-dateutil
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via
     #   -r base.in
     #   rich

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 aiodns==3.0.0
     # via -r base.in
-aiohttp==3.8.4
+aiohttp==3.8.5
     # via
     #   -r base.in
     #   aiohttp-json-rpc
@@ -22,23 +22,23 @@ brotli==1.0.9
     # via -r base.in
 cffi==1.15.1
     # via pycares
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via aiohttp
-click==8.1.3
+click==8.1.6
     # via -r base.in
 contextlib2==21.6.0
     # via schema
-discord-py==2.3.0
+discord-py==2.3.1
     # via
     #   -r base.in
     #   red-lavalink
-frozenlist==1.3.3
+frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
 idna==3.4
     # via yarl
-importlib-metadata==6.6.0
+importlib-metadata==6.8.0
     # via markdown
 markdown==3.4.3
     # via -r base.in
@@ -50,11 +50,11 @@ multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-orjson==3.9.1
+orjson==3.9.2
     # via -r base.in
 packaging==23.1
     # via -r base.in
-platformdirs==3.5.3
+platformdirs==3.9.1
     # via -r base.in
 psutil==5.9.5
     # via -r base.in
@@ -68,9 +68,9 @@ python-dateutil==2.8.2
     # via -r base.in
 pytz==2023.3
     # via babel
-pyyaml==6.0
+pyyaml==6.0.1
     # via -r base.in
-rapidfuzz==3.1.1
+rapidfuzz==3.1.2
     # via -r base.in
 red-commons==1.0.0
     # via
@@ -84,7 +84,7 @@ schema==0.7.5
     # via -r base.in
 six==1.16.0
     # via python-dateutil
-typing-extensions==4.6.3
+typing-extensions==4.7.1
     # via
     #   -r base.in
     #   rich
@@ -92,7 +92,7 @@ yarl==1.9.2
     # via
     #   -r base.in
     #   aiohttp
-zipp==3.15.0
+zipp==3.16.2
     # via importlib-metadata
 colorama==0.4.6; sys_platform == "win32"
     # via click

--- a/requirements/extra-doc.in
+++ b/requirements/extra-doc.in
@@ -2,5 +2,5 @@
 
 Sphinx
 sphinx-prompt
-sphinx_rtd_theme
+sphinx_rtd_theme>1
 sphinxcontrib-trio

--- a/requirements/extra-doc.txt
+++ b/requirements/extra-doc.txt
@@ -1,6 +1,6 @@
 alabaster==0.7.13
     # via sphinx
-certifi==2023.5.7
+certifi==2023.7.22
     # via requests
 docutils==0.18.1
     # via
@@ -44,5 +44,5 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sphinxcontrib-trio==1.1.2
     # via -r extra-doc.in
-urllib3==2.0.3
+urllib3==2.0.4
     # via requests

--- a/requirements/extra-doc.txt
+++ b/requirements/extra-doc.txt
@@ -11,9 +11,9 @@ imagesize==1.4.1
     # via sphinx
 jinja2==3.1.2
     # via sphinx
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
-requests==2.30.0
+requests==2.31.0
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
@@ -26,7 +26,7 @@ sphinx==6.2.1
     #   sphinxcontrib-trio
 sphinx-prompt==1.6.0
     # via -r extra-doc.in
-sphinx-rtd-theme==1.2.0
+sphinx-rtd-theme==1.2.2
     # via -r extra-doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -44,5 +44,5 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sphinxcontrib-trio==1.1.2
     # via -r extra-doc.in
-urllib3==2.0.2
+urllib3==2.0.3
     # via requests

--- a/requirements/extra-postgres.txt
+++ b/requirements/extra-postgres.txt
@@ -1,2 +1,2 @@
-asyncpg==0.27.0
+asyncpg==0.28.0
     # via -r extra-postgres.in

--- a/requirements/extra-style.txt
+++ b/requirements/extra-style.txt
@@ -1,4 +1,4 @@
-black==23.3.0
+black==23.7.0
     # via -r extra-style.in
 mypy-extensions==1.0.0
     # via black

--- a/requirements/extra-test.txt
+++ b/requirements/extra-test.txt
@@ -1,4 +1,4 @@
-astroid==2.15.4
+astroid==2.15.5
     # via pylint
 dill==0.3.6
     # via pylint
@@ -16,7 +16,7 @@ pluggy==1.0.0
     # via pytest
 pylint==2.17.4
     # via -r extra-test.in
-pytest==7.3.1
+pytest==7.3.2
     # via
     #   -r extra-test.in
     #   pytest-asyncio

--- a/requirements/extra-test.txt
+++ b/requirements/extra-test.txt
@@ -1,8 +1,8 @@
-astroid==2.15.5
+astroid==2.15.6
     # via pylint
-dill==0.3.6
+dill==0.3.7
     # via pylint
-exceptiongroup==1.1.1
+exceptiongroup==1.1.2
     # via pytest
 iniconfig==2.0.0
     # via pytest
@@ -12,18 +12,18 @@ lazy-object-proxy==1.9.0
     # via astroid
 mccabe==0.7.0
     # via pylint
-pluggy==1.0.0
+pluggy==1.2.0
     # via pytest
 pylint==2.17.4
     # via -r extra-test.in
-pytest==7.3.2
+pytest==7.4.0
     # via
     #   -r extra-test.in
     #   pytest-asyncio
     #   pytest-mock
-pytest-asyncio==0.21.0
+pytest-asyncio==0.21.1
     # via -r extra-test.in
-pytest-mock==3.10.0
+pytest-mock==3.11.1
     # via -r extra-test.in
 tomli==2.0.1
     # via


### PR DESCRIPTION
### Description of the changes

Meaningful changes:
- orjson wheels are built for base x86-64 instruction set again
    - Should we back out on dropping support for it considering that this was the only dependency that was causing problems for us?
- the search in sphinx-rtd-theme now works again

### Have the changes in this PR been tested?

Yes

macOS x86_64: https://github.com/Jackenmen/Red-Install-Tests/actions/runs/5336827530
Everything else: https://cirrus-ci.com/build/5771016132100096
