### PR TITLE
implemented warn by userID

### DIFF
--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -373,7 +373,7 @@ class Warnings(commands.Cog):
     async def warn(
         self,
         ctx: commands.Context,
-        member: discord.Member,
+        identifier: str, 
         points: UserInputOptional[int] = 1,
         *,
         reason: str,
@@ -386,6 +386,19 @@ class Warnings(commands.Cog):
         or a custom reason if ``[p]warningset allowcustomreasons`` is set.
         """
         guild = ctx.guild
+
+        """User can be warned by ID or warned by their name."""
+        if identifier.isdigit():
+            member = ctx.guild.get_member(int(identifier))
+            # await ctx.send("Got member by ID")
+        else:
+            member = ctx.guild.get_member_named(identifier)
+            # await ctx.send("Got member by name")
+
+        if not member:
+            await ctx.send(f"User `{identifier}` not found.")
+            return
+        
         if member == ctx.author:
             return await ctx.send(_("You cannot warn yourself."))
         if member.bot:


### PR DESCRIPTION
### Description of the changes

As per #6445, added feature to make reddiscordbot be able to warn a user by their userID or their name. It was a simple short change

### Have the changes in this PR been tested?

![image](https://github.com/user-attachments/assets/174bfbc6-8ebb-4ff2-930e-3fdb85d1a453)
![image](https://github.com/user-attachments/assets/1bfd60a2-2d91-4874-bc96-dc93a50d7ced)
