### PR TITLE
[Audio] Update yt source version

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -299,7 +299,7 @@ class LavalinkVersion:
 
 class ServerManager:
     JAR_VERSION: Final[str] = LavalinkVersion(3, 7, 11, red=3)
-    YT_PLUGIN_VERSION: Final[str] = "1.5.1"
+    YT_PLUGIN_VERSION: Final[str] = "1.5.2"
 
     LAVALINK_DOWNLOAD_URL: Final[str] = (
         "https://github.com/Cog-Creators/Lavalink-Jars/releases/download/"


### PR DESCRIPTION
### Description of the changes

Update the yt source plugin for Audio to version 1.5.2. This fixes some age-restricted tracks not playing.

### Have the changes in this PR been tested?

Yes