### PR TITLE
Increase default timeout for ctx.send_interactive to 60

### DIFF
--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -151,7 +151,7 @@ class Context(DPYContext):
         self,
         messages: Iterable[str],
         box_lang: Optional[str] = None,
-        timeout: int = 15,
+        timeout: int = 60,
         join_character: str = "",
     ) -> List[discord.Message]:
         """


### PR DESCRIPTION
### Description of the changes
I realized that `ctx.send_interactive`'s timeout changes is being forgotten in #6346
This PR also changes the timeout of `ctx.send_interactive` to 60 seconds.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
