### PR TITLE
[Audio] Update Lavalink.jar and yt source build numbers

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -298,8 +298,8 @@ class LavalinkVersion:
 
 
 class ServerManager:
-    JAR_VERSION: Final[str] = LavalinkVersion(3, 7, 11, red=3)
-    YT_PLUGIN_VERSION: Final[str] = "1.5.2"
+    JAR_VERSION: Final[str] = LavalinkVersion(3, 7, 12, red=1)
+    YT_PLUGIN_VERSION: Final[str] = "1.7.2"
 
     LAVALINK_DOWNLOAD_URL: Final[str] = (
         "https://github.com/Cog-Creators/Lavalink-Jars/releases/download/"


### PR DESCRIPTION
### Description of the changes

Updates the Lavalink.jar to the newest pre-release which uses the v8 voice gateway.
Updates the yt source plugin to the latest which fixes livestream detection and offers other authentication methods for unmanaged instances.

### Have the changes in this PR been tested?
Yes
