### PR TITLE
Issue #6274 added the break for once the valid time duration is found

### DIFF
--- a/redbot/cogs/mutes/converters.py
+++ b/redbot/cogs/mutes/converters.py
@@ -52,6 +52,7 @@ class MuteTime(Converter):
             for k, v in time.groupdict().items():
                 if v:
                     time_data[k] = int(v)
+            break # Break after the first valid match
         if time_data:
             try:
                 result["duration"] = timedelta(**time_data)


### PR DESCRIPTION
---

Implemented the fix as suggested in https://github.com/Cog-Creators/Red-DiscordBot/issues/6274#issuecomment-1837224077.

### Description of the changes

This pull request addresses Issue #6274 by incorporating the suggested fix from the discussion in the provided GitHub issue comment. The fix involves adding a `break` statement to halt the iteration once a valid time duration is found. This enhancement optimizes the time duration validation process within the specified functionality, improving efficiency and accuracy.

### Have the changes in this PR been tested?

No

---