### PR TITLE
[Trivia] Correct typos in World Cup trivia list for Golden Glove questions

### DIFF
--- a/redbot/cogs/trivia/data/lists/worldcup.yaml
+++ b/redbot/cogs/trivia/data/lists/worldcup.yaml
@@ -637,16 +637,16 @@ Who won the Golden Boot award in 2022 Qatar?:
 
 # Golden Glove
 
-Who won the Golden Boot award in 2010 South Africa?:
+Who won the Golden Glove award in 2010 South Africa?:
 - Iker Casillas
 - Casillas
-Who won the Golden Boot award in 2014 Brazil?:
+Who won the Golden Glove award in 2014 Brazil?:
 - Manuel Neuer
 - Neuer
-Who won the Golden Boot award in 2018 Russia?:
+Who won the Golden Glove award in 2018 Russia?:
 - Thibaut Courtois
 - Courtois
-Who won the Golden Boot award in 2022 Qatar?:
+Who won the Golden Glove award in 2022 Qatar?:
 - Emiliano Martínez
 - Martínez
 - Martinez


### PR DESCRIPTION
### Description of the changes
Corrected the questions in `worldcup` trivia: it was asking who won the "Golden Boot" when it should have asked who won the "Golden Glove".


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
