### PR TITLE
Remove traceback suppression from buttonized menu()

### DIFF
--- a/redbot/core/utils/menus.py
+++ b/redbot/core/utils/menus.py
@@ -49,10 +49,7 @@ class _GenericButton(discord.ui.Button):
             if self.emoji.is_unicode_emoji()
             else (ctx.bot.get_emoji(self.emoji.id) or self.emoji)
         )
-        try:
-            await self.func(ctx, pages, controls, message, page, timeout, emoji)
-        except Exception:
-            pass
+        await self.func(ctx, pages, controls, message, page, timeout, emoji)
 
 
 async def menu(


### PR DESCRIPTION
### Description of the changes

With this change, incorrect `menu()` action implementations will now properly log the traceback for buttonized (`[p]set usebuttons 1`) menus:
![image](https://github.com/Cog-Creators/Red-DiscordBot/assets/6032823/a24c3413-61dc-4251-92ea-c41f4d93aebd)

### Have the changes in this PR been tested?

Yes
