### PR TITLE
Fix checks not properly handling Group commands type

### DIFF
--- a/redbot/core/commands/requires.py
+++ b/redbot/core/commands/requires.py
@@ -33,10 +33,10 @@ from .errors import BotMissingPermissions
 from redbot.core import utils
 
 if TYPE_CHECKING:
-    from .commands import Command
+    from .commands import Command, Group
     from .context import Context
 
-    _CommandOrCoro = TypeVar("_CommandOrCoro", Callable[..., Awaitable[Any]], Command)
+    _CommandOrCoro = TypeVar("_CommandOrCoro", Callable[..., Awaitable[Any]], Command, Group)
 
 __all__ = [
     "CheckPredicate",


### PR DESCRIPTION
### Description of the changes

This PR propose to add the type `Group` to the type variable used in `Requires.get_decorator` (Which is used by [Red's checks](https://docs.discord.red/en/stable/framework_checks.html)).

This was made as creating a command group, in addition of one of Red's provided check, would alert Pylance of incorrect type, expecting type `Command` only.

**Before**

![image](https://github.com/user-attachments/assets/a17b134c-5ad0-4ab3-9966-59db33f2acbe)


**After**
![image](https://github.com/user-attachments/assets/8e38adc4-ba7d-4e0c-aedc-62512d5743da)
![image](https://github.com/user-attachments/assets/89c17c55-9484-439e-85c6-7d22d3132a1f)

The correct type is now reflected.
Same issue and fix apply for `@commands.hybrid_group`

### Have the changes in this PR been tested?

Yes
