### PR TITLE
Add Ubuntu 24.04 instructions + support for Fedora 40

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -282,7 +282,7 @@ If you want to do it, follow these steps.
 2. **Install Linux**
 
   Most of the VPS providers have tools for installing Linux automatically. If
-  you're a beginner, we recommend **Ubuntu 22.04 LTS**.
+  you're a beginner, we recommend **Ubuntu 24.04 LTS**.
 
   For Raspberry Pi users, just install `Raspbian
   <https://www.raspberrypi.org/software/>`_ on a micro-SD card.

--- a/docs/install_guides/index.rst
+++ b/docs/install_guides/index.rst
@@ -6,7 +6,7 @@ Installing Red
 The list below shows the installation guides available based on the operating system being used.
 
 If you want to host Red on a VPS and are unsure what operating system you should choose,
-we recommend **Ubuntu 22.04 LTS**.
+we recommend **Ubuntu 24.04 LTS**.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/install_guides/index.rst
+++ b/docs/install_guides/index.rst
@@ -35,4 +35,5 @@ we recommend **Ubuntu 22.04 LTS**.
    rocky-linux-9
    ubuntu-2004
    ubuntu-2204
+   ubuntu-2404
    ubuntu-non-lts

--- a/docs/install_guides/ubuntu-2404.rst
+++ b/docs/install_guides/ubuntu-2404.rst
@@ -1,0 +1,33 @@
+.. _install-ubuntu-2404:
+
+==================================
+Installing Red on Ubuntu 24.04 LTS
+==================================
+
+.. include:: _includes/supported-arch-x64+aarch64.rst
+
+.. include:: _includes/linux-preamble.rst
+
+-------------------------------
+Installing the pre-requirements
+-------------------------------
+
+We recommend adding the ``deadsnakes`` ppa to install Python 3.11:
+
+.. prompt:: bash
+
+    sudo apt update
+    sudo apt -y install software-properties-common
+    sudo add-apt-repository -y ppa:deadsnakes/ppa
+
+Now install the pre-requirements with apt:
+
+.. prompt:: bash
+
+    sudo apt -y install python3.11 python3.11-dev python3.11-venv git openjdk-17-jre-headless build-essential nano
+
+.. Include common instructions:
+
+.. include:: _includes/create-env-with-venv3.11.rst
+
+.. include:: _includes/install-and-setup-red-unix.rst

--- a/docs/version_guarantees.rst
+++ b/docs/version_guarantees.rst
@@ -66,6 +66,7 @@ Debian 11 Bullseye                 x86-64, aarch64, armv7l   ~2024-07 (`End of l
 Debian 12 Bookworm                 x86-64, aarch64, armv7l   ~2026-09 (`End of life <https://wiki.debian.org/DebianReleases#Production_Releases>`__)
 Fedora Linux 38                    x86-64, aarch64           2024-05-14 (`End of Life <https://docs.fedoraproject.org/en-US/releases/lifecycle/#_maintenance_schedule>`__)
 Fedora Linux 39                    x86-64, aarch64           2024-11-12 (`End of Life <https://docs.fedoraproject.org/en-US/releases/lifecycle/#_maintenance_schedule>`__)
+Fedora Linux 40                    x86-64, aarch64           2025-05-13 (`End of Life <https://docs.fedoraproject.org/en-US/releases/lifecycle/#_maintenance_schedule>`__)
 openSUSE Leap 15.5                 x86-64, aarch64           2024-12-31 (`end of maintenance life cycle <https://en.opensuse.org/Lifetime#openSUSE_Leap>`__)
 openSUSE Tumbleweed                x86-64, aarch64           forever (support is only provided for an up-to-date system)
 Oracle Linux 8                     x86-64, aarch64           2029-07-31 (`End of Premier Support <https://www.oracle.com/us/support/library/elsp-lifetime-069338.pdf>`__)
@@ -80,9 +81,10 @@ RHEL 9.0                           x86-64, aarch64           2024-05-31 (`End of
 RHEL 9.2                           x86-64, aarch64           2025-05-31 (`End of Extended Update Support <https://access.redhat.com/support/policy/updates/errata#Extended_Update_Support>`__)
 Rocky Linux 8                      x86-64, aarch64           2029-05-31 (`end-of-life <https://rockylinux.org/download/>`__)
 Rocky Linux 9                      x86-64, aarch64           2032-05-31 (`end-of-life <https://rockylinux.org/download/>`__)
-Ubuntu 20.04 LTS                   x86-64, aarch64           2025-04-30 (`End of Standard Support <https://wiki.ubuntu.com/Releases#Current>`__)
-Ubuntu 22.04 LTS                   x86-64, aarch64           2027-04-30 (`End of Standard Support <https://wiki.ubuntu.com/Releases#Current>`__)
+Ubuntu 20.04 LTS                   x86-64, aarch64           2025-06-30 (`End of Standard Support <https://wiki.ubuntu.com/Releases#Current>`__)
+Ubuntu 22.04 LTS                   x86-64, aarch64           2027-06-30 (`End of Standard Support <https://wiki.ubuntu.com/Releases#Current>`__)
 Ubuntu 23.10                       x86-64, aarch64           2024-07-31 (`End of Standard Support <https://wiki.ubuntu.com/Releases#Current>`__)
+Ubuntu 24.04 LTS                   x86-64, aarch64           2029-06-30 (`End of Standard Support <https://wiki.ubuntu.com/Releases#Current>`__)
 ================================   =======================   ============================================================
 
 .. _developer-guarantees:


### PR DESCRIPTION
### Description of the changes

Preparations for April distro releases:
- Fedora 40 - 2024-04-23
- Ubuntu 24.04 - 2024-04-25

Fedora 40 and Ubuntu 24.04 LTS instructions have been tested.

### Have the changes in this PR been tested?

Yes

macOS 12 & 13 x86_64: https://github.com/Jackenmen/Red-Install-Tests/actions/runs/8869849998
Everything else: https://cirrus-ci.com/build/5108694101262336