### PR TITLE
Update the invite Regex pattern with a new accepted format.

### DIFF
--- a/redbot/core/utils/common_filters.py
+++ b/redbot/core/utils/common_filters.py
@@ -16,7 +16,9 @@ __all__ = [
 # regexes
 URL_RE = re.compile(r"(https?|s?ftp)://(\S+)", re.I)
 
-INVITE_URL_RE = re.compile(r"(discord\.(?:gg|io|me|li)|discord(?:app)?\.com\/invite)[\/\\](\S+)", re.I)
+INVITE_URL_RE = re.compile(
+    r"(discord\.(?:gg|io|me|li)|discord(?:app)?\.com\/invite)[\/\\](\S+)", re.I
+)
 
 MASS_MENTION_RE = re.compile(r"(@)(?=everyone|here)")  # This only matches the @ for sanitizing
 

--- a/redbot/core/utils/common_filters.py
+++ b/redbot/core/utils/common_filters.py
@@ -17,7 +17,7 @@ __all__ = [
 URL_RE = re.compile(r"(https?|s?ftp)://(\S+)", re.I)
 
 INVITE_URL_RE = re.compile(
-    r"(discord\.(?:gg|io|me|li)|discord(?:app)?\.com\/invite)[\/\\](\S+)", re.I
+    r"(?<!promos\.)(discord\.(?:gg|io|me|li)|discord(?:app)?\.com\/invite)[\/\\](\S+)", re.I
 )
 
 MASS_MENTION_RE = re.compile(r"(@)(?=everyone|here)")  # This only matches the @ for sanitizing

--- a/redbot/core/utils/common_filters.py
+++ b/redbot/core/utils/common_filters.py
@@ -16,7 +16,7 @@ __all__ = [
 # regexes
 URL_RE = re.compile(r"(https?|s?ftp)://(\S+)", re.I)
 
-INVITE_URL_RE = re.compile(r"(discord\.(?:gg|io|me|li)|discord(?:app)?\.com\/invite)\/(\S+)", re.I)
+INVITE_URL_RE = re.compile(r"(discord\.(?:gg|io|me|li)|discord(?:app)?\.com\/invite)[\/\\](\S+)", re.I)
 
 MASS_MENTION_RE = re.compile(r"(@)(?=everyone|here)")  # This only matches the @ for sanitizing
 


### PR DESCRIPTION

### Description of the changes

Hello,
Last week we noticed on several servers where I'm staff that a new invite format is displayed by Discord as valid but is not currently supported by most bots, leaving the door open to scam bots. The new format is `discordapp.com/invite\<code>`.
<img width="741" height="712" alt="image" src="https://github.com/user-attachments/assets/58f524dd-2a5f-4813-a649-0ae64682ec6f" />
I'm using this modified pattern in one of my cogs, while waiting for a modification in Red.
Thanks in advance,
Have a nice day,
AAA3A

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
