### PR TITLE
[Audio] Add a [p]repeatcurrent setting for looping a single song

### DIFF
--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -142,6 +142,12 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
             + ": "
             + ("\N{WHITE HEAVY CHECK MARK}" if repeat else "\N{CROSS MARK}")
         )
+        text += (
+            (" | " if text else "")
+            + _("Repeat Current")
+            + ": "
+            + ("\N{WHITE HEAVY CHECK MARK}" if player.repeat_current else "\N{CROSS MARK}")
+        )
 
         message = await self.send_embed_msg(ctx, embed=embed, footer=text)
 
@@ -783,6 +789,46 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
         await self.send_embed_msg(ctx, embed=embed)
         if self._player_check(ctx):
             await self.set_player_settings(ctx)
+
+    @commands.command(name="repeatcurrent")
+    @commands.guild_only()
+    @commands.bot_has_permissions(embed_links=True)
+    async def command_repeat_current(self, ctx: commands.Context):
+        """Toggle repeat current."""
+        dj_enabled = self._dj_status_cache.setdefault(
+            ctx.guild.id, await self.config.guild(ctx.guild).dj_enabled()
+        )
+        can_skip = await self._can_instaskip(ctx, ctx.author)
+        if dj_enabled and not can_skip and not await self._has_dj_role(ctx, ctx.author):
+            return await self.send_embed_msg(
+                ctx,
+                title=_("Unable To Toggle Repeat Current"),
+                description=_("You need the DJ role to toggle repeat current."),
+            )
+        if not self._player_check(ctx):
+            return await self.send_embed_msg(
+                ctx,
+                title=_("Unable To Toggle Repeat Current"),
+                description=_("Nothing playing."),
+            )
+
+        await self.set_player_settings(ctx)
+        player = lavalink.get_player(ctx.guild.id)
+        if (not ctx.author.voice or ctx.author.voice.channel != player.channel) and not can_skip:
+            return await self.send_embed_msg(
+                ctx,
+                title=_("Unable To Toggle Repeat Current"),
+                description=_("You must be in the voice channel to toggle repeat current."),
+            )
+        player.store("notify_channel", ctx.channel.id)
+
+        msg = _("Repeat current track: {true_or_false}.").format(
+            true_or_false=_("Enabled") if not player.repeat_current else _("Disabled")
+        )
+        player.repeat_current = not player.repeat_current
+
+        embed = discord.Embed(title=_("Setting Changed"), description=msg)
+        await self.send_embed_msg(ctx, embed=embed)
 
     @commands.command(name="remove")
     @commands.guild_only()

--- a/redbot/cogs/audio/core/commands/queue.py
+++ b/redbot/cogs/audio/core/commands/queue.py
@@ -106,6 +106,12 @@ class QueueCommands(MixinMeta, metaclass=CompositeMetaClass):
                 + ": "
                 + ("\N{WHITE HEAVY CHECK MARK}" if repeat else "\N{CROSS MARK}")
             )
+            text += (
+                (" | " if text else "")
+                + _("Repeat Current")
+                + ": "
+                + ("\N{WHITE HEAVY CHECK MARK}" if player.repeat_current else "\N{CROSS MARK}")
+            )
             embed.set_footer(text=text)
             message = await self.send_embed_msg(ctx, embed=embed)
             dj_enabled = self._dj_status_cache.setdefault(ctx.guild.id, guild_data["dj_enabled"])

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -127,6 +127,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
 
     async def _skip_action(self, ctx: commands.Context, skip_to_track: int = None) -> None:
         player = lavalink.get_player(ctx.guild.id)
+        player.repeat_current = False
         autoplay = await self.config.guild(player.guild).auto_play()
         if not player.current or (not player.queue and not autoplay):
             try:

--- a/redbot/cogs/audio/core/utilities/queue.py
+++ b/redbot/cogs/audio/core/utilities/queue.py
@@ -110,6 +110,12 @@ class QueueUtilities(MixinMeta, metaclass=CompositeMetaClass):
             + ": "
             + ("\N{WHITE HEAVY CHECK MARK}" if repeat else "\N{CROSS MARK}")
         )
+        text += (
+            (" | " if text else "")
+            + _("Repeat Current")
+            + ": "
+            + ("\N{WHITE HEAVY CHECK MARK}" if player.repeat_current else "\N{CROSS MARK}")
+        )
         embed.set_footer(text=text)
         return embed
 


### PR DESCRIPTION
### Description of the changes

Adds the ability to repeat the current track, ignoring the rest of the queue, via a new command `[p]repeatcurrent`. I considered adapting the existing `[p]repeat` command via e.g. `[p]repeat current` vs. `[p]repeat queue`, but I wanted to avoid interfering with existing behavior and they are also somewhat semantically different; Repeat Current is a property of the current track (and is deliberately not persisted across sessions and set to false upon `[p]skip`), while Repeat is a property of the queue as a whole.

Fixes #6467.

Depends on https://github.com/Cog-Creators/Red-Lavalink/pull/138.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->

I've been running an instance with this change (among others) for ~2.5 years; I'm in the process of organizing those changes into individual features and submitting them upstream.
