### PR TITLE
Allow enforcing reason to be filled in Mod cog commands

### DIFF
--- a/docs/cog_guides/mod.rst
+++ b/docs/cog_guides/mod.rst
@@ -268,6 +268,28 @@ and reason as to why they were kicked/banned.
 
 .. _mod-command-modset-hierarchy:
 
+"""""""""
+modset reason
+"""""""""
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]modset reason [enabled]
+
+**Description**
+
+Toggle whether a reason is required for mod actions.
+        
+If this is enabled, the bot will require a reason to be provided for all mod actions.
+
+**Arguments**
+
+* ``[enabled]``: Whether a reason should be required when performing mod actions. |bool-input|
+
+.. _mod-command-modset-hierarchy:
+
 """"""""""""""""
 modset hierarchy
 """"""""""""""""

--- a/docs/cog_guides/mod.rst
+++ b/docs/cog_guides/mod.rst
@@ -266,17 +266,17 @@ and reason as to why they were kicked/banned.
 
 * ``[enabled]``: Whether a message should be sent to a user when they are kicked/banned. |bool-input|
 
-.. _mod-command-modset-hierarchy:
+.. _mod-command-modset-reason:
 
-"""""""""
-modset reason
-"""""""""
+""""""""""""""""""""
+modset requirereason
+""""""""""""""""""""
 
 **Syntax**
 
 .. code-block:: none
 
-    [p]modset reason [enabled]
+    [p]modset requirereason [enabled]
 
 **Description**
 

--- a/docs/cog_guides/mod.rst
+++ b/docs/cog_guides/mod.rst
@@ -266,7 +266,7 @@ and reason as to why they were kicked/banned.
 
 * ``[enabled]``: Whether a message should be sent to a user when they are kicked/banned. |bool-input|
 
-.. _mod-command-modset-reason:
+.. _mod-command-modset-requirereason:
 
 """"""""""""""""""""
 modset requirereason

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -117,8 +117,8 @@ class KickBanMixin(MixinMeta):
 
         removed_temp = False
 
-        if await self.config.guild(guild).mod_reason():
-            if reason is None:
+        if reason is None:
+            if await self.config.guild(guild).mod_reason():
                 return False, _("You must provide a reason for the ban.")
 
         if not (0 <= days <= 7):
@@ -307,8 +307,8 @@ class KickBanMixin(MixinMeta):
         author = ctx.author
         guild = ctx.guild
 
-        if await self.config.guild(guild).mod_reason():
-            if reason is None:
+        if reason is None:
+            if await self.config.guild(guild).mod_reason():
                 await ctx.send(_("You must provide a reason for the kick."))
                 return
 
@@ -437,8 +437,8 @@ class KickBanMixin(MixinMeta):
         errors = {}
         upgrades = []
 
-        if await self.config.guild(ctx.guild).mod_reason():
-            if reason is None:
+        if reason is None:
+            if await self.config.guild(ctx.guild).mod_reason():
                 await ctx.send(_("You must provide a reason for the massban."))
                 return
 
@@ -619,8 +619,8 @@ class KickBanMixin(MixinMeta):
         guild = ctx.guild
         author = ctx.author
 
-        if await self.config.guild(guild).mod_reason():
-            if reason is None:
+        if reason is None:
+            if await self.config.guild(guild).mod_reason():
                 await ctx.send(_("You must provide a reason for the tempban."))
                 return
 
@@ -703,8 +703,8 @@ class KickBanMixin(MixinMeta):
         guild = ctx.guild
         author = ctx.author
 
-        if await self.config.guild(guild).mod_reason():
-            if reason is None:
+        if reason is None:
+            if await self.config.guild(guild).mod_reason():
                 await ctx.send(_("You must provide a reason for the softban."))
                 return
 
@@ -795,8 +795,8 @@ class KickBanMixin(MixinMeta):
         self, ctx: commands.Context, member: discord.Member, *, reason: str = None
     ):
         """Kick a member from a voice channel."""
-        if await self.config.guild(ctx.guild).mod_reason():
-            if reason is None:
+        if reason is None:
+            if await self.config.guild(ctx.guild).mod_reason():
                 await ctx.send(_("You must provide a reason for the voicekick."))
                 return
 
@@ -847,8 +847,8 @@ class KickBanMixin(MixinMeta):
         self, ctx: commands.Context, member: discord.Member, *, reason: str = None
     ):
         """Unban a user from speaking and listening in the server's voice channels."""
-        if await self.config.guild(ctx.guild).mod_reason():
-            if reason is None:
+        if reason is None:
+            if await self.config.guild(ctx.guild).mod_reason():
                 await ctx.send(_("You must provide a reason for the voiceunban."))
                 return
 
@@ -893,8 +893,8 @@ class KickBanMixin(MixinMeta):
     @commands.admin_or_permissions(mute_members=True, deafen_members=True)
     async def voiceban(self, ctx: commands.Context, member: discord.Member, *, reason: str = None):
         """Ban a user from speaking and listening in the server's voice channels."""
-        if await self.config.guild(ctx.guild).mod_reason():
-            if reason is None:
+        if reason is None:
+            if await self.config.guild(ctx.guild).mod_reason():
                 await ctx.send(_("You must provide a reason for the voiceban."))
                 return
 
@@ -947,8 +947,8 @@ class KickBanMixin(MixinMeta):
         1. Copy it from the mod log case (if one was created), or
         2. Enable Developer Mode, go to Bans in this server's settings, right-click the user and select 'Copy ID'.
         """
-        if await self.config.guild(ctx.guild).mod_reason():
-            if reason is None:
+        if reason is None:
+            if await self.config.guild(ctx.guild).mod_reason():
                 await ctx.send(_("You must provide a reason for the unban."))
                 return
 

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -117,6 +117,10 @@ class KickBanMixin(MixinMeta):
 
         removed_temp = False
 
+        if await self.config.guild(guild).mod_reason():
+            if reason is None:
+                return False, _("You must provide a reason for the ban.")
+
         if not (0 <= days <= 7):
             return False, _("Invalid days. Must be between 0 and 7.")
 
@@ -303,6 +307,11 @@ class KickBanMixin(MixinMeta):
         author = ctx.author
         guild = ctx.guild
 
+        if await self.config.guild(guild).mod_reason():
+            if reason is None:
+                await ctx.send(_("You must provide a reason for the kick."))
+                return
+
         if author == member:
             await ctx.send(
                 _("I cannot let you do that. Self-harm is bad {emoji}").format(
@@ -427,6 +436,11 @@ class KickBanMixin(MixinMeta):
         banned = []
         errors = {}
         upgrades = []
+
+        if await self.config.guild(ctx.guild).mod_reason():
+            if reason is None:
+                await ctx.send(_("You must provide a reason for the massban."))
+                return
 
         async def show_results():
             text = _("Banned {num} users from the server.").format(
@@ -605,6 +619,11 @@ class KickBanMixin(MixinMeta):
         guild = ctx.guild
         author = ctx.author
 
+        if await self.config.guild(guild).mod_reason():
+            if reason is None:
+                await ctx.send(_("You must provide a reason for the tempban."))
+                return
+
         if author == member:
             await ctx.send(
                 _("I cannot let you do that. Self-harm is bad {}").format("\N{PENSIVE FACE}")
@@ -683,6 +702,11 @@ class KickBanMixin(MixinMeta):
         """Kick a user and delete 1 day's worth of their messages."""
         guild = ctx.guild
         author = ctx.author
+
+        if await self.config.guild(guild).mod_reason():
+            if reason is None:
+                await ctx.send(_("You must provide a reason for the softban."))
+                return
 
         if author == member:
             await ctx.send(
@@ -771,6 +795,11 @@ class KickBanMixin(MixinMeta):
         self, ctx: commands.Context, member: discord.Member, *, reason: str = None
     ):
         """Kick a member from a voice channel."""
+        if await self.config.guild(ctx.guild).mod_reason():
+            if reason is None:
+                await ctx.send(_("You must provide a reason for the voicekick."))
+                return
+
         author = ctx.author
         guild = ctx.guild
         user_voice_state: discord.VoiceState = member.voice
@@ -818,6 +847,11 @@ class KickBanMixin(MixinMeta):
         self, ctx: commands.Context, member: discord.Member, *, reason: str = None
     ):
         """Unban a user from speaking and listening in the server's voice channels."""
+        if await self.config.guild(ctx.guild).mod_reason():
+            if reason is None:
+                await ctx.send(_("You must provide a reason for the voiceunban."))
+                return
+
         user_voice_state = member.voice
         if (
             await self._voice_perm_check(
@@ -859,6 +893,11 @@ class KickBanMixin(MixinMeta):
     @commands.admin_or_permissions(mute_members=True, deafen_members=True)
     async def voiceban(self, ctx: commands.Context, member: discord.Member, *, reason: str = None):
         """Ban a user from speaking and listening in the server's voice channels."""
+        if await self.config.guild(ctx.guild).mod_reason():
+            if reason is None:
+                await ctx.send(_("You must provide a reason for the voiceban."))
+                return
+
         user_voice_state: discord.VoiceState = member.voice
         if (
             await self._voice_perm_check(
@@ -908,6 +947,11 @@ class KickBanMixin(MixinMeta):
         1. Copy it from the mod log case (if one was created), or
         2. Enable Developer Mode, go to Bans in this server's settings, right-click the user and select 'Copy ID'.
         """
+        if await self.config.guild(ctx.guild).mod_reason():
+            if reason is None:
+                await ctx.send(_("You must provide a reason for the unban."))
+                return
+
         guild = ctx.guild
         author = ctx.author
         audit_reason = get_audit_reason(ctx.author, reason, shorten=True)

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -617,7 +617,7 @@ class KickBanMixin(MixinMeta):
         author = ctx.author
 
         if reason is None and await self.config.guild(guild).require_reason():
-            await ctx.send(_("You must provide a reason for the tempban."))
+            await ctx.send(_("You must provide a reason for the temporary ban."))
             return
 
         if author == member:
@@ -791,7 +791,7 @@ class KickBanMixin(MixinMeta):
     ):
         """Kick a member from a voice channel."""
         if reason is None and await self.config.guild(ctx.guild).require_reason():
-            await ctx.send(_("You must provide a reason for the voicekick."))
+            await ctx.send(_("You must provide a reason for the voice kick."))
             return
 
         author = ctx.author
@@ -842,7 +842,7 @@ class KickBanMixin(MixinMeta):
     ):
         """Unban a user from speaking and listening in the server's voice channels."""
         if reason is None and await self.config.guild(ctx.guild).require_reason():
-            await ctx.send(_("You must provide a reason for the voiceunban."))
+            await ctx.send(_("You must provide a reason for the voice unban."))
             return
 
         user_voice_state = member.voice
@@ -887,7 +887,7 @@ class KickBanMixin(MixinMeta):
     async def voiceban(self, ctx: commands.Context, member: discord.Member, *, reason: str = None):
         """Ban a user from speaking and listening in the server's voice channels."""
         if reason is None and await self.config.guild(ctx.guild).require_reason():
-            await ctx.send(_("You must provide a reason for the voiceban."))
+            await ctx.send(_("You must provide a reason for the voice ban."))
             return
 
         user_voice_state: discord.VoiceState = member.voice

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -117,7 +117,7 @@ class KickBanMixin(MixinMeta):
 
         removed_temp = False
 
-        if reason is None and await self.config.guild(guild).mod_reason():
+        if reason is None and await self.config.guild(guild).require_reason():
             return False, _("You must provide a reason for the ban.")
 
         if not (0 <= days <= 7):
@@ -306,7 +306,7 @@ class KickBanMixin(MixinMeta):
         author = ctx.author
         guild = ctx.guild
 
-        if reason is None and await self.config.guild(guild).mod_reason():
+        if reason is None and await self.config.guild(guild).require_reason():
             await ctx.send(_("You must provide a reason for the kick."))
             return
 
@@ -435,7 +435,7 @@ class KickBanMixin(MixinMeta):
         errors = {}
         upgrades = []
 
-        if reason is None and await self.config.guild(ctx.guild).mod_reason():
+        if reason is None and await self.config.guild(ctx.guild).require_reason():
             await ctx.send(_("You must provide a reason for the massban."))
             return
 
@@ -616,7 +616,7 @@ class KickBanMixin(MixinMeta):
         guild = ctx.guild
         author = ctx.author
 
-        if reason is None and await self.config.guild(guild).mod_reason():
+        if reason is None and await self.config.guild(guild).require_reason():
             await ctx.send(_("You must provide a reason for the tempban."))
             return
 
@@ -699,7 +699,7 @@ class KickBanMixin(MixinMeta):
         guild = ctx.guild
         author = ctx.author
 
-        if reason is None and await self.config.guild(guild).mod_reason():
+        if reason is None and await self.config.guild(guild).require_reason():
             await ctx.send(_("You must provide a reason for the softban."))
             return
 
@@ -790,7 +790,7 @@ class KickBanMixin(MixinMeta):
         self, ctx: commands.Context, member: discord.Member, *, reason: str = None
     ):
         """Kick a member from a voice channel."""
-        if reason is None and await self.config.guild(ctx.guild).mod_reason():
+        if reason is None and await self.config.guild(ctx.guild).require_reason():
             await ctx.send(_("You must provide a reason for the voicekick."))
             return
 
@@ -841,7 +841,7 @@ class KickBanMixin(MixinMeta):
         self, ctx: commands.Context, member: discord.Member, *, reason: str = None
     ):
         """Unban a user from speaking and listening in the server's voice channels."""
-        if reason is None and await self.config.guild(ctx.guild).mod_reason():
+        if reason is None and await self.config.guild(ctx.guild).require_reason():
             await ctx.send(_("You must provide a reason for the voiceunban."))
             return
 
@@ -886,7 +886,7 @@ class KickBanMixin(MixinMeta):
     @commands.admin_or_permissions(mute_members=True, deafen_members=True)
     async def voiceban(self, ctx: commands.Context, member: discord.Member, *, reason: str = None):
         """Ban a user from speaking and listening in the server's voice channels."""
-        if reason is None and await self.config.guild(ctx.guild).mod_reason():
+        if reason is None and await self.config.guild(ctx.guild).require_reason():
             await ctx.send(_("You must provide a reason for the voiceban."))
             return
 
@@ -939,7 +939,7 @@ class KickBanMixin(MixinMeta):
         1. Copy it from the mod log case (if one was created), or
         2. Enable Developer Mode, go to Bans in this server's settings, right-click the user and select 'Copy ID'.
         """
-        if reason is None and await self.config.guild(ctx.guild).mod_reason():
+        if reason is None and await self.config.guild(ctx.guild).require_reason():
             await ctx.send(_("You must provide a reason for the unban."))
             return
 

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -117,9 +117,8 @@ class KickBanMixin(MixinMeta):
 
         removed_temp = False
 
-        if reason is None:
-            if await self.config.guild(guild).mod_reason():
-                return False, _("You must provide a reason for the ban.")
+        if reason is None and await self.config.guild(guild).mod_reason():
+            return False, _("You must provide a reason for the ban.")
 
         if not (0 <= days <= 7):
             return False, _("Invalid days. Must be between 0 and 7.")
@@ -307,10 +306,9 @@ class KickBanMixin(MixinMeta):
         author = ctx.author
         guild = ctx.guild
 
-        if reason is None:
-            if await self.config.guild(guild).mod_reason():
-                await ctx.send(_("You must provide a reason for the kick."))
-                return
+        if reason is None and await self.config.guild(guild).mod_reason():
+            await ctx.send(_("You must provide a reason for the kick."))
+            return
 
         if author == member:
             await ctx.send(
@@ -437,10 +435,9 @@ class KickBanMixin(MixinMeta):
         errors = {}
         upgrades = []
 
-        if reason is None:
-            if await self.config.guild(ctx.guild).mod_reason():
-                await ctx.send(_("You must provide a reason for the massban."))
-                return
+        if reason is None and await self.config.guild(ctx.guild).mod_reason():
+            await ctx.send(_("You must provide a reason for the massban."))
+            return
 
         async def show_results():
             text = _("Banned {num} users from the server.").format(
@@ -619,10 +616,9 @@ class KickBanMixin(MixinMeta):
         guild = ctx.guild
         author = ctx.author
 
-        if reason is None:
-            if await self.config.guild(guild).mod_reason():
-                await ctx.send(_("You must provide a reason for the tempban."))
-                return
+        if reason is None and await self.config.guild(guild).mod_reason():
+            await ctx.send(_("You must provide a reason for the tempban."))
+            return
 
         if author == member:
             await ctx.send(
@@ -703,10 +699,9 @@ class KickBanMixin(MixinMeta):
         guild = ctx.guild
         author = ctx.author
 
-        if reason is None:
-            if await self.config.guild(guild).mod_reason():
-                await ctx.send(_("You must provide a reason for the softban."))
-                return
+        if reason is None and await self.config.guild(guild).mod_reason():
+            await ctx.send(_("You must provide a reason for the softban."))
+            return
 
         if author == member:
             await ctx.send(
@@ -795,10 +790,9 @@ class KickBanMixin(MixinMeta):
         self, ctx: commands.Context, member: discord.Member, *, reason: str = None
     ):
         """Kick a member from a voice channel."""
-        if reason is None:
-            if await self.config.guild(ctx.guild).mod_reason():
-                await ctx.send(_("You must provide a reason for the voicekick."))
-                return
+        if reason is None and await self.config.guild(ctx.guild).mod_reason():
+            await ctx.send(_("You must provide a reason for the voicekick."))
+            return
 
         author = ctx.author
         guild = ctx.guild
@@ -847,10 +841,9 @@ class KickBanMixin(MixinMeta):
         self, ctx: commands.Context, member: discord.Member, *, reason: str = None
     ):
         """Unban a user from speaking and listening in the server's voice channels."""
-        if reason is None:
-            if await self.config.guild(ctx.guild).mod_reason():
-                await ctx.send(_("You must provide a reason for the voiceunban."))
-                return
+        if reason is None and await self.config.guild(ctx.guild).mod_reason():
+            await ctx.send(_("You must provide a reason for the voiceunban."))
+            return
 
         user_voice_state = member.voice
         if (
@@ -893,10 +886,9 @@ class KickBanMixin(MixinMeta):
     @commands.admin_or_permissions(mute_members=True, deafen_members=True)
     async def voiceban(self, ctx: commands.Context, member: discord.Member, *, reason: str = None):
         """Ban a user from speaking and listening in the server's voice channels."""
-        if reason is None:
-            if await self.config.guild(ctx.guild).mod_reason():
-                await ctx.send(_("You must provide a reason for the voiceban."))
-                return
+        if reason is None and await self.config.guild(ctx.guild).mod_reason():
+            await ctx.send(_("You must provide a reason for the voiceban."))
+            return
 
         user_voice_state: discord.VoiceState = member.voice
         if (
@@ -947,10 +939,9 @@ class KickBanMixin(MixinMeta):
         1. Copy it from the mod log case (if one was created), or
         2. Enable Developer Mode, go to Bans in this server's settings, right-click the user and select 'Copy ID'.
         """
-        if reason is None:
-            if await self.config.guild(ctx.guild).mod_reason():
-                await ctx.send(_("You must provide a reason for the unban."))
-                return
+        if reason is None and await self.config.guild(ctx.guild).mod_reason():
+            await ctx.send(_("You must provide a reason for the unban."))
+            return
 
         guild = ctx.guild
         author = ctx.author

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -57,6 +57,7 @@ class Mod(
         "reinvite_on_unban": False,
         "current_tempbans": [],
         "dm_on_kickban": False,
+        "mod_reason": False,
         "default_days": 0,
         "default_tempban_duration": 60 * 60 * 24,
         "track_nicknames": True,

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -57,7 +57,7 @@ class Mod(
         "reinvite_on_unban": False,
         "current_tempbans": [],
         "dm_on_kickban": False,
-        "mod_reason": False,
+        "require_reason": False,
         "default_days": 0,
         "default_tempban_duration": 60 * 60 * 24,
         "track_nicknames": True,

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -372,6 +372,30 @@ class ModSettings(MixinMeta):
 
     @modset.command()
     @commands.guild_only()
+    # add command for setting reason requirement for mod actions
+    async def reason(self, ctx: commands.Context, enabled: bool = None):
+        """
+        Toggle whether a reason is required for mod actions.
+
+        If this is enabled, the bot will require a reason to be provided for all mod actions.
+        """
+        guild = ctx.guild
+        if enabled is None:
+            setting = await self.config.guild(guild).mod_reason()
+            await ctx.send(
+                _("Mod action reason requirement is currently set to: {setting}").format(
+                    setting=setting
+                )
+            )
+            return
+        await self.config.guild(guild).mod_reason.set(enabled)
+        if enabled:
+            await ctx.send(_("Bot will now require a reason for all mod actions."))
+        else:
+            await ctx.send(_("Bot will no longer require a reason for all mod actions."))
+
+    @modset.command()
+    @commands.guild_only()
     async def defaultdays(self, ctx: commands.Context, days: int = 0):
         """Set the default number of days worth of messages to be deleted when a user is banned.
 

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -372,8 +372,7 @@ class ModSettings(MixinMeta):
 
     @modset.command()
     @commands.guild_only()
-    # add command for setting reason requirement for mod actions
-    async def reason(self, ctx: commands.Context, enabled: bool = None):
+    async def requirereason(self, ctx: commands.Context, enabled: bool = None):
         """
         Toggle whether a reason is required for mod actions.
 

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -380,14 +380,14 @@ class ModSettings(MixinMeta):
         """
         guild = ctx.guild
         if enabled is None:
-            setting = await self.config.guild(guild).mod_reason()
+            setting = await self.config.guild(guild).require_reason()
             await ctx.send(
                 _("Mod action reason requirement is currently set to: {setting}").format(
                     setting=setting
                 )
             )
             return
-        await self.config.guild(guild).mod_reason.set(enabled)
+        await self.config.guild(guild).require_reason.set(enabled)
         if enabled:
             await ctx.send(_("Bot will now require a reason for all mod actions."))
         else:


### PR DESCRIPTION
### Description of the changes

This PR adds an option to classify reason in moderation actions as required. Users are able to use `!modset requirereason true` to specify if a reason is required for running any moderation action. It adds the requirement to all moderation commands including `ban`, `kick`, `massban`, `tempban`, `softban`, `voicekick`, `voiceunban`, `voiceban`, and `unban`. If a user runs a mod command when the reason setting is enabled but doesn't include a reason, the bot reasons by telling the user that a reason is required.

Closes #6105

### Have the changes in this PR been tested?

Yes, I manually tested my changes by running each moderation command with and without the requirement. The bot successfully executed the command when a reason is provided and rejects the command if a reason isn't provided when reasons are required.
