### PR TITLE
Add explicit Sphinx config to .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,9 @@ build:
   tools:
     python: "3.8"
 
+sphinx:
+  configuration: docs/conf.py
+
 python:
   install:
     - method: pip


### PR DESCRIPTION
### Description of the changes

See https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

### Have the changes in this PR been tested?

Yes
