### PR TITLE
Fix info.json keys in approved CC guide

### DIFF
--- a/docs/guide_cog_creators.rst
+++ b/docs/guide_cog_creators.rst
@@ -41,17 +41,16 @@ Any Cog Creator that does not follow these requirements will have their repo rem
 - Repo-wide ``info.json`` file with the keys
 
   - ``author``
-  - ``name``
   - ``short``
   - ``description``
 
 - Cog ``info.json`` files with the keys
 
   - ``author``
-  - ``name``
   - ``short``
   - ``requirements`` (if applicable)
   - ``description``
+  - ``min_python_version`` (if applicable)
 
   See `info-json-format` for more information on how to set up ``info.json`` files.
 


### PR DESCRIPTION
### Description of the changes
Like many people, I simply referenced other people's cogs to make my `info.json`s, and an extra phantom key from the V2 days made its way into our docs. I removed the `name` key from both the repo and cog requirements, and added the conditional `min_python_version` key since lots of cogs lately have needed that one.

Technically the cookie cutter repo and the policies should also be updated, but I don't want to do that :(

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
