### PR TITLE
Audio status to voice channel 

### DIFF
--- a/docs/cog_guides/audio.rst
+++ b/docs/cog_guides/audio.rst
@@ -180,6 +180,7 @@ Owner-Only Audioset Commands
   reduce 429 Forbidden errors from song services, and also caches Spotify song lookups. Most users will not need to touch this option.
 * ``[p]audioset cacheage`` - How long the entries in the cache last. By default, song metadata is cached for 365 days (1 year).
 * ``[p]audioset status`` - Show the now playing song in the bot's status, or show how many servers the bot is playing music on, if more than one.
+* ``[p]audioset voicestatus`` - Show the now playing song in the current voice channel status.
 * ``[p]audioset restrictions global`` - Manage the keyword blocklist/allowlist for the whole bot.
 
 .. _guild-audioset-commands:
@@ -1763,6 +1764,24 @@ audioset status
 **Description**
 
 Enable/disable tracks' titles as status.
+
+.. _audio-command-audioset-voicestatus:
+
+""""""""""""""""""""
+audioset voicestatus
+""""""""""""""""""""
+
+.. note:: |owner-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]audioset voicestatus 
+
+**Description**
+
+Enable/disable tracks' titles as voice channel status.
 
 .. _audio-command-audioset-thumbnail:
 

--- a/redbot/cogs/audio/core/__init__.py
+++ b/redbot/cogs/audio/core/__init__.py
@@ -104,6 +104,7 @@ class Audio(
             global_db_enabled=False,
             global_db_get_timeout=5,
             status=False,
+            vc_status=False,
             use_external_lavalink=False,
             restrict=True,
             localpath=str(cog_data_path(raw_name="Audio")),

--- a/redbot/cogs/audio/core/abc.py
+++ b/redbot/cogs/audio/core/abc.py
@@ -103,7 +103,7 @@ class MixinMeta(ABC):
 
     @abstractmethod
     async def update_voice_channel_presence(
-        self, channel: discord.VoiceChannel, track: lavalink.Track, playing_servers: int
+        self, channel: discord.VoiceChannel, track: lavalink.Track
     ) -> None:
         raise NotImplementedError()
 

--- a/redbot/cogs/audio/core/abc.py
+++ b/redbot/cogs/audio/core/abc.py
@@ -112,6 +112,10 @@ class MixinMeta(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    async def get_current_track_title(self) -> str:
+        raise NotImplementedError()
+
+    @abstractmethod
     async def increase_error_counter(self, player: lavalink.Player) -> bool:
         raise NotImplementedError()
 

--- a/redbot/cogs/audio/core/abc.py
+++ b/redbot/cogs/audio/core/abc.py
@@ -102,6 +102,12 @@ class MixinMeta(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    async def update_voice_channel_presence(
+        self, channel: discord.VoiceChannel, track: lavalink.Track, playing_servers: int
+    ) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
     async def get_active_player_count(self) -> Tuple[str, int]:
         raise NotImplementedError()
 

--- a/redbot/cogs/audio/core/commands/audioset.py
+++ b/redbot/cogs/audio/core/commands/audioset.py
@@ -1037,7 +1037,7 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
             "Shuffle bumped:   [{bumpped_shuffle}]\n"
             "Song notify msgs: [{notify}]\n"
             "Songs as status:  [{status}]\n"
-            "Songs as voice channel status:  [{vc_status}]\n"
+            "Song as vc status:[{vc_status}]\n"
             "Spotify search:   [{countrycode}]\n"
         ).format(
             max_volume=maxvolume,

--- a/redbot/cogs/audio/core/commands/audioset.py
+++ b/redbot/cogs/audio/core/commands/audioset.py
@@ -988,6 +988,7 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
         bumpped_shuffle = _("Enabled") if data["shuffle_bumped"] else _("Disabled")
         song_notify = _("Enabled") if data["notify"] else _("Disabled")
         song_status = _("Enabled") if global_data["status"] else _("Disabled")
+        voice_channel_status = _("Enabled") if global_data["vc_status"] else _("Disabled")
         persist_queue = _("Enabled") if data["persist_queue"] else _("Disabled")
 
         countrycode = data["country_code"]
@@ -1036,6 +1037,7 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
             "Shuffle bumped:   [{bumpped_shuffle}]\n"
             "Song notify msgs: [{notify}]\n"
             "Songs as status:  [{status}]\n"
+            "Songs as voice channel status:  [{vc_status}]\n"
             "Spotify search:   [{countrycode}]\n"
         ).format(
             max_volume=maxvolume,
@@ -1045,6 +1047,7 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
             shuffle=song_shuffle,
             notify=song_notify,
             status=song_status,
+            vc_status=voice_channel_status,
             bumpped_shuffle=bumpped_shuffle,
         )
         if thumbnail:
@@ -1218,6 +1221,21 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
             title=_("Setting Changed"),
             description=_("Song titles as status: {true_or_false}.").format(
                 true_or_false=_("Enabled") if not status else _("Disabled")
+            ),
+        )
+
+    @command_audioset.command(name="voicestatus")
+    @commands.is_owner()
+    @commands.guild_only()
+    async def command_audioset_voicestatus(self, ctx: commands.Context):
+        """Enable/disable tracks' titles as voice channel status."""
+        vc_status = await self.config.vc_status()
+        await self.config.vc_status.set(not vc_status)
+        await self.send_embed_msg(
+            ctx,
+            title=_("Setting Changed"),
+            description=_("Song titles as voice channel status: {true_or_false}.").format(
+                true_or_false=_("Enabled") if not vc_status else _("Disabled")
             ),
         )
 

--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -124,6 +124,7 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
             current_track, self.local_folder_current_path
         )
         status = await self.config.status()
+        vc_status = await self.config.vc_status()
         prev_song: lavalink.Track = player.fetch("prev_song")
         await self.maybe_reset_error_counter(player)
 
@@ -226,6 +227,20 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                 log.debug("Track ended for %s, updating bot status", guild_id)
                 player_check = await self.get_active_player_count()
                 await self.update_bot_presence(*player_check)
+
+        if event_type == lavalink.LavalinkEvents.TRACK_START and vc_status:
+            log.debug("Track started for %s, updating voice channel status", guild_id)
+            voice_channel = current_channel
+            player_check = await self.get_active_player_count()
+            await self.update_voice_channel_presence(voice_channel, *player_check)
+
+        if event_type == lavalink.LavalinkEvents.TRACK_END and vc_status:
+            await asyncio.sleep(1)
+            if not player.is_playing:
+                log.debug("Track ended for %s, updating voice bot status", guild_id)
+                voice_channel = current_channel
+                player_check = await self.get_active_player_count()
+                await self.update_voice_channel_presence(voice_channel, *player_check)
 
         if event_type == lavalink.LavalinkEvents.QUEUE_END:
             if not autoplay:

--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -232,15 +232,15 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
             log.debug("Track started for %s, updating voice channel status", guild_id)
             voice_channel = current_channel
             player_check = await self.get_active_player_count()
-            await self.update_voice_channel_presence(voice_channel, *player_check)
+            await self.update_voice_channel_presence(voice_channel, player_check[0])
 
         if event_type == lavalink.LavalinkEvents.TRACK_END and vc_status:
             await asyncio.sleep(1)
             if not player.is_playing:
-                log.debug("Track ended for %s, updating voice bot status", guild_id)
+                log.debug("Track ended for %s, updating voice channel status", guild_id)
                 voice_channel = current_channel
                 player_check = await self.get_active_player_count()
-                await self.update_voice_channel_presence(voice_channel, *player_check)
+                await self.update_voice_channel_presence(voice_channel, player_check[0])
 
         if event_type == lavalink.LavalinkEvents.QUEUE_END:
             if not autoplay:
@@ -264,7 +264,11 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                 log.debug("Queue ended for %s, updating bot status", guild_id)
                 player_check = await self.get_active_player_count()
                 await self.update_bot_presence(*player_check)
-
+            if vc_status:
+                log.debug("Queue ended for %s, updating voice channel status", guild_id)
+                voice_channel = current_channel
+                player_check = await self.get_active_player_count()
+                await self.update_voice_channel_presence(voice_channel, player_check[0])
         if event_type in [
             lavalink.LavalinkEvents.TRACK_EXCEPTION,
             lavalink.LavalinkEvents.TRACK_STUCK,

--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -231,16 +231,16 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
         if event_type == lavalink.LavalinkEvents.TRACK_START and vc_status:
             log.debug("Track started for %s, updating voice channel status", guild_id)
             voice_channel = current_channel
-            player_check = await self.get_active_player_count()
-            await self.update_voice_channel_presence(voice_channel, player_check[0])
+            track_title = await self.get_current_track_title()
+            await self.update_voice_channel_presence(voice_channel, track_title)
 
         if event_type == lavalink.LavalinkEvents.TRACK_END and vc_status:
             await asyncio.sleep(1)
             if not player.is_playing:
                 log.debug("Track ended for %s, updating voice channel status", guild_id)
                 voice_channel = current_channel
-                player_check = await self.get_active_player_count()
-                await self.update_voice_channel_presence(voice_channel, player_check[0])
+                track_title = await self.get_current_track_title()
+                await self.update_voice_channel_presence(voice_channel, track_title)
 
         if event_type == lavalink.LavalinkEvents.QUEUE_END:
             if not autoplay:
@@ -267,8 +267,8 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
             if vc_status:
                 log.debug("Queue ended for %s, updating voice channel status", guild_id)
                 voice_channel = current_channel
-                player_check = await self.get_active_player_count()
-                await self.update_voice_channel_presence(voice_channel, player_check[0])
+                track_title = await self.get_current_track_title()
+                await self.update_voice_channel_presence(voice_channel, track_title)
         if event_type in [
             lavalink.LavalinkEvents.TRACK_EXCEPTION,
             lavalink.LavalinkEvents.TRACK_STUCK,

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -65,6 +65,23 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             playing_servers = 0
         return get_single_title, playing_servers
 
+    async def get_current_track_title(self) -> str:
+        try:
+            current = next(
+                (
+                    player.current
+                    for player in lavalink.active_players()
+                    if player.current is not None
+                ),
+                None,
+            )
+            get_single_title = await self.get_track_description_unformatted(
+                current, self.local_folder_current_path
+            )
+        except (IndexError, NodeNotFound, PlayerNotFound):
+            get_single_title = None
+        return get_single_title
+
     async def update_bot_presence(self, track: Optional[str], playing_servers: int) -> None:
         if playing_servers == 0:
             await self.bot.change_presence(activity=None)

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -80,6 +80,14 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 )
             )
 
+    async def update_voice_channel_presence(
+        self, channel: discord.VoiceChannel, track: Optional[str], playing_servers: int
+    ) -> None:
+        if playing_servers == 0:
+            await channel.edit(status=None)
+        else:
+            await channel.edit(status=track)
+
     async def _can_instaskip(self, ctx: commands.Context, member: discord.Member) -> bool:
         dj_enabled = self._dj_status_cache.setdefault(
             ctx.guild.id, await self.config.guild(ctx.guild).dj_enabled()

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -81,11 +81,8 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             )
 
     async def update_voice_channel_presence(
-        self, channel: discord.VoiceChannel, track: Optional[str], playing_servers: int
+        self, channel: discord.VoiceChannel, track: Optional[str]
     ) -> None:
-        if playing_servers == 0:
-            await channel.edit(status=None)
-        else:
             await channel.edit(status=track)
 
     async def _can_instaskip(self, ctx: commands.Context, member: discord.Member) -> bool:

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -83,7 +83,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
     async def update_voice_channel_presence(
         self, channel: discord.VoiceChannel, track: Optional[str]
     ) -> None:
-            await channel.edit(status=track)
+        await channel.edit(status=track)
 
     async def _can_instaskip(self, ctx: commands.Context, member: discord.Member) -> bool:
         dj_enabled = self._dj_status_cache.setdefault(


### PR DESCRIPTION
### Description of the changes

Add enhancement to audio cog to enable Red to update the Voice Channel status to the current playing song.

Added an additional command to allow for both Bot status updates ([p]audioset status) and Voice Channel status updates ([p]audioset voicestatus)

![Capture](https://github.com/user-attachments/assets/19174e75-3c7d-45b7-96cb-a03f4b655a5a)
<img width="374" height="302" alt="Screenshot 2025-07-31 213328" src="https://github.com/user-attachments/assets/50028f45-c7a7-4d8e-82f8-25c7f65c95ea" />
<img width="1018" height="257" alt="Screenshot 2025-07-31 213212" src="https://github.com/user-attachments/assets/19976798-9a85-4438-9465-30cfbc22b47c" />

Related: Cog-Creators/Red-DiscordBot#6442

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
