### PR TITLE
Add `--enable-debug-events` flag to CLI

### DIFF
--- a/redbot/core/_cli.py
+++ b/redbot/core/_cli.py
@@ -136,6 +136,9 @@ def parse_cli_flags(args):
     parser.add_argument("--version", "-V", action="store_true", help="Show Red's current version")
     parser.add_argument("--debuginfo", action="store_true", help="Show debug information.")
     parser.add_argument(
+        "--enable-debug-events", action="store_true", help="Enable discord.py socket debug events."
+    )
+    parser.add_argument(
         "--list-instances",
         action="store_true",
         help="List all instance names setup with 'redbot-setup'",

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -232,6 +232,9 @@ class Red(
         kwargs["max_messages"] = message_cache_size
         self._max_messages = message_cache_size
 
+        if cli_flags.enable_debug_events:
+            kwargs["enable_debug_events"] = True
+
         self._uptime = None
         self._checked_time_accuracy = None
 


### PR DESCRIPTION
### Description of the changes

Enables discord.py socket debug events. I think they are useful sometimes (for cog dev) and should be toggle-able through the CLI.


### Have the changes in this PR been tested?

Yes