### PR TITLE
guild id most be integer.

### DIFF
--- a/redbot/core/config.py
+++ b/redbot/core/config.py
@@ -988,7 +988,7 @@ class Config(metaclass=ConfigMeta):
             The guild's Group object.
 
         """
-        return self._get_base_group(self.GUILD, str(guild.id))
+        return self._get_base_group(self.GUILD, int(guild.id))
 
     def channel_from_id(self, channel_id: int) -> Group:
         """Returns a `Group` for the given channel id.


### PR DESCRIPTION
When the input is a string, you will get None. To fix this, it should be an integer.

data = await self.bot.get_cog("something").config.guild(self.bot.get_guild(channel_name)).channel_count.set(how_many_users) File "/root/redenv/lib/python3.11/site-packages/redbot/core/config.py", line 991, in guild return self._get_base_group(self.GUILD, str(guild.id))
                                        ^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'id'

### Description of the changes



### Have the changes in this PR been tested?
yes
Choose one (remove the line that doesn't apply):
-->
Yes
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
