### PR TITLE
Use more restrictive tag pattern in publish release workflow

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -2,7 +2,7 @@ name: Publish Release
 on:
   push:
     tags:
-      - "*"
+      - "3.[0-9]+.[0-9]+"
 
 jobs:
   release_information:


### PR DESCRIPTION
### Description of the changes

I am mostly doing this because I figured that I wanted to delete the 3.4 branch but keep a ref under the tag with the same name ([`3.4`](https://github.com/Cog-Creators/Red-DiscordBot/releases/tag/3.4)). I already did it by temporarily disabling the publish release workflow before the push but I figured it should really just be restricted in the workflow. It could make sense to use the on-release event at some point but I don't think it really matters for us at the current time.

### Have the changes in this PR been tested?

No
