### PR TITLE
[Audio] Fix attachment suffix reading on playlist upload w/ urllib

### DIFF
--- a/redbot/cogs/audio/core/commands/playlists.py
+++ b/redbot/cogs/audio/core/commands/playlists.py
@@ -7,6 +7,7 @@ import time
 
 from io import BytesIO
 from pathlib import Path
+from urllib.parse import urlparse
 from typing import cast
 
 import discord
@@ -1823,7 +1824,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                 file_url = file_message.attachments[0].url
             except IndexError:
                 return await self.send_embed_msg(ctx, title=_("Upload cancelled."))
-            file_suffix = file_url.rsplit(".", 1)[1]
+            file_suffix = urlparse(file_url).path.rsplit(".", 1)[1]
             if file_suffix != "txt":
                 return await self.send_embed_msg(
                     ctx, title=_("Only Red playlist files can be uploaded.")
@@ -1848,7 +1849,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
             if len(track_list) > 10000:
                 return await self.send_embed_msg(ctx, title=_("This playlist is too large."))
             uploaded_playlist_name = uploaded_playlist.get(
-                "name", (file_url.split("/")[6]).split(".")[0]
+                "name", (urlparse(file_url).path.split("/")[-1]).rsplit(".", 1)[0]
             )
             try:
                 if self.api_interface is not None and (


### PR DESCRIPTION
### Description of the changes
Alternative to #6279

Uses the URL format parsing in `urllib` to explicitly ignore queries, hashes, and site-specific logic when parsing a playlist file uploaded to `[p]playlist upload`.



Closes #6279
### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
