### PR TITLE
Fix formatting of nested result lists in `[p]diagnoseissues`

### DIFF
--- a/redbot/core/_diagnoser.py
+++ b/redbot/core/_diagnoser.py
@@ -939,7 +939,7 @@ class IssueDiagnoser(RootDiagnosersMixin, IssueDiagnoserBase):
                 if subresult.success
                 else _("Failed") + " \N{NO ENTRY}\N{VARIATION SELECTOR-16}"
             )
-            lines.append(f"{prefix}{idx}. {subresult.label}: {status}")
+            lines.append(f"\u200b{prefix}{idx}. {subresult.label}: {status}")
             lines.extend(
                 self._get_message_from_check_result(subresult, prefix=f"  {prefix}{idx}.")
             )


### PR DESCRIPTION
### Description of the changes

Due to changes in Discord Markdown related to lists, the formatting of the nested lists in `[p]diagnoseissues` broke. This fixes it.
You can reproduce it by running `[p]diagnoseissues` command with pretty much any set of parameters where the user can't run the command.

### Have the changes in this PR been tested?

Yes
