### PR TITLE
Fix edge case where perm names are not validated in custom Red decos

### DIFF
--- a/redbot/core/commands/requires.py
+++ b/redbot/core/commands/requires.py
@@ -357,6 +357,7 @@ class Requires:
                 if user_perms is None:
                     func.__requires_user_perms__ = None
                 else:
+                    _validate_perms_dict(user_perms)
                     if getattr(func, "__requires_user_perms__", None) is None:
                         func.__requires_user_perms__ = discord.Permissions.none()
                     func.__requires_user_perms__.update(**user_perms)


### PR DESCRIPTION
### Description of the changes
`_validate_perms_dict` is supposed to be used to validate that the permissions names passed to decorators such as `@commands.admin_or_permissions` are actual permissions. The `get_decorator` helper used to build these decorators currently returns a decorator that fails to validate permission names if the decorated object is a coroutine. This causes the check to never properly happen in cases where the decorator executes _before_ `@commands.command` (ie, if it is on the bottom). This potentially could cause unexpected behavior if a permission name is misspelled when passed to one of these decorators.

Found by `@untir_l`.

**Reproduction example:**
```py
import discord
from redbot.core import commands

class Test(commands.Cog):
    @commands.command()
    @commands.admin_or_permissions(NONEXISTENT_PERM=True)
    async def test(self, ctx):
        await ctx.reply("Boop!")
```

**Already properly handled (prevents load):**
```py
import discord
from redbot.core import commands

class Test(commands.Cog):
    @commands.admin_or_permissions(NONEXISTENT_PERM=True)
    @commands.command()
    async def test(self, ctx):
        await ctx.reply("Boop!")
```
### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
