### PR TITLE
Set ProcessType in macOS auto-restart service to 'interactive'

### DIFF
--- a/docs/autostart_mac.rst
+++ b/docs/autostart_mac.rst
@@ -57,6 +57,8 @@ Paste the following and replace the following:
             <string>username</string>
             <key>InitGroups</key>
             <true/>
+            <key>ProcessType</key>
+            <string>Interactive</string>
         </dict>
     </plist>
 


### PR DESCRIPTION
### Description of the changes

This should help with audio stuttering that some users experienced only when using macOS auto-restart service but not when using it interactively.

Relevant documentation:
> If [ProcessType is] left unspecified, the system will apply light resource limits to the job, throttling its CPU usage and I/O bandwidth.
> [...]
> Interactive jobs run with the same resource limitations as apps, that is to say, none. Interactive jobs are critical to maintaining a responsive user experience, and this key should only be used if an app's ability to be responsive depends on it, and cannot be made Adaptive.

### Have the changes in this PR been tested?

No

I did not test these changes but they appeared to help at least one person in our support server.