### PR TITLE
Allow SimpleMenu to delete ephemeral responses

### DIFF
--- a/redbot/core/utils/views.py
+++ b/redbot/core/utils/views.py
@@ -65,7 +65,11 @@ class _StopButton(discord.ui.Button):
 
     async def callback(self, interaction: discord.Interaction):
         self.view.stop()
-        await interaction.message.delete()
+        if interaction.message.flags.ephemeral:
+            await interaction.response.defer(thinking=False)
+            await interaction.delete_original_response()
+        else:
+            await interaction.message.delete()
 
 
 class SimpleMenu(discord.ui.View):

--- a/redbot/core/utils/views.py
+++ b/redbot/core/utils/views.py
@@ -65,9 +65,6 @@ class _StopButton(discord.ui.Button):
 
     async def callback(self, interaction: discord.Interaction):
         self.view.stop()
-        if interaction.message.flags.ephemeral:
-            await interaction.response.edit_message(view=None)
-            return
         await interaction.message.delete()
 
 
@@ -194,7 +191,7 @@ class SimpleMenu(discord.ui.View):
 
     async def on_timeout(self):
         try:
-            if self.delete_after_timeout and not self.message.flags.ephemeral:
+            if self.delete_after_timeout:
                 await self.message.delete()
             elif self.disable_after_timeout:
                 for child in self.children:


### PR DESCRIPTION
### Description of the changes
Discord allows deleting ephemeral messages now, updating SimpleMenu to support that


### Have the changes in this PR been tested?
Yes