### PR TITLE
Fix `header` utility docstring

### DIFF
--- a/redbot/core/utils/chat_formatting.py
+++ b/redbot/core/utils/chat_formatting.py
@@ -68,7 +68,7 @@ def header(text: str, size: Literal["small", "medium", "large"]) -> str:
     ----------
     text : str
         The text for the header.
-    url : Literal['small', 'medium', 'large']
+    size : Literal['small', 'medium', 'large']
         The size of the header ('small', 'medium' or 'large')
 
     Returns


### PR DESCRIPTION
### Description of the changes

Fixes the incorrectly named argument in the header function's docstring. #6102 