### PR TITLE
Fix http errors for interaction deferring and message changes

### DIFF
--- a/redbot/core/utils/menus.py
+++ b/redbot/core/utils/menus.py
@@ -37,6 +37,7 @@ class _GenericButton(discord.ui.Button):
         self.func = func
 
     async def callback(self, interaction: discord.Interaction):
+        await interaction.response.defer()
         ctx = self.view.ctx
         pages = self.view.source.entries
         controls = None
@@ -52,7 +53,6 @@ class _GenericButton(discord.ui.Button):
             await self.func(ctx, pages, controls, message, page, timeout, emoji)
         except Exception:
             pass
-        await interaction.response.defer()
 
 
 async def menu(


### PR DESCRIPTION
### Description of the changes

Moves interaction deferring to the beginning of the generic button (is there a good reason not to? CC: @TrustyJAID) and suppresses HTTP exceptions that may happen on timeout in `SimpleMenu` and `ConfirmView` views when trying to edit/delete a message that no longer exists *or* one that we have no permission to alter.

Fixes #6228 

### Have the changes in this PR been tested?

Yes
