### PR TITLE
[Audio] Fix trying to send notify message with no channel object

### DIFF
--- a/redbot/cogs/audio/core/events/cog.py
+++ b/redbot/cogs/audio/core/events/cog.py
@@ -198,6 +198,8 @@ class AudioEvents(MixinMeta, metaclass=CompositeMetaClass):
         if not guild:
             return
         notify_channel = guild.get_channel_or_thread(player.fetch("notify_channel"))
+        if not notify_channel:
+            return
         has_perms = self._has_notify_perms(notify_channel)
         tries = 0
         while not player._is_playing:

--- a/redbot/cogs/audio/core/utilities/miscellaneous.py
+++ b/redbot/cogs/audio/core/utilities/miscellaneous.py
@@ -105,8 +105,9 @@ class MiscellaneousUtilities(MixinMeta, metaclass=CompositeMetaClass):
             discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread
         ],
     ) -> bool:
-        perms = channel.permissions_for(channel.guild.me)
-        return all((can_user_send_messages_in(channel.guild.me, channel), perms.embed_links))
+        if channel is not None:
+            perms = channel.permissions_for(channel.guild.me)
+            return all((can_user_send_messages_in(channel.guild.me, channel), perms.embed_links))
 
     async def maybe_run_pending_db_tasks(self, ctx: commands.Context) -> None:
         if self.api_interface is not None:

--- a/redbot/cogs/audio/core/utilities/miscellaneous.py
+++ b/redbot/cogs/audio/core/utilities/miscellaneous.py
@@ -105,9 +105,8 @@ class MiscellaneousUtilities(MixinMeta, metaclass=CompositeMetaClass):
             discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread
         ],
     ) -> bool:
-        if channel is not None:
-            perms = channel.permissions_for(channel.guild.me)
-            return all((can_user_send_messages_in(channel.guild.me, channel), perms.embed_links))
+        perms = channel.permissions_for(channel.guild.me)
+        return all((can_user_send_messages_in(channel.guild.me, channel), perms.embed_links))
 
     async def maybe_run_pending_db_tasks(self, ctx: commands.Context) -> None:
         if self.api_interface is not None:


### PR DESCRIPTION
### Description of the changes
A user in Red support submitted this traceback.

![image](https://github.com/user-attachments/assets/c96185e9-e297-4140-9102-fbe0c893608f)

The player object has a channel reference inside the extra information telling it where to display messages and the channel was deleted or unreachable. This change checks for a channel object before trying to fetch its permissions.

### Have the changes in this PR been tested?

Yesn't

I tested this change and checked for the _has_notify_perms condition returning False when an audioset notify channel is set to a deleted channel. After this change the player continues playing without throwing an error when a track changes and a notify message or autoplay message needs to be sent. There are a lot of points where interacting with audio and sending a command will readjust the notify channel saved in the player, so there isn't much of a need to clear that non-existent channel object as it will do it on its own with most usage.

If someone else would like to do any kind of sanity check on this please feel free. Otherwise I'm mostly confident I didn't break more things. 🤞 
