### PR TITLE
Support and switch to Java 17 everywhere except CentOS 7

### DIFF
--- a/docs/cog_guides/audio.rst
+++ b/docs/cog_guides/audio.rst
@@ -116,18 +116,18 @@ How can I use this playlist link with playlist commands in audio?**
     :ref:`setting up Audio for multiple bots<multibots>`. Otherwise, another process is using the 
     port, so you need to figure out what is using port 2333 and terminate/disconnect it yourself.
     
-**Q: My terminal is saying that I "must install Java 11 for Lavalink to run". How can I fix this?**
+**Q: My terminal is saying that I "must install Java 17 or 11 for Lavalink to run". How can I fix this?**
 
     You are getting this error because you have a different version of Java installed, or you don't have
-    Java installed at all. As the error states, Java 11 is required, and can be installed from
-    `here <https://adoptium.net/temurin/releases/?version=11>`__.
+    Java installed at all. As the error states, Java 17 or 11 is required, and can be installed from
+    `here <https://adoptium.net/temurin/releases/?version=17>`__.
     
-    If you have Java 11 installed, and are still getting this error, you will have to manually tell Audio where your Java install is located.
-    Use ``[p]llset java <path_to_java_11_executable>``, to make Audio launch Lavalink with a
+    If you have Java 17 or 11 installed, and are still getting this error, you will have to manually tell Audio where your Java install is located.
+    Use ``[p]llset java <path_to_java_17_or_11_executable>``, to make Audio launch Lavalink with a
     specific Java binary. To do this, you will need to locate your ``java.exe``/``java`` file
-    in your **Java 11 install**.
+    in your **Java 17 or 11 install**.
     
-    Alternatively, update your PATH settings so that Java 11 is the one used by ``java``. However,
+    Alternatively, update your PATH settings so that Java 17 or 11 is the one used by ``java``. However,
     you should confirm that nothing other than Red is running on the machine that requires Java.
 
 .. _queue_commands:
@@ -544,11 +544,11 @@ following commands one by one.
     sudo apt install curl nano -y
 
 If you have no preference in which Java version you install on your target system, Red 
-uses OpenJDK 11 in the managed Lavalink configuration. It can be installed by running:
+uses OpenJDK 17 in the managed Lavalink configuration. It can be installed by running:
 
 .. code-block:: sh
 
-    sudo apt install openjdk-11-jre-headless -y
+    sudo apt install openjdk-17-jre-headless -y
 
 Otherwise, Lavalink works well with most versions of Java 11, 13, 15, 16, 17, and 18. Azul 
 Zulu builds are suggested, see `here <https://github.com/freyacodes/Lavalink/#requirements>`__ for more information.
@@ -3651,7 +3651,7 @@ This command shouldn't need to be used most of the time,
 and is only useful if the host machine has conflicting Java versions.
 
 If changing this make sure that the Java executable you set is supported by Audio.
-The current supported version is Java 11.
+The current supported versions are Java 17 and 11.
 
 **Arguments**
 

--- a/docs/install_guides/_includes/install-guide-rhel8-derivatives.rst
+++ b/docs/install_guides/_includes/install-guide-rhel8-derivatives.rst
@@ -15,13 +15,13 @@ Install them with dnf:
 
     sudo dnf -y update
     sudo dnf -y group install development
-    sudo dnf -y install python39 python39-devel java-11-openjdk-headless nano git
+    sudo dnf -y install python39 python39-devel java-17-openjdk-headless nano git
 
-Set ``java`` executable to point to Java 11:
+Set ``java`` executable to point to Java 17:
 
 .. prompt:: bash
 
-    sudo alternatives --set java "java-11-openjdk.$(uname -i)"
+    sudo alternatives --set java "java-17-openjdk.$(uname -i)"
 
 .. Include common instructions:
 

--- a/docs/install_guides/_includes/install-guide-rhel9-derivatives.rst
+++ b/docs/install_guides/_includes/install-guide-rhel9-derivatives.rst
@@ -13,7 +13,7 @@ Install them with dnf:
 
 .. prompt:: bash
 
-    sudo dnf -y install python39 python3-devel git java-11-openjdk-headless @development nano
+    sudo dnf -y install python39 python3-devel git java-17-openjdk-headless @development nano
 
 .. Include common instructions:
 

--- a/docs/install_guides/arch.rst
+++ b/docs/install_guides/arch.rst
@@ -16,7 +16,7 @@ Install the pre-requirements with pacman:
 
 .. prompt:: bash
 
-    sudo pacman -Syu git jre11-openjdk-headless base-devel nano
+    sudo pacman -Syu git jre17-openjdk-headless base-devel nano
 
 On Arch Linux, Python 3.9 can be installed from the Arch User Repository (AUR) from the ``python39`` package.
 

--- a/docs/install_guides/debian-11.rst
+++ b/docs/install_guides/debian-11.rst
@@ -18,7 +18,7 @@ with apt:
 .. prompt:: bash
 
     sudo apt update
-    sudo apt -y install python3 python3-dev python3-venv git openjdk-11-jre-headless build-essential nano
+    sudo apt -y install python3 python3-dev python3-venv git openjdk-17-jre-headless build-essential nano
 
 .. Include common instructions:
 

--- a/docs/install_guides/debian-12.rst
+++ b/docs/install_guides/debian-12.rst
@@ -1,0 +1,27 @@
+.. _install-debian-12:
+
+====================================
+Installing Red on Debian 12 Bookworm
+====================================
+
+.. include:: _includes/supported-arch-x64+aarch64+armv7l.rst
+
+.. include:: _includes/linux-preamble.rst
+
+-------------------------------
+Installing the pre-requirements
+-------------------------------
+
+Debian 12 "Bookworm" has all required packages available in official repositories. Install them
+with apt:
+
+.. prompt:: bash
+
+    sudo apt update
+    sudo apt -y install python3 python3-dev python3-venv git openjdk-17-jre-headless build-essential nano
+
+.. Include common instructions:
+
+.. include:: _includes/create-env-with-venv3.11.rst
+
+.. include:: _includes/install-and-setup-red-unix.rst

--- a/docs/install_guides/fedora.rst
+++ b/docs/install_guides/fedora.rst
@@ -17,7 +17,7 @@ them with dnf:
 
 .. prompt:: bash
 
-    sudo dnf -y install python3.11 python3.11-devel git java-11-openjdk-headless @development-tools nano
+    sudo dnf -y install python3.11 python3.11-devel git java-17-openjdk-headless @development-tools nano
 
 .. Include common instructions:
 

--- a/docs/install_guides/index.rst
+++ b/docs/install_guides/index.rst
@@ -20,6 +20,7 @@ we recommend **Ubuntu 22.04 LTS**.
    centos-stream-8
    centos-stream-9
    debian-11
+   debian-12
    fedora
    opensuse-leap-15
    opensuse-tumbleweed

--- a/docs/install_guides/mac.rst
+++ b/docs/install_guides/mac.rst
@@ -29,7 +29,7 @@ one-by-one:
     brew install python@3.11
     brew install git
     brew tap homebrew/cask-versions
-    brew install --cask temurin11
+    brew install --cask temurin17
 
 By default, Python installed through Homebrew is not added to the load path.
 To fix this, you should run these commands:

--- a/docs/install_guides/opensuse-leap-15.rst
+++ b/docs/install_guides/opensuse-leap-15.rst
@@ -17,7 +17,7 @@ with zypper:
 
 .. prompt:: bash
 
-    sudo zypper -n install python310 python310-devel git-core java-11-openjdk-headless nano
+    sudo zypper -n install python310 python310-devel git-core java-17-openjdk-headless nano
     sudo zypper -n install -t pattern devel_basis
 
 .. Include common instructions:

--- a/docs/install_guides/opensuse-tumbleweed.rst
+++ b/docs/install_guides/opensuse-tumbleweed.rst
@@ -17,7 +17,7 @@ with zypper:
 
 .. prompt:: bash
 
-    sudo zypper -n install python311 python311-devel git-core java-11-openjdk-headless nano
+    sudo zypper -n install python311 python311-devel git-core java-17-openjdk-headless nano
     sudo zypper -n install -t pattern devel_basis
 
 .. Include common instructions:

--- a/docs/install_guides/raspberry-pi-os-10.rst
+++ b/docs/install_guides/raspberry-pi-os-10.rst
@@ -40,7 +40,7 @@ Raspberry Pi OS. This guide will tell you how. First, run the following commands
 .. prompt:: bash
 
     sudo apt update
-    sudo apt -y install cmake make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev libgdbm-dev uuid-dev python3-openssl git openjdk-11-jre-headless nano
+    sudo apt -y install cmake make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev libgdbm-dev uuid-dev python3-openssl git openjdk-17-jre-headless nano
     CXX=/usr/bin/g++
 
 .. Include common instructions:

--- a/docs/install_guides/raspberry-pi-os-11.rst
+++ b/docs/install_guides/raspberry-pi-os-11.rst
@@ -33,7 +33,7 @@ with apt:
 .. prompt:: bash
 
     sudo apt update
-    sudo apt -y install python3 python3-dev python3-venv git openjdk-11-jre-headless build-essential nano
+    sudo apt -y install python3 python3-dev python3-venv git openjdk-17-jre-headless build-essential nano
 
 .. Include common instructions:
 

--- a/docs/install_guides/ubuntu-2004.rst
+++ b/docs/install_guides/ubuntu-2004.rst
@@ -18,7 +18,7 @@ with apt:
 .. prompt:: bash
 
     sudo apt update
-    sudo apt -y install python3.9 python3.9-dev python3.9-venv git openjdk-11-jre-headless build-essential nano
+    sudo apt -y install python3.9 python3.9-dev python3.9-venv git openjdk-17-jre-headless build-essential nano
 
 .. Include common instructions:
 

--- a/docs/install_guides/ubuntu-2204.rst
+++ b/docs/install_guides/ubuntu-2204.rst
@@ -18,7 +18,7 @@ with apt:
 .. prompt:: bash
 
     sudo apt update
-    sudo apt -y install python3.10 python3.10-dev python3.10-venv git openjdk-11-jre-headless build-essential nano
+    sudo apt -y install python3.10 python3.10-dev python3.10-venv git openjdk-17-jre-headless build-essential nano
 
 .. Include common instructions:
 

--- a/docs/install_guides/ubuntu-non-lts.rst
+++ b/docs/install_guides/ubuntu-non-lts.rst
@@ -17,7 +17,7 @@ Now install the pre-requirements with apt:
 .. prompt:: bash
 
     sudo apt update
-    sudo apt -y install python3.11 python3.11-dev python3.11-venv git openjdk-11-jre-headless build-essential nano
+    sudo apt -y install python3.11 python3.11-dev python3.11-venv git openjdk-17-jre-headless build-essential nano
 
 .. Include common instructions:
 

--- a/docs/install_guides/windows.rst
+++ b/docs/install_guides/windows.rst
@@ -39,7 +39,7 @@ For Audio support, you should also run the following command before exiting:
 
 .. prompt:: powershell
 
-    choco upgrade temurin11 -y
+    choco upgrade temurin17 -y
 
 
 From here, exit the prompt then continue onto `creating-venv-windows`.
@@ -66,7 +66,7 @@ Manually installing dependencies
 
 .. attention:: Please choose the option to "Git from the command line and also from 3rd-party software" in Git's setup.
 
-* `Java 11 <https://adoptium.net/temurin/releases/?version=11>`_ - needed for Audio
+* `Java 17 <https://adoptium.net/temurin/releases/?version=17>`_ - needed for Audio
 
 From here, continue onto `creating-venv-windows`.
 

--- a/docs/version_guarantees.rst
+++ b/docs/version_guarantees.rst
@@ -62,6 +62,7 @@ CentOS 7                           x86-64, aarch64           2024-06-30 (`end of
 CentOS Stream 8                    x86-64, aarch64           2024-05-31 (`end of Maintenance Updates <https://wiki.centos.org/About/Product>`__)
 CentOS Stream 9                    x86-64, aarch64           2027-05-31 (`expected EOL <https://centos.org/stream9/#timeline>`__)
 Debian 11 Bullseye                 x86-64, aarch64, armv7l   ~2024-07 (`End of life <https://wiki.debian.org/DebianReleases#Production_Releases>`__)
+Debian 12 Bookworm                 x86-64, aarch64, armv7l   ~2026-09 (`End of life <https://wiki.debian.org/DebianReleases#Production_Releases>`__)
 Fedora Linux 37                    x86-64, aarch64           2023-11-14 (`End of Life <https://docs.fedoraproject.org/en-US/releases/lifecycle/#_maintenance_schedule>`__)
 Fedora Linux 38                    x86-64, aarch64           2024-05-14 (`End of Life <https://docs.fedoraproject.org/en-US/releases/lifecycle/#_maintenance_schedule>`__)
 openSUSE Leap 15.4                 x86-64, aarch64           2023-11-30 (`end of maintenance life cycle <https://en.opensuse.org/Lifetime#openSUSE_Leap>`__)

--- a/redbot/cogs/audio/core/commands/llset.py
+++ b/redbot/cogs/audio/core/commands/llset.py
@@ -51,7 +51,7 @@ class LavalinkSetupCommands(MixinMeta, metaclass=CompositeMetaClass):
         This command shouldn't need to be used most of the time, and is only useful if the host machine has conflicting Java versions.
 
         If changing this make sure that the Java executable you set is supported by Audio.
-        The current supported version is Java 11.
+        The current supported versions are Java 17 and 11.
 
         Enter nothing or "java" to reset it back to default.
         """

--- a/redbot/cogs/audio/core/events/dpy.py
+++ b/redbot/cogs/audio/core/events/dpy.py
@@ -83,7 +83,7 @@ DANGEROUS_COMMANDS = {
         "This command will change the executable path of Java, "
         "this is useful if you have multiple installations of Java and the default one is causing issues. "
         "Please don't change this unless you are certain that the Java version you are specifying is supported by Red. "
-        "The default and supported version is currently Java 11."
+        "The default and supported versions are currently Java 17 and 11."
     ),
     "command_llset_heapsize": _(
         "This command will change the maximum RAM allocation for the managed Lavalink node, "

--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -365,20 +365,19 @@ class ServerManager:
             raise UnsupportedJavaException(
                 await replace_p_with_prefix(
                     self.cog.bot,
-                    f"The managed Lavalink node requires Java 11 to run{extras};\n"
-                    "Either install version 11 and restart the bot or connect to an external Lavalink node "
+                    f"The managed Lavalink node requires Java 17 or 11 to run{extras};\n"
+                    "Either install version 17 (or 11) and restart the bot or connect to an external Lavalink node "
                     "(https://docs.discord.red/en/stable/install_guides/index.html)\n"
-                    "If you already have Java 11 installed then then you will need to specify the executable path, "
-                    "use '[p]llset java' to set the correct Java 11 executable.",
+                    "If you already have Java 17 or 11 installed then then you will need to specify the executable path, "
+                    "use '[p]llset java' to set the correct Java 17 or 11 executable.",
                 )  # TODO: Replace with Audio docs when they are out
             )
         java_xms, java_xmx = list((await self._config.java.all()).values())
         match = re.match(r"^(\d+)([MG])$", java_xmx, flags=re.IGNORECASE)
-        command_args = [
-            self._java_exc,
-            "-Djdk.tls.client.protocols=TLSv1.2",
-            f"-Xms{java_xms}",
-        ]
+        command_args = [self._java_exc]
+        if self._java_version[0] < 12:
+            command_args.append("-Djdk.tls.client.protocols=TLSv1.2")
+        command_args.append(f"-Xms{java_xms}")
         meta = 0, None
         invalid = None
         if match and (
@@ -408,7 +407,7 @@ class ServerManager:
             self._java_version = None
         else:
             self._java_version = await self._get_java_version()
-            self._java_available = (11, 0) <= self._java_version < (12, 0)
+            self._java_available = self._java_version[0] in (11, 17)
             self._java_exc = java_exec
         return self._java_available, self._java_version
 


### PR DESCRIPTION
### Description of the changes

Also adds Debian 12 install guide since it doesn't have Java 11.

### Have the changes in this PR been tested?

Yes

Install tests can be found here:
https://cirrus-ci.com/build/4950515914637312
https://github.com/Jackenmen/Red-Install-Tests/actions/runs/5300865214