### PR TITLE
Improve unreleased Command.is_enabled() and document related methods

### DIFF
--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -461,11 +461,32 @@ class Command(CogCommandMixin, DPYCommand):
             if not change_permission_state:
                 ctx.permission_state = original_state
 
-    def is_enabled(self, ctx) -> bool:
+    def is_enabled(self, guild: Optional[discord.abc.Snowflake] = None) -> bool:
+        """
+        Check if the command is enabled globally or in a guild.
+
+        When guild is provided, this method checks whether
+        the command is enabled both globally and in the guild.
+
+        This is generally set by the settings managed with
+        the ``[p]command enable/disable global/server`` commands.
+
+        Parameters
+        ----------
+        guild : discord.abc.Snowflake, optional
+            The guild to check that the command is enabled in.
+            If this is ``None``, this will check whether
+            the command is enabled globally.
+
+        Returns
+        -------
+        bool
+            ``True`` if the command is enabled.
+        """
         if not self.enabled:
             return False
-        if ctx.guild:
-            if self._disabled_in.has(ctx.guild.id):
+        if guild is not None:
+            if self._disabled_in.has(guild.id):
                 return False
 
         return True
@@ -473,7 +494,7 @@ class Command(CogCommandMixin, DPYCommand):
     async def prepare(self, ctx, /):
         ctx.command = self
 
-        cmd_enabled = self.is_enabled(ctx)
+        cmd_enabled = self.is_enabled(ctx.guild)
         if not cmd_enabled:
             raise DisabledCommand(f"{self.name} command is disabled")
 
@@ -530,7 +551,15 @@ class Command(CogCommandMixin, DPYCommand):
         return True
 
     def disable_in(self, guild: discord.Guild) -> bool:
-        """Disable this command in the given guild.
+        """
+        Disable this command in the given guild.
+
+        This is generally called by the settings managed with
+        the ``[p]command disable global/server`` commands and
+        any changes made outside of that will not persist after cog
+        reload and may also be affected when either of those commands
+        is called on this command. It is not recommended to rely on
+        this method, if you want a consistent behavior.
 
         Parameters
         ----------
@@ -541,7 +570,6 @@ class Command(CogCommandMixin, DPYCommand):
         -------
         bool
             ``True`` if the command wasn't already disabled.
-
         """
         if self._disabled_in.has(guild.id):
             return False
@@ -552,6 +580,13 @@ class Command(CogCommandMixin, DPYCommand):
     def enable_in(self, guild: discord.Guild) -> bool:
         """Enable this command in the given guild.
 
+        This is generally called by the settings managed with
+        the ``[p]command disable global/server`` commands and
+        any changes made outside of that will not persist after cog
+        reload and may also be affected when either of those commands
+        is called on this command. It is not recommended to rely on
+        this method, if you want a consistent behavior.
+
         Parameters
         ----------
         guild : discord.Guild
@@ -561,7 +596,6 @@ class Command(CogCommandMixin, DPYCommand):
         -------
         bool
             ``True`` if the command wasn't already enabled.
-
         """
         try:
             self._disabled_in.remove(guild.id)

--- a/redbot/core/commands/commands.py
+++ b/redbot/core/commands/commands.py
@@ -555,8 +555,8 @@ class Command(CogCommandMixin, DPYCommand):
         Disable this command in the given guild.
 
         This is generally called by the settings managed with
-        the ``[p]command disable global/server`` commands and
-        any changes made outside of that will not persist after cog
+        the ``[p]command disable global/server`` commands.
+        Any changes made outside of that will not persist after cog
         reload and may also be affected when either of those commands
         is called on this command. It is not recommended to rely on
         this method, if you want a consistent behavior.
@@ -581,8 +581,8 @@ class Command(CogCommandMixin, DPYCommand):
         """Enable this command in the given guild.
 
         This is generally called by the settings managed with
-        the ``[p]command disable global/server`` commands and
-        any changes made outside of that will not persist after cog
+        the ``[p]command disable global/server`` commands.
+        Any changes made outside of that will not persist after cog
         reload and may also be affected when either of those commands
         is called on this command. It is not recommended to rely on
         this method, if you want a consistent behavior.


### PR DESCRIPTION
### Description of the changes

Changes the unreleased `Command.is_enabled()` method (see #5552 where that was introduced) to have a more reasonable public API. I also added documentation to this method and some additional preservations to `Command.disable/enable_in()` methods. The public aspect of this API was not touched on during the previous review which means that we would be intentionally exposing an API we did not intend to. This means that this PR should be considered a release blocker.

This resolves #4130 and closes #5001. Note that these methods are named opposite than in both of mentioned issues - `is_enabled()` instead of `is_disabled()`. I'm not necessarily sure that I prefer it but it is consistent with the existing `enabled` attribute so it probably makes more sense this way.

### Have the changes in this PR been tested?

Yes

