### PR TITLE
Fixed [p]ban raising an unhandled error if an ID too large is provided

### DIFF
--- a/redbot/core/commands/converter.py
+++ b/redbot/core/commands/converter.py
@@ -51,8 +51,11 @@ __all__ = [
 
 _ = Translator("commands.converter", __file__)
 
+# You'd think that Discord's documentation showing an example of 2 ** 64 - 1 snowflake would mean that
+# this is going to be accepted by everything in their API but nope... Let's assume 2 ** 63 - 1 as the max instead.
 ID_REGEX = re.compile(r"([0-9]{15,19})")
 USER_MENTION_REGEX = re.compile(r"<@!?([0-9]{15,19})>$")
+_MAX_ID = 2**63 - 1
 
 
 # Taken with permission from
@@ -242,8 +245,8 @@ class RawUserIdConverter(dpy_commands.Converter):
         if match := ID_REGEX.fullmatch(argument) or USER_MENTION_REGEX.fullmatch(argument):
             user_id = int(match.group(1))
 
-            # Validate user ID range (Discord user IDs are 64-bit integers but must be ≤ 2^63 - 1)
-            if user_id > 9223372036854775807:  # 2^63 - 1
+            # Validate user ID range
+            if user_id > _MAX_ID:
                 raise BadArgument(
                     f"The ID '{argument}' is too large to be a valid Discord user ID."
                 )


### PR DESCRIPTION
### Description of the changes
Closes #6431 

Added ID validation within RawUserIdConverter, and adjusted Regex matching to fit standard Discord ID format. Also switched usage of regex.match to regex.fullmatch so IDs aren't truncated. Should no longer give error in console when using [p]ban with an ID that is too large.


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
