### PR TITLE
Bump dependencies

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,4 @@
-aiohttp
+aiohttp<3.10
 aiohttp-json-rpc
 apsw
 babel

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ aiosignal==1.3.1
     # via aiohttp
 apsw==3.46.0.1
     # via -r base.in
-attrs==23.2.0
+attrs==24.1.0
     # via aiohttp
 babel==2.15.0
     # via -r base.in
@@ -52,7 +52,7 @@ python-dateutil==2.9.0.post0
     # via -r base.in
 pyyaml==6.0.1
     # via -r base.in
-rapidfuzz==3.9.4
+rapidfuzz==3.9.5
     # via -r base.in
 red-commons==1.0.0
     # via
@@ -80,7 +80,7 @@ colorama==0.4.6; sys_platform == "win32"
     # via click
 distro==1.9.0; sys_platform == "linux" and sys_platform == "linux"
     # via -r base.in
-importlib-metadata==8.0.0; python_version != "3.10" and python_version != "3.11"
+importlib-metadata==8.2.0; python_version != "3.10" and python_version != "3.11"
     # via markdown
 pytz==2024.1; python_version == "3.8"
     # via babel

--- a/requirements/extra-doc.txt
+++ b/requirements/extra-doc.txt
@@ -11,7 +11,7 @@ docutils==0.20.1
     #   sphinx-rtd-theme
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
     #   -c base.txt
     #   sphinx

--- a/requirements/extra-test.txt
+++ b/requirements/extra-test.txt
@@ -1,4 +1,4 @@
-astroid==3.2.2
+astroid==3.2.4
     # via pylint
 dill==0.3.8
     # via pylint
@@ -10,7 +10,7 @@ mccabe==0.7.0
     # via pylint
 pluggy==1.5.0
     # via pytest
-pylint==3.2.5
+pylint==3.2.6
     # via -r extra-test.in
 pytest==7.4.4
     # via
@@ -23,7 +23,7 @@ pytest-mock==3.14.0
     # via -r extra-test.in
 tomlkit==0.13.0
     # via pylint
-exceptiongroup==1.2.1; python_version != "3.11"
+exceptiongroup==1.2.2; python_version != "3.11"
     # via pytest
 tomli==2.0.1; python_version != "3.11"
     # via


### PR DESCRIPTION
### Description of the changes

Bumps everything but aiohttp - we would like to avoid the following change for now:
aio-libs/aiohttp@5a9e500

### Have the changes in this PR been tested?

Yes

macOS 12 x86_64 & macOS 13/14 ARM64: https://github.com/Jackenmen/Red-Install-Tests/actions/runs/10239320962
Everything else: https://cirrus-ci.com/build/4564464219979776
