### PR TITLE
Update macOS instructions to use default cask

### DIFF
--- a/docs/install_guides/mac.rst
+++ b/docs/install_guides/mac.rst
@@ -28,8 +28,7 @@ one-by-one:
 
     brew install python@3.11
     brew install git
-    brew tap homebrew/cask-versions
-    brew install --cask temurin17
+    brew install temurin@17
 
 By default, Python installed through Homebrew is not added to the load path.
 To fix this, you should run these commands:


### PR DESCRIPTION
### Description of the changes

See https://github.com/Homebrew/homebrew-cask-versions/pull/20190

### Have the changes in this PR been tested?

Yes

macOS 12 & 13 x86_64: https://github.com/Jackenmen/Red-Install-Tests/actions/runs/8869931246
Everything else: https://cirrus-ci.com/build/5662373585879040