### PR TITLE
Use build.jobs.install to avoid installing unnecessary deps

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,9 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.8"
+  jobs:
+    install:
+      - pip install .[doc]
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
### Description of the changes

https://docs.readthedocs.com/platform/latest/config-file/v2.html#build-jobs
https://docs.readthedocs.com/platform/latest/build-customization.html

Closes #5773 

### Have the changes in this PR been tested?

No
