### PR TITLE
Fix `[p]diagnoseissues` edge case for commands without a cog

### DIFF
--- a/redbot/core/_diagnoser.py
+++ b/redbot/core/_diagnoser.py
@@ -485,9 +485,7 @@ class DetailedCommandChecksMixin(IssueDiagnoserBase):
         return await self._check_requires(_("Permissions verification"), self.ctx.command)
 
     async def _check_requires_cog(self) -> CheckResult:
-        label = _("Permissions verification for {cog} cog").format(
-            cog=inline(self.ctx.cog.qualified_name)
-        )
+        label = _("Cog permissions verification")
         if self.ctx.cog is None:
             return CheckResult(True, label)
         return await self._check_requires(label, self.ctx.cog)


### PR DESCRIPTION
### Description of the changes

`ctx.cog` can be `None` for commands without a cog which I do account for in the logic but apparently I forgot to also account for it when making the label. I simply rephrased it such that it doesn't include the cog name.

The issue can be reproduced by adding a global deny rule (through Permissions cog) for the help command for a user (make sure NOT to check on bot owner who can run commands regardless of permissions cog):
```
permissions addglobalrule deny help USER
```

With that setup, running `diagnoseissues USER help` without this PR should cause this uncatched exception:
```
╭─────────────────────────────── Traceback (most recent call last) ───────────────────────────────╮
│ /home/ubuntu/work/Red-DiscordBot/.venv/lib/python3.8/site-packages/discord/ext/commands/core.py │
│ :235 in wrapped                                                                                 │
│ ❱  235             ret = await coro(*args, **kwargs)                                            │
│ /home/ubuntu/work/Red-DiscordBot/redbot/core/core_commands.py:4782 in diagnoseissues            │
│ ❱ 4782         await ctx.send(await issue_diagnoser.diagnose())                                 │
│ /home/ubuntu/work/Red-DiscordBot/redbot/core/_diagnoser.py:959 in diagnose                      │
│ ❱ 959         result = await self._check_until_fail(                                            │
│ /home/ubuntu/work/Red-DiscordBot/redbot/core/_diagnoser.py:84 in _check_until_fail              │
│ ❱  84             check_result = await check()                                                  │
│ /home/ubuntu/work/Red-DiscordBot/redbot/core/_diagnoser.py:908 in _check_can_run_issues         │
│ ❱ 908         return await self._check_until_fail(                                              │
│ /home/ubuntu/work/Red-DiscordBot/redbot/core/_diagnoser.py:84 in _check_until_fail              │
│ ❱  84             check_result = await check()                                                  │
│ /home/ubuntu/work/Red-DiscordBot/redbot/core/_diagnoser.py:489 in _check_requires_cog           │
│ ❱ 489             cog=inline(self.ctx.cog.qualified_name)                                       │
╰─────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'NoneType' object has no attribute 'qualified_name'
```
With this PR, however, the issue is properly reported and there are no uncatched exceptions.

### Have the changes in this PR been tested?

Yes
