### PR TITLE
Bump Python versions in pyenv instructions

### DIFF
--- a/docs/install_guides/_includes/install-python310-pyenv.rst
+++ b/docs/install_guides/_includes/install-python310-pyenv.rst
@@ -10,7 +10,7 @@ virtual environment.
 
 .. prompt:: bash
 
-    CONFIGURE_OPTS=--enable-optimizations pyenv install 3.10.12 -v
+    CONFIGURE_OPTS=--enable-optimizations pyenv install 3.10.13 -v
 
 This may take a long time to complete, depending on your hardware. For some machines (such as
 Raspberry Pis and micro-tier VPSes), it may take over an hour; in this case, you may wish to remove
@@ -22,6 +22,6 @@ After that is finished, run:
 
 .. prompt:: bash
 
-    pyenv global 3.10.12
+    pyenv global 3.10.13
 
 Pyenv is now installed and your system should be configured to run Python 3.10.

--- a/docs/install_guides/_includes/install-python39-pyenv.rst
+++ b/docs/install_guides/_includes/install-python39-pyenv.rst
@@ -10,7 +10,7 @@ virtual environment.
 
 .. prompt:: bash
 
-    CONFIGURE_OPTS=--enable-optimizations pyenv install 3.9.17 -v
+    CONFIGURE_OPTS=--enable-optimizations pyenv install 3.9.18 -v
 
 This may take a long time to complete, depending on your hardware. For some machines (such as
 Raspberry Pis and micro-tier VPSes), it may take over an hour; in this case, you may wish to remove
@@ -22,6 +22,6 @@ After that is finished, run:
 
 .. prompt:: bash
 
-    pyenv global 3.9.17
+    pyenv global 3.9.18
 
 Pyenv is now installed and your system should be configured to run Python 3.9.


### PR DESCRIPTION
### Description of the changes

Bumps versions of Python 3.9 and 3.10 in pyenv instructions to 3.9.18 and 3.10.13.

### Have the changes in this PR been tested?

Yes

CentOS 7: https://cirrus-ci.com/task/5734053089902592
Raspberry Pi OS 10: tests missing
