### PR TITLE
Catch TypeError when setting global locale

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -1147,7 +1147,7 @@ class Red(
         i18n_locale = await self._config.locale()
         try:
             _i18n.set_global_locale(i18n_locale)
-        except ValueError:
+        except (ValueError, TypeError):
             log.warning(
                 "The bot's global locale was set to an invalid value (%r)"
                 " and will be reset to default (%s).",
@@ -1159,7 +1159,7 @@ class Red(
         i18n_regional_format = await self._config.regional_format()
         try:
             _i18n.set_global_regional_format(i18n_regional_format)
-        except ValueError:
+        except (ValueError, TypeError):
             log.warning(
                 "The bot's global regional format was set to an invalid value (%r)"
                 " and will be reset to default (which is to inherit global locale, i.e. %s).",


### PR DESCRIPTION
### Description of the changes

Since we're assuming the input might be invalid, let's catch type errors too.

Before:
![image](https://github.com/user-attachments/assets/aab21b89-9bbf-48f7-bf5a-6280ac321fb7)

After:
![image](https://github.com/user-attachments/assets/9d0d236a-46de-4297-af21-645fc3481b0f)

### Have the changes in this PR been tested?

Yes

