### PR TITLE
Bump dependencies and drop openSUSE Leap 15.5

### DIFF
--- a/docs/install_guides/opensuse-leap-15.rst
+++ b/docs/install_guides/opensuse-leap-15.rst
@@ -1,7 +1,7 @@
 .. _install-opensuse-leap-15:
 
 =====================================
-Installing Red on openSUSE Leap 15.5+
+Installing Red on openSUSE Leap 15.6+
 =====================================
 
 .. include:: _includes/supported-arch-x64+aarch64.rst
@@ -12,7 +12,7 @@ Installing Red on openSUSE Leap 15.5+
 Installing the pre-requirements
 -------------------------------
 
-openSUSE Leap 15.5+ has all required dependencies available in official repositories. Install them
+openSUSE Leap 15.6+ has all required dependencies available in official repositories. Install them
 with zypper:
 
 .. prompt:: bash

--- a/docs/version_guarantees.rst
+++ b/docs/version_guarantees.rst
@@ -63,7 +63,6 @@ CentOS Stream 9                    x86-64, aarch64           2027-05-31 (`expect
 Debian 12 Bookworm                 x86-64, aarch64, armv7l   ~2026-09 (`End of life <https://wiki.debian.org/DebianReleases#Production_Releases>`__)
 Fedora Linux 40                    x86-64, aarch64           2025-05-28 (`End of Life <https://docs.fedoraproject.org/en-US/releases/lifecycle/#_maintenance_schedule>`__)
 Fedora Linux 41                    x86-64, aarch64           2025-11-19 (`End of Life <https://docs.fedoraproject.org/en-US/releases/lifecycle/#_maintenance_schedule>`__)
-openSUSE Leap 15.5                 x86-64, aarch64           2024-12-31 (`end of maintenance life cycle <https://en.opensuse.org/Lifetime#openSUSE_Leap>`__)
 openSUSE Leap 15.6                 x86-64, aarch64           2025-12-31 (`end of maintenance life cycle <https://en.opensuse.org/Lifetime#openSUSE_Leap>`__)
 openSUSE Tumbleweed                x86-64, aarch64           forever (support is only provided for an up-to-date system)
 Oracle Linux 8                     x86-64, aarch64           2029-07-31 (`End of Premier Support <https://www.oracle.com/us/support/library/elsp-lifetime-069338.pdf>`__)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,9 +10,9 @@ aiosignal==1.3.1
     # via aiohttp
 apsw==3.46.1.0
     # via -r base.in
-attrs==24.3.0
+attrs==25.1.0
     # via aiohttp
-babel==2.16.0
+babel==2.17.0
     # via -r base.in
 brotli==1.1.0
     # via -r base.in
@@ -38,7 +38,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-orjson==3.10.12
+orjson==3.10.15
     # via -r base.in
 packaging==24.2
     # via -r base.in
@@ -48,7 +48,7 @@ propcache==0.2.0
     # via yarl
 psutil==6.1.1
     # via -r base.in
-pygments==2.18.0
+pygments==2.19.1
     # via rich
 python-dateutil==2.9.0.post0
     # via -r base.in
@@ -83,11 +83,11 @@ colorama==0.4.6; sys_platform == "win32"
     # via click
 distro==1.9.0; sys_platform == "linux" and sys_platform == "linux"
     # via -r base.in
-importlib-metadata==8.5.0; python_version != "3.10" and python_version != "3.11"
+importlib-metadata==8.5.0; python_version != "3.11" and python_version != "3.10"
     # via markdown
-pytz==2024.2; python_version == "3.8"
+pytz==2025.1; python_version == "3.8"
     # via babel
 uvloop==0.21.0; (sys_platform != "win32" and platform_python_implementation == "CPython") and sys_platform != "win32"
     # via -r base.in
-zipp==3.20.2; python_version != "3.10" and python_version != "3.11"
+zipp==3.20.2; python_version != "3.11" and python_version != "3.10"
     # via importlib-metadata

--- a/requirements/extra-doc.txt
+++ b/requirements/extra-doc.txt
@@ -1,8 +1,8 @@
 alabaster==0.7.13
     # via sphinx
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 docutils==0.20.1
     # via
@@ -17,7 +17,7 @@ jinja2==3.1.5
     # via sphinx
 markupsafe==2.1.5
     # via jinja2
-pytz==2024.2
+pytz==2025.1
     # via babel
 requests==2.32.3
     # via sphinx


### PR DESCRIPTION
### Description of the changes

Two things:
- bump dependencies - no major changes here, for some reason order of `python_version` env markers was flipped in the newly built files but that's unimportant
- drop openSUSE Leap 15.5 as it has reached EOL

### Have the changes in this PR been tested?

No

macOS 13 x86_64 & macOS 14-15 M1: https://github.com/Jackenmen/Red-Install-Tests/actions/runs/13104050922
Everything else: https://cirrus-ci.com/build/4675196759572480