### PR TITLE
Handle invalid locale configuration graciously during startup

### DIFF
--- a/redbot/core/_i18n.py
+++ b/redbot/core/_i18n.py
@@ -22,8 +22,9 @@ __all__ = (
 )
 
 
+FRESH_INSTALL_LOCALE = "en-US"
 current_locale = ContextVar("current_locale")
-current_locale_default = "en-US"
+current_locale_default = FRESH_INSTALL_LOCALE
 current_regional_format = ContextVar("current_regional_format")
 current_regional_format_default = None
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1148,23 +1148,25 @@ class Red(
         try:
             _i18n.set_global_locale(i18n_locale)
         except ValueError:
+            log.warning(
+                "The bot's global locale was set to an invalid value (%r)"
+                " and will be reset to default (%s).",
+                i18n_locale,
+                _i18n.FRESH_INSTALL_LOCALE,
+            )
             i18n_locale = _i18n.FRESH_INSTALL_LOCALE
             await self._config.locale.clear()
-            log.warning(
-                "The bot's global locale was set to an invalid value and has been reset"
-                " to default (%s).",
-                i18n_locale,
-            )
         i18n_regional_format = await self._config.regional_format()
         try:
             _i18n.set_global_regional_format(i18n_regional_format)
         except ValueError:
-            await self._config.regional_format.clear()
             log.warning(
-                "The bot's global regional format was set to an invalid value and has been reset"
-                " to default (which is to inherit global locale, i.e. %s).",
+                "The bot's global regional format was set to an invalid value (%r)"
+                " and will be reset to default (which is to inherit global locale, i.e. %s).",
+                i18n_regional_format,
                 i18n_locale,
             )
+            await self._config.regional_format.clear()
 
     async def _pre_connect(self) -> None:
         """

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -115,7 +115,7 @@ class Red(
             owner=None,
             whitelist=[],
             blacklist=[],
-            locale="en-US",
+            locale=_i18n.FRESH_INSTALL_LOCALE,
             regional_format=None,
             embeds=True,
             color=15158332,
@@ -1145,9 +1145,26 @@ class Red(
             self.owner_ids.add(self._owner_id_overwrite)
 
         i18n_locale = await self._config.locale()
-        _i18n.set_global_locale(i18n_locale)
+        try:
+            _i18n.set_global_locale(i18n_locale)
+        except ValueError:
+            i18n_locale = _i18n.FRESH_INSTALL_LOCALE
+            await self._config.locale.clear()
+            log.warning(
+                "The bot's global locale was set to an invalid value and has been reset"
+                " to default (%s).",
+                i18n_locale,
+            )
         i18n_regional_format = await self._config.regional_format()
-        _i18n.set_global_regional_format(i18n_regional_format)
+        try:
+            _i18n.set_global_regional_format(i18n_regional_format)
+        except ValueError:
+            await self._config.regional_format.clear()
+            log.warning(
+                "The bot's global regional format was set to an invalid value and has been reset"
+                " to default (which is to inherit global locale, i.e. %s).",
+                i18n_locale,
+            )
 
     async def _pre_connect(self) -> None:
         """


### PR DESCRIPTION
### Description of the changes

Fix startup issue on invalid locale configuration:
```
[2025-02-02 22:09:10] [CRITICAL] red.main: The main bot task didn't handle an exception and has crashed
Traceback (most recent call last):
  File "/data/venv/lib/python3.11/site-packages/redbot/core/_i18n.py", line 40, in _get_standardized_locale_name
    locale = Locale.parse(language_code, sep="-")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/venv/lib/python3.11/site-packages/babel/core.py", line 349, in parse
    raise ValueError(msg)  # `parse_locale` would raise a ValueError, so let's do that here
    ^^^^^^^^^^^^^^^^^^^^^
ValueError: ("Empty locale identifier value: ''\n\nIf you didn't explicitly pass an empty value to a Babel function, this could be caused by there being no suitable locale environment variables for the API you tried to use.",)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/venv/lib/python3.11/site-packages/redbot/__main__.py", line 470, in red_exception_handler
    red_task.result()
  File "/data/venv/lib/python3.11/site-packages/redbot/__main__.py", line 369, in run_bot
    await red.start(token)
  File "/data/venv/lib/python3.11/site-packages/redbot/core/bot.py", line 1278, in start
    await self._pre_login()
  File "/data/venv/lib/python3.11/site-packages/redbot/core/bot.py", line 1150, in _pre_login
    _i18n.set_global_regional_format(i18n_regional_format)
  File "/data/venv/lib/python3.11/site-packages/redbot/core/_i18n.py", line 60, in set_global_regional_format
    language_code = _get_standardized_locale_name(language_code)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/venv/lib/python3.11/site-packages/redbot/core/_i18n.py", line 42, in _get_standardized_locale_name
    raise ValueError("Invalid language code. Use format: `en-US`")
ValueError: Invalid language code. Use format: `en-US`
```
with config such as:
```
... "locale": "en-US", "regional_format": ""}
```

While an empty string is not something that could have been set by Core, a previously public i18n API for setting locale did not validate its input and as such, some users could have such values in their config files.

### Have the changes in this PR been tested?

No
