### PR TITLE
Remove type-breaking annotation on cog_i18n decorator

### DIFF
--- a/redbot/core/i18n.py
+++ b/redbot/core/i18n.py
@@ -8,7 +8,7 @@ import logging
 import discord
 
 from pathlib import Path
-from typing import Callable, TYPE_CHECKING, Union, Dict, Optional
+from typing import Callable, TYPE_CHECKING, Union, Dict, Optional, TypeVar
 from contextvars import ContextVar
 
 import babel.localedata
@@ -358,11 +358,13 @@ def get_babel_regional_format(regional_format: Optional[str] = None) -> babel.co
 # noinspection PyPep8
 from . import commands
 
+_TypeT = TypeVar("_TypeT", bound=type)
+
 
 def cog_i18n(translator: Translator):
     """Get a class decorator to link the translator to this cog."""
 
-    def decorator(cog_class):
+    def decorator(cog_class: _TypeT):
         cog_class.__translator__ = translator
         for name, attr in cog_class.__dict__.items():
             if isinstance(attr, (commands.Group, commands.Command)):

--- a/redbot/core/i18n.py
+++ b/redbot/core/i18n.py
@@ -361,10 +361,10 @@ from . import commands
 _TypeT = TypeVar("_TypeT", bound=type)
 
 
-def cog_i18n(translator: Translator):
+def cog_i18n(translator: Translator) -> Callable[[_TypeT], _TypeT]:
     """Get a class decorator to link the translator to this cog."""
 
-    def decorator(cog_class: _TypeT):
+    def decorator(cog_class: _TypeT) -> _TypeT:
         cog_class.__translator__ = translator
         for name, attr in cog_class.__dict__.items():
             if isinstance(attr, (commands.Group, commands.Command)):

--- a/redbot/core/i18n.py
+++ b/redbot/core/i18n.py
@@ -362,7 +362,7 @@ from . import commands
 def cog_i18n(translator: Translator):
     """Get a class decorator to link the translator to this cog."""
 
-    def decorator(cog_class: type):
+    def decorator(cog_class):
         cog_class.__translator__ = translator
         for name, attr in cog_class.__dict__.items():
             if isinstance(attr, (commands.Group, commands.Command)):


### PR DESCRIPTION
### Description of the changes

This `type` annotation voids all typing when using this decorator, thus all instances and explicit typing of the class would be interpreted as `type` by linters.

It was replaced by a TypeVar, preserving the original type.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
