### PR TITLE
Remove unused direct dependencies orjson, Brotli and zstandard from configuration files

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,11 +2,9 @@ aiohttp<3.10
 aiohttp-json-rpc
 apsw
 babel
-Brotli
 click
 discord.py
 markdown
-orjson
 packaging
 platformdirs
 psutil
@@ -19,6 +17,5 @@ rich
 schema
 typing_extensions
 yarl
-zstandard
 distro; sys_platform == "linux"
 uvloop; sys_platform != "win32" and platform_python_implementation == "CPython"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,8 +14,6 @@ attrs==25.3.0
     # via aiohttp
 babel==2.17.0
     # via -r base.in
-brotli==1.1.0
-    # via -r base.in
 click==8.1.8
     # via -r base.in
 discord-py==2.5.2
@@ -38,8 +36,6 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-orjson==3.10.15
-    # via -r base.in
 packaging==25.0
     # via -r base.in
 platformdirs==4.3.6
@@ -77,8 +73,6 @@ yarl==1.15.2
     # via
     #   -r base.in
     #   aiohttp
-zstandard==0.23.0
-    # via -r base.in
 async-timeout==4.0.3; python_version != "3.11"
     # via aiohttp
 colorama==0.4.6; sys_platform == "win32"


### PR DESCRIPTION
### Description of the changes

As part of our ongoing research on Python dependency management we noticed a potential improvement in your project’s dependency management.

Specifically, the direct dependencies `orjson`, `zstandard` and  `Brotli` are specified as a requirement in the `base.in` and `base.txt` files, when in reality they are not needed.


Hope this is helpful!

Best regards


### Have the changes in this PR been tested?

Yes, `tox` was used.
