### PR TITLE
Fix CancelledError handling in done callbacks of cog init tasks

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -98,14 +98,19 @@ class Downloader(commands.Cog):
 
     def create_init_task(self):
         def _done_callback(task: asyncio.Task) -> None:
-            exc = task.exception()
-            if exc is not None:
+            try:
+                exc = task.exception()
+            except asyncio.CancelledError:
+                pass
+            else:
+                if exc is None:
+                    return
                 log.error(
                     "An unexpected error occurred during Downloader's initialization.",
                     exc_info=exc,
                 )
-                self._ready_raised = True
-                self._ready.set()
+            self._ready_raised = True
+            self._ready.set()
 
         self._init_task = asyncio.create_task(self.initialize())
         self._init_task.add_done_callback(_done_callback)

--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -117,14 +117,19 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
 
     def create_init_task(self) -> None:
         def _done_callback(task: asyncio.Task) -> None:
-            exc = task.exception()
-            if exc is not None:
+            try:
+                exc = task.exception()
+            except asyncio.CancelledError:
+                pass
+            else:
+                if exc is None:
+                    return
                 log.error(
                     "An unexpected error occurred during Mutes's initialization.",
                     exc_info=exc,
                 )
-                self._ready_raised = True
-                self._ready.set()
+            self._ready_raised = True
+            self._ready.set()
 
         self._init_task = asyncio.create_task(self.initialize())
         self._init_task.add_done_callback(_done_callback)


### PR DESCRIPTION
### Description of the changes

Stops the done callback from raising on `CancelledError`, returning silently instead.

### Have the changes in this PR been tested?

Yes

