### PR TITLE
Support [botname] substitutions in cog install messages too

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -936,7 +936,11 @@ class Downloader(commands.Cog):
         await self.send_pagified(ctx, f"{message}{deprecation_notice}\n---")
         for cog in installed_cogs:
             if cog.install_msg:
-                await ctx.send(cog.install_msg.replace("[p]", ctx.clean_prefix))
+                await ctx.send(
+                    cog.install_msg.replace("[p]", ctx.clean_prefix).replace(
+                        "[botname]", ctx.me.display_name
+                    )
+                )
 
     @cog.command(name="uninstall", require_var_positional=True)
     async def _cog_uninstall(self, ctx: commands.Context, *cogs: InstalledCog) -> None:


### PR DESCRIPTION
### Description of the changes

#6443 was meant to add support for this in downloader install messages but it has only done it for repo install messages, skipping cog install messages. This PR fixes that.

### Have the changes in this PR been tested?

No
