### PR TITLE
[Audio] Fix attachment suffix reading on playlist upload

### DIFF
--- a/redbot/cogs/audio/core/commands/playlists.py
+++ b/redbot/cogs/audio/core/commands/playlists.py
@@ -1823,7 +1823,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                 file_url = file_message.attachments[0].url
             except IndexError:
                 return await self.send_embed_msg(ctx, title=_("Upload cancelled."))
-            file_suffix = file_url.rsplit(".", 1)[1]
+            file_suffix = file_url.rsplit(".", 1)[1][:3]
             if file_suffix != "txt":
                 return await self.send_embed_msg(
                     ctx, title=_("Only Red playlist files can be uploaded.")


### PR DESCRIPTION
### Description of the changes

With Discord's new file attachment expiration, the file suffix for an upload is longer than just "txt", causing playlist upload to fail. This changes it to only read the first 3 characters of the suffix provided.

### Have the changes in this PR been tested?

Yes

