### PR TITLE
Add Amazon Linux 2023 install guide

### DIFF
--- a/docs/install_guides/amazon-linux-2023.rst
+++ b/docs/install_guides/amazon-linux-2023.rst
@@ -1,0 +1,26 @@
+.. _install-amazon-linux-2023:
+
+===================================
+Installing Red on Amazon Linux 2023
+===================================
+
+.. include:: _includes/supported-arch-x64+aarch64.rst
+
+.. include:: _includes/linux-preamble.rst
+
+-------------------------------
+Installing the pre-requirements
+-------------------------------
+
+Amazon Linux 2023 has all required packages available in official repositories. Install
+them with dnf:
+
+.. prompt:: bash
+
+    sudo dnf -y install python3.11 python3.11-devel git java-17-amazon-corretto-headless @development nano
+
+.. Include common instructions:
+
+.. include:: _includes/create-env-with-venv3.11.rst
+
+.. include:: _includes/install-and-setup-red-unix.rst

--- a/docs/install_guides/index.rst
+++ b/docs/install_guides/index.rst
@@ -15,6 +15,7 @@ we recommend **Ubuntu 22.04 LTS**.
    mac
    alma-linux-8
    alma-linux-9
+   amazon-linux-2023
    arch
    centos-7
    centos-stream-8

--- a/docs/version_guarantees.rst
+++ b/docs/version_guarantees.rst
@@ -57,6 +57,7 @@ macOS 13 (Ventura)                 x86-64, aarch64           ~2025-10
 macOS 14 (Sonoma)                  x86-64, aarch64           ~2026-10
 Alma Linux 8                       x86-64, aarch64           2029-05-31 (`How long will CloudLinux support AlmaLinux? <https://wiki.almalinux.org/FAQ.html#how-long-will-almalinux-be-supported>`__)
 Alma Linux 9                       x86-64, aarch64           2032-05-31
+Amazon Linux 2023                  x86-64, aarch64           2028-03-15 (`end-of-life <https://docs.aws.amazon.com/linux/al2023/release-notes/support-info-by-support-statement.html#support-info-by-support-statement-eol>`__)
 Arch Linux                         x86-64                    forever (support is only provided for an up-to-date system)
 CentOS 7                           x86-64, aarch64           2024-06-30 (`end of Maintenance Updates <https://wiki.centos.org/About/Product>`__)
 CentOS Stream 8                    x86-64, aarch64           2024-05-31 (`end of Maintenance Updates <https://wiki.centos.org/About/Product>`__)


### PR DESCRIPTION
### Description of the changes

I somehow missed that the new Amazon Linux (Amazon Linux 2022/2023) reached general availability in March 2023. This PR adds install instructions for it.

### Have the changes in this PR been tested?

Yes

Install instructions test run: https://cirrus-ci.com/build/5889330764316672