### PR TITLE
Fix Picarto channel avatar in Streams cog

### DIFF
--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -487,9 +487,7 @@ class PicartoStream(Stream):
             raise APIError(r.status, data)
 
     def make_embed(self, data):
-        avatar = rnd(
-            "https://picarto.tv/user_data/usrimg/{}/dsdefault.jpg".format(data["name"].lower())
-        )
+        avatar = rnd(data["avatar"])
         url = "https://picarto.tv/" + data["name"]
         thumbnail = data["thumbnails"]["web"]
         embed = discord.Embed(title=data["title"], url=url, color=0x4C90F3)


### PR DESCRIPTION
### Description of the changes

Fixes the thumbnail in embeds for Picarto channels starting a stream.
This PR gets the avatar URL from the `avatar` field in the returned data, instead of trying to make our own URL.

### Have the changes in this PR been tested?

No
