### PR TITLE
Update image formats listed as supported by `set bot avatar`

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2889,7 +2889,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 _(
                     "Failed. Remember that you can edit my avatar "
                     "up to two times a hour. The URL or attachment "
-                    "must be a valid image in either JPG, PNG or GIF format."
+                    "must be a valid image in either JPG, PNG, or GIF format."
                 )
             )
         except ValueError:

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2889,11 +2889,11 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                 _(
                     "Failed. Remember that you can edit my avatar "
                     "up to two times a hour. The URL or attachment "
-                    "must be a valid image in either JPG or PNG format."
+                    "must be a valid image in either JPG, PNG or GIF format."
                 )
             )
         except ValueError:
-            await ctx.send(_("JPG / PNG format only."))
+            await ctx.send(_("JPG / PNG / GIF format only."))
         else:
             await ctx.send(_("Done."))
 


### PR DESCRIPTION
### Description of the changes

Discord now allows animated avatars for bot users, this PR changes two strings to mention it.


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
