### PR TITLE
Fix an issue with alias quote detection

### DIFF
--- a/redbot/cogs/alias/alias_entry.py
+++ b/redbot/cogs/alias/alias_entry.py
@@ -55,11 +55,15 @@ class AliasEntry:
         known_content_length = len(prefix) + len(self.name)
         extra = message.content[known_content_length:]
         view = StringView(extra)
+        view.skip_ws()
         extra = []
         while not view.eof:
-            view.skip_ws()
             prev = view.index
-            word = view.get_quoted_word()
+            try:
+                word = view.get_quoted_word()
+            except discord.ext.commands.errors.UnexpectedQuoteError:
+                view.skip_ws()
+                continue
             if len(word) < view.index - prev:
                 word = "".join((view.buffer[prev], word, view.buffer[view.index - 1]))
             extra.append(word.strip(" "))

--- a/redbot/cogs/alias/alias_entry.py
+++ b/redbot/cogs/alias/alias_entry.py
@@ -55,9 +55,9 @@ class AliasEntry:
         known_content_length = len(prefix) + len(self.name)
         extra = message.content[known_content_length:]
         view = StringView(extra)
-        view.skip_ws()
         extra = []
         while not view.eof:
+            view.skip_ws()
             prev = view.index
             word = view.get_quoted_word()
             if len(word) < view.index - prev:


### PR DESCRIPTION
### Description of the changes
When an alias is used to invoke a command and the user uses "double quotes" to capture spaces alias would error without responding to the user's input at all. This PR fixes the StringView lookup by stripping whitespace if it encounters it and then a quote character allowing it to pull the quoted text instead.


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
