### PR TITLE
Forcefully shutdown RPC to prevent hangs

### DIFF
--- a/redbot/core/_rpc.py
+++ b/redbot/core/_rpc.py
@@ -93,7 +93,14 @@ class RPC:
             self._started, _discard, self._site = (
                 True,
                 await self._runner.setup(),
-                web.TCPSite(self._runner, host="127.0.0.1", port=port, shutdown_timeout=0),
+                web.TCPSite(
+                    self._runner,
+                    host="127.0.0.1",
+                    port=port,
+                    shutdown_timeout=120
+                    # Give the RPC server 2 minutes to finish up, else slap it!
+                    # Seems like a reasonable time. See Red#6391
+                ),
             )
         except Exception as exc:
             log.exception("RPC setup failure", exc_info=exc)


### PR DESCRIPTION
### Description of the changes

Fixed #6391.

### Have the changes in this PR been tested?

No, but it should just work. If not, its aiohttp's fault.
