### PR TITLE
Update LL version stringification and make parsing stricter

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -160,10 +160,16 @@ class LavalinkOldVersion:
     def from_version_output(cls, output: bytes) -> Self:
         build_match = LAVALINK_BUILD_LINE.search(output)
         if build_match is None:
-            raise ValueError("Could not find Build line in the given `--version` output.")
+            raise ValueError(
+                "Could not find 'Build' line in the given `--version` output,"
+                " or invalid build number given."
+            )
         version_match = LAVALINK_VERSION_LINE_PRE35.search(output)
         if version_match is None:
-            raise ValueError("Could not find Version line in the given `--version` output.")
+            raise ValueError(
+                "Could not find 'Version' line in the given `--version` output,"
+                " or invalid version number given."
+            )
         return cls(
             raw_version=version_match["version"].decode(),
             build_number=int(build_match["build"]),
@@ -236,7 +242,10 @@ class LavalinkVersion:
             # >=3.5-rc4, <3.6
             match = LAVALINK_VERSION_LINE_PRE36.search(output)
         if match is None:
-            raise ValueError("Could not find Version line in the given `--version` output.")
+            raise ValueError(
+                "Could not find 'Version' line in the given `--version` output,"
+                " or invalid version number given."
+            )
         return LavalinkVersion(
             major=int(match["major"]),
             minor=int(match["minor"]),
@@ -604,16 +613,28 @@ class ServerManager:
         stdout = (await _proc.communicate())[0]
         if (branch := LAVALINK_BRANCH_LINE.search(stdout)) is None:
             # Output is unexpected, suspect corrupted jarfile
-            raise ValueError("Could not find 'Branch' line in the `--version` output.")
+            raise ValueError(
+                "Could not find 'Branch' line in the `--version` output,"
+                " or invalid branch name given."
+            )
         if (java := LAVALINK_JAVA_LINE.search(stdout)) is None:
             # Output is unexpected, suspect corrupted jarfile
-            raise ValueError("Could not find 'JVM' line in the `--version` output.")
+            raise ValueError(
+                "Could not find 'JVM' line in the `--version` output,"
+                " or invalid version number given."
+            )
         if (lavaplayer := LAVALINK_LAVAPLAYER_LINE.search(stdout)) is None:
             # Output is unexpected, suspect corrupted jarfile
-            raise ValueError("Could not find 'Lavaplayer' line in the `--version` output.")
+            raise ValueError(
+                "Could not find 'Lavaplayer' line in the `--version` output,"
+                " or invalid version number given."
+            )
         if (buildtime := LAVALINK_BUILD_TIME_LINE.search(stdout)) is None:
             # Output is unexpected, suspect corrupted jarfile
-            raise ValueError("Could not find 'Build time' line in the `--version` output.")
+            raise ValueError(
+                "Could not find 'Build time' line in the `--version` output,"
+                " or invalid build time given."
+            )
 
         self._lavalink_version = (
             LavalinkOldVersion.from_version_output(stdout)

--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -646,7 +646,7 @@ class ServerManager:
             log.info(
                 "Lavalink version outdated, triggering update from %s to %s...",
                 self._lavalink_version,
-                self.JAR_VERSION
+                self.JAR_VERSION,
             )
             await self._download_jar()
 

--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -206,9 +206,9 @@ class LavalinkVersion:
     def __str__(self) -> None:
         version = f"{self.major}.{self.minor}.{self.patch}"
         if self.rc is not None:
-            version += f"-rc{self.rc}"
+            version += f"-rc.{self.rc}"
         if self.red:
-            version += f"_red{self.red}"
+            version += f"+red.{self.red}"
         return version
 
     @classmethod

--- a/tests/cogs/audio/test_manager.py
+++ b/tests/cogs/audio/test_manager.py
@@ -49,6 +49,10 @@ def test_old_ll_version_parsing(
     assert str(actual) == f"{raw_version}_{raw_build_number}"
 
 
+def _generate_ll_version_line(raw_version: str) -> bytes:
+    return b"Version: " + raw_version.encode()
+
+
 @pytest.mark.parametrize(
     "raw_version,expected_str,expected",
     (
@@ -70,11 +74,58 @@ def test_old_ll_version_parsing(
 def test_ll_version_parsing(
     raw_version: str, expected_str: Optional[str], expected: LavalinkVersion
 ) -> None:
-    line = b"Version: " + raw_version.encode()
+    line = _generate_ll_version_line(raw_version)
     actual = LavalinkVersion.from_version_output(line)
     expected_str = expected_str or raw_version
     assert actual == expected
     assert str(actual) == expected_str
+
+
+@pytest.mark.parametrize(
+    "raw_version",
+    (
+        # 3.5.0-rc4 is first version to not have build number
+        # 3.5 stripped `.0` from version number
+        "3.5",
+        # RC version don't need a dot for RC versions...
+        "3.5-rc4",
+        # ...but that doesn't mean they can't
+        "3.5-rc.5",
+        # regular 3.5.x version
+        "3.5.5",
+        # one more RC version with non-zero patch version
+        "3.5.5-rc1",
+    ),
+)
+def test_ll_version_accepts_less_strict_below_3_6(raw_version: str) -> None:
+    line = _generate_ll_version_line(raw_version)
+    # check that the version can be parsed
+    LavalinkVersion.from_version_output(line)
+
+
+@pytest.mark.parametrize(
+    "raw_version",
+    (
+        # `.0` releases <3.6 had their `.0` stripped so this is not valid:
+        "3.5.0-rc4",
+        # 3.6 is first to require stricter format
+        "3.6.0-rc4",
+        "3.6",
+        # another single digit minor version newer than 3.6
+        "3.7",
+        # double digit minor version
+        "3.11.3-rc1",
+        # newer major version
+        "4.0.0-rc5",
+        # double digit major version
+        "11.0.0-rc5",
+    ),
+)
+def test_ll_version_rejects_less_strict_on_3_6_and_above(raw_version: str) -> None:
+    line = _generate_ll_version_line(raw_version)
+
+    with pytest.raises(ValueError):
+        LavalinkVersion.from_version_output(line)
 
 
 def test_ll_version_comparison() -> None:


### PR DESCRIPTION
### Description of the changes

It turns out that the stringification of Lavalink versions with `rc` and/or `red` suffixes was broken but the test suite didn't detect it due to being written incorrectly:
- `3.5.0-rc.4` was incorrectly stringified to: `3.5.0-rc4`
- `3.6.0-rc.1` was incorrectly stringified to: `3.6.0-rc1`
- `3.7.5-rc.1+red.1` was incorrectly stringified to: `3.7.5-rc1_red1`
- `3.7.5-rc.1+red.123` was incorrectly stringified to: `3.7.5-rc1_red123`
- `3.7.5+red.1` was incorrectly stringified to: `3.7.5_red1`
- `3.7.5+red.123` was incorrectly stringified to: `3.7.5_red123`

This PR fixes that. Note that the current RC release ([`3.7.12-rc1+red1`](https://github.com/Cog-Creators/Lavalink-Jars/releases/tag/3.7.12-rc1%2Bred.1)) is missing a dot between `rc` and the number so it is NOT possible to test that the download works correctly by only updating the version:
```diff
-    JAR_VERSION: Final[str] = LavalinkVersion(3, 7, 11)
+    JAR_VERSION: Final[str] = LavalinkVersion(3, 7, 12, rc=1, red=1)
```
I did, however, change the tagged release for a few minutes just so that I can validate this and it is, in fact, downloading the jar without issues.

Additionally, per @aikaterna's suggestion, I made our version parser stricter to prevent incorrect formatting of the version in the future.

Last but not least, the reason for the jar download (first-time download, parsing failure, or outdated version) is now logged.

### Have the changes in this PR been tested?

Yes
