### PR TITLE
Fix behavior of the menu() function calls without user param

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,12 +63,12 @@ Changes
 - **Core - Utils Package** - The `menu()` utility function received a new `provisional <developer-guarantees-exclusions>` ``user`` parameter for defining who can interact with the menu (instead of the default ``ctx.author``) (:issue:`4913`)
 
     If no issues arise, we plan on including this parameter under developer guarantees
-    in the first release made after 2024-05-18.
+    in the first release made after 2024-05-24.
 
 - **Core - Utils Package** - The `SimpleMenu.start()` method received a new `provisional <developer-guarantees-exclusions>` ``user`` parameter for defining who can interact with the menu (instead of the default ``ctx.author``) (:issue:`4913`)
 
     If no issues arise, we plan on including this parameter under developer guarantees
-    in the first release made after 2024-05-18.
+    in the first release made after 2024-05-24.
 
 Fixes
 *****

--- a/redbot/core/utils/menus.py
+++ b/redbot/core/utils/menus.py
@@ -80,7 +80,7 @@ async def menu(
 
         The ``user`` parameter is considered `provisional <developer-guarantees-exclusions>`.
         If no issues arise, we plan on including it under developer guarantees
-        in the first release made after 2024-05-18.
+        in the first release made after 2024-05-24.
 
     .. warning::
 
@@ -168,7 +168,7 @@ async def menu(
 
             This parameter is `provisional <developer-guarantees-exclusions>`.
             If no issues arise, we plan on including it under developer guarantees
-            in the first release made after 2024-05-18.
+            in the first release made after 2024-05-24.
 
     Raises
     ------
@@ -287,7 +287,7 @@ async def menu(
 
         if len(done) == 0:
             raise asyncio.TimeoutError()
-        react, user = done.pop().result()
+        react, __ = done.pop().result()
     except asyncio.TimeoutError:
         if not ctx.me:
             return

--- a/redbot/core/utils/views.py
+++ b/redbot/core/utils/views.py
@@ -249,7 +249,7 @@ class SimpleMenu(discord.ui.View):
 
             The ``user`` parameter is considered `provisional <developer-guarantees-exclusions>`.
             If no issues arise, we plan on including it under developer guarantees
-            in the first release made after 2024-05-18.
+            in the first release made after 2024-05-24.
 
         Parameters
         ----------
@@ -263,7 +263,7 @@ class SimpleMenu(discord.ui.View):
 
                     This parameter is `provisional <developer-guarantees-exclusions>`.
                     If no issues arise, we plan on including it under developer guarantees
-                    in the first release made after 2024-05-18.
+                    in the first release made after 2024-05-24.
             ephemeral: `bool`
                 Send the message ephemerally. This only works
                 if the context is from a slash command interaction.


### PR DESCRIPTION
### Description of the changes

Fixes an issue with `menu()`'s new `user` param that was caused by accidental reassignment of the `user` variable.

### Have the changes in this PR been tested?

Yes
