### PR TITLE
fix the discord format in ban, kick and tempban

### DIFF
--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -292,9 +292,9 @@ class KickBanMixin(MixinMeta):
         Kick a user.
 
         Examples:
-           - `[p]kick 428675506947227648 wanted to be kicked.`
+        - `[p]kick 428675506947227648 wanted to be kicked.`
             This will kick the user with ID 428675506947227648 from the server.
-           - `[p]kick @Twentysix wanted to be kicked.`
+        - `[p]kick @Twentysix wanted to be kicked.`
             This will kick Twentysix from the server.
 
         If a reason is specified, it will be the reason that shows up
@@ -380,9 +380,9 @@ class KickBanMixin(MixinMeta):
         `days` is the amount of days of messages to cleanup on ban.
 
         Examples:
-           - `[p]ban 428675506947227648 7 Continued to spam after told to stop.`
+        - `[p]ban 428675506947227648 7 Continued to spam after told to stop.`
             This will ban the user with ID 428675506947227648 and it will delete 7 days worth of messages.
-           - `[p]ban @Twentysix 7 Continued to spam after told to stop.`
+        - `[p]ban @Twentysix 7 Continued to spam after told to stop.`
             This will ban Twentysix and it will delete 7 days worth of messages.
 
         A user ID should be provided if the user is not a member of this server.
@@ -595,11 +595,11 @@ class KickBanMixin(MixinMeta):
         `days` is the amount of days of messages to cleanup on tempban.
 
         Examples:
-           - `[p]tempban @Twentysix Because I say so`
+        - `[p]tempban @Twentysix Because I say so`
             This will ban Twentysix for the default amount of time set by an administrator.
-           - `[p]tempban @Twentysix 15m You need a timeout`
+        - `[p]tempban @Twentysix 15m You need a timeout`
             This will ban Twentysix for 15 minutes.
-           - `[p]tempban 428675506947227648 1d2h15m 5 Evil person`
+        - `[p]tempban 428675506947227648 1d2h15m 5 Evil person`
             This will ban the user with ID 428675506947227648 for 1 day 2 hours 15 minutes and will delete the last 5 days of their messages.
         """
         guild = ctx.guild


### PR DESCRIPTION
### Description of the changes

Fixed format on ban, kick and tempban.

BEFORE:
![Skjermbilde 2023-09-05 195058](https://github.com/Cog-Creators/Red-DiscordBot/assets/63972751/281e0f16-6cfe-40db-8ab9-de1ff52e5b43)
![Skjermbilde 2023-09-05 195108](https://github.com/Cog-Creators/Red-DiscordBot/assets/63972751/6a585733-b05a-41cb-acc4-d1cc8b75ca14)
![Skjermbilde 2023-09-05 195116](https://github.com/Cog-Creators/Red-DiscordBot/assets/63972751/0847b645-6dab-4e86-9e25-d5614bdeeece)

AFTER:
![Skjermbilde 2023-09-05 195102](https://github.com/Cog-Creators/Red-DiscordBot/assets/63972751/fa5208c0-08bf-4e85-b485-38411bd8ad70)
![Skjermbilde 2023-09-05 195112](https://github.com/Cog-Creators/Red-DiscordBot/assets/63972751/f9b0ba27-9752-4d3e-a614-255f6d5400f6)
![Skjermbilde 2023-09-05 195248](https://github.com/Cog-Creators/Red-DiscordBot/assets/63972751/e6c166d0-9d5e-4056-b46f-0e94fec215a2)


### Have the changes in this PR been tested?
yes

