### PR TITLE
Docs: remove Atom from the list of recommended editors

### DIFF
--- a/docs/guide_cog_creation.rst
+++ b/docs/guide_cog_creation.rst
@@ -55,7 +55,7 @@ the purposes of this example, we'll call this :code:`mycog`).
 In this folder, create three files: :code:`__init__.py`,
 :code:`mycog.py`, and :code:`info.json`. Open the folder in
 a text editor or IDE (examples include `Sublime Text 3 <https://www.sublimetext.com/>`_,
-`Visual Studio Code <https://code.visualstudio.com/>`_, `Atom <https://atom.io/>`_, and
+`Visual Studio Code <https://code.visualstudio.com/>`_, and
 `PyCharm <http://www.jetbrains.com/pycharm/>`_).
 
 .. attention:: 


### PR DESCRIPTION
### Description of the changes

Atom has been deprecated/archived since December 15 of 2022, and https://atom.io/ now redirects to a GitHub blog post detailing the deprecation.  
I don't think it's a good idea to be recommending software that hasn't been officially supported in over a year, when there's far superior options available (such as the other recommended editors).

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
