### PR TITLE
Ask for confirmation before setting prefix on first-time setup

### DIFF
--- a/redbot/core/_cli.py
+++ b/redbot/core/_cli.py
@@ -80,7 +80,7 @@ async def interactive_config(red, token_set, prefix_set, *, print_header=True):
         print(
             "\nPick a prefix. A prefix is what you type before a "
             "command. Example:\n"
-            "!help\n^ The exclamation mark is the prefix in this case.\n"
+            "!help\n^ The exclamation mark (!) is the prefix in this case.\n"
             "The prefix can be multiple characters. You will be able to change it "
             "later and add more of them.\nChoose your prefix:\n"
         )
@@ -93,6 +93,12 @@ async def interactive_config(red, token_set, prefix_set, *, print_header=True):
                 print(
                     "Prefixes cannot start with '/', as it conflicts with Discord's slash commands."
                 )
+                prefix = ""
+            if prefix and not confirm(
+                f'You chose "{prefix}" as your prefix. To run the help command,'
+                f" you will have to send:\n{prefix}help\n\n"
+                "Do you want to continue with this prefix?"
+            ):
                 prefix = ""
             if prefix:
                 await red._config.prefix.set([prefix])


### PR DESCRIPTION
### Description of the changes

A simple change asking the user to confirm their choice with an example of how the bot would be used with the selected prefix. This *might* help avoid issues where the user sets their prefix to something such as "!help" since the example usage will then be "!helphelp". I was also considering doing `.endswith("help")` with "Are you sure that's correct?" like we have for long prefixes but I figured this more generic solution should work just as well and doesn't require special casing.

### Have the changes in this PR been tested?

No
