### PR TITLE
Fix broken "Edit on GitHub" URLs in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,7 +138,7 @@ html_context = {
     "display_github": True,
     "github_user": "Cog-Creators",
     "github_repo": "Red-DiscordBot",
-    "github_version": "V3/develop/docs/",
+    "github_version": "V3/develop",
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
### Description of the changes

If you go to any documentation page, and try clicking on "Edit on GitHub" in the top right corner, you will go to URL: `https://github.com/Cog-Creators/Red-DiscordBot/blob/V3/develop/docs//docs/document_name.rst`. This should fix that.

### Have the changes in this PR been tested?

Yes
