### PR TITLE
Add missing dependency in label pattern exhaustiveness check

### DIFF
--- a/.github/workflows/check_label_pattern_exhaustiveness.yaml
+++ b/.github/workflows/check_label_pattern_exhaustiveness.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install script's pre-requirements
         run: |
           python -m pip install -U pip
-          python -m pip install -U pathspec pyyaml rich
+          python -m pip install -U pathspec pyyaml rich typing_extensions
       - name: Check label pattern exhaustiveness
         run: |
           python .github/workflows/scripts/check_label_pattern_exhaustiveness.py


### PR DESCRIPTION
adds typing_exenstions to the pip install command

### Description of the changes

adds typing_exenstions to the pip install command in the check_label_pattern_exhaustiveness file which makes it work again 
tested it on my personal bencos17 repo and my main jarvis one I use all the time and it works perfectly

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes

<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
