### PR TITLE
Update docs vars to work with RTD changes

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -5,7 +5,7 @@
     <p class="first admonition-title">Warning</p>
     <p class="last">
         This document is for Red's development version, which can be significantly different from previous releases.
-        If you're a regular user, you should read the <a href="{{ dict(versions)['stable'] }}">Red documentation for the current stable release</a>.
+        If you're a regular user, you should read the <a href="/{{ rtd_language }}/stable/">Red documentation for the current stable release</a>.
     </p>
 </div>
 {% endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,6 +139,9 @@ html_context = {
     "github_user": "Cog-Creators",
     "github_repo": "Red-DiscordBot",
     "github_version": "V3/develop",
+    "version_slug": os.environ.get("READTHEDOCS_VERSION", ""),
+    "rtd_language": os.environ.get("READTHEDOCS_LANGUAGE", ""),
+    "READTHEDOCS": os.environ.get("READTHEDOCS", "") == "True",
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
### Description of the changes

Few small changes to accommodate the planned removal of Sphinx context injection on RTD.

Depending on what changes are made to sphinx-rtd-theme, more changes may be needed.

### Have the changes in this PR been tested?

No

It is not possible to test this until Sphinx context injection is disabled for all existing projects on RTD. Either way, I did base this on RTD's compatibility extension:
https://github.com/readthedocs/sphinx-build-compatibility/blob/58aabc5f207c6c2421f23d3578adc0b14af57047/sphinx_build_compatibility/extension.py#L123