### PR TITLE
Fix local search's issue with bad escapes causing non-local playback

### DIFF
--- a/redbot/cogs/audio/core/utilities/local_tracks.py
+++ b/redbot/cogs/audio/core/utilities/local_tracks.py
@@ -122,7 +122,7 @@ class LocalTrackUtilities(MixinMeta, metaclass=CompositeMetaClass):
             if percent_match > 85:
                 search_list.extend(
                     [
-                        discord.utils.escape_markdown(i.to_string_user())
+                        i.to_string_user()
                         for i in to_search
                         if i.local_track_path is not None
                         and i.local_track_path.name == track_match


### PR DESCRIPTION
### Description of the changes

Fixes wrong rendering caused by escaping markdown in a place where there's no need to - output of `_build_local_search_list()` is passed to `command_search` which already always aims to escape the track names/artists. By extension, this also fixes `[p]local search` queuing tracks to play from YT due to file paths not matching.

### Have the changes in this PR been tested?

Yes
