### PR TITLE
Make use of dpy commands.Range on set status commands

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3202,7 +3202,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @_set_status.command(name="custom")
     @commands.bot_in_a_guild()
     @commands.is_owner()
-    async def _set_status_custom(self, ctx: commands.Context, *, text: commands.Range[str, 1, 128] = None):
+    async def _set_status_custom(
+        self, ctx: commands.Context, *, text: commands.Range[str, 1, 128] = None
+    ):
         """Sets [botname]'s custom status.
 
         This will appear as `<text>`.

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3035,7 +3035,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     async def _set_status_stream(
         self,
         ctx: commands.Context,
-        streamer: commands.Range[str, 1, 511] = None,
+        streamer: commands.Range[str, 1, 489] = None,
         *,
         stream_title: commands.Range[str, 1, 128] = None,
     ):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3202,7 +3202,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @_set_status.command(name="custom")
     @commands.bot_in_a_guild()
     @commands.is_owner()
-    async def _set_status_custom(self, ctx: commands.Context, *, text: str = None):
+    async def _set_status_custom(self, ctx: commands.Context, *, text: commands.Range[str, 1, 128] = None):
         """Sets [botname]'s custom status.
 
         This will appear as `<text>`.
@@ -3219,9 +3219,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         status = ctx.bot.guilds[0].me.status if len(ctx.bot.guilds) > 0 else discord.Status.online
         if text:
-            if len(text) > 128:
-                await ctx.send(_("The maximum length of custom statuses is 128 characters."))
-                return
             activity = discord.Activity(name=text, state=text, type=discord.ActivityType.custom)
         else:
             activity = None

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3032,7 +3032,13 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     )
     @commands.bot_in_a_guild()
     @commands.is_owner()
-    async def _set_status_stream(self, ctx: commands.Context, streamer=None, *, stream_title=None):
+    async def _set_status_stream(
+        self,
+        ctx: commands.Context,
+        streamer: str = None,
+        *,
+        stream_title: commands.Range[str, 1, 128] = None,
+    ):
         """Sets [botname]'s streaming status to a twitch stream.
 
         This will appear as `Streaming <stream_title>` or `LIVE ON TWITCH` depending on the context.
@@ -3074,7 +3080,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @_set_status.command(name="playing", aliases=["game"])
     @commands.bot_in_a_guild()
     @commands.is_owner()
-    async def _set_status_game(self, ctx: commands.Context, *, game: str = None):
+    async def _set_status_game(
+        self, ctx: commands.Context, *, game: commands.Range[str, 1, 128] = None
+    ):
         """Sets [botname]'s playing status.
 
         This will appear as `Playing <game>` or `PLAYING A GAME: <game>` depending on the context.
@@ -3106,7 +3114,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @_set_status.command(name="listening")
     @commands.bot_in_a_guild()
     @commands.is_owner()
-    async def _set_status_listening(self, ctx: commands.Context, *, listening: str = None):
+    async def _set_status_listening(
+        self, ctx: commands.Context, *, listening: commands.Range[str, 1, 128] = None
+    ):
         """Sets [botname]'s listening status.
 
         This will appear as `Listening to <listening>`.
@@ -3142,7 +3152,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @_set_status.command(name="watching")
     @commands.bot_in_a_guild()
     @commands.is_owner()
-    async def _set_status_watching(self, ctx: commands.Context, *, watching: str = None):
+    async def _set_status_watching(
+        self, ctx: commands.Context, *, watching: commands.Range[str, 1, 128] = None
+    ):
         """Sets [botname]'s watching status.
 
         This will appear as `Watching <watching>`.
@@ -3174,7 +3186,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     @_set_status.command(name="competing")
     @commands.bot_in_a_guild()
     @commands.is_owner()
-    async def _set_status_competing(self, ctx: commands.Context, *, competing: str = None):
+    async def _set_status_competing(
+        self, ctx: commands.Context, *, competing: commands.Range[str, 1, 128] = None
+    ):
         """Sets [botname]'s competing status.
 
         This will appear as `Competing in <competing>`.

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3035,7 +3035,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
     async def _set_status_stream(
         self,
         ctx: commands.Context,
-        streamer: str = None,
+        streamer: commands.Range[str, 1, 511] = None,
         *,
         stream_title: commands.Range[str, 1, 128] = None,
     ):
@@ -3062,12 +3062,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             stream_title = stream_title.strip()
             if "twitch.tv/" not in streamer:
                 streamer = "https://www.twitch.tv/" + streamer
-            if len(streamer) > 511:
-                await ctx.send(_("The maximum length of the streamer url is 511 characters."))
-                return
-            if len(stream_title) > 128:
-                await ctx.send(_("The maximum length of the stream title is 128 characters."))
-                return
             activity = discord.Streaming(url=streamer, name=stream_title)
             await ctx.bot.change_presence(status=status, activity=activity)
         elif streamer is not None:
@@ -3098,9 +3092,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """
 
         if game:
-            if len(game) > 128:
-                await ctx.send(_("The maximum length of game descriptions is 128 characters."))
-                return
             game = discord.Game(name=game)
         else:
             game = None
@@ -3133,11 +3124,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         status = ctx.bot.guilds[0].me.status if len(ctx.bot.guilds) > 0 else discord.Status.online
         if listening:
-            if len(listening) > 128:
-                await ctx.send(
-                    _("The maximum length of listening descriptions is 128 characters.")
-                )
-                return
             activity = discord.Activity(name=listening, type=discord.ActivityType.listening)
         else:
             activity = None
@@ -3171,9 +3157,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         status = ctx.bot.guilds[0].me.status if len(ctx.bot.guilds) > 0 else discord.Status.online
         if watching:
-            if len(watching) > 128:
-                await ctx.send(_("The maximum length of watching descriptions is 128 characters."))
-                return
             activity = discord.Activity(name=watching, type=discord.ActivityType.watching)
         else:
             activity = None
@@ -3205,11 +3188,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         status = ctx.bot.guilds[0].me.status if len(ctx.bot.guilds) > 0 else discord.Status.online
         if competing:
-            if len(competing) > 128:
-                await ctx.send(
-                    _("The maximum length of competing descriptions is 128 characters.")
-                )
-                return
             activity = discord.Activity(name=competing, type=discord.ActivityType.competing)
         else:
             activity = None


### PR DESCRIPTION
### Description of the changes

This PR make uses `commands.Range` for maximum length of `[p]set status` commands.

### Have the changes in this PR been tested?

Yes
