### PR TITLE
`[p]warn` ask to ban when user not in server

### DIFF
--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -402,10 +402,7 @@ class Warnings(commands.Cog):
                     view=confirm,
                 )
                 await confirm.wait()
-                if confirm.result is None:
-                    await ctx.send("No response received within 10 seconds. No action taken.")
-                    return
-                elif confirm.result:
+                if confirm.result:
                     await ctx.guild.ban(user_obj, reason=reason)
                 else:
                     confirm.message = await ctx.send(_("No action taken."))

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -391,6 +391,9 @@ class Warnings(commands.Cog):
         if isinstance(user, discord.Member):
             member = user
         elif isinstance(user, int):
+            if not ctx.channel.permissions_for(ctx.guild.me).ban_members:
+                await ctx.send(_("User {user} is not in the server."),format(user=user))
+                return
             user_obj = self.bot.get_user(user) or discord.Object(id=user)
             try:
                 confirm = ConfirmView(ctx.author, timeout=10)

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -373,7 +373,7 @@ class Warnings(commands.Cog):
     async def warn(
         self,
         ctx: commands.Context,
-        member: discord.Member,
+        identifier: str, 
         points: UserInputOptional[int] = 1,
         *,
         reason: str,
@@ -386,6 +386,19 @@ class Warnings(commands.Cog):
         or a custom reason if ``[p]warningset allowcustomreasons`` is set.
         """
         guild = ctx.guild
+
+        """User can be warned by ID or warned by their name."""
+        if identifier.isdigit():
+            member = ctx.guild.get_member(int(identifier))
+            # await ctx.send("Got member by ID")
+        else:
+            member = ctx.guild.get_member_named(identifier)
+            # await ctx.send("Got member by name")
+
+        if not member:
+            await ctx.send(f"User `{identifier}` not found.")
+            return
+        
         if member == ctx.author:
             return await ctx.send(_("You cannot warn yourself."))
         if member.bot:

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -427,9 +427,9 @@ class Warnings(commands.Cog):
                     "The person you're trying to warn is equal or higher than you in the discord hierarchy, you cannot warn them."
                 )
             )
-
         guild_settings = await self.config.guild(ctx.guild).all()
         custom_allowed = guild_settings["allow_custom_reasons"]
+
         reason_type = None
         async with self.config.guild(ctx.guild).reasons() as registered_reasons:
             if (reason_type := registered_reasons.get(reason.lower())) is None:

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -392,7 +392,7 @@ class Warnings(commands.Cog):
             member = user
         elif isinstance(user, int):
             if not ctx.channel.permissions_for(ctx.guild.me).ban_members:
-                await ctx.send(_("I cannot ban users. Missing the permission to ban members."))
+                await ctx.send(_("User {user} is not in the server.").format(user=user))
                 return
             user_obj = self.bot.get_user(user) or discord.Object(id=user)
 
@@ -427,10 +427,7 @@ class Warnings(commands.Cog):
             else:
                 confirm.message = await ctx.send(_("No action taken."))
 
-            if ctx.channel.permissions_for(ctx.guild.me).add_reactions:
-                await confirm.message.add_reaction("\N{WHITE HEAVY CHECK MARK}")
-            else:
-                await ctx.tick()
+            ctx.tick()
             return
 
         if member == ctx.author:

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -416,17 +416,18 @@ class Warnings(commands.Cog):
             return
 
         if member == ctx.author:
-            return await ctx.send("You cannot warn yourself.")
+            return await ctx.send(_("You cannot warn yourself."))
         if member.bot:
-            return await ctx.send("You cannot warn other bots.")
+            return await ctx.send(_("You cannot warn other bots."))
         if member == ctx.guild.owner:
-            return await ctx.send("You cannot warn the server owner.")
+            return await ctx.send(_("You cannot warn the server owner."))
         if member.top_role >= ctx.author.top_role and ctx.author != ctx.guild.owner:
             return await ctx.send(
-                "The person you're trying to warn is equal or higher than you in the Discord hierarchy, you cannot warn them."
+                _(
+                    "The person you're trying to warn is equal or higher than you in the discord hierarchy, you cannot warn them."
+                )
             )
 
-        await ctx.send(f"User `{member}` has been warned for: {reason}")
         guild_settings = await self.config.guild(ctx.guild).all()
         custom_allowed = guild_settings["allow_custom_reasons"]
         reason_type = None

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -405,7 +405,7 @@ class Warnings(commands.Cog):
                 elif confirm.result:
                     await ctx.guild.ban(user_obj, reason=reason)
                 else:
-                    confirm.message = await ctx.send("No action taken.")
+                    confirm.message = await ctx.send(_("No action taken."))
 
                 await confirm.message.add_reaction("\N{WHITE HEAVY CHECK MARK}")
 

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -411,7 +411,7 @@ class Warnings(commands.Cog):
                         self.bot,
                         guild,
                         ctx.message.created_at,
-                        "ban",
+                        "hackban",
                         user,
                         ctx.author,
                         reason,
@@ -427,7 +427,7 @@ class Warnings(commands.Cog):
             else:
                 confirm.message = await ctx.send(_("No action taken."))
 
-            ctx.tick()
+            await ctx.tick()
             return
 
         if member == ctx.author:

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -398,7 +398,7 @@ class Warnings(commands.Cog):
             try:
                 confirm = ConfirmView(ctx.author, timeout=30)
                 confirm.message = await ctx.send(
-                    f"User `{user}` is not in the server but has been found globally. Would you like to ban them instead?",
+                    _("User `{user}` is not in the server. Would you like to ban them instead?").format(user=user),
                     view=confirm,
                 )
                 await confirm.wait()

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -410,9 +410,9 @@ class Warnings(commands.Cog):
                 await confirm.message.add_reaction("\N{WHITE HEAVY CHECK MARK}")
 
             except discord.Forbidden:
-                await ctx.send("I don't have permission to ban this user.")
+                await ctx.send(_("I don't have permission to ban this user."))
             except discord.HTTPException:
-                await ctx.send("An error occurred while trying to ban the user.")
+                await ctx.send(_("An error occurred while trying to ban the user."))
             return
 
         if member == ctx.author:

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -392,7 +392,7 @@ class Warnings(commands.Cog):
             member = user
         elif isinstance(user, int):
             if not ctx.channel.permissions_for(ctx.guild.me).ban_members:
-                await ctx.send(_("User {user} is not in the server.").format(user=user))
+                await ctx.send(_("User `{user}` is not in the server.").format(user=user))
                 return
             user_obj = self.bot.get_user(user) or discord.Object(id=user)
 

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -396,7 +396,7 @@ class Warnings(commands.Cog):
                 return
             user_obj = self.bot.get_user(user) or discord.Object(id=user)
             try:
-                confirm = ConfirmView(ctx.author, timeout=10)
+                confirm = ConfirmView(ctx.author, timeout=30)
                 confirm.message = await ctx.send(
                     f"User `{user}` is not in the server but has been found globally. Would you like to ban them instead?",
                     view=confirm,


### PR DESCRIPTION
### Description of the changes

![image](https://github.com/user-attachments/assets/ef7b7e57-fcd6-4953-bb2f-1f26dc26a3b6)

This is to follow up with what @Flame442 said: "If a disruptive user is leaving before a moderator is able to take action, it may often make sense to consider them a troll and bypass the server's standard warnings track."

Instead of warning them, I check if they are in the discord guild; if they are not, then they will be banned. 

Closes #6445

### Have the changes in this PR been tested?
![image](https://github.com/user-attachments/assets/cf90bbb1-b02f-43ac-9c3b-0578e57a5c36)

Note: the command here is "[p]wasd" because I tested it by implementing a new temporary cog.