### PR TITLE
Fix Unicode handling in debug command

### DIFF
--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -54,8 +54,10 @@ def sanitize_output(ctx: commands.Context, to_sanitize: str) -> str:
     """Hides the bot's token from a string."""
     token = ctx.bot.http.token
     if token:
-        return re.sub(re.escape(token), "[EXPUNGED]", to_sanitize, re.I)
-    return to_sanitize
+        to_sanitize = re.sub(re.escape(token), "[EXPUNGED]", to_sanitize, flags=re.IGNORECASE)
+    
+    # Validate encoding and let exceptions propagate
+    return to_sanitize.encode('utf-8', 'strict').decode('utf-8')
 
 
 def async_compile(source: str, filename: str, mode: Literal["eval", "exec"]) -> CodeType:
@@ -164,9 +166,16 @@ class DevOutput:
         return sanitize_output(self.ctx, "".join(output))
 
     async def send(self, *, tick: bool = True) -> None:
-        await self.ctx.send_interactive(get_pages(str(self)), box_lang="py")
-        if tick and not self.formatted_exc:
-            await self.ctx.tick()
+        try:
+            output_str = str(self)
+            await self.ctx.send_interactive(get_pages(output_str), box_lang="py")
+            if tick and not self.formatted_exc:
+                await self.ctx.tick()
+        except UnicodeEncodeError as exc:
+            self.set_exception(exc)
+            # Now that we've set the exception, str(self) will include the traceback
+            output_with_traceback = str(self)
+            await self.ctx.send_interactive(get_pages(output_with_traceback), box_lang="py")
 
     def set_exception(self, exc: Exception, *, skip_frames: int = 1) -> None:
         self.formatted_exc = self.format_exception(exc, skip_frames=skip_frames)

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -55,9 +55,9 @@ def sanitize_output(ctx: commands.Context, to_sanitize: str) -> str:
     token = ctx.bot.http.token
     if token:
         to_sanitize = re.sub(re.escape(token), "[EXPUNGED]", to_sanitize, flags=re.IGNORECASE)
-    
+
     # Validate encoding and let exceptions propagate
-    return to_sanitize.encode('utf-8', 'strict').decode('utf-8')
+    return to_sanitize.encode("utf-8", "strict").decode("utf-8")
 
 
 def async_compile(source: str, filename: str, mode: Literal["eval", "exec"]) -> CodeType:


### PR DESCRIPTION
### Description of the changes
- Solve #6485 
- Improved output sanitization by ensuring the output is UTF-8 validated. 
- Added error handling for `UnicodeEncodeError` in the `send()` method to provide clearer debug information and prevent crashes.

#### Before changes
<img width="800" height="171" alt="image" src="https://github.com/user-attachments/assets/9aa42118-4db8-498a-90be-b366fde70d4f" />

#### After changes
<img width="1078" height="372" alt="image" src="https://github.com/user-attachments/assets/daa5fe7f-595c-402e-9fbd-805e916b7a98" />

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes, for py3.8 and py3.11.
```cmd
All done! ✨ 🍰 ✨
225 files would be left unchanged.
  py38: OK (219.88=setup[179.23]+cmd[0.50,40.14] seconds)
  py39: SKIP (0.69 seconds)
  py310: SKIP (0.16 seconds)
  py311: OK (163.14=setup[130.80]+cmd[0.45,31.89] seconds)
  docs: OK (186.52=setup[141.80]+cmd[36.59,8.12] seconds)
  style: OK (81.72=setup[74.59]+cmd[7.12] seconds)
  congratulations :) (652.45 seconds)
```