### PR TITLE
[Cleanup] Fix `[p]cleanup self` inside DMs

### DIFF
--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -148,7 +148,7 @@ class Cleanup(commands.Cog):
         """
         Sends a notification to the channel that a certain number of messages have been deleted.
         """
-        if not hasattr(channel, "guild") or await self.config.guild(channel.guild).notify():
+        if not getattr(channel, "guild", None) or await self.config.guild(channel.guild).notify():
             if subtract_invoking:
                 num -= 1
             if num == 1:

--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -148,7 +148,7 @@ class Cleanup(commands.Cog):
         """
         Sends a notification to the channel that a certain number of messages have been deleted.
         """
-        if not getattr(channel, "guild", None) or await self.config.guild(channel.guild).notify():
+        if not channel.guild or await self.config.guild(channel.guild).notify():
             if subtract_invoking:
                 num -= 1
             if num == 1:


### PR DESCRIPTION
### Description of the changes

This should fix `[p]cleanup self` in DMs, `getattr` should be used instead of `hasattr`, as all of the channel types in the union have a guild attribute which needs to be checked.

Fixes #6196 

### Have the changes in this PR been tested?

No