### PR TITLE
Fix an issue with autocomplete in ignored channels/servers

### DIFF
--- a/redbot/core/tree.py
+++ b/redbot/core/tree.py
@@ -334,6 +334,20 @@ class RedTree(CommandTree):
         else:
             log.exception(type(error).__name__, exc_info=error)
 
+    async def _send_interaction_check_failure(
+        self, interaction: discord.Interaction, message: str
+    ):
+        """Handles responding to interaction check failures.
+        Mainly used for when an interaction is an autocomplete and
+        providing the message in the autocomplete response.
+        """
+        if interaction.type is discord.InteractionType.autocomplete:
+            await interaction.response.autocomplete(
+                [discord.app_commands.Choice(name=message[:80], value="None")]
+            )
+            return
+        await interaction.response.send_message(message, ephemeral=True)
+
     async def interaction_check(self, interaction: discord.Interaction):
         """Global checks for app commands."""
         if interaction.user.bot:
@@ -341,36 +355,15 @@ class RedTree(CommandTree):
 
         if interaction.guild:
             if not (await self.client.ignored_channel_or_guild(interaction)):
-                if interaction.type is discord.InteractionType.autocomplete:
-                    await interaction.response.autocomplete(
-                        [
-                            discord.app_commands.Choice(
-                                name=_("This channel or server is ignored."), value="None"
-                            )
-                        ]
-                    )
-                    return False
-                await interaction.response.send_message(
-                    "This channel or server is ignored.", ephemeral=True
+                await self._send_interaction_check_failure(
+                    interaction, _("This channel or server is ignored.")
                 )
                 return False
 
         if not (await self.client.allowed_by_whitelist_blacklist(interaction.user)):
-            if interaction.type is discord.InteractionType.autocomplete:
-                await interaction.response.autocomplete(
-                    [
-                        discord.app_commands.Choice(
-                            name=_(
-                                "You are not permitted to use commands because of an allowlist or blocklist."
-                            ),
-                            value="None",
-                        )
-                    ]
-                )
-                return False
-            await interaction.response.send_message(
-                "You are not permitted to use commands because of an allowlist or blocklist.",
-                ephemeral=True,
+            await self._send_interaction_check_failure(
+                interaction,
+                _("You are not permitted to use commands because of an allowlist or blocklist."),
             )
             return False
 

--- a/redbot/core/tree.py
+++ b/redbot/core/tree.py
@@ -342,11 +342,13 @@ class RedTree(CommandTree):
         if interaction.guild:
             if not (await self.client.ignored_channel_or_guild(interaction)):
                 if interaction.type is discord.InteractionType.autocomplete:
-                    await interaction.response.autocomplete([
-                        discord.app_commands.Choice(
-                            name=_("This channel or server is ignored."), value="None"
-                        )
-                    ])
+                    await interaction.response.autocomplete(
+                        [
+                            discord.app_commands.Choice(
+                                name=_("This channel or server is ignored."), value="None"
+                            )
+                        ]
+                    )
                     return False
                 await interaction.response.send_message(
                     "This channel or server is ignored.", ephemeral=True

--- a/redbot/core/tree.py
+++ b/redbot/core/tree.py
@@ -360,7 +360,10 @@ class RedTree(CommandTree):
                 await interaction.response.autocomplete(
                     [
                         discord.app_commands.Choice(
-                            name=_("This channel or server is ignored."), value="None"
+                            name=_(
+                                "You are not permitted to use commands because of an allowlist or blocklist."
+                            ),
+                            value="None",
                         )
                     ]
                 )

--- a/redbot/core/tree.py
+++ b/redbot/core/tree.py
@@ -356,6 +356,15 @@ class RedTree(CommandTree):
                 return False
 
         if not (await self.client.allowed_by_whitelist_blacklist(interaction.user)):
+            if interaction.type is discord.InteractionType.autocomplete:
+                await interaction.response.autocomplete(
+                    [
+                        discord.app_commands.Choice(
+                            name=_("This channel or server is ignored."), value="None"
+                        )
+                    ]
+                )
+                return False
             await interaction.response.send_message(
                 "You are not permitted to use commands because of an allowlist or blocklist.",
                 ephemeral=True,

--- a/redbot/core/tree.py
+++ b/redbot/core/tree.py
@@ -341,6 +341,13 @@ class RedTree(CommandTree):
 
         if interaction.guild:
             if not (await self.client.ignored_channel_or_guild(interaction)):
+                if interaction.type is discord.InteractionType.autocomplete:
+                    await interaction.response.autocomplete([
+                        discord.app_commands.Choice(
+                            name=_("This channel or server is ignored."), value="None"
+                        )
+                    ])
+                    return False
                 await interaction.response.send_message(
                     "This channel or server is ignored.", ephemeral=True
                 )


### PR DESCRIPTION
### Description of the changes
Resolves #6374 by replacing the text response on an autocomplete interaction with choices stating why the command won't function properly


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
![image](https://github.com/Cog-Creators/Red-DiscordBot/assets/4099256/941a154b-5c6b-4c09-8893-9062c3cc293f)

