### PR TITLE
A lot of actions bumping,

### DIFF
--- a/.github/workflows/check_label_pattern_exhaustiveness.yaml
+++ b/.github/workflows/check_label_pattern_exhaustiveness.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,14 +34,13 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: 'python'
         # Override the default behavior so that the action doesn't attempt
         # to auto-install Python dependencies
         # Learn more...
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#analyzing-python-dependencies
-        setup-python-dependencies: false
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -55,4 +54,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/.github/workflows/crowdin_upload_strings.yml
+++ b/.github/workflows/crowdin_upload_strings.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.repository == 'Cog-Creators/Red-DiscordBot'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/lint_python.yaml
+++ b/.github/workflows/lint_python.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Lint Python
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ env.ref }}
       - uses: actions/setup-python@v4

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -16,7 +16,7 @@ jobs:
     needs: pr_stable_bump
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
       milestone_number: ${{ steps.get_milestone_number.outputs.result }}
     steps:
       # Checkout repository and install Python
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout repository and install Python
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -57,7 +57,7 @@ jobs:
     name: Build package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -75,7 +75,7 @@ jobs:
         run: python -m twine check dist/*
 
       - name: Upload packaged distributions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-output
           path: ./dist
@@ -84,7 +84,7 @@ jobs:
     name: Generate default application.yml
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -102,7 +102,7 @@ jobs:
           python .github/workflows/scripts/get_default_ll_server_config.py "release_assets/$APP_YML_FILE"
 
       - name: Upload default application.yml
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ll-default-server-config
           path: ./release_assets
@@ -120,13 +120,13 @@ jobs:
       id-token: write
     steps:
       - name: Download packaged distributions
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-output
           path: dist/
 
       - name: Download default application.yml
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ll-default-server-config
           path: release_assets/
@@ -160,7 +160,7 @@ jobs:
         run: |
           echo "BASE_BRANCH=${TAG_BASE_BRANCH#'refs/heads/'}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ env.BASE_BRANCH }}
       - name: Set up Python

--- a/.github/workflows/run_pip_compile.yaml
+++ b/.github/workflows/run_pip_compile.yaml
@@ -15,7 +15,7 @@ jobs:
           - macos-latest
     steps:
       - name: Checkout the repository.
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.8.
         uses: actions/setup-python@v4
@@ -48,7 +48,7 @@ jobs:
           python .github/workflows/scripts/compile_requirements.py
 
       - name: Upload requirements files.
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.compile_requirements.outputs.sys_platform }}
           path: requirements/${{ steps.compile_requirements.outputs.sys_platform }}-*.txt
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository.
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.8.
         uses: actions/setup-python@v4
@@ -71,17 +71,17 @@ jobs:
           python -m pip install -U "packaging>=22.0"
 
       - name: Download Windows requirements.
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: win32
           path: requirements
       - name: Download Linux requirements.
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: linux
           path: requirements
       - name: Download macOS requirements.
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: darwin
           path: requirements
@@ -91,7 +91,7 @@ jobs:
           python .github/workflows/scripts/merge_requirements.py
 
       - name: Upload merged requirements files.
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: merged
           path: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
         fail-fast: false
       name: Tox - ${{ matrix.friendly_name }}
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
           with:
             ref: ${{ env.ref }}
         - name: Set up Python
@@ -76,7 +76,7 @@ jobs:
             POSTGRES_PASSWORD: postgres
             POSTGRES_USER: postgres
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
           with:
             ref: ${{ env.ref }}
         - name: Set up Python


### PR DESCRIPTION
### Description of the changes

Due to deprecations we have to bump versions by a lot. Sooo, let us all be annoyed 🥲 

> Artifacts v3 brownouts
>
>Artifact actions v3 will be closing down by January 30th, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using v3 of actions/upload-artifact or actions/download-artifact. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
– January 9th 5pm – 6pm UTC
– January 16th 3pm – 7pm UTC
– January 23rd 2pm – 10pm UTC

### Have the changes in this PR been tested?
Lets find out!
