### PR TITLE
Split out non-Python assets in Publish Release workflow

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -98,14 +98,14 @@ jobs:
         env:
           APP_YML_FILE: "Red-DiscordBot-${{ github.ref_name }}-default-lavalink-application.yml"
         run: |
-          mkdir -p dist
-          python .github/workflows/scripts/get_default_ll_server_config.py "dist/$APP_YML_FILE"
+          mkdir -p release_assets
+          python .github/workflows/scripts/get_default_ll_server_config.py "release_assets/$APP_YML_FILE"
 
       - name: Upload default application.yml
         uses: actions/upload-artifact@v3
         with:
           name: ll-default-server-config
-          path: ./dist
+          path: ./release_assets
 
   release_to_pypi:
     needs:
@@ -129,13 +129,13 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ll-default-server-config
-          path: dist/
+          path: release_assets/
 
       - name: Upload dists to GitHub Release
         env:
           GITHUB_TOKEN: "${{ github.token }}"
         run: |
-          gh release upload "$GITHUB_REF_NAME" dist/* --repo "$GITHUB_REPOSITORY"
+          gh release upload "$GITHUB_REF_NAME" dist/* release_assets/* --repo "$GITHUB_REPOSITORY"
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
### Description of the changes

The last release wasn't *fully* released through automation as usual since the recent changes to the workflow had a few issues.

Two of them have been solved while releasing:
- [Missing information about repository (repo is not cloned when publishing artifacts)](https://github.com/Cog-Creators/Red-DiscordBot/commit/9ca0ced2d8434fb675b0c774c6625827e9b089c5)
- [Missing perms to upload to release](https://github.com/Cog-Creators/Red-DiscordBot/commit/88b11f2b9c6ec5739acc4d4d8148e858b5d5914f)

But one remained - the `dist/` directory containing files that aren't Python package distribution files caused the upload to PyPI to fail while collecting files to upload. This PR aims to fix that by splitting out `application.yml` (the only non-distribution artifact) into a different directory.

### Have the changes in this PR been tested?

No
