### PR TITLE
Add support for SimpleMenu to use custom select options

### DIFF
--- a/redbot/core/utils/views.py
+++ b/redbot/core/utils/views.py
@@ -269,6 +269,11 @@ class SimpleMenu(discord.ui.View):
                 Send the message ephemerally. This only works
                 if the context is from a slash command interaction.
         """
+        if self.use_select_menu and self.source.is_paginating():
+            self.remove_item(self.select_menu)
+            # we added a default one in init so we want to remove it and add any changes here
+            self.select_menu = self._get_select_menu()
+            self.add_item(self.select_menu)
         self._fallback_author_to_ctx = True
         if user is not None:
             self.author = user
@@ -285,6 +290,11 @@ class SimpleMenu(discord.ui.View):
             user: `discord.User`
                 The user that will be direct messaged by the bot.
         """
+        if self.use_select_menu and self.source.is_paginating():
+            self.remove_item(self.select_menu)
+            # we added a default one in init so we want to remove it and add any changes here
+            self.select_menu = self._get_select_menu()
+            self.add_item(self.select_menu)
         self.author = user
         kwargs = await self.get_page(self.current_page)
         self.message = await user.send(**kwargs)

--- a/redbot/core/utils/views.py
+++ b/redbot/core/utils/views.py
@@ -107,6 +107,17 @@ class SimpleMenu(discord.ui.View):
         under the select menu in this instance.
         Defaults to False.
 
+    Attributes
+    ----------
+    select_menu: `discord.ui.Select`
+        A select menu with a list of pages. The usage of this attribute is discouraged
+        as it may store different instances throughout the menu's lifetime.
+
+        .. deprecated-removed:: 3.5.14 60
+            Any behaviour enabled by the usage of this attribute should no longer be depended on.
+            If you need this for something and cannot replace it with the other functionality,
+            create an issue on Red's issue tracker.
+
     Examples
     --------
         You can provide a list of strings::


### PR DESCRIPTION
### Description of the changes

Add the ability to customize the select options on SimpleMenu before sending. This Closes #6455.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
