### PR TITLE
Inject guild locale information in app commands

### DIFF
--- a/redbot/core/tree.py
+++ b/redbot/core/tree.py
@@ -19,7 +19,10 @@ from .app_commands import (
     TransformerError,
     UserFeedbackCheckFailure,
 )
-from .i18n import Translator
+from redbot.core.i18n import (
+    Translator,
+    set_contextual_locales_from_guild,
+)
 from .utils.chat_formatting import humanize_list, inline
 
 import logging
@@ -395,3 +398,9 @@ class RedTree(CommandTree):
 
         for key in remove:
             del self._disabled_global_commands[key]
+
+    # DEP-WARN
+    async def _call(self, interaction: discord.Interaction, *args, **kwargs) -> None:
+        """Configure the contextual locale based on the interaction guild prior to invoking."""
+        await set_contextual_locales_from_guild(interaction.client, interaction.guild)
+        await super()._call(interaction, *args, **kwargs)


### PR DESCRIPTION
### Description of the changes
Previously, app commands had no guild locale information, and would only use the global locale settings. This PR causes the locale information to be injected prior to calling the command, similar to the current logic for text commands.

The chain of app command execution in dpy is not the same as text commands, with the command processing logic a public method that can be explicitly called when `on_message` is overriden. As a result, this is currently being done by overriding a private `CommandTree` method. We are already messing with the internals of this object enough that it's probably fine to mess with it a little more.
1. `state.py` `parse_interaction_create`
2. `CommandTree._from_interaction`
3. `CommandTree._call` <--- injected here

Fixes #6272


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
