### PR TITLE
[Audio] Bump YT plugin version

### DIFF
--- a/redbot/cogs/audio/managed_node/version_pins.py
+++ b/redbot/cogs/audio/managed_node/version_pins.py
@@ -12,7 +12,7 @@ __all__ = (
 
 
 JAR_VERSION: Final[LavalinkVersion] = LavalinkVersion(3, 7, 12, red=1)
-YT_PLUGIN_VERSION: Final[str] = "1.11.4"
+YT_PLUGIN_VERSION: Final[str] = "1.11.5"
 # keep this sorted from oldest to latest
 SUPPORTED_JAVA_VERSIONS: Final[Tuple[int, ...]] = (11, 17)
 LATEST_SUPPORTED_JAVA_VERSION: Final = SUPPORTED_JAVA_VERSIONS[-1]


### PR DESCRIPTION
### Description of the changes

Updates audio's yt plugin to latest version.

### Have the changes in this PR been tested?

Yes, but I did not have instances affected by the issue in the previous plugin so I am not able to explicitly verify that the new plugin version works. We can assume based on the lack of screaming in the support server for this plugin that everything is copacetic, for now.