### PR TITLE
Remove deprecated options from `.pylintrc`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -26,14 +26,6 @@ unsafe-load-any-extension=no
 # run arbitrary code
 extension-pkg-whitelist=
 
-# Allow optimization of some AST trees. This will activate a peephole AST
-# optimizer, which will apply various small optimizations. For instance, it can
-# be used to obtain the result of joining multiple strings with the addition
-# operator. Joining a lot of strings can lead to a maximum recursion error in
-# Pylint and this flag can prevent that. It has one side effect, the resulting
-# AST will be different than the one from reality.
-optimize-ast=no
-
 
 [MESSAGES CONTROL]
 
@@ -66,7 +58,6 @@ disable=C, # black is enforcing this for us already, incompatibly
 [REPORTS]
 
 output-format=parseable
-files-output=no
 reports=no
 
 


### PR DESCRIPTION
### Description of the changes

Remove `optimize-ast` and `files-output` from our pylintrc given that those options were removed from pylint in 2017

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
