### PR TITLE
Bump dependencies + drop F40, add F42 to support matrix

### DIFF
--- a/docs/install_guides/fedora.rst
+++ b/docs/install_guides/fedora.rst
@@ -12,7 +12,7 @@ Installing Red on Fedora Linux
 Installing the pre-requirements
 -------------------------------
 
-Fedora Linux 40 and above has all required packages available in official repositories. Install
+Fedora Linux 41 and above has all required packages available in official repositories. Install
 them with dnf:
 
 .. prompt:: bash

--- a/docs/install_guides/fedora.rst
+++ b/docs/install_guides/fedora.rst
@@ -17,7 +17,9 @@ them with dnf:
 
 .. prompt:: bash
 
-    sudo dnf -y install python3.11 python3.11-devel git java-17-openjdk-headless @development-tools nano
+    sudo dnf -y install python3.11 python3.11-devel git adoptium-temurin-java-repository @development-tools nano
+    sudo dnf config-manager setopt adoptium-temurin-java-repository.enabled=1
+    sudo dnf -y install temurin-17-jre
 
 .. Include common instructions:
 

--- a/docs/version_guarantees.rst
+++ b/docs/version_guarantees.rst
@@ -63,6 +63,7 @@ CentOS Stream 9                    x86-64, aarch64           2027-05-31 (`expect
 Debian 12 Bookworm                 x86-64, aarch64, armv7l   ~2026-09 (`End of life <https://wiki.debian.org/DebianReleases#Production_Releases>`__)
 Fedora Linux 40                    x86-64, aarch64           2025-05-28 (`End of Life <https://docs.fedoraproject.org/en-US/releases/lifecycle/#_maintenance_schedule>`__)
 Fedora Linux 41                    x86-64, aarch64           2025-11-19 (`End of Life <https://docs.fedoraproject.org/en-US/releases/lifecycle/#_maintenance_schedule>`__)
+Fedora Linux 42                    x86-64, aarch64           2026-05-13 (`End of Life <https://docs.fedoraproject.org/en-US/releases/lifecycle/#_maintenance_schedule>`__)
 openSUSE Leap 15.6                 x86-64, aarch64           2025-12-31 (`end of maintenance life cycle <https://en.opensuse.org/Lifetime#openSUSE_Leap>`__)
 openSUSE Tumbleweed                x86-64, aarch64           forever (support is only provided for an up-to-date system)
 Oracle Linux 8                     x86-64, aarch64           2029-07-31 (`End of Premier Support <https://www.oracle.com/us/support/library/elsp-lifetime-069338.pdf>`__)

--- a/docs/version_guarantees.rst
+++ b/docs/version_guarantees.rst
@@ -61,7 +61,6 @@ Amazon Linux 2023                  x86-64, aarch64           2028-03-15 (`end-of
 Arch Linux                         x86-64                    forever (support is only provided for an up-to-date system)
 CentOS Stream 9                    x86-64, aarch64           2027-05-31 (`expected EOL <https://centos.org/stream9/#timeline>`__)
 Debian 12 Bookworm                 x86-64, aarch64, armv7l   ~2026-09 (`End of life <https://wiki.debian.org/DebianReleases#Production_Releases>`__)
-Fedora Linux 40                    x86-64, aarch64           2025-05-28 (`End of Life <https://docs.fedoraproject.org/en-US/releases/lifecycle/#_maintenance_schedule>`__)
 Fedora Linux 41                    x86-64, aarch64           2025-11-19 (`End of Life <https://docs.fedoraproject.org/en-US/releases/lifecycle/#_maintenance_schedule>`__)
 Fedora Linux 42                    x86-64, aarch64           2026-05-13 (`End of Life <https://docs.fedoraproject.org/en-US/releases/lifecycle/#_maintenance_schedule>`__)
 openSUSE Leap 15.6                 x86-64, aarch64           2025-12-31 (`end of maintenance life cycle <https://en.opensuse.org/Lifetime#openSUSE_Leap>`__)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -40,7 +40,7 @@ multidict==6.1.0
     #   yarl
 orjson==3.10.15
     # via -r base.in
-packaging==24.2
+packaging==25.0
     # via -r base.in
 platformdirs==4.3.6
     # via -r base.in
@@ -62,13 +62,13 @@ red-commons==1.0.0
     #   red-lavalink
 red-lavalink==0.11.0
     # via -r base.in
-rich==13.9.4
+rich==14.0.0
     # via -r base.in
 schema==0.7.7
     # via -r base.in
 six==1.17.0
     # via python-dateutil
-typing-extensions==4.13.0
+typing-extensions==4.13.2
     # via
     #   -r base.in
     #   multidict

--- a/requirements/extra-doc.txt
+++ b/requirements/extra-doc.txt
@@ -1,6 +1,6 @@
 alabaster==0.7.13
     # via sphinx
-certifi==2025.1.31
+certifi==2025.4.26
     # via requests
 charset-normalizer==3.4.1
     # via requests

--- a/requirements/extra-style.txt
+++ b/requirements/extra-style.txt
@@ -1,6 +1,6 @@
 black==23.12.1
     # via -r extra-style.in
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via black
 pathspec==0.12.1
     # via black

--- a/requirements/extra-test.txt
+++ b/requirements/extra-test.txt
@@ -1,6 +1,6 @@
 astroid==3.2.4
     # via pylint
-dill==0.3.9
+dill==0.4.0
     # via pylint
 iniconfig==2.1.0
     # via pytest


### PR DESCRIPTION
### Description of the changes

On the dependency update side, there's nothing major really - Rich 14 doesn't seem to really introduce any incompatibility despite being a major release.
On the OS matrix side, we added Fedora 42, which was released about two weeks ago, and removed Fedora 40, which will be EOL in a month. We're removing it a bit early because the changes in Fedora 42 around Java version, along with the DNF 5 update in Fedora 41, make it harder to _also_ support Fedora 40.

### Have the changes in this PR been tested?

Yes

macOS 13 x86_64, macOS 14-15 arm64: https://github.com/Jackenmen/Red-Install-Tests/actions/runs/14686554659
Rest: https://cirrus-ci.com/build/5482886238830592
