### PR TITLE
Fix AUTHOR field in startrek trivia

### DIFF
--- a/redbot/cogs/trivia/data/lists/startrek.yaml
+++ b/redbot/cogs/trivia/data/lists/startrek.yaml
@@ -1,4 +1,4 @@
-Author: ["scarecr0w12", "Sashasonic", "aikaterna"]
+AUTHOR: scarecr0w12, Sashasonic, aikaterna
 In what year did the Vulcans make official first contact with Zefram Cochrane?:
 - 2063
 In what state is Carbon Creek located?:


### PR DESCRIPTION
### Description of the changes

This was missed because the field was spelled `Author` instead of `AUTHOR` and so our schema just treated it as another question with an answer list.

### Have the changes in this PR been tested?

Yes