### PR TITLE
Fix editrole color

### DIFF
--- a/redbot/cogs/admin/admin.py
+++ b/redbot/cogs/admin/admin.py
@@ -273,7 +273,7 @@ class Admin(commands.Cog):
         """
         author = ctx.author
         reason = _("{author} ({author.id}) changed the colour of role '{role.name}'").format(
-            author=author, role=role.name
+            author=author, role=role
         )
 
         if not self.pass_user_hierarchy_check(ctx, role):


### PR DESCRIPTION
### Description of the changes
Doubled `.name` caused an `AttributeError`
[[Ref](https://discord.com/channels/133049272517001216/387398816317440000/1174735344348958800)]

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
