### PR TITLE
[config] prevents registering defaults for reserved identifiers

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -141,6 +141,9 @@ class Value:
 
     """
 
+    # to reserve these attributes for __getattr__
+    __slots__ = ("identifier_data", "default", "_driver", "_config", "__dict__")
+
     def __init__(self, identifier_data: IdentifierData, default_value, driver, config: "Config"):
         self.identifier_data = identifier_data
         self.default = default_value
@@ -290,6 +293,9 @@ class Group(Value):
         Same as `Config.force_registration`.
 
     """
+
+    # to reserve these attributes for __getattr__
+    __slots__ = ("_defaults", "force_registration")
 
     def __init__(
         self,
@@ -640,6 +646,18 @@ class Config(metaclass=ConfigMeta):
     USER = "USER"
     MEMBER = "MEMBER"
 
+    # to reserve these attributes for __getattr__
+    __slots__ = (
+        "cog_name",
+        "unique_identifier",
+        "_driver",
+        "force_registration",
+        "_defaults",
+        "custom_groups",
+        "_lock_cache",
+        "__weakref__",
+    )
+
     def __init__(
         self,
         cog_name: str,
@@ -782,6 +800,8 @@ class Config(metaclass=ConfigMeta):
         for i, k in enumerate(splitted, start=1):
             if not k.isidentifier():
                 raise RuntimeError("'{}' is an invalid config key.".format(k))
+            if k in [*vars(Config), *vars(Group), *vars(Value)]:
+                raise RuntimeError("'{}' is a reserved config key.".format(k))
             if i == len(splitted):
                 partial[k] = value
             else:

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -800,7 +800,7 @@ class Config(metaclass=ConfigMeta):
         for i, k in enumerate(splitted, start=1):
             if not k.isidentifier():
                 raise RuntimeError("'{}' is an invalid config key.".format(k))
-            if k in [*vars(Config), *vars(Group), *vars(Value)]:
+            if k in [*dir(Config), *dir(Group), *dir(Value)]:
                 raise RuntimeError("'{}' is a reserved config key.".format(k))
             if i == len(splitted):
                 partial[k] = value

--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -656,6 +656,7 @@ class Config(metaclass=ConfigMeta):
         "custom_groups",
         "_lock_cache",
         "__weakref__",
+        "__dict__",
     )
 
     def __init__(

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -16,6 +16,12 @@ def test_config_register_global_badvalues(config):
         config.register_global(**{"invalid var name": True})
 
 
+def test_config_register_reserved_keys(config):
+    for attr in vars(config):
+        with pytest.raises((RuntimeError, ValueError)):
+            config.register_global(**{attr: True})
+
+
 async def test_config_register_guild(config, empty_guild):
     config.register_guild(enabled=False, some_list=[], some_dict={})
     assert config.defaults[config.GUILD]["enabled"] is False

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -17,8 +17,9 @@ def test_config_register_global_badvalues(config):
 
 
 def test_config_register_reserved_keys(config):
-    for attr in vars(config):
-        with pytest.raises((RuntimeError, ValueError)):
+    config.register_global(**{"group": {"value": True}, "value": True})
+    for attr in [*dir(config), *dir(config.group), *dir(config.value)]:
+        with pytest.raises(RuntimeError):
             config.register_global(**{attr: True})
 
 


### PR DESCRIPTION
### Description of the changes

Fixes #6290 by raising a `RuntimeError` when registering config with an identifier that's already in `Config`/`Group`/`Value` objects

It does so using `__slots__`, so that changes the behavior of `Config` objects in that you can't set arbitrary attributes to them anymore. ~~If that's a problem, we can add `__dict__` to its `__slots__` just like I do to `Value`.~~ I went ahead and added it in case cog creators had set attributes on config

I don't believe using `__slots__` to solve this presents any other complications, but perhaps this should be solved another way (like using class attributes). Let me know and I can adjust

### Have the changes in this PR been tested?

Yes, at least through `tox` with a new test added, and the most common case "default"

<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
