### PR TITLE
Add custom status support

### DIFF
--- a/docs/cog_guides/core.rst
+++ b/docs/cog_guides/core.rst
@@ -3769,6 +3769,35 @@ Maximum length for a competing status is 128 characters.
 **Arguments:**
     - ``[competing]`` - The text to follow ``Competing in``. Leave blank to clear the current activity status.
 
+.. _core-command-set-status-custom:
+
+""""""""""""""""""""
+set status custom
+""""""""""""""""""""
+
+.. note:: |owner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]set status custom [text]
+
+**Description**
+
+Sets Red's custom status.
+
+This will appear as ``<text>``.
+
+Maximum length for a custom status is 128 characters.
+
+**Examples:**
+    - ``[p]set status custom`` - Clears the activity status.
+    - ``[p]set status custom Running cogs...``
+
+**Arguments:**
+    - ``[text]`` - The custom status text. Leave blank to clear the current activity status.
+
 .. _core-command-set-status-dnd:
 
 """"""""""""""

--- a/docs/cog_guides/core.rst
+++ b/docs/cog_guides/core.rst
@@ -3771,9 +3771,9 @@ Maximum length for a competing status is 128 characters.
 
 .. _core-command-set-status-custom:
 
-""""""""""""""""""""
+"""""""""""""""""
 set status custom
-""""""""""""""""""""
+"""""""""""""""""
 
 .. note:: |owner-lock|
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3213,7 +3213,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     async def _set_status_custom(self, ctx: commands.Context, *, text: str = None):
         """Sets [botname]'s custom status.
 
-        This will appear as `<name>`.
+        This will appear as `<text>`.
 
         Maximum length for a custom status is 128 characters.
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3210,7 +3210,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @_set_status.command(name="custom")
     @commands.bot_in_a_guild()
     @commands.is_owner()
-    async def _set_status_custom(self, ctx: commands.Context, *, name: str = None):
+    async def _set_status_custom(self, ctx: commands.Context, *, text: str = None):
         """Sets [botname]'s custom status.
 
         This will appear as `<name>`.
@@ -3222,20 +3222,20 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         - `[p]set status custom Running cogs...`
 
         **Arguments:**
-        - `[custom]` - The custom status text. Leave blank to clear the current activity status.
+        - `[text]` - The custom status text. Leave blank to clear the current activity status.
         """
 
         status = ctx.bot.guilds[0].me.status if len(ctx.bot.guilds) > 0 else discord.Status.online
-        if name:
-            if len(name) > 128:
+        if text:
+            if len(text) > 128:
                 await ctx.send(_("The maximum length of custom statuses is 128 characters."))
                 return
-            activity = discord.Activity(name=name, state=name, type=discord.ActivityType.custom)
+            activity = discord.Activity(name=text, state=text, type=discord.ActivityType.custom)
         else:
             activity = None
         await ctx.bot.change_presence(status=status, activity=activity)
         if activity:
-            await ctx.send(_("Custom status set to `{name}`.").format(name=name))
+            await ctx.send(_("Custom status set to `{text}`.").format(text=text))
         else:
             await ctx.send(_("Custom status cleared."))
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3233,18 +3233,14 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         status = ctx.bot.guilds[0].me.status if len(ctx.bot.guilds) > 0 else discord.Status.online
         if name:
             if len(name) > 128:
-                await ctx.send(
-                    _("The maximum length of custom descriptions is 128 characters.")
-                )
+                await ctx.send(_("The maximum length of custom statuses is 128 characters."))
                 return
             activity = discord.Activity(name=name, state=name, type=discord.ActivityType.custom)
         else:
             activity = None
         await ctx.bot.change_presence(status=status, activity=activity)
         if activity:
-            await ctx.send(
-                _("Status set to `{name}`.").format(name=name)
-            )
+            await ctx.send(_("Custom status set to `{name}`.").format(name=name))
         else:
             await ctx.send(_("Custom status cleared."))
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3212,6 +3212,47 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         await ctx.bot.change_presence(status=status, activity=game)
         return await ctx.send(_("Status changed to {}.").format(status))
 
+    @_set_status.command(name="custom")
+    @commands.bot_in_a_guild()
+    @commands.is_owner()
+    async def _set_status_custom(self, ctx: commands.Context, *, name: str = None):
+        """Sets [botname]'s custom status.
+
+        This will appear as `<name>`.
+
+        Maximum length for a custom status is 128 characters.
+
+        **Examples:**
+        - `[p]set status custom` - Clears the activity status.
+        - `[p]set status custom Running cogs...`
+
+        **Arguments:**
+        - `[custom]` - The custom status text. Leave blank to clear the current activity status.
+        """
+
+        status = ctx.bot.guilds[0].me.status if len(ctx.bot.guilds) > 0 else discord.Status.online
+        if name:
+            if len(name) > 128:
+                await ctx.send(
+                    _("The maximum length of custom descriptions is 128 characters.")
+                )
+                return
+            activity = discord.Activity(name=name, state=name, type=discord.ActivityType.custom)
+        else:
+            activity = None
+        await ctx.bot.change_presence(status=status, activity=activity)
+        if activity:
+            await ctx.send(
+                _("Status set to `{name}`.").format(name=name)
+            )
+        else:
+            await ctx.send(_("Custom status cleared."))
+
+    async def _set_my_status(self, ctx: commands.Context, status: discord.Status):
+        game = ctx.bot.guilds[0].me.activity if len(ctx.bot.guilds) > 0 else None
+        await ctx.bot.change_presence(status=status, activity=game)
+        return await ctx.send(_("Status changed to {}.").format(status))
+
     @_set_status.command(name="online")
     @commands.bot_in_a_guild()
     @commands.is_owner()

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3207,11 +3207,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             await ctx.send(_("Competing cleared."))
 
-    async def _set_my_status(self, ctx: commands.Context, status: discord.Status):
-        game = ctx.bot.guilds[0].me.activity if len(ctx.bot.guilds) > 0 else None
-        await ctx.bot.change_presence(status=status, activity=game)
-        return await ctx.send(_("Status changed to {}.").format(status))
-
     @_set_status.command(name="custom")
     @commands.bot_in_a_guild()
     @commands.is_owner()


### PR DESCRIPTION
### Description of the changes

This PR adds support for custom status in `[p]set status` command group.
Custom status for bots are now supported since August 8th 2023 https://github.com/discord/discord-api-docs/pull/6345.

### Have the changes in this PR been tested?

Yes.
