### PR TITLE
Disable Rich tracebacks by default

### DIFF
--- a/redbot/core/_cli.py
+++ b/redbot/core/_cli.py
@@ -301,20 +301,31 @@ def parse_cli_flags(args):
         "This flag can be used multiple times to specify multiple intents.",
     )
     parser.add_argument(
-        "--rich-logging",
-        "--force-rich-logging",  # potentially up for removal in Red 3.6
+        "--force-rich-logging",
         action="store_true",
         dest="rich_logging",
         default=None,
-        help="Enable the Rich logging handlers.",
+        help="Forcefully enables the Rich logging handlers. This is normally enabled for supported active terminals.",
     )
     parser.add_argument(
-        "--no-rich-logging",
-        "--force-disable-rich-logging",  # potentially up for removal in Red 3.6
+        "--force-disable-rich-logging",
         action="store_false",
         dest="rich_logging",
         default=None,
-        help="Disable the Rich logging handlers. This is currently the default behavior.",
+        help="Forcefully disables the Rich logging handlers.",
+    )
+    # DEP-WARN: use argparse.BooleanOptionalAction when we drop support for Python 3.8
+    parser.add_argument(
+        "--rich-tracebacks",
+        action="store_true",
+        default=False,
+        help="Format the tracebacks using Rich."
+        " *May* be useful to increase traceback readability during development.",
+    )
+    parser.add_argument(
+        "--no-rich-tracebacks",
+        action="store_false",
+        dest="rich_tracebacks",
     )
     parser.add_argument(
         "--rich-traceback-extra-lines",

--- a/redbot/core/_cli.py
+++ b/redbot/core/_cli.py
@@ -319,7 +319,7 @@ def parse_cli_flags(args):
         "--rich-tracebacks",
         action="store_true",
         default=False,
-        help="Format the tracebacks using Rich."
+        help="Format the Python exception tracebacks using Rich (with syntax highlighting)."
         " *May* be useful to increase traceback readability during development.",
     )
     parser.add_argument(

--- a/redbot/core/_cli.py
+++ b/redbot/core/_cli.py
@@ -301,18 +301,20 @@ def parse_cli_flags(args):
         "This flag can be used multiple times to specify multiple intents.",
     )
     parser.add_argument(
-        "--force-rich-logging",
+        "--rich-logging",
+        "--force-rich-logging",  # potentially up for removal in Red 3.6
         action="store_true",
         dest="rich_logging",
         default=None,
-        help="Forcefully enables the Rich logging handlers. This is normally enabled for supported active terminals.",
+        help="Enable the Rich logging handlers.",
     )
     parser.add_argument(
-        "--force-disable-rich-logging",
+        "--no-rich-logging",
+        "--force-disable-rich-logging",  # potentially up for removal in Red 3.6
         action="store_false",
         dest="rich_logging",
         default=None,
-        help="Forcefully disables the Rich logging handlers.",
+        help="Disable the Rich logging handlers. This is currently the default behavior.",
     )
     parser.add_argument(
         "--rich-traceback-extra-lines",

--- a/redbot/logging.py
+++ b/redbot/logging.py
@@ -307,13 +307,7 @@ def init_logging(level: int, location: pathlib.Path, cli_flags: argparse.Namespa
     # this highlighter which dims most of the path and therefore makes it unreadable on Mac.
     PathHighlighter.highlights = []
 
-    enable_rich_logging = False
-
-    if isatty(0) and cli_flags.rich_logging is None:
-        # Check if the bot thinks it has a active terminal.
-        enable_rich_logging = True
-    elif cli_flags.rich_logging is True:
-        enable_rich_logging = True
+    enable_rich_logging = cli_flags.rich_logging
 
     file_formatter = logging.Formatter(
         "[{asctime}] [{levelname}] {name}: {message}", datefmt="%Y-%m-%d %H:%M:%S", style="{"

--- a/redbot/logging.py
+++ b/redbot/logging.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import logging.handlers
 import pathlib
 import re
@@ -33,6 +34,7 @@ from rich.traceback import PathHighlighter, Traceback  # DEP-WARN
 
 
 MAX_OLD_LOGS = 8
+log = logging.getLogger("red.logging")
 
 
 class RotatingFileHandler(logging.handlers.RotatingFileHandler):
@@ -379,3 +381,9 @@ def init_logging(level: int, location: pathlib.Path, cli_flags: argparse.Namespa
     for fhandler in (latest_fhandler, all_fhandler):
         fhandler.setFormatter(file_formatter)
         root_logger.addHandler(fhandler)
+
+    if not enable_rich_logging and cli_flags.rich_tracebacks:
+        log.warning(
+            "Rich tracebacks were requested but they will not be enabled"
+            " as Rich logging is not active."
+        )

--- a/redbot/logging.py
+++ b/redbot/logging.py
@@ -307,7 +307,13 @@ def init_logging(level: int, location: pathlib.Path, cli_flags: argparse.Namespa
     # this highlighter which dims most of the path and therefore makes it unreadable on Mac.
     PathHighlighter.highlights = []
 
-    enable_rich_logging = cli_flags.rich_logging
+    enable_rich_logging = False
+
+    if isatty(0) and cli_flags.rich_logging is None:
+        # Check if the bot thinks it has a active terminal.
+        enable_rich_logging = True
+    elif cli_flags.rich_logging is True:
+        enable_rich_logging = True
 
     file_formatter = logging.Formatter(
         "[{asctime}] [{levelname}] {name}: {message}", datefmt="%Y-%m-%d %H:%M:%S", style="{"
@@ -316,7 +322,7 @@ def init_logging(level: int, location: pathlib.Path, cli_flags: argparse.Namespa
         rich_formatter = logging.Formatter("{message}", datefmt="[%X]", style="{")
 
         stdout_handler = RedRichHandler(
-            rich_tracebacks=True,
+            rich_tracebacks=cli_flags.rich_tracebacks,
             show_path=False,
             highlighter=NullHighlighter(),
             tracebacks_extra_lines=cli_flags.rich_traceback_extra_lines,


### PR DESCRIPTION
### Description of the changes

Rich tracebacks trade usability for the "nice look". We don't want that as a default experience. It's been a constant support nightmare due to how much it inflates the text length of tracebacks, doesn't react well to terminal resizing, and, empirically, probably also slows down console logging noticeably...
I feel like this has been a known "ah, yes, this does kinda suck and we'd like to change it at some point" for a while.

### Have the changes in this PR been tested?

Yes
