### PR TITLE
[ModLog] allow modlog to log manual kicks

### DIFF
--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -102,7 +102,7 @@ async def _init(bot: Red):
         guild = entry.guild
         if guild.unavailable:
             return
-        if entry.action not in (discord.AuditLogAction.ban, discord.AuditLogAction.unban):
+        if entry.action not in (discord.AuditLogAction.ban, discord.AuditLogAction.unban, discord.AuditLogAction.kick):
             return
 
         try:


### PR DESCRIPTION
### Description of the changes

Just added discord.AuditLogAction.kick from the audit log entry listener.

### Have the changes in this PR been tested?

<!-- 
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
