### PR TITLE
Bump dependencies

### DIFF
--- a/.github/workflows/run_pip_compile.yaml
+++ b/.github/workflows/run_pip_compile.yaml
@@ -20,12 +20,27 @@ jobs:
       - name: Set up Python 3.8.
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: |
+            3.11
+            3.10
+            3.9
+            3.8
 
-      - name: Install dependencies
+      - name: Install dependencies on Linux/macOS
+        if: matrix.os != 'windows-latest'
         run: |
-          python -m pip install -U pip
-          python -m pip install -U pip-tools
+          python3.11 -m pip install -U pip pip-tools
+          python3.10 -m pip install -U pip pip-tools
+          python3.9 -m pip install -U pip pip-tools
+          python3.8 -m pip install -U pip pip-tools
+
+      - name: Install dependencies on Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          py -3.11 -m pip install -U pip pip-tools
+          py -3.10 -m pip install -U pip pip-tools
+          py -3.9 -m pip install -U pip pip-tools
+          py -3.8 -m pip install -U pip pip-tools
 
       - name: Generate requirements files.
         id: compile_requirements

--- a/.github/workflows/scripts/compile_requirements.py
+++ b/.github/workflows/scripts/compile_requirements.py
@@ -10,10 +10,11 @@ REQUIREMENTS_FOLDER = Path(__file__).parents[3].absolute() / "requirements"
 os.chdir(REQUIREMENTS_FOLDER)
 
 
-def pip_compile(name: str) -> None:
+def pip_compile(version: str, name: str) -> None:
+    executable = ("py", f"-{version}") if sys.platform == "win32" else (f"python{version}",)
     subprocess.check_call(
         (
-            sys.executable,
+            *executable,
             "-m",
             "piptools",
             "compile",
@@ -22,15 +23,17 @@ def pip_compile(name: str) -> None:
             "--verbose",
             f"{name}.in",
             "--output-file",
-            f"{sys.platform}-{name}.txt",
+            f"{sys.platform}-{version}-{name}.txt",
         )
     )
 
 
-pip_compile("base")
-shutil.copyfile(f"{sys.platform}-base.txt", "base.txt")
-for file in REQUIREMENTS_FOLDER.glob("extra-*.in"):
-    pip_compile(file.stem)
+for minor in range(8, 11 + 1):
+    version = f"3.{minor}"
+    pip_compile(version, "base")
+    shutil.copyfile(f"{sys.platform}-{version}-base.txt", "base.txt")
+    for file in REQUIREMENTS_FOLDER.glob("extra-*.in"):
+        pip_compile(version, file.stem)
 
 with open(GITHUB_OUTPUT, "a", encoding="utf-8") as fp:
     fp.write(f"sys_platform={sys.platform}\n")

--- a/.github/workflows/scripts/compile_requirements.py
+++ b/.github/workflows/scripts/compile_requirements.py
@@ -1,16 +1,22 @@
 import os
+import re
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 
+EXCLUDE_STEM_RE = re.compile(r".*-3\.(?!8-)(\d+)-extra-(doc|style)")
 GITHUB_OUTPUT = os.environ["GITHUB_OUTPUT"]
 REQUIREMENTS_FOLDER = Path(__file__).parents[3].absolute() / "requirements"
 os.chdir(REQUIREMENTS_FOLDER)
 
 
 def pip_compile(version: str, name: str) -> None:
+    stem = f"{sys.platform}-{version}-{name}"
+    if EXCLUDE_STEM_RE.fullmatch(stem):
+        return
+
     executable = ("py", f"-{version}") if sys.platform == "win32" else (f"python{version}",)
     subprocess.check_call(
         (
@@ -23,7 +29,7 @@ def pip_compile(version: str, name: str) -> None:
             "--verbose",
             f"{name}.in",
             "--output-file",
-            f"{sys.platform}-{version}-{name}.txt",
+            f"{stem}.txt",
         )
     )
 

--- a/.github/workflows/scripts/merge_requirements.py
+++ b/.github/workflows/scripts/merge_requirements.py
@@ -135,15 +135,13 @@ for name in names:
             elif len(python_versions) < len(all_python_versions - python_versions):
                 # requirement present on less Python versions than not
                 python_version_marker = " or ".join(
-                    f"python_version == '{env_name}'" for env_name in envs
-                    # f"python_version == '{python_version}'" for python_version in python_versions
+                    f"python_version == '{python_version}'" for python_version in python_versions
                 )
             else:
                 # requirement present on more Python versions than not
                 python_version_marker = " and ".join(
-                    f"python_version != '{env_name}'" for env_name in all_envs - envs.keys()
-                    # f"python_version != '{python_version}'"
-                    # for python_version in all_python_versions - python_versions
+                    f"python_version != '{python_version}'"
+                    for python_version in all_python_versions - python_versions
                 )
 
             platform_marker = ""
@@ -153,14 +151,12 @@ for name in names:
             elif len(platforms) < len(all_platforms - platforms):
                 # requirement present on less platforms than not
                 platform_marker = " or ".join(
-                    f"sys_platform == '{env_name}'" for env_name in envs
-                    # f"sys_platform == '{platform}'" for platform in platforms
+                    f"sys_platform == '{platform}'" for platform in platforms
                 )
             else:
                 # requirement present on more platforms than not
                 platform_marker = " and ".join(
-                    f"sys_platform != '{env_name}'" for env_name in all_envs - envs.keys()
-                    # f"sys_platform != '{platform}'" for platform in all_platforms - platforms
+                    f"sys_platform != '{platform}'" for platform in all_platforms - platforms
                 )
 
             if python_version_marker and platform_marker:

--- a/.github/workflows/scripts/merge_requirements.py
+++ b/.github/workflows/scripts/merge_requirements.py
@@ -176,11 +176,7 @@ for name in names:
                 )
             )
 
-        new_marker = (
-            f"({req.marker}) and ({env_marker})"
-            if req.marker is not None
-            else env_marker
-        )
+        new_marker = f"({req.marker}) and ({env_marker})" if req.marker is not None else env_marker
         req.marker = Marker(new_marker)
         if base_req is not None and base_req.marker == req.marker:
             continue

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,3 @@
-aiodns
 aiohttp
 aiohttp-json-rpc
 apsw

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,4 @@
-aiodns==3.0.0
-    # via -r base.in
-aiohttp==3.8.5
+aiohttp==3.9.3
     # via
     #   -r base.in
     #   aiohttp-json-rpc
@@ -10,20 +8,14 @@ aiohttp-json-rpc==0.13.3
     # via -r base.in
 aiosignal==1.3.1
     # via aiohttp
-apsw==3.43.1.0
+apsw==3.45.2.0
     # via -r base.in
-async-timeout==4.0.3
+attrs==23.2.0
     # via aiohttp
-attrs==23.1.0
-    # via aiohttp
-babel==2.12.1
+babel==2.14.0
     # via -r base.in
 brotli==1.1.0
     # via -r base.in
-cffi==1.15.1
-    # via pycares
-charset-normalizer==3.2.0
-    # via aiohttp
 click==8.1.7
     # via -r base.in
 contextlib2==21.6.0
@@ -32,45 +24,37 @@ discord-py==2.3.2
     # via
     #   -r base.in
     #   red-lavalink
-frozenlist==1.4.0
+frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-idna==3.4
+idna==3.6
     # via yarl
-importlib-metadata==6.8.0
-    # via markdown
-markdown==3.4.4
+markdown==3.6
     # via -r base.in
 markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-orjson==3.9.7
+orjson==3.9.15
     # via -r base.in
-packaging==23.1
+packaging==24.0
     # via -r base.in
-platformdirs==3.10.0
+platformdirs==4.2.0
     # via -r base.in
-psutil==5.9.5
+psutil==5.9.8
     # via -r base.in
-pycares==4.3.0
-    # via aiodns
-pycparser==2.21
-    # via cffi
-pygments==2.16.1
+pygments==2.17.2
     # via rich
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via -r base.in
-pytz==2023.3.post1
-    # via babel
 pyyaml==6.0.1
     # via -r base.in
-rapidfuzz==3.3.0
+rapidfuzz==3.6.2
     # via -r base.in
 red-commons==1.0.0
     # via
@@ -78,25 +62,31 @@ red-commons==1.0.0
     #   red-lavalink
 red-lavalink==0.11.0
     # via -r base.in
-rich==13.5.2
+rich==13.7.1
     # via -r base.in
 schema==0.7.5
     # via -r base.in
 six==1.16.0
     # via python-dateutil
-typing-extensions==4.7.1
+typing-extensions==4.10.0
     # via
     #   -r base.in
     #   rich
-yarl==1.9.2
+yarl==1.9.4
     # via
     #   -r base.in
     #   aiohttp
-zipp==3.16.2
-    # via importlib-metadata
+async-timeout==4.0.3; python_version != "3.11"
+    # via aiohttp
 colorama==0.4.6; sys_platform == "win32"
     # via click
-distro==1.8.0; sys_platform == "linux" and sys_platform == "linux"
+distro==1.9.0; sys_platform == "linux" and sys_platform == "linux"
     # via -r base.in
-uvloop==0.17.0; (sys_platform != "win32" and platform_python_implementation == "CPython") and sys_platform != "win32"
+importlib-metadata==7.1.0; python_version != "3.10" and python_version != "3.11"
+    # via markdown
+pytz==2024.1; python_version == "3.8"
+    # via babel
+uvloop==0.19.0; (sys_platform != "win32" and platform_python_implementation == "CPython") and sys_platform != "win32"
     # via -r base.in
+zipp==3.18.1; python_version != "3.10" and python_version != "3.11"
+    # via importlib-metadata

--- a/requirements/extra-doc.txt
+++ b/requirements/extra-doc.txt
@@ -1,18 +1,28 @@
 alabaster==0.7.13
     # via sphinx
-certifi==2023.7.22
+certifi==2024.2.2
     # via requests
-docutils==0.18.1
+charset-normalizer==3.3.2
+    # via requests
+docutils==0.20.1
     # via
     #   sphinx
     #   sphinx-prompt
     #   sphinx-rtd-theme
 imagesize==1.4.1
     # via sphinx
-jinja2==3.1.2
+importlib-metadata==7.1.0
+    # via
+    #   -c base.txt
+    #   sphinx
+jinja2==3.1.3
     # via sphinx
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via jinja2
+pytz==2024.1
+    # via
+    #   -c base.txt
+    #   babel
 requests==2.31.0
     # via sphinx
 snowballstemmer==2.2.0
@@ -26,7 +36,7 @@ sphinx==7.1.2
     #   sphinxcontrib-trio
 sphinx-prompt==1.7.0
     # via -r extra-doc.in
-sphinx-rtd-theme==1.3.0
+sphinx-rtd-theme==2.0.0
     # via -r extra-doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -44,5 +54,9 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sphinxcontrib-trio==1.1.2
     # via -r extra-doc.in
-urllib3==2.0.4
+urllib3==2.2.1
     # via requests
+zipp==3.18.1
+    # via
+    #   -c base.txt
+    #   importlib-metadata

--- a/requirements/extra-postgres.txt
+++ b/requirements/extra-postgres.txt
@@ -1,2 +1,6 @@
-asyncpg==0.28.0
+async-timeout==4.0.3
+    # via
+    #   -c base.txt
+    #   asyncpg
+asyncpg==0.29.0
     # via -r extra-postgres.in

--- a/requirements/extra-style.txt
+++ b/requirements/extra-style.txt
@@ -1,8 +1,8 @@
-black==23.9.1
+black==23.12.1
     # via -r extra-style.in
 mypy-extensions==1.0.0
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 tomli==2.0.1
     # via black

--- a/requirements/extra-test.in
+++ b/requirements/extra-test.in
@@ -1,6 +1,6 @@
 -c base.txt
 
 pylint
-pytest
-pytest-asyncio
+pytest<8
+pytest-asyncio<0.22
 pytest-mock

--- a/requirements/extra-test.txt
+++ b/requirements/extra-test.txt
@@ -1,35 +1,31 @@
-astroid==2.15.6
+astroid==3.1.0
     # via pylint
-dill==0.3.7
+dill==0.3.8
     # via pylint
-exceptiongroup==1.1.3
-    # via pytest
 iniconfig==2.0.0
     # via pytest
-isort==5.12.0
+isort==5.13.2
     # via pylint
-lazy-object-proxy==1.9.0
-    # via astroid
 mccabe==0.7.0
     # via pylint
-pluggy==1.3.0
+pluggy==1.4.0
     # via pytest
-pylint==2.17.5
+pylint==3.1.0
     # via -r extra-test.in
-pytest==7.4.2
+pytest==7.4.4
     # via
     #   -r extra-test.in
     #   pytest-asyncio
     #   pytest-mock
 pytest-asyncio==0.21.1
     # via -r extra-test.in
-pytest-mock==3.11.1
+pytest-mock==3.12.0
     # via -r extra-test.in
-tomli==2.0.1
+tomlkit==0.12.4
+    # via pylint
+exceptiongroup==1.2.0; python_version != "3.11"
+    # via pytest
+tomli==2.0.1; python_version != "3.11"
     # via
     #   pylint
     #   pytest
-tomlkit==0.12.1
-    # via pylint
-wrapt==1.15.0
-    # via astroid


### PR DESCRIPTION
### Description of the changes

This PR does a few things:
- drops `aiodns` dependency
    - While aiohttp does have an aiodns implementation, it has been
disabling it unconditionally for the last 8 years:
https://github.com/aio-libs/aiohttp/commit/9fbb7d708375e0ba01d435c1e8cf41912381c0fc
- bumps all dependencies before release as usual
    - this doesn't include Black 24 bump which affects code style
    - this required setting an upper-bound for pytest-asyncio to `0.21.*` (+ pytest <8 due to incompatibility) - there is a known issue with `0.23.*` on the upstream side for now
- updates scripts for generating dependency lists to consider differences between Python versions

### Have the changes in this PR been tested?

Partially yes, see results:

Test run of updated install instructions:
- macOS x86_64 12 and 13 (14 on GitHub is M1 so same as Cirrus CI): https://github.com/Jackenmen/Red-Install-Tests/actions/runs/8369137984
- everything else: https://cirrus-ci.com/build/4744265834692608
