### PR TITLE
Fix `@commands.can_manage_channel` always passing

### DIFF
--- a/redbot/core/commands/requires.py
+++ b/redbot/core/commands/requires.py
@@ -761,7 +761,7 @@ def bot_can_react() -> Callable[[_T], _T]:
 
 
 def _can_manage_channel_deco(
-    privilege_level: Optional[PrivilegeLevel] = None, allow_thread_owner: bool = False
+    *, privilege_level: Optional[PrivilegeLevel] = None, allow_thread_owner: bool = False
 ) -> Callable[[_T], _T]:
     async def predicate(ctx: "Context") -> bool:
         if utils.can_user_manage_channel(
@@ -803,7 +803,7 @@ def can_manage_channel(*, allow_thread_owner: bool = False) -> Callable[[_T], _T
         as that, in addition to members with manage channel/threads permission,
         can also be done by the thread owner.
     """
-    return _can_manage_channel_deco(None, allow_thread_owner)
+    return _can_manage_channel_deco(allow_thread_owner=allow_thread_owner)
 
 
 def is_owner():
@@ -837,7 +837,9 @@ def guildowner_or_can_manage_channel(*, allow_thread_owner: bool = False) -> Cal
         as that, in addition to members with manage channel/threads permission,
         can also be done by the thread owner.
     """
-    return _can_manage_channel_deco(PrivilegeLevel.GUILD_OWNER, allow_thread_owner)
+    return _can_manage_channel_deco(
+        privilege_level=PrivilegeLevel.GUILD_OWNER, allow_thread_owner=allow_thread_owner
+    )
 
 
 def guildowner():
@@ -871,7 +873,9 @@ def admin_or_can_manage_channel(*, allow_thread_owner: bool = False) -> Callable
         as that, in addition to members with manage channel/threads permission,
         can also be done by the thread owner.
     """
-    return _can_manage_channel_deco(PrivilegeLevel.ADMIN, allow_thread_owner)
+    return _can_manage_channel_deco(
+        privilege_level=PrivilegeLevel.ADMIN, allow_thread_owner=allow_thread_owner
+    )
 
 
 def admin():
@@ -905,7 +909,9 @@ def mod_or_can_manage_channel(*, allow_thread_owner: bool = False) -> Callable[[
         as that, in addition to members with manage channel/threads permission,
         can also be done by the thread owner.
     """
-    return _can_manage_channel_deco(PrivilegeLevel.MOD, allow_thread_owner)
+    return _can_manage_channel_deco(
+        privilege_level=PrivilegeLevel.MOD, allow_thread_owner=allow_thread_owner
+    )
 
 
 def mod():

--- a/redbot/core/commands/requires.py
+++ b/redbot/core/commands/requires.py
@@ -803,7 +803,7 @@ def can_manage_channel(*, allow_thread_owner: bool = False) -> Callable[[_T], _T
         as that, in addition to members with manage channel/threads permission,
         can also be done by the thread owner.
     """
-    return _can_manage_channel_deco(allow_thread_owner)
+    return _can_manage_channel_deco(None, allow_thread_owner)
 
 
 def is_owner():


### PR DESCRIPTION
### Description of the changes
https://github.com/Cog-Creators/Red-DiscordBot/blob/ad1e1aa2ba804cceae29757b48cce0c0c0ae4703/redbot/core/commands/requires.py#L791-L806
`@commands.can_manage_channel` passes the `bool` value `allow_thread_owner` as the first parameter to `_can_manage_channel_deco`


https://github.com/Cog-Creators/Red-DiscordBot/blob/ad1e1aa2ba804cceae29757b48cce0c0c0ae4703/redbot/core/commands/requires.py#L763-L778
`_can_manage_channel_deco` expects the first parameter to be a `PrivilegeLevel`. When a `bool` is passed instead, the eventual comparison results in `if await PrivilegeLevel.from_ctx(ctx) >= <bool>`.


https://github.com/Cog-Creators/Red-DiscordBot/blob/ad1e1aa2ba804cceae29757b48cce0c0c0ae4703/redbot/core/commands/requires.py#L97-L117
Since `enum.auto` increments starting from `1`, and `bool`s are interpreted as an int of `0` or `1`, the `PrivilegeLevel` requirement is always passed. As a result, this check always passes, regardless of the channel state or the permissions of the invoker. This is not the case for all other checks that use the `_can_manage_channel_deco` helper, as those checks explicitly pass a `PrivilegeLevel`.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
