### PR TITLE
Bump YT source plugin version to 1.5.1 and add custom plugin config

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -299,7 +299,7 @@ class LavalinkVersion:
 
 class ServerManager:
     JAR_VERSION: Final[str] = LavalinkVersion(3, 7, 11, red=3)
-    YT_PLUGIN_VERSION: Final[str] = "1.4.0"
+    YT_PLUGIN_VERSION: Final[str] = "1.5.1"
 
     LAVALINK_DOWNLOAD_URL: Final[str] = (
         "https://github.com/Cog-Creators/Lavalink-Jars/releases/download/"

--- a/redbot/cogs/audio/utils.py
+++ b/redbot/cogs/audio/utils.py
@@ -83,6 +83,24 @@ DEFAULT_LAVALINK_YAML = {
     "yaml__logging__level__lavalink": "INFO",
     "yaml__logging__logback__rollingpolicy__max_history": 15,
     "yaml__logging__logback__rollingpolicy__max_size": "10MB",
+    # plugin configuration - note that the plugin may be disabled by the manager
+    "yaml__plugins__youtube__enabled": True,
+    "yaml__plugins__youtube__allowSearch": True,
+    "yaml__plugins__youtube__allowDirectVideoIds": True,
+    "yaml__plugins__youtube__allowDirectPlaylistIds": True,
+    "yaml__plugins__youtube__clients": [
+        "MUSIC",
+        "WEB",
+        "ANDROID_TESTSUITE",
+        "TVHTML5EMBEDDED",
+        "ANDROID_LITE",
+        "MEDIA_CONNECT",
+        "IOS",
+    ],
+    "yaml__plugins__youtube__WEB__playback": True,
+    "yaml__plugins__youtube__TVHTML5EMBEDDED__playlistLoading": False,
+    "yaml__plugins__youtube__TVHTML5EMBEDDED__videoLoading": False,
+    "yaml__plugins__youtube__TVHTML5EMBEDDED__searching": False,
 }
 
 DEFAULT_LAVALINK_SETTINGS = {

--- a/redbot/cogs/audio/utils.py
+++ b/redbot/cogs/audio/utils.py
@@ -8,7 +8,7 @@ import time
 
 from enum import Enum, unique
 from pathlib import Path
-from typing import MutableMapping, Tuple, Union
+from typing import Any, MutableMapping, Tuple, Union
 
 import discord
 import psutil
@@ -128,17 +128,16 @@ def convert_function(key: str) -> str:
 
 
 def change_dict_naming_convention(data) -> dict:
-    new = {}
-    for k, v in data.items():
-        new_v = v
-        if isinstance(v, dict):
-            new_v = change_dict_naming_convention(v)
-        elif isinstance(v, list):
-            new_v = list()
-            for x in v:
-                new_v.append(change_dict_naming_convention(x))
-        new[convert_function(k)] = new_v
-    return new
+    ret: Any = data
+    if isinstance(data, dict):
+        ret = {}
+        for key, value in data.items():
+            ret[convert_function(key)] = change_dict_naming_convention(value)
+    elif isinstance(data, list):
+        ret = []
+        for value in data:
+            ret.append(change_dict_naming_convention(value))
+    return ret
 
 
 class CacheLevel:


### PR DESCRIPTION
### Description of the changes

Fixes #6414 and bumps YT source plugin version.

I tested that this works properly both with the YT source disabled (i.e. when the manager doesn't add the YT plugin section) and enabled. It works in both cases and generates the following application.yml files:
- disabled case: [application.yml](https://github.com/user-attachments/files/16448077/application.yml.txt)
- enabled case: [application.yml](https://github.com/user-attachments/files/16448078/application.yml.txt)

The `change_dict_naming_convention()` function had to be updated since it apparently assumed that when it encounters a list, that list is going to consist of dicts. This is not the case for the new `plugins.youtube.clients` key - it consists of strings.

### Have the changes in this PR been tested?

Yes
