### PR TITLE
Fix safety of ``[p]repo list``

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -655,7 +655,11 @@ class Downloader(commands.Cog):
                 joined += "- **{}:** {}\n  - {}\n".format(
                     repo.name,
                     repo.short or "",
-                    "<{}>".format(repo.url),
+                    (
+                        f"<{repo.clean_url}>"
+                        if repo.clean_url.startswith(("http://", "https://"))
+                        else repo.clean_url
+                    ),
                 )
 
         for page in pagify(joined, ["\n"], shorten_by=16):


### PR DESCRIPTION
### Description of the changes

This PR does 2 things:
- fixes safety of `[p]repo list` by switching from `repo.url` to `repo.clean_url` (removes basic Auth from the URL)
- only wraps the URL in `<>` when HTTP/HTTPS protocol is used to prevent the following:
![image](https://github.com/user-attachments/assets/3cb94204-42e3-4973-9894-17ec6ffe5ae5)

### Have the changes in this PR been tested?

Yes
