### PR TITLE
Truncate service names

### DIFF
--- a/redbot/core/utils/views.py
+++ b/redbot/core/utils/views.py
@@ -380,7 +380,11 @@ class SetApiModal(discord.ui.Modal):
         self.title = _("Set API Keys")
         self.keys_label = _("Keys and tokens")
         if self.default_service is not None:
-            truncated_service_name = (self.default_service[:20] + '…') if len(self.default_service) > 20 else self.default_service
+            truncated_service_name = (
+                (self.default_service[:20] + "…")
+                if len(self.default_service) > 20
+                else self.default_service
+            )
             self.keys_label = _("Keys and tokens for {service}").format(
                 service=truncated_service_name
             )

--- a/redbot/core/utils/views.py
+++ b/redbot/core/utils/views.py
@@ -380,9 +380,9 @@ class SetApiModal(discord.ui.Modal):
         self.title = _("Set API Keys")
         self.keys_label = _("Keys and tokens")
         if self.default_service is not None:
-            self.title = _("Set API Keys for {service}").format(service=self.default_service)
+            truncated_service_name = (self.default_service[:20] + '…') if len(self.default_service) > 20 else self.default_service
             self.keys_label = _("Keys and tokens for {service}").format(
-                service=self.default_service
+                service=truncated_service_name
             )
             self.default_service = self.default_service.lower()
             # Lower here to prevent someone from capitalizing a service name for the sake of UX.


### PR DESCRIPTION
### Description of the changes
Truncate the names of service names to ensure that they don't error out due to a too long name. Fixes #6478


### Have the changes in this PR been tested?

Yes

