### PR TITLE
Increase default timeout for send_interactive to 60

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -2324,7 +2324,7 @@ class Red(
         *,
         user: Optional[discord.User] = None,
         box_lang: Optional[str] = None,
-        timeout: int = 15,
+        timeout: int = 60,
         join_character: str = "",
     ) -> List[discord.Message]:
         """


### PR DESCRIPTION
### Description of the changes
15 seconds to respond to whether you want a file or more pages from `send_interactive` feels just a bit too short. This increases the default to 60 seconds allowing more time for individuals to recognize what the bot is asking you for and respond.


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
