### PR TITLE
Fix poor fuzzy results due to changes in rapidfuzz 3.0

### DIFF
--- a/redbot/cogs/audio/core/utilities/local_tracks.py
+++ b/redbot/cogs/audio/core/utilities/local_tracks.py
@@ -7,7 +7,7 @@ import discord
 import lavalink
 from red_commons.logging import getLogger
 
-from rapidfuzz import process
+import rapidfuzz
 from redbot.core import commands
 from redbot.core.i18n import Translator
 from redbot.core.utils import AsyncIter
@@ -116,7 +116,9 @@ class LocalTrackUtilities(MixinMeta, metaclass=CompositeMetaClass):
         to_search_string = {
             i.local_track_path.name for i in to_search if i.local_track_path is not None
         }
-        search_results = process.extract(search_words, to_search_string, limit=50)
+        search_results = rapidfuzz.process.extract(
+            search_words, to_search_string, limit=50, processor=rapidfuzz.utils.default_process
+        )
         search_list = []
         async for track_match, percent_match, __ in AsyncIter(search_results):
             if percent_match > 85:

--- a/redbot/cogs/audio/core/utilities/queue.py
+++ b/redbot/cogs/audio/core/utilities/queue.py
@@ -7,7 +7,7 @@ import discord
 import lavalink
 from red_commons.logging import getLogger
 
-from rapidfuzz import process
+import rapidfuzz
 from redbot.core import commands
 from redbot.core.i18n import Translator
 from redbot.core.utils import AsyncIter
@@ -132,7 +132,9 @@ class QueueUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 track_title = track.title
 
             tracks[queue_idx] = track_title
-        search_results = process.extract(search_words, tracks, limit=50)
+        search_results = rapidfuzz.process.extract(
+            search_words, tracks, limit=50, processor=rapidfuzz.utils.default_process
+        )
         search_list = []
         async for title, percent_match, queue_position in AsyncIter(search_results):
             if percent_match > 89:

--- a/redbot/cogs/customcom/customcom.py
+++ b/redbot/cogs/customcom/customcom.py
@@ -6,7 +6,7 @@ from typing import Iterable, List, Mapping, Tuple, Dict, Set, Literal, Union
 from urllib.parse import quote_plus
 
 import discord
-from rapidfuzz import process
+import rapidfuzz
 
 from redbot.core import Config, commands
 from redbot.core.commands import Parameter
@@ -324,7 +324,9 @@ class CustomCommands(commands.Cog):
         - `<query>` The query to search for. Can be multiple words.
         """
         cc_commands = await CommandObj.get_commands(self.config.guild(ctx.guild))
-        extracted = process.extract(query, list(cc_commands.keys()))
+        extracted = rapidfuzz.process.extract(
+            query, list(cc_commands.keys()), processor=rapidfuzz.utils.default_process
+        )
         accepted = []
         for key, score, __ in extracted:
             if score > 60:

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -32,7 +32,7 @@ from typing import (
 import aiohttp
 import discord
 from packaging.requirements import Requirement
-from rapidfuzz import fuzz, process
+import rapidfuzz
 from rich.progress import ProgressColumn
 from rich.progress_bar import ProgressBar
 from red_commons.logging import VERBOSE, TRACE
@@ -154,7 +154,13 @@ async def fuzzy_command_search(
         choices = {c: c.qualified_name for c in commands}
 
     # Do the scoring. `extracted` is a list of tuples in the form `(cmd_name, score, cmd)`
-    extracted = process.extract(term, choices, limit=5, scorer=fuzz.QRatio)
+    extracted = rapidfuzz.process.extract(
+        term,
+        choices,
+        limit=5,
+        scorer=rapidfuzz.fuzz.QRatio,
+        processor=rapidfuzz.utils.default_process,
+    )
     if not extracted:
         return None
 


### PR DESCRIPTION
### Description of the changes

I missed this notable regression caused by the lack of ANY pre-processing being done on strings in rapidfuzz 3.0 that I upgraded us to in #6100. This PR simply updates our usage of rapidfuzz to use the `rapidfuzz.utils.default_process()` function that preprocesses strings in the same way that rapidfuzz < 3 did *and* fuzzywuzzy/thefuzz do *by default*. This should close the gap that I accidentally created between 3.4.19 and 3.5.0.

### Have the changes in this PR been tested?

Yes
