### PR TITLE
[Audio] Update Lavalink.jar build

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -294,7 +294,7 @@ class LavalinkVersion:
 
 
 class ServerManager:
-    JAR_VERSION: Final[str] = LavalinkVersion(3, 7, 11)
+    JAR_VERSION: Final[str] = LavalinkVersion(3, 7, 11, red=2)
     LAVALINK_DOWNLOAD_URL: Final[str] = (
         "https://github.com/Cog-Creators/Lavalink-Jars/releases/download/"
         f"{JAR_VERSION}/"


### PR DESCRIPTION
### Description of the changes

This changes audio's manager to download and use version 3.7.11+red.2 of our Lavalink.jar.

### Have the changes in this PR been tested?

Yes

Lavalink Changelog:
This new file resolves some recent issues where the wrong video would be served for a playback request.
