### PR TITLE
feat: use f-string instead of format

### DIFF
--- a/redbot/cogs/general/general.py
+++ b/redbot/cogs/general/general.py
@@ -220,7 +220,7 @@ class General(commands.Cog):
     async def lmgtfy(self, ctx, *, search_terms: str):
         """Create a lmgtfy link."""
         search_terms = escape(urllib.parse.quote_plus(search_terms), mass_mentions=True)
-        await ctx.send("https://lmgtfy.app/?q={}&s=g".format(search_terms))
+        await ctx.send(f"https://lmgtfy.app/?q={search_terms}&s=g")
 
     @commands.command(hidden=True)
     @commands.guild_only()


### PR DESCRIPTION
### Description of the changes

This PR propose to change the LMGTFY link from `https://lmgtfy.app` to `https://letmegooglethat.com` as it seems that the old domain seems to experience problems that will never be resolved.

It's been weeks since the HSTS error has been happening.

![image](https://github.com/Cog-Creators/Red-DiscordBot/assets/61093863/0885b519-21ae-4b56-b93a-d82d1b980726)

Also remove the `s` query parameter, it seems unused.

### Have the changes in this PR been tested?

No, but should be fine.
