### PR TITLE
Fix audio command docstrings not translating

### DIFF
--- a/redbot/cogs/audio/core/__init__.py
+++ b/redbot/cogs/audio/core/__init__.py
@@ -3,7 +3,6 @@ import datetime
 import json
 
 from collections import Counter, defaultdict
-from pathlib import Path
 from typing import Mapping, Dict
 
 import aiohttp
@@ -13,7 +12,6 @@ from redbot.core import Config
 from redbot.core.bot import Red
 from redbot.core.commands import Cog
 from redbot.core.data_manager import cog_data_path
-from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils.antispam import AntiSpam
 
 from ..utils import (
@@ -25,10 +23,7 @@ from ..utils import (
 from . import abc, cog_utils, commands, events, tasks, utilities
 from .cog_utils import CompositeMetaClass
 
-_ = Translator("Audio", Path(__file__))
 
-
-@cog_i18n(_)
 class Audio(
     commands.Commands,
     events.Events,

--- a/redbot/cogs/audio/core/__init__.py
+++ b/redbot/cogs/audio/core/__init__.py
@@ -32,8 +32,6 @@ class Audio(
     Cog,
     metaclass=CompositeMetaClass,
 ):
-    """Play audio through voice channels."""
-
     llset_captcha_intervals = [
         (datetime.timedelta(days=1), 1),
     ]

--- a/redbot/cogs/audio/core/commands/__init__.py
+++ b/redbot/cogs/audio/core/commands/__init__.py
@@ -13,6 +13,7 @@ from redbot.core.i18n import Translator, cog_i18n
 
 _ = Translator("Audio", __file__)
 
+
 @cog_i18n(_)
 class Commands(
     AudioSetCommands,

--- a/redbot/cogs/audio/core/commands/__init__.py
+++ b/redbot/cogs/audio/core/commands/__init__.py
@@ -27,4 +27,4 @@ class Commands(
     QueueCommands,
     metaclass=CompositeMetaClass,
 ):
-    """Class joining all command subclasses"""
+    """Play audio through voice channels."""

--- a/redbot/cogs/audio/core/commands/__init__.py
+++ b/redbot/cogs/audio/core/commands/__init__.py
@@ -8,8 +8,12 @@ from .miscellaneous import MiscellaneousCommands
 from .player import PlayerCommands
 from .playlists import PlaylistCommands
 from .queue import QueueCommands
+from redbot.core.i18n import Translator, cog_i18n
 
 
+_ = Translator("Audio", __file__)
+
+@cog_i18n(_)
 class Commands(
     AudioSetCommands,
     PlayerControllerCommands,


### PR DESCRIPTION
### Description of the changes
The `cog_i18n` translator object was referencing a directory which contains no commands. Moved where this is applied to the directory with commands.

Fixes #6608


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
