### PR TITLE
Add `--cog-path` CLI argument

### DIFF
--- a/redbot/core/_cli.py
+++ b/redbot/core/_cli.py
@@ -220,6 +220,15 @@ def parse_cli_flags(args):
         help="Force unloading specified cogs.",
     )
     parser.add_argument(
+        "--cog-path",
+        type=str,
+        default=[],
+        nargs="+",
+        action="extend",
+        help="Add a specific path to the list of cog paths. "
+        "This can be used multiple times to add multiple paths.",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Makes Red quit with code 0 just before the "

--- a/redbot/core/_cog_manager.py
+++ b/redbot/core/_cog_manager.py
@@ -144,8 +144,8 @@ class CogManager:
         ----------
         path : `pathlib.Path` or `str`
             Path to add.
-        persist : `bool`
-            Whether or not the path should be persisted through restarts.
+        persist : `bool`, optional
+            Whether or not the path should be persisted through restarts. Defaults to True.
 
         Raises
         ------

--- a/redbot/core/_cog_manager.py
+++ b/redbot/core/_cog_manager.py
@@ -88,7 +88,7 @@ class CogManager:
             A list of user-defined paths.
 
         """
-        return list(map(Path, deduplicate_iterables(_TEMP_PATHS, await self.config.paths())))
+        return list(map(Path, deduplicate_iterables(await self.config.paths())))
 
     async def set_install_path(self, path: Path) -> Path:
         """Set the install path for 3rd party cogs.
@@ -230,7 +230,9 @@ class CogManager:
                 name=name,
             )
 
-        real_paths = list(map(str, [await self.install_path()] + await self.user_defined_paths()))
+        real_paths = list(
+            map(str, [await self.install_path()] + _TEMP_PATHS + await self.user_defined_paths())
+        )
 
         for finder, module_name, _ in pkgutil.iter_modules(real_paths):
             if name == module_name:
@@ -307,7 +309,7 @@ class CogManager:
 
     async def available_modules(self) -> List[str]:
         """Finds the names of all available modules to load."""
-        paths = list(map(str, await self.paths()))
+        paths = list(map(str, _TEMP_PATHS + await self.paths()))
 
         ret = []
         for finder, module_name, _ in pkgutil.iter_modules(paths):
@@ -348,15 +350,24 @@ class CogManagerUI(commands.Cog):
         core_path = cog_mgr.CORE_PATH
         cog_paths = await cog_mgr.user_defined_paths()
 
-        msg = _("Install Path: {install_path}\nCore Path: {core_path}\n\n").format(
-            install_path=install_path, core_path=core_path
+        temporary_paths = [str(path) for path in _TEMP_PATHS]
+
+        paths = []
+        for index, path in enumerate(cog_paths, start=1):
+            paths.append(f"{index}. {path}")
+
+        msg = _(
+            (
+                "Install Path: {install_path}\nCore Path: {core_path}\n\n"
+                "Temporary Paths:{temporary_paths}\n\nCog Paths:{cog_paths}"
+            )
+        ).format(
+            install_path=install_path,
+            core_path=core_path,
+            temporary_paths=("\n" + "\n".join(temporary_paths)) if temporary_paths else _(" None"),
+            cog_paths=("\n" + "\n".join(paths)) if paths else _(" None"),
         )
 
-        partial = []
-        for i, p in enumerate(cog_paths, start=1):
-            partial.append("{}. {}".format(i, p))
-
-        msg += "\n".join(partial)
         await ctx.send(box(msg))
 
     @commands.command()

--- a/redbot/core/_cog_manager.py
+++ b/redbot/core/_cog_manager.py
@@ -23,6 +23,8 @@ from .utils.chat_formatting import box, pagify, humanize_list, inline
 
 __all__ = ("CogManager", "CogManagerUI")
 
+_TEMP_PATHS: List[Path] = []
+
 
 class NoSuchCog(ImportError):
     """Thrown when a cog is missing.
@@ -86,7 +88,7 @@ class CogManager:
             A list of user-defined paths.
 
         """
-        return list(map(Path, deduplicate_iterables(await self.config.paths())))
+        return list(map(Path, deduplicate_iterables(_TEMP_PATHS, await self.config.paths())))
 
     async def set_install_path(self, path: Path) -> Path:
         """Set the install path for 3rd party cogs.
@@ -133,7 +135,7 @@ class CogManager:
         """
         return Path(path)
 
-    async def add_path(self, path: Union[Path, str]) -> None:
+    async def add_path(self, path: Union[Path, str], *, persist: bool = True) -> None:
         """Add a cog path to current list.
 
         This will ignore duplicates.
@@ -142,6 +144,8 @@ class CogManager:
         ----------
         path : `pathlib.Path` or `str`
             Path to add.
+        persist : `bool`
+            Whether or not the path should be persisted through restarts.
 
         Raises
         ------
@@ -163,10 +167,14 @@ class CogManager:
         if path == self.CORE_PATH:
             raise ValueError("Cannot add the core path as an additional path.")
 
-        current_paths = await self.user_defined_paths()
-        if path not in current_paths:
-            current_paths.append(path)
-            await self.set_paths(current_paths)
+        if persist:
+            current_paths = await self.user_defined_paths()
+            if path not in current_paths:
+                current_paths.append(path)
+                await self.set_paths(current_paths)
+        else:
+            if path not in _TEMP_PATHS:
+                _TEMP_PATHS.append(path)
 
     async def remove_path(self, path: Union[Path, str]) -> None:
         """Remove a path from the current paths list.

--- a/redbot/core/_cog_manager.py
+++ b/redbot/core/_cog_manager.py
@@ -57,13 +57,16 @@ class CogManager:
         -------
         List[pathlib.Path]
             A list of paths where cog packages can be found. The
-            install path is highest priority, followed by the
-            user-defined paths, and the core path has the lowest
-            priority.
+            install path is highest priority, followed by temporary
+            paths, then the user-defined paths, and the core path
+            has the lowest priority.
 
         """
         return deduplicate_iterables(
-            [await self.install_path()], await self.user_defined_paths(), [self.CORE_PATH]
+            [await self.install_path()],
+            _TEMP_PATHS,
+            await self.user_defined_paths(),
+            [self.CORE_PATH],
         )
 
     async def install_path(self) -> Path:
@@ -309,7 +312,7 @@ class CogManager:
 
     async def available_modules(self) -> List[str]:
         """Finds the names of all available modules to load."""
-        paths = list(map(str, _TEMP_PATHS + await self.paths()))
+        paths = list(map(str, await self.paths()))
 
         ret = []
         for finder, module_name, _ in pkgutil.iter_modules(paths):

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1240,6 +1240,15 @@ class Red(
                 )
             )
 
+        if self._cli_flags.cog_path:
+            for path in self._cli_flags.cog_path:
+                path = Path(path)
+                try:
+                    await self._cog_mgr.add_path(path, persist=False)
+                    log.info("Added cog path: %s", path)
+                except Exception:
+                    log.exception("Failed to add cog path: %s", path)
+
         if packages:
             # Load permissions first, for security reasons
             try:


### PR DESCRIPTION
### Description of the changes

This PR adds an argument, `--cog-path`, to the `redbot` CLI that accepts a path, validates that the provided path exists, and adds the path via `self._cog_mgr.add_path()`, so that cogs can be loaded from that path. The argument can be passed multiple times to add more than one path at a time. These paths are stored in memory and never to disk, so restarting the bot without the argument will "remove" the paths.

Additionally, this PR adds a `persist` argument to `CogManager.add_path()`, which defaults to `True`. The original behavior of appending the added path to a list and then calling `.set_path()` on that list is retained through this argument being set to `True`. Setting this argument to `False` will append the path to a module-level list of paths, stored in memory. These are, as I mentioned earlier, never written to the bot's config, and are effectively discarded on shutdown.

Closes #6506.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yeah, but not super thoroughly
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
