### PR TITLE
Respect `[p]bypasscooldowns` in `[p]slash sync`

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -2375,6 +2375,11 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """Custom cooldown error message."""
         if not isinstance(error, commands.CommandOnCooldown):
             return await ctx.bot.on_command_error(ctx, error, unhandled_by_cog=True)
+        if ctx.bot._bypass_cooldowns and ctx.author.id in ctx.bot.owner_ids:
+            ctx.command.reset_cooldown(ctx)
+            new_ctx = await ctx.bot.get_context(ctx.message)
+            await ctx.bot.invoke(new_ctx)
+            return
         await ctx.send(
             _(
                 "You seem to be attempting to sync after recently syncing. Discord does not like it "


### PR DESCRIPTION
### Description of the changes
Previously, the manual `@error` handling of `[p]slash sync`'s cooldown prevented the `[p]bypasscooldowns` dev command from bypassing its cooldown. This change adds a manual check for this setting in that error handler.


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
