### PR TITLE
Allow humanize_timedelta to parse negative timedeltas

### DIFF
--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -519,7 +519,10 @@ def format_perms_list(perms: discord.Permissions) -> str:
 
 
 def humanize_timedelta(
-    *, timedelta: Optional[datetime.timedelta] = None, seconds: Optional[SupportsInt] = None
+    *,
+    timedelta: Optional[datetime.timedelta] = None,
+    seconds: Optional[SupportsInt] = None,
+    negative_unit: Optional[str] = None,
 ) -> str:
     """
     Get a locale aware human timedelta representation.
@@ -535,6 +538,10 @@ def humanize_timedelta(
         A timedelta object
     seconds: Optional[SupportsInt]
         A number of seconds
+    negative_unit: Optional[str]
+        What to use in instances of negative timedeltas.
+        This is mainly used if you want to use `-` instead of the
+        word "negative"
 
     Returns
     -------
@@ -561,7 +568,12 @@ def humanize_timedelta(
         (_("minute"), _("minutes"), 60),
         (_("second"), _("seconds"), 1),
     ]
-
+    negative = ""
+    if seconds < 0:
+        seconds = -1 * seconds
+        negative = _("negative ")
+    if negative_unit is not None:
+        negative = negative_unit
     strings = []
     for period_name, plural_period_name, period_seconds in periods:
         if seconds >= period_seconds:
@@ -571,7 +583,7 @@ def humanize_timedelta(
             unit = plural_period_name if period_value > 1 else period_name
             strings.append(f"{period_value} {unit}")
 
-    return ", ".join(strings)
+    return negative + ", ".join(strings)
 
 
 def humanize_number(val: Union[int, float], override_locale=None) -> str:

--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -540,7 +540,7 @@ def humanize_timedelta(
         A number of seconds
     negative_unit: Optional[str]
         What to use in instances of negative timedeltas.
-        This is mainly used if you want to use `-` instead of the
+        This is mainly used if you want to use "-" instead of the
         word "negative"
 
     Returns

--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -572,8 +572,8 @@ def humanize_timedelta(
     if seconds < 0:
         seconds = -1 * seconds
         negative = _("negative ")
-    if negative_unit is not None:
-        negative = negative_unit
+        if negative_unit is not None:
+            negative = negative_unit
     strings = []
     for period_name, plural_period_name, period_seconds in periods:
         if seconds >= period_seconds:


### PR DESCRIPTION
### Description of the changes
This allows humanize_timedelta to still return something if the delta is in the negatives. A bit of a niche use case but I did encounter it since the default str representation of timedeltas isn't great. 

This adds a new kwarg on humanize_timedelta if you want to explicitly pass `-` or some other string to represent a negative timedelta. By default this will return `negative 5 hours` as an example.


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
