### PR TITLE
Bump dependencies

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -274,7 +274,7 @@ class IgnoreCoroSubstitution(SphinxTransform):
     def apply(self, **kwargs) -> None:
         for ref in self.document.traverse(nodes.substitution_reference):
             if ref["refname"] == "coro":
-                ref.replace_self(nodes.Text("", ""))
+                ref.replace_self(nodes.Text(""))
 
 
 def setup(app):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ aiohttp-json-rpc==0.13.3
     # via -r base.in
 aiosignal==1.3.1
     # via aiohttp
-apsw==3.43.0.0
+apsw==3.43.1.0
     # via -r base.in
 async-timeout==4.0.3
     # via aiohttp

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ aiohttp-json-rpc==0.13.3
     # via -r base.in
 aiosignal==1.3.1
     # via aiohttp
-apsw==3.42.0.1
+apsw==3.43.0.0
     # via -r base.in
 async-timeout==4.0.3
     # via aiohttp
@@ -18,13 +18,13 @@ attrs==23.1.0
     # via aiohttp
 babel==2.12.1
     # via -r base.in
-brotli==1.0.9
+brotli==1.1.0
     # via -r base.in
 cffi==1.15.1
     # via pycares
 charset-normalizer==3.2.0
     # via aiohttp
-click==8.1.6
+click==8.1.7
     # via -r base.in
 contextlib2==21.6.0
     # via schema
@@ -50,7 +50,7 @@ multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-orjson==3.9.4
+orjson==3.9.7
     # via -r base.in
 packaging==23.1
     # via -r base.in
@@ -66,11 +66,11 @@ pygments==2.16.1
     # via rich
 python-dateutil==2.8.2
     # via -r base.in
-pytz==2023.3
+pytz==2023.3.post1
     # via babel
 pyyaml==6.0.1
     # via -r base.in
-rapidfuzz==3.2.0
+rapidfuzz==3.3.0
     # via -r base.in
 red-commons==1.0.0
     # via

--- a/requirements/extra-doc.txt
+++ b/requirements/extra-doc.txt
@@ -17,16 +17,16 @@ requests==2.31.0
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==6.2.1
+sphinx==7.1.2
     # via
     #   -r extra-doc.in
     #   sphinx-prompt
     #   sphinx-rtd-theme
     #   sphinxcontrib-jquery
     #   sphinxcontrib-trio
-sphinx-prompt==1.6.0
+sphinx-prompt==1.7.0
     # via -r extra-doc.in
-sphinx-rtd-theme==1.2.2
+sphinx-rtd-theme==1.3.0
     # via -r extra-doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/requirements/extra-style.txt
+++ b/requirements/extra-style.txt
@@ -1,4 +1,4 @@
-black==23.7.0
+black==23.9.1
     # via -r extra-style.in
 mypy-extensions==1.0.0
     # via black

--- a/requirements/extra-test.txt
+++ b/requirements/extra-test.txt
@@ -2,7 +2,7 @@ astroid==2.15.6
     # via pylint
 dill==0.3.7
     # via pylint
-exceptiongroup==1.1.2
+exceptiongroup==1.1.3
     # via pytest
 iniconfig==2.0.0
     # via pytest
@@ -12,11 +12,11 @@ lazy-object-proxy==1.9.0
     # via astroid
 mccabe==0.7.0
     # via pylint
-pluggy==1.2.0
+pluggy==1.3.0
     # via pytest
 pylint==2.17.5
     # via -r extra-test.in
-pytest==7.4.0
+pytest==7.4.2
     # via
     #   -r extra-test.in
     #   pytest-asyncio


### PR DESCRIPTION
### Description of the changes

Nothing major, Sphinx update has a few incompatible changes but none that affect us.

Aside from the dep bump, I went ahead and fixed the deprecation warning in our doctuils usage though it's not a bump that was introduced with this PR.

### Have the changes in this PR been tested?

Yes

macOS x86_64: https://github.com/Jackenmen/Red-Install-Tests/actions/runs/6188093798
Rest of OSes: https://cirrus-ci.com/build/5080481574682624