### PR TITLE
Update project config to use newly standardized and non-beta features

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "wheel"]
+requires = ["setuptools>=80", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -12,7 +12,6 @@ classifiers = [
     "Framework :: AsyncIO",
     "Intended Audience :: Developers",
     "Intended Audience :: End Users/Desktop",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Natural Language :: English",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
@@ -24,6 +23,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Topic :: Communications :: Chat",
 ]
+license = "GPL-3.0-only"
+license-files = ["LICENSE", "redbot/**/*.LICENSE"]
 dynamic = ["version", "requires-python", "dependencies", "optional-dependencies"]
 
 [project.urls]
@@ -41,6 +42,9 @@ redbot-setup = "redbot.setup:run_cli"
 
 [project.entry-points.pytest11]
 red-discordbot = "redbot.pytest"
+
+[tool.setuptools.packages.find]
+include = ["redbot", "redbot.*"]
 
 [tool.black]
 line-length = 99

--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,4 @@ setup(
     # TODO: use [tool.setuptools.dynamic] table once this feature gets out of beta
     install_requires=install_requires,
     extras_require=extras_require,
-    # TODO: use [project] table once PEP 639 gets accepted
-    license_files=["LICENSE", "redbot/**/*.LICENSE"],
-    # TODO: use [tool.setuptools.packages] table once this feature gets out of beta
-    packages=find_namespace_packages(include=["redbot", "redbot.*"]),
 )


### PR DESCRIPTION
### Description of the changes

`[tool.setuptools.packages.find]` is no longer a beta feature, and the project license specification has been standardised with a now-accepted PEP 639.
This is a draft because we cannot do this transition *yet* but I imagine I'll forget once we can, if I don't create PR for it now.

### Have the changes in this PR been tested?

Yes
