### PR TITLE
Add note to refresh client after syncing slash commands

### DIFF
--- a/docs/guide_slash_and_interactions.rst
+++ b/docs/guide_slash_and_interactions.rst
@@ -39,6 +39,11 @@ Go ahead and load your cog. Once it is loaded, we will have to enable and sync o
 We can do this by using the :ref:`[p]slash<core-command-slash>` command to manage our slash commands.
 Once you have registered your slash commands, you can test them out by typing ``/hello`` in your server.
 
+.. tip::
+
+    You may need to restart your Discord client with ``Ctrl + R`` (or your device's equivalent) to force
+    your client to see the new command after syncing.
+
 ----------------------------
 Slash Commands and Arguments
 ----------------------------


### PR DESCRIPTION
### Description of the changes
When `[p]slash sync`ing new commands, the client's command cache is often not updated immediately. This can be bypassed by manually refreshing the client. This PR adds a tip to the "Getting Started" section of the guide to creating slash commands to inform users of this step.


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
