### PR TITLE
Mod cog: Option to show an extra field with custom content on the ban embed

### DIFF
--- a/docs/cog_guides/mod.rst
+++ b/docs/cog_guides/mod.rst
@@ -253,7 +253,23 @@ modset dm
 
 .. code-block:: none
 
-    [p]modset dm [enabled]
+    [p]modset dm
+
+**Description**
+
+Settings for messaging the user on moderation action.
+
+.. _mod-command-modset-dm-sendmessage:
+
+"""""""""
+modset dm sendmessage
+"""""""""
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]modset dm sendmessage [enabled]
 
 **Description**
 
@@ -265,6 +281,71 @@ and reason as to why they were kicked/banned.
 **Arguments**
 
 * ``[enabled]``: Whether a message should be sent to a user when they are kicked/banned. |bool-input|
+
+.. _mod-command-modset-banshowextrafield:
+
+"""""""""
+modset dm banshowextrafield
+"""""""""
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]modset dm banshowextrafield [enabled]
+
+**Description**
+
+
+Toggle whether to show an extra customizable field when banning. This is useful to add information such as a ban appeal link.
+
+**Arguments**
+
+* ``[enabled]``: If an extra customizable embed field should appear when banning. |bool-input|
+
+.. _mod-command-modset-banextrafieldtitle:
+
+"""""""""
+modset dm banextrafieldtitle
+"""""""""
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]modset dm banextrafieldtitle [title]
+
+**Description**
+
+Set the title for the optional extra embed on ban
+
+Set to "clear" to remove.
+
+**Arguments**
+
+* ``[title]``: The title of the embed field. Can by any string of text.
+
+.. _mod-command-modset-banextrafieldcontents:
+
+"""""""""
+modset dm banextrafieldcontents
+"""""""""
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]modset dm banextrafieldcontents [contents]
+
+**Description**
+
+Set the contents for the optional extra embed on ban
+
+Set to "clear" to remove.
+
+**Arguments**
+
+* ``[contents]``: The contents of the embed field. Can by any string of text.
 
 .. _mod-command-modset-requirereason:
 

--- a/docs/cog_guides/mod.rst
+++ b/docs/cog_guides/mod.rst
@@ -318,7 +318,7 @@ modset dm banextrafieldtitle
 
 **Description**
 
-Set the title for the optional extra embed on ban
+Set the title for the optional extra embed on ban.
 
 Cannot be over 252 characters long.
 

--- a/docs/cog_guides/mod.rst
+++ b/docs/cog_guides/mod.rst
@@ -257,13 +257,13 @@ modset dm
 
 **Description**
 
-Settings for messaging the user on moderation action.
+Settings for messaging the user when being kicked or banned.
 
 .. _mod-command-modset-dm-sendmessage:
 
-"""""""""
+"""""""""""""""""""""
 modset dm sendmessage
-"""""""""
+"""""""""""""""""""""
 
 **Syntax**
 
@@ -284,9 +284,9 @@ and reason as to why they were kicked/banned.
 
 .. _mod-command-modset-banshowextrafield:
 
-"""""""""
+"""""""""""""""""""""""""""
 modset dm banshowextrafield
-"""""""""
+"""""""""""""""""""""""""""
 
 **Syntax**
 
@@ -296,8 +296,9 @@ modset dm banshowextrafield
 
 **Description**
 
+Toggle whether to show an extra customizable field when banning.
 
-Toggle whether to show an extra customizable field when banning. This is useful to add information such as a ban appeal link.
+This can be used to add additional information for the banned user, such as a ban appeal link.
 
 **Arguments**
 
@@ -305,9 +306,9 @@ Toggle whether to show an extra customizable field when banning. This is useful 
 
 .. _mod-command-modset-banextrafieldtitle:
 
-"""""""""
+""""""""""""""""""""""""""""
 modset dm banextrafieldtitle
-"""""""""
+""""""""""""""""""""""""""""
 
 **Syntax**
 
@@ -319,17 +320,17 @@ modset dm banextrafieldtitle
 
 Set the title for the optional extra embed on ban
 
-Set to "clear" to remove.
+Cannot be over 252 characters long.
 
 **Arguments**
 
-* ``[title]``: The title of the embed field. Can by any string of text.
+* ``[title]``: The title of the embed field. Can by any string of text under 252 charcters long.
 
 .. _mod-command-modset-banextrafieldcontents:
 
-"""""""""
+"""""""""""""""""""""""""""""""
 modset dm banextrafieldcontents
-"""""""""
+"""""""""""""""""""""""""""""""
 
 **Syntax**
 
@@ -341,11 +342,11 @@ modset dm banextrafieldcontents
 
 Set the contents for the optional extra embed on ban
 
-Set to "clear" to remove.
+Cannot be over 1024 characters long.
 
 **Arguments**
 
-* ``[contents]``: The contents of the embed field. Can by any string of text.
+* ``[contents]``: The contents of the embed field. Can by any string of text under 1024 charcters long.
 
 .. _mod-command-modset-requirereason:
 

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -162,7 +162,7 @@ class KickBanMixin(MixinMeta):
                         ).ban_extra_embed_contents()
 
                         em.add_field(
-                            name=bold(extra_embed_title),
+                            name=bold(extra_embed_title, False),
                             value=extra_embed_contents,
                             inline=False,
                         )
@@ -201,7 +201,7 @@ class KickBanMixin(MixinMeta):
         else:
             user_handle = str(user) if isinstance(user, discord.abc.User) else "Unknown"
             try:
-                await guild.ban(user, reason=audit_reason, delete_message_seconds=days * 86400)
+                # await guild.ban(user, reason=audit_reason, delete_message_seconds=days * 86400)
                 log.info(
                     "%s (%s) %sned %s (%s), deleting %s days worth of messages.",
                     author,
@@ -689,7 +689,7 @@ class KickBanMixin(MixinMeta):
             )
             if invite:
                 em.add_field(
-                    name=bold("Here is an invite for when your ban expires"),
+                    name=bold(_("Here is an invite for when your ban expires")),
                     value=invite,
                     inline=False,
                 )

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -201,7 +201,7 @@ class KickBanMixin(MixinMeta):
         else:
             user_handle = str(user) if isinstance(user, discord.abc.User) else "Unknown"
             try:
-                # await guild.ban(user, reason=audit_reason, delete_message_seconds=days * 86400)
+                await guild.ban(user, reason=audit_reason, delete_message_seconds=days * 86400)
                 log.info(
                     "%s (%s) %sned %s (%s), deleting %s days worth of messages.",
                     author,

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -143,6 +143,8 @@ class KickBanMixin(MixinMeta):
 
             toggle = await self.config.guild(guild).dm_on_kickban()
             if toggle:
+                extra_embed = await self.config.guild(guild).ban_show_extra()
+
                 with contextlib.suppress(discord.HTTPException):
                     em = discord.Embed(
                         title=bold(_("You have been banned from {guild}.").format(guild=guild)),
@@ -153,6 +155,15 @@ class KickBanMixin(MixinMeta):
                         value=reason if reason is not None else _("No reason was given."),
                         inline=False,
                     )
+                    if extra_embed:
+                        extra_embed_title = await self.config.guild(guild).ban_extra_embed_title()
+                        extra_embed_contents = await self.config.guild(guild).ban_extra_embed_contents()
+
+                        em.add_field(
+                            name=bold(extra_embed_title),
+                            value=extra_embed_contents,
+                            inline=False,
+                        )
                     await user.send(embed=em)
 
             ban_type = "ban"
@@ -658,16 +669,37 @@ class KickBanMixin(MixinMeta):
 
         with contextlib.suppress(discord.HTTPException):
             # We don't want blocked DMs preventing us from banning
-            msg = _("You have been temporarily banned from {server_name} until {date}.").format(
-                server_name=guild.name, date=discord.utils.format_dt(unban_time)
-            )
-            if guild_data["dm_on_kickban"] and reason:
-                msg += _("\n\n**Reason:** {reason}").format(reason=reason)
-            if invite:
-                msg += _("\n\nHere is an invite for when your ban expires: {invite_link}").format(
-                    invite_link=invite
+
+            extra_embed = await self.config.guild(guild).ban_show_extra()
+
+            with contextlib.suppress(discord.HTTPException):
+                em = discord.Embed(
+                    title=bold(_("You have been temporarily banned from {guild} until {date}.").format(
+                        guild=guild,
+                        date=discord.utils.format_dt(unban_time))),
+                    color=await self.bot.get_embed_color(member),
                 )
-            await member.send(msg)
+                em.add_field(
+                    name=_("**Reason**"),
+                    value=reason if reason is not None else _("No reason was given."),
+                    inline=False,
+                )
+                if invite:
+                    em.add_field(
+                        name=bold("Here is an invite for when your ban expires"),
+                        value=invite,
+                        inline=False,
+                    )
+                if extra_embed:
+                    extra_embed_title = await self.config.guild(guild).ban_extra_embed_title()
+                    extra_embed_contents = await self.config.guild(guild).ban_extra_embed_contents()
+
+                    em.add_field(
+                        name=bold(extra_embed_title),
+                        value=extra_embed_contents,
+                        inline=False,
+                    )
+                await member.send(embed=em)
 
         audit_reason = get_audit_reason(author, reason, shorten=True)
 

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -698,7 +698,7 @@ class KickBanMixin(MixinMeta):
                 extra_embed_contents = await self.config.guild(guild).ban_extra_embed_contents()
 
                 em.add_field(
-                    name=bold(extra_embed_title),
+                    name=bold(extra_embed_title, escape_formatting=False),
                     value=extra_embed_contents,
                     inline=False,
                 )

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -157,7 +157,9 @@ class KickBanMixin(MixinMeta):
                     )
                     if extra_embed:
                         extra_embed_title = await self.config.guild(guild).ban_extra_embed_title()
-                        extra_embed_contents = await self.config.guild(guild).ban_extra_embed_contents()
+                        extra_embed_contents = await self.config.guild(
+                            guild
+                        ).ban_extra_embed_contents()
 
                         em.add_field(
                             name=bold(extra_embed_title),
@@ -673,9 +675,11 @@ class KickBanMixin(MixinMeta):
             extra_embed = await self.config.guild(guild).ban_show_extra()
 
             em = discord.Embed(
-                title=bold(_("You have been temporarily banned from {guild} until {date}.").format(
-                    guild=guild,
-                    date=discord.utils.format_dt(unban_time))),
+                title=bold(
+                    _("You have been temporarily banned from {guild} until {date}.").format(
+                        guild=guild, date=discord.utils.format_dt(unban_time)
+                    )
+                ),
                 color=await self.bot.get_embed_color(member),
             )
             em.add_field(

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -672,34 +672,33 @@ class KickBanMixin(MixinMeta):
 
             extra_embed = await self.config.guild(guild).ban_show_extra()
 
-            with contextlib.suppress(discord.HTTPException):
-                em = discord.Embed(
-                    title=bold(_("You have been temporarily banned from {guild} until {date}.").format(
-                        guild=guild,
-                        date=discord.utils.format_dt(unban_time))),
-                    color=await self.bot.get_embed_color(member),
-                )
+            em = discord.Embed(
+                title=bold(_("You have been temporarily banned from {guild} until {date}.").format(
+                    guild=guild,
+                    date=discord.utils.format_dt(unban_time))),
+                color=await self.bot.get_embed_color(member),
+            )
+            em.add_field(
+                name=_("**Reason**"),
+                value=reason if reason is not None else _("No reason was given."),
+                inline=False,
+            )
+            if invite:
                 em.add_field(
-                    name=_("**Reason**"),
-                    value=reason if reason is not None else _("No reason was given."),
+                    name=bold("Here is an invite for when your ban expires"),
+                    value=invite,
                     inline=False,
                 )
-                if invite:
-                    em.add_field(
-                        name=bold("Here is an invite for when your ban expires"),
-                        value=invite,
-                        inline=False,
-                    )
-                if extra_embed:
-                    extra_embed_title = await self.config.guild(guild).ban_extra_embed_title()
-                    extra_embed_contents = await self.config.guild(guild).ban_extra_embed_contents()
+            if extra_embed:
+                extra_embed_title = await self.config.guild(guild).ban_extra_embed_title()
+                extra_embed_contents = await self.config.guild(guild).ban_extra_embed_contents()
 
-                    em.add_field(
-                        name=bold(extra_embed_title),
-                        value=extra_embed_contents,
-                        inline=False,
-                    )
-                await member.send(embed=em)
+                em.add_field(
+                    name=bold(extra_embed_title),
+                    value=extra_embed_contents,
+                    inline=False,
+                )
+            await member.send(embed=em)
 
         audit_reason = get_audit_reason(author, reason, shorten=True)
 

--- a/redbot/cogs/mod/kickban.py
+++ b/redbot/cogs/mod/kickban.py
@@ -162,7 +162,7 @@ class KickBanMixin(MixinMeta):
                         ).ban_extra_embed_contents()
 
                         em.add_field(
-                            name=bold(extra_embed_title, False),
+                            name=bold(extra_embed_title, escape_formatting=False),
                             value=extra_embed_contents,
                             inline=False,
                         )

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -61,6 +61,9 @@ class Mod(
         "default_days": 0,
         "default_tempban_duration": 60 * 60 * 24,
         "track_nicknames": True,
+        "ban_show_extra": False,
+        "ban_extra_embed_title": "Message from staff",
+        "ban_extra_embed_contents": "Please set me",
     }
 
     default_channel_settings = {"ignored": False}

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -402,13 +402,15 @@ class ModSettings(MixinMeta):
             return
         await self.config.guild(guild).ban_show_extra.set(enabled)
         if enabled:
-            await ctx.send(_("An extra field will be shown when banning. "
-                             f"Configure it with `{ctx.clean_prefix}modset dm banextrafieldtitle` "
-                             f"and `{ctx.clean_prefix}modset dm banextrafieldcontents`"))
-        else:
             await ctx.send(
-                _("An extra field will be no longer be shown when banning.")
+                _(
+                    "An extra field will be shown when banning. "
+                    f"Configure it with `{ctx.clean_prefix}modset dm banextrafieldtitle` "
+                    f"and `{ctx.clean_prefix}modset dm banextrafieldcontents`"
+                )
             )
+        else:
+            await ctx.send(_("An extra field will be no longer be shown when banning."))
 
     @dm.command(name="banextrafieldtitle")
     async def dm_banextrafieldtitle(self, ctx: commands.Context, *, title: str) -> None:
@@ -422,7 +424,6 @@ class ModSettings(MixinMeta):
             await self.config.guild(guild).ban_extra_embed_title.clear()
             await ctx.send("Cleared embed title")
         else:
-
             await self.config.guild(guild).ban_extra_embed_title.set(title)
             await ctx.send(_("Embed Title has been set to `{title}`").format(title=title))
 
@@ -439,7 +440,9 @@ class ModSettings(MixinMeta):
             await ctx.send("Cleared embed contents")
         else:
             await self.config.guild(guild).ban_extra_embed_contents.set(contents)
-            await ctx.send(_("Embed Contents has been set to `{contents}`").format(contents=contents))
+            await ctx.send(
+                _("Embed Contents has been set to `{contents}`").format(contents=contents)
+            )
 
     @modset.command()
     @commands.guild_only()

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -391,7 +391,7 @@ class ModSettings(MixinMeta):
     @dm.command(name="banshowextrafield")
     async def dm_banshowextrafield(self, ctx: commands.Context, enabled: bool = None):
         """
-        Toggle whether to show an extra field when banning. This is useful to add information such as a ban appeal link.
+        Toggle whether to show an extra customizable field when banning. This is useful to add information such as a ban appeal link.
         """
         guild = ctx.guild
         if enabled is None:
@@ -417,7 +417,7 @@ class ModSettings(MixinMeta):
         """
         Set the title for the optional extra embed on ban
 
-        Set to "Clear" to remove.
+        Set to "clear" to remove.
         """
         guild = ctx.guild
         if title == "clear":
@@ -432,7 +432,7 @@ class ModSettings(MixinMeta):
         """
         Set the contents for the optional extra embed on ban
 
-        Set to "Clear" to remove.
+        Set to "clear" to remove.
         """
         guild = ctx.guild
         if contents == "clear":

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -48,6 +48,9 @@ class ModSettings(MixinMeta):
         dm_on_kickban = data["dm_on_kickban"]
         default_days = data["default_days"]
         default_tempban_duration = data["default_tempban_duration"]
+        ban_show_extra = data["ban_show_extra"]
+        ban_extra_embed_title = data["ban_extra_embed_title"]
+        ban_extra_embed_contents = data["ban_extra_embed_contents"]
         if not track_all_names and track_nicknames:
             yes_or_no = _("Overridden by another setting")
         else:
@@ -98,8 +101,17 @@ class ModSettings(MixinMeta):
             )
         else:
             msg += _("Default message history delete on ban: Don't delete any\n")
-        msg += _("Default tempban duration: {duration}").format(
+        msg += _("Default tempban duration: {duration}\n").format(
             duration=humanize_timedelta(seconds=default_tempban_duration)
+        )
+        msg += _("Show optional information field in embed: {yes_or_no}\n").format(
+            yes_or_no=_("Yes") if ban_show_extra else _("No")
+        )
+        msg += _("Title of the optional extra field: {ban_embed_title}\n").format(
+            ban_embed_title=ban_extra_embed_title if ban_extra_embed_title else _("None")
+        )
+        msg += _("Contents of the optional extra field: {ban_embed_contents}").format(
+            ban_embed_contents=ban_extra_embed_contents if ban_extra_embed_contents else _("None")
         )
         await ctx.send(box(msg))
 
@@ -347,9 +359,15 @@ class ModSettings(MixinMeta):
                 )
             )
 
-    @modset.command()
+    @modset.group()
     @commands.guild_only()
-    async def dm(self, ctx: commands.Context, enabled: bool = None):
+    async def dm(self, ctx: commands.Context):
+        """
+        Settings for messaging the user on moderation action.
+        """
+
+    @dm.command(name="sendmessage")
+    async def dm_sendmessage(self, ctx: commands.Context, enabled: bool = None):
         """Toggle whether a message should be sent to a user when they are kicked/banned.
 
         If this option is enabled, the bot will attempt to DM the user with the guild name
@@ -369,6 +387,59 @@ class ModSettings(MixinMeta):
             await ctx.send(
                 _("Bot will no longer attempt to send a DM to user before kick and ban.")
             )
+
+    @dm.command(name="banshowextrafield")
+    async def dm_banshowextrafield(self, ctx: commands.Context, enabled: bool = None):
+        """
+        Toggle whether to show an extra field when banning. This is useful to add information such as a ban appeal link.
+        """
+        guild = ctx.guild
+        if enabled is None:
+            setting = await self.config.guild(guild).ban_show_extra()
+            await ctx.send(
+                _("The extra embed field is currently set to: {setting}").format(setting=setting)
+            )
+            return
+        await self.config.guild(guild).ban_show_extra.set(enabled)
+        if enabled:
+            await ctx.send(_("An extra field will be shown when banning. "
+                             f"Configure it with `{ctx.clean_prefix}modset dm banextrafieldtitle` "
+                             f"and `{ctx.clean_prefix}modset dm banextrafieldcontents`"))
+        else:
+            await ctx.send(
+                _("An extra field will be no longer be shown when banning.")
+            )
+
+    @dm.command(name="banextrafieldtitle")
+    async def dm_banextrafieldtitle(self, ctx: commands.Context, *, title: str) -> None:
+        """
+        Set the title for the optional extra embed on ban
+
+        Set to "Clear" to remove.
+        """
+        guild = ctx.guild
+        if title == "clear":
+            await self.config.guild(guild).ban_extra_embed_title.clear()
+            await ctx.send("Cleared embed title")
+        else:
+
+            await self.config.guild(guild).ban_extra_embed_title.set(title)
+            await ctx.send(_("Embed Title has been set to `{title}`").format(title=title))
+
+    @dm.command(name="banextrafieldcontents")
+    async def dm_banextrafieldcontents(self, ctx: commands.Context, *, contents: str) -> None:
+        """
+        Set the contents for the optional extra embed on ban
+
+        Set to "Clear" to remove.
+        """
+        guild = ctx.guild
+        if contents == "clear":
+            await self.config.guild(guild).ban_extra_embed_contents.clear()
+            await ctx.send("Cleared embed contents")
+        else:
+            await self.config.guild(guild).ban_extra_embed_contents.set(contents)
+            await ctx.send(_("Embed Contents has been set to `{contents}`").format(contents=contents))
 
     @modset.command()
     @commands.guild_only()

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -406,7 +406,9 @@ class ModSettings(MixinMeta):
         if enabled:
             await ctx.send(
                 _(
-                    "An extra field will be shown when banning. Configure it with `{prefix}modset dm banextrafieldtitle` and `{prefix}modset dm banextrafieldcontents`".format(prefix=ctx.prefix)
+                    "An extra field will be shown when banning. Configure it with `{prefix}modset dm banextrafieldtitle` and `{prefix}modset dm banextrafieldcontents`".format(
+                        prefix=ctx.prefix
+                    )
                 )
             )
         else:
@@ -443,7 +445,9 @@ class ModSettings(MixinMeta):
             await ctx.send(_("Embed contents cannot be over 1024 characters long."))
         else:
             await self.config.guild(guild).ban_extra_embed_contents.set(contents)
-            await ctx.send(_("Embed Contents has been set to `{contents}`").format(contents=contents))
+            await ctx.send(
+                _("Embed Contents has been set to `{contents}`").format(contents=contents)
+            )
 
     @modset.command()
     @commands.guild_only()

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -406,10 +406,8 @@ class ModSettings(MixinMeta):
         if enabled:
             await ctx.send(
                 _(
-                    "An extra field will be shown when banning. Configure it with `{prefix}modset dm banextrafieldtitle` and `{prefix}modset dm banextrafieldcontents`".format(
-                        prefix=ctx.prefix
-                    )
-                )
+                    "An extra field will be shown when banning. Configure it with `{prefix}modset dm banextrafieldtitle` and `{prefix}modset dm banextrafieldcontents`"
+                ).format(prefix=ctx.prefix)
             )
         else:
             await ctx.send(_("An extra field will be no longer be shown when banning."))

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -426,10 +426,8 @@ class ModSettings(MixinMeta):
         # All the bold function used in the embeds does is add those star characters and some other convenience stuffs.
         # Such as escaping formatting.
         if len(title) > 252:
-            await ctx.send(str(len(title)))
             await ctx.send(_("Embed title cannot be over 252 characters long."))
         else:
-            await ctx.send(str(len(title)))
             await self.config.guild(guild).ban_extra_embed_title.set(title)
             await ctx.send(_("Embed Title has been set to `{title}`").format(title=title))
 

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -417,7 +417,7 @@ class ModSettings(MixinMeta):
     @dm.command(name="banextrafieldtitle")
     async def dm_banextrafieldtitle(self, ctx: commands.Context, *, title: str) -> None:
         """
-        Set the title for the optional extra embed on ban
+        Set the title for the optional extra embed on ban.
 
         Cannot be over 252 characters long.
         """

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -363,7 +363,7 @@ class ModSettings(MixinMeta):
     @commands.guild_only()
     async def dm(self, ctx: commands.Context):
         """
-        Settings for messaging the user on moderation action.
+        Settings for messaging the user when being kicked or banned.
         """
 
     @dm.command(name="sendmessage")
@@ -391,7 +391,9 @@ class ModSettings(MixinMeta):
     @dm.command(name="banshowextrafield")
     async def dm_banshowextrafield(self, ctx: commands.Context, enabled: bool = None):
         """
-        Toggle whether to show an extra customizable field when banning. This is useful to add information such as a ban appeal link.
+        Toggle whether to show an extra customizable field when banning.
+
+        This can be used to add additional information for the banned user, such as a ban appeal link.
         """
         guild = ctx.guild
         if enabled is None:
@@ -404,9 +406,7 @@ class ModSettings(MixinMeta):
         if enabled:
             await ctx.send(
                 _(
-                    "An extra field will be shown when banning. "
-                    f"Configure it with `{ctx.clean_prefix}modset dm banextrafieldtitle` "
-                    f"and `{ctx.clean_prefix}modset dm banextrafieldcontents`"
+                    "An extra field will be shown when banning. Configure it with `{prefix}modset dm banextrafieldtitle` and `{prefix}modset dm banextrafieldcontents`".format(prefix=ctx.prefix)
                 )
             )
         else:
@@ -417,13 +417,17 @@ class ModSettings(MixinMeta):
         """
         Set the title for the optional extra embed on ban
 
-        Set to "clear" to remove.
+        Cannot be over 252 characters long.
         """
         guild = ctx.guild
-        if title == "clear":
-            await self.config.guild(guild).ban_extra_embed_title.clear()
-            await ctx.send("Cleared embed title")
+        # Bolding the text is 4 characters (**bolded**)
+        # All the bold function used in the embeds does is add those star characters and some other convenience stuffs.
+        # Such as escaping formatting.
+        if len(title) > 252:
+            await ctx.send(str(len(title)))
+            await ctx.send(_("Embed title cannot be over 252 characters long."))
         else:
+            await ctx.send(str(len(title)))
             await self.config.guild(guild).ban_extra_embed_title.set(title)
             await ctx.send(_("Embed Title has been set to `{title}`").format(title=title))
 
@@ -432,17 +436,14 @@ class ModSettings(MixinMeta):
         """
         Set the contents for the optional extra embed on ban
 
-        Set to "clear" to remove.
+        Cannot be over 1024 characters long.
         """
         guild = ctx.guild
-        if contents == "clear":
-            await self.config.guild(guild).ban_extra_embed_contents.clear()
-            await ctx.send("Cleared embed contents")
+        if len(contents) > 1024:
+            await ctx.send(_("Embed contents cannot be over 1024 characters long."))
         else:
             await self.config.guild(guild).ban_extra_embed_contents.set(contents)
-            await ctx.send(
-                _("Embed Contents has been set to `{contents}`").format(contents=contents)
-            )
+            await ctx.send(_("Embed Contents has been set to `{contents}`").format(contents=contents))
 
     @modset.command()
     @commands.guild_only()


### PR DESCRIPTION
### Description of the changes
Added a new option to the base mod cog to show a new field embed with customizable text on the ban embed. The intended reason in this example (and my usage) will be to link a ban appeal link or some other kind of information the banned user may want.

Previously to get this effect you needed to potentially set up a custom cog or another way to first send a message to the user before running the actual ban command.

Additional changes:
- TempBan now has an embed.

The code is... meh, I have not used python in years and this code seemed pretty old.

Fixes #5591

<img width="695" height="403" alt="image" src="https://github.com/user-attachments/assets/600d3ace-0890-418b-8bbe-b3b52d9dc7c3" />


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes I have, I have tested all cases I could think off.
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
