### PR TITLE
Indicate when a core cog is overridden in [p]cogs and debuginfo

### DIFF
--- a/redbot/core/_cog_manager.py
+++ b/redbot/core/_cog_manager.py
@@ -2,9 +2,9 @@ import contextlib
 import keyword
 import pkgutil
 from importlib import import_module, invalidate_caches
-from importlib.machinery import ModuleSpec
+from importlib.machinery import FileFinder, ModuleSpec
 from pathlib import Path
-from typing import Union, List, Optional
+from typing import Union, List, Optional, Tuple
 
 import redbot.cogs
 from redbot.core.commands import positive_int
@@ -288,15 +288,37 @@ class CogManager:
         with contextlib.suppress(NoSuchCog):
             return await self._find_core_cog(name)
 
-    async def available_modules(self) -> List[str]:
-        """Finds the names of all available modules to load."""
-        paths = list(map(str, await self.paths()))
-
-        ret = []
+    def _iter_cogs(self, paths: List[str]) -> List[Tuple[str, bool]]:
+        """Find the names of all available cogs to load from given paths."""
         for finder, module_name, _ in pkgutil.iter_modules(paths):
             # reject package names that can't be valid python identifiers
             if module_name.isidentifier() and not keyword.iskeyword(module_name):
-                ret.append(module_name)
+                yield finder, module_name
+
+    def available_core_cogs(self) -> List[str]:
+        """Find the names of all available core cogs to load."""
+        return [module_name for _, module_name in self._iter_cogs([self.CORE_PATH])]
+
+    async def available_cogs(self) -> List[Tuple[str, bool]]:
+        """
+        Find the names of all available cog packages to load.
+
+        Includes info about whether the cog would be loaded from a core path.
+
+        Returns
+        -------
+        List[Tuple[str, bool]]
+            A list of (str, bool) pairs where the first item is the cog package name
+            and the second item is a bool indicating whether the cog would be loaded
+            from a core path.
+        """
+        paths = list(map(str, await self.paths()))
+
+        ret = []
+        core_path = str(self.CORE_PATH)
+        for finder, module_name in self._iter_cogs(paths):
+            is_from_core_path = isinstance(finder, FileFinder) and finder.path == core_path
+            ret.append((module_name, is_from_core_path))
         return ret
 
     @staticmethod
@@ -456,12 +478,18 @@ class CogManagerUI(commands.Cog):
         """
         loaded = set(ctx.bot.extensions.keys())
 
-        all_cogs = set(await ctx.bot._cog_mgr.available_modules())
+        core_cogs = set(ctx.bot._cog_mgr.available_core_cogs())
+        all_cogs = set()
+        overridden_core_cogs = set()
+        for cog_name, is_from_core_path in await ctx.bot._cog_mgr.available_cogs():
+            all_cogs.add(cog_name)
+            if not is_from_core_path and cog_name in core_cogs:
+                overridden_core_cogs.add(cog_name)
 
         unloaded = all_cogs - loaded
 
-        loaded = sorted(list(loaded), key=str.lower)
-        unloaded = sorted(list(unloaded), key=str.lower)
+        loaded = sorted(loaded, key=str.lower)
+        unloaded = sorted(unloaded, key=str.lower)
 
         if await ctx.embed_requested():
             loaded = _("**{} loaded:**\n").format(len(loaded)) + ", ".join(loaded)

--- a/redbot/core/_debuginfo.py
+++ b/redbot/core/_debuginfo.py
@@ -165,6 +165,12 @@ class DebugInfo:
             # and calling repr() on prefix strings ensures that the list isn't ambiguous.
             prefixes = ", ".join(map(repr, await self.bot._config.prefix()))
             parts.append(f"Global prefix(es): {prefixes}")
+            core_cogs = set(self.bot._cog_mgr.available_core_cogs())
+            overridden_core_cogs = set()
+            for cog_name, is_from_core_path in await self.bot._cog_mgr.available_cogs():
+                if not is_from_core_path and cog_name in core_cogs:
+                    overridden_core_cogs.add(cog_name)
+            parts.append(f"Overridden core cogs: {', '.join(overridden_core_cogs) or 'None'}")
 
         if self.is_logged_in:
             owners = []


### PR DESCRIPTION
### Description of the changes

Since core cogs can be overridden by 3rd-party cogs, this PR adds information about which cogs are overridden to debug info *and* provides the base implementation for `[p]cogs` to build on top on for @aikaterna who said that she could do the UX part. The UX isn't part of my interest here but I'll just mention that the two options that were brought up are:
- the third section that shows only when there are any overridden cogs
- different formatting (bold/italics/etc.) for the overridden cogs in the loaded and unloaded sections
	- this may prove a bit more difficult for the non-embed variant of the command

In both of these cases, it would be important that the user can clearly tell what this is so either the section title or additional footer with a properly worded sentence explaining it would be needed.

### Have the changes in this PR been tested?

Yes

