### PR TITLE
Fix Reports in dm's not checking the selected guild for a configured channel

### DIFF
--- a/redbot/cogs/reports/reports.py
+++ b/redbot/cogs/reports/reports.py
@@ -307,7 +307,7 @@ class Reports(commands.Cog):
 
         with contextlib.suppress(discord.Forbidden, discord.HTTPException):
             if val is None:
-                if await self.config.guild(ctx.guild).output_channel() is None:
+                if await self.config.guild(guild).output_channel() is None:
                     await author.send(
                         _(
                             "This server has no reports channel set up. Please contact a server admin."


### PR DESCRIPTION
### Description of the changes
When using `[p]report` in dm's with the bot and selecting a guild, the command erroneously tries to check the current context guild setting instead of the selected guild.


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
