### PR TITLE
Add warning to [p]set api if <>s are included in secret

### DIFF
--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -221,17 +221,16 @@ class YoutubeStream(Stream):
         if vid_data["liveStreamingDetails"].get("scheduledStartTime", None) is not None:
             if "actualStartTime" not in vid_data["liveStreamingDetails"]:
                 start_time = parse_time(vid_data["liveStreamingDetails"]["scheduledStartTime"])
+                start_time_unix = time.mktime(start_time.timetuple())
                 start_in = start_time - datetime.now(timezone.utc)
                 if start_in.total_seconds() > 0:
-                    embed.description = _("This stream will start in {time}").format(
-                        time=humanize_timedelta(
-                            timedelta=timedelta(minutes=start_in.total_seconds() // 60)
-                        )  # getting rid of seconds
+                    embed.description = _("This stream will start <t:{time}:R>").format(
+                        time=int(start_time_unix)
                     )
                 else:
-                    embed.description = _(
-                        "This stream was scheduled for {min} minutes ago"
-                    ).format(min=round((start_in.total_seconds() * -1) // 60))
+                    embed.description = _("This stream was scheduled for <t:{time}:R>").format(
+                        time=int(start_time_unix)
+                    )
                 embed.timestamp = start_time
                 is_schedule = True
             else:

--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -221,16 +221,17 @@ class YoutubeStream(Stream):
         if vid_data["liveStreamingDetails"].get("scheduledStartTime", None) is not None:
             if "actualStartTime" not in vid_data["liveStreamingDetails"]:
                 start_time = parse_time(vid_data["liveStreamingDetails"]["scheduledStartTime"])
-                start_time_unix = time.mktime(start_time.timetuple())
                 start_in = start_time - datetime.now(timezone.utc)
                 if start_in.total_seconds() > 0:
-                    embed.description = _("This stream will start <t:{time}:R>").format(
-                        time=int(start_time_unix)
+                    embed.description = _("This stream will start in {time}").format(
+                        time=humanize_timedelta(
+                            timedelta=timedelta(minutes=start_in.total_seconds() // 60)
+                        )  # getting rid of seconds
                     )
                 else:
-                    embed.description = _("This stream was scheduled for <t:{time}:R>").format(
-                        time=int(start_time_unix)
-                    )
+                    embed.description = _(
+                        "This stream was scheduled for {min} minutes ago"
+                    ).format(min=round((start_in.total_seconds() * -1) // 60))
                 embed.timestamp = start_time
                 is_schedule = True
             else:

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3633,7 +3633,20 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             if ctx.bot_permissions.manage_messages:
                 await ctx.message.delete()
+            print(tokens)
+            embed = discord.Embed()
+            for dict_key, token in tokens.items():
+                if token.startswith("<") and token.endswith(">"):
+                    angle_bracket_warning = _(
+                        "Your `{dict_key}` was set including the <> symbols. If this was an accident you may experience"
+                        " issues with `{service}`. In that case, please try setting your `{dict_key}` again with"
+                        " the < and > removed"
+                    ).format(dict_key=dict_key, service=service)
+                    log.warning(angle_bracket_warning)
+                    embed.add_field(name="Warning", value=angle_bracket_warning)
             await ctx.bot.set_shared_api_tokens(service, **tokens)
+            if embed:
+                await ctx.send(embed=embed)
             await ctx.send(_("`{service}` API tokens have been set.").format(service=service))
 
     @_set_api.command(name="list")

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3633,7 +3633,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             if ctx.bot_permissions.manage_messages:
                 await ctx.message.delete()
-            print(tokens)
             embed = discord.Embed()
             for dict_key, token in tokens.items():
                 if token.startswith("<") and token.endswith(">"):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3634,19 +3634,21 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             if ctx.bot_permissions.manage_messages:
                 await ctx.message.delete()
             embed = discord.Embed()
-            for dict_key, token in tokens.items():
+            for api_service_name, token in tokens.items():
                 if token.startswith("<") and token.endswith(">"):
-                    angle_bracket_warning = _(
-                        "Your `{dict_key}` was set including the <> symbols. If this was an accident you may experience"
-                        " issues with `{service}`. In that case, please try setting your `{dict_key}` again with"
-                        " the < and > removed"
-                    ).format(dict_key=dict_key, service=service)
+                    angle_bracket_warning = (
+                        "You may have failed to properly format your {api_service_name}. If you were told to enter a key"
+                        " with an example such as [p]set api {service} api_key <your_api_key_here>, and your API key"
+                        " was HREDFGWE, make sure to run [p]set api {service} api_key HREDFGWE, and not "
+                        " [p]set api {service} api_key <HREDFGWE>"
+                    ).format(api_service_name=api_service_name, service=service)
                     log.warning(angle_bracket_warning)
-                    embed.add_field(name="Warning", value=angle_bracket_warning)
+                    embed.add_field(name=_("Warning"), value=_(angle_bracket_warning))
             await ctx.bot.set_shared_api_tokens(service, **tokens)
-            if embed:
-                await ctx.send(embed=embed)
-            await ctx.send(_("`{service}` API tokens have been set.").format(service=service))
+            await ctx.send(
+                _("`{service}` API tokens have been set.").format(service=service),
+                embed=embed if len(embed.fields) > 0 else None,
+            )
 
     @_set_api.command(name="list")
     async def _set_api_list(self, ctx: commands.Context):


### PR DESCRIPTION
### Description of the changes

Closes #6253
For every given secret, check if its wrapped in <>, if it is, add a message to an embed with a warning that that secret may not be set properly. I tested this on a local instance of the bot and it seems to be working as expected. The warning is also logged

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
