### PR TITLE
Update autostart_systemd.rst

### DIFF
--- a/docs/autostart_systemd.rst
+++ b/docs/autostart_systemd.rst
@@ -32,9 +32,9 @@ Next, your python :code:`path` can be fetched with the following commands:
     $ pyenv shell <virtualenv_name>
     (redenv) $ pyenv which python
 
-Then create the new service file:
+Then create the new service file (replace InstanceName with the name of your Instance):
 
-:code:`sudo nano /etc/systemd/system/red@.service`
+:code:`sudo nano /etc/systemd/system/red@InstanceName.service`
 
 Paste the following in the file, and replace all instances of :code:`username` with the Linux username you retrieved above, and :code:`path` with the python path you retrieved above.
 


### PR DESCRIPTION
When creating the name of the of the systemd file you need to add the instance name after the @ symbol, e.g. red@MyInstance.service, as the service file uses the %I for this information.

### Description of the changes

added some text explaining that the instance name needs to be used when naming the file.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
