### PR TITLE
[Audio] Add a Keep in Queue mode, where the queue acts more like a playlist and is progressed through non-destructively

### DIFF
--- a/redbot/cogs/audio/apis/interface.py
+++ b/redbot/cogs/audio/apis/interface.py
@@ -624,7 +624,9 @@ class AudioAPIInterface:
                 if enqueue:
                     if len(player.queue) >= 10000:
                         continue
-                    if guild_data["maxlength"] > 0 and not self.cog.is_track_length_allowed(single_track, guild_data["maxlength"]):
+                    if guild_data["maxlength"] > 0 and not self.cog.is_track_length_allowed(
+                        single_track, guild_data["maxlength"]
+                    ):
                         continue
 
                     enqueued_tracks += 1

--- a/redbot/cogs/audio/apis/interface.py
+++ b/redbot/cogs/audio/apis/interface.py
@@ -624,39 +624,24 @@ class AudioAPIInterface:
                 if enqueue:
                     if len(player.queue) >= 10000:
                         continue
-                    if guild_data["maxlength"] > 0:
-                        if self.cog.is_track_length_allowed(single_track, guild_data["maxlength"]):
-                            enqueued_tracks += 1
-                            single_track.extras.update(
-                                {
-                                    "enqueue_time": int(time.time()),
-                                    "vc": player.channel.id,
-                                    "requester": ctx.author.id,
-                                }
-                            )
-                            player.add(ctx.author, single_track)
-                            self.bot.dispatch(
-                                "red_audio_track_enqueue",
-                                player.guild,
-                                single_track,
-                                ctx.author,
-                            )
-                    else:
-                        enqueued_tracks += 1
-                        single_track.extras.update(
-                            {
-                                "enqueue_time": int(time.time()),
-                                "vc": player.channel.id,
-                                "requester": ctx.author.id,
-                            }
-                        )
-                        player.add(ctx.author, single_track)
-                        self.bot.dispatch(
-                            "red_audio_track_enqueue",
-                            player.guild,
-                            single_track,
-                            ctx.author,
-                        )
+                    if guild_data["maxlength"] > 0 and not self.cog.is_track_length_allowed(single_track, guild_data["maxlength"]):
+                        continue
+
+                    enqueued_tracks += 1
+                    single_track.extras.update(
+                        {
+                            "enqueue_time": int(time.time()),
+                            "vc": player.channel.id,
+                            "requester": ctx.author.id,
+                        }
+                    )
+                    player.add(ctx.author, single_track)
+                    self.bot.dispatch(
+                        "red_audio_track_enqueue",
+                        player.guild,
+                        single_track,
+                        ctx.author,
+                    )
 
                     if not player.current:
                         await player.play()

--- a/redbot/cogs/audio/core/__init__.py
+++ b/redbot/cogs/audio/core/__init__.py
@@ -134,6 +134,7 @@ class Audio(
             prefer_lyrics=False,
             repeat=False,
             shuffle=False,
+            keep_in_queue=False,
             shuffle_bumped=True,
             thumbnail=False,
             volume=100,

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -142,6 +142,12 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
             + ": "
             + ("\N{WHITE HEAVY CHECK MARK}" if repeat else "\N{CROSS MARK}")
         )
+        text += (
+            (" | " if text else "")
+            + _("Repeat Current")
+            + ": "
+            + ("\N{WHITE HEAVY CHECK MARK}" if player.repeat_current else "\N{CROSS MARK}")
+        )
 
         message = await self.send_embed_msg(ctx, embed=embed, footer=text)
 
@@ -783,6 +789,46 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
         await self.send_embed_msg(ctx, embed=embed)
         if self._player_check(ctx):
             await self.set_player_settings(ctx)
+
+    @commands.command(name="repeatcurrent")
+    @commands.guild_only()
+    @commands.bot_has_permissions(embed_links=True)
+    async def command_repeat_current(self, ctx: commands.Context):
+        """Toggle repeat current."""
+        dj_enabled = self._dj_status_cache.setdefault(
+            ctx.guild.id, await self.config.guild(ctx.guild).dj_enabled()
+        )
+        can_skip = await self._can_instaskip(ctx, ctx.author)
+        if dj_enabled and not can_skip and not await self._has_dj_role(ctx, ctx.author):
+            return await self.send_embed_msg(
+                ctx,
+                title=_("Unable To Toggle Repeat Current"),
+                description=_("You need the DJ role to toggle repeat current."),
+            )
+        if not self._player_check(ctx):
+            return await self.send_embed_msg(
+                ctx,
+                title=_("Unable To Toggle Repeat Current"),
+                description=_("Nothing playing."),
+            )
+
+        await self.set_player_settings(ctx)
+        player = lavalink.get_player(ctx.guild.id)
+        if (not ctx.author.voice or ctx.author.voice.channel != player.channel) and not can_skip:
+            return await self.send_embed_msg(
+                ctx,
+                title=_("Unable To Toggle Repeat Current"),
+                description=_("You must be in the voice channel to toggle repeat current."),
+            )
+        player.store("notify_channel", ctx.channel.id)
+
+        msg = _("Repeat current track: {true_or_false}.").format(
+            true_or_false=_("Enabled") if not player.repeat_current else _("Disabled")
+        )
+        player.repeat_current = not player.repeat_current
+
+        embed = discord.Embed(title=_("Setting Changed"), description=msg)
+        await self.send_embed_msg(ctx, embed=embed)
 
     @commands.command(name="remove")
     @commands.guild_only()

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -124,6 +124,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
         shuffle = guild_data["shuffle"]
         repeat = guild_data["repeat"]
         autoplay = guild_data["auto_play"]
+        keep_in_queue = guild_data["keep_in_queue"]
         text = ""
         text += (
             _("Auto-Play")
@@ -147,6 +148,12 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
             + _("Repeat Current")
             + ": "
             + ("\N{WHITE HEAVY CHECK MARK}" if player.repeat_current else "\N{CROSS MARK}")
+        )
+        text += (
+            (" | " if text else "")
+            + _("Keep in Queue")
+            + ": "
+            + ("\N{WHITE HEAVY CHECK MARK}" if keep_in_queue else "\N{CROSS MARK}")
         )
 
         message = await self.send_embed_msg(ctx, embed=embed, footer=text)
@@ -608,6 +615,7 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
             if eq:
                 await self.config.custom("EQUALIZER", ctx.guild.id).eq_bands.set(eq.bands)
             player.queue = []
+            player.next_queue_position = 0
             player.store("playing_song", None)
             player.store("prev_requester", None)
             player.store("prev_song", None)
@@ -830,6 +838,46 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
         embed = discord.Embed(title=_("Setting Changed"), description=msg)
         await self.send_embed_msg(ctx, embed=embed)
 
+    @commands.command(name="keepinqueue")
+    @commands.guild_only()
+    @commands.bot_has_permissions(embed_links=True)
+    async def command_keepinqueue(self, ctx: commands.Context):
+        """Toggle keep in queue."""
+        dj_enabled = self._dj_status_cache.setdefault(
+            ctx.guild.id, await self.config.guild(ctx.guild).dj_enabled()
+        )
+        can_skip = await self._can_instaskip(ctx, ctx.author)
+        if dj_enabled and not can_skip and not await self._has_dj_role(ctx, ctx.author):
+            return await self.send_embed_msg(
+                ctx,
+                title=_("Unable To Toggle Keep In Queue"),
+                description=_("You need the DJ role to toggle keep in queue."),
+            )
+        if self._player_check(ctx):
+            await self.set_player_settings(ctx)
+            player = lavalink.get_player(ctx.guild.id)
+            if (
+                not ctx.author.voice or ctx.author.voice.channel != player.channel
+            ) and not can_skip:
+                return await self.send_embed_msg(
+                    ctx,
+                    title=_("Unable To Toggle Keep In Queue"),
+                    description=_("You must be in the voice channel to toggle keep in queue."),
+                )
+            player.store("notify_channel", ctx.channel.id)
+
+        keep_in_queue = await self.config.guild(ctx.guild).keep_in_queue()
+        msg = ""
+        msg += _("Keep tracks in queue: {true_or_false}.").format(
+            true_or_false=_("Enabled") if not keep_in_queue else _("Disabled")
+        )
+        await self.config.guild(ctx.guild).keep_in_queue.set(not keep_in_queue)
+
+        embed = discord.Embed(title=_("Setting Changed"), description=msg)
+        await self.send_embed_msg(ctx, embed=embed)
+        if self._player_check(ctx):
+            await self.set_player_settings(ctx)
+
     @commands.command(name="remove")
     @commands.guild_only()
     @commands.bot_has_permissions(embed_links=True)
@@ -868,6 +916,9 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 )
             index_or_url -= 1
             removed = player.queue.pop(index_or_url)
+            if index_or_url < player.next_queue_position:
+                player.next_queue_position -= 1
+
             await self.api_interface.persistent_queue_api.played(
                 ctx.guild.id, removed.extras.get("enqueue_time")
             )
@@ -989,6 +1040,11 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
         player.store("notify_channel", ctx.channel.id)
         removed = player.queue.pop(from_index - 1)
         player.queue.insert(to_index - 1, removed)
+        original_next = player.next_queue_position
+        if from_index - 1 < original_next:
+            player.next_queue_position -= 1
+        if to_index - 1 < original_next:
+            player.next_queue_position += 1
         description = await self.get_track_description(removed, self.local_folder_current_path)
         await self.send_embed_msg(
             ctx,

--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -901,3 +901,51 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
         await self.send_embed_msg(
             ctx, title=_("Moved track to the top of the queue."), description=description
         )
+
+    @commands.command(name="move")
+    @commands.guild_only()
+    @commands.bot_has_permissions(embed_links=True)
+    async def command_move(self, ctx: commands.Context, from_index: int, to_index: int):
+        """Move a track number to another place in the queue."""
+        dj_enabled = self._dj_status_cache.setdefault(
+            ctx.guild.id, await self.config.guild(ctx.guild).dj_enabled()
+        )
+        if not self._player_check(ctx):
+            return await self.send_embed_msg(ctx, title=_("Nothing playing."))
+        player = lavalink.get_player(ctx.guild.id)
+        can_skip = await self._can_instaskip(ctx, ctx.author)
+        if (not ctx.author.voice or ctx.author.voice.channel != player.channel) and not can_skip:
+            return await self.send_embed_msg(
+                ctx,
+                title=_("Unable To Move Track"),
+                description=_("You must be in the voice channel to move a track."),
+            )
+        if dj_enabled and not can_skip:
+            return await self.send_embed_msg(
+                ctx,
+                title=_("Unable To Move Track"),
+                description=_("You need the DJ role to move tracks."),
+            )
+        if from_index > len(player.queue) or from_index < 1:
+            return await self.send_embed_msg(
+                ctx,
+                title=_("Unable To Move Track"),
+                description=_("Song number must be greater than 1 and within the queue limit."),
+            )
+        if to_index > len(player.queue) or to_index < 1:
+            return await self.send_embed_msg(
+                ctx,
+                title=_("Unable To Move Track"),
+                description=_(
+                    "Move target number must be greater than 1 and within the queue limit."
+                ),
+            )
+        player.store("notify_channel", ctx.channel.id)
+        removed = player.queue.pop(from_index - 1)
+        player.queue.insert(to_index - 1, removed)
+        description = await self.get_track_description(removed, self.local_folder_current_path)
+        await self.send_embed_msg(
+            ctx,
+            title=_("Moved track to the position {to_index}.").format(to_index=to_index),
+            description=description,
+        )

--- a/redbot/cogs/audio/core/commands/player.py
+++ b/redbot/cogs/audio/core/commands/player.py
@@ -295,29 +295,15 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Unable To Play Tracks"),
                 description=_("This track is not allowed in this server."),
             )
-        elif guild_data["maxlength"] > 0:
-            if self.is_track_length_allowed(single_track, guild_data["maxlength"]):
-                single_track.requester = ctx.author
-                single_track.extras.update(
-                    {
-                        "enqueue_time": int(time.time()),
-                        "vc": player.channel.id,
-                        "requester": ctx.author.id,
-                    }
-                )
-                player.queue.insert(0, single_track)
-                player.maybe_shuffle()
-                self.bot.dispatch(
-                    "red_audio_track_enqueue", player.guild, single_track, ctx.author
-                )
-            else:
-                self.update_player_lock(ctx, False)
-                return await self.send_embed_msg(
-                    ctx,
-                    title=_("Unable To Play Tracks"),
-                    description=_("Track exceeds maximum length."),
-                )
-
+        elif guild_data["maxlength"] > 0 and not self.is_track_length_allowed(
+            single_track, guild_data["maxlength"]
+        ):
+            self.update_player_lock(ctx, False)
+            return await self.send_embed_msg(
+                ctx,
+                title=_("Unable To Play Tracks"),
+                description=_("Track exceeds maximum length."),
+            )
         else:
             single_track.requester = ctx.author
             single_track.extras["bumped"] = True

--- a/redbot/cogs/audio/core/commands/queue.py
+++ b/redbot/cogs/audio/core/commands/queue.py
@@ -106,6 +106,12 @@ class QueueCommands(MixinMeta, metaclass=CompositeMetaClass):
                 + ": "
                 + ("\N{WHITE HEAVY CHECK MARK}" if repeat else "\N{CROSS MARK}")
             )
+            text += (
+                (" | " if text else "")
+                + _("Repeat Current")
+                + ": "
+                + ("\N{WHITE HEAVY CHECK MARK}" if player.repeat_current else "\N{CROSS MARK}")
+            )
             embed.set_footer(text=text)
             message = await self.send_embed_msg(ctx, embed=embed)
             dj_enabled = self._dj_status_cache.setdefault(ctx.guild.id, guild_data["dj_enabled"])

--- a/redbot/cogs/audio/core/commands/queue.py
+++ b/redbot/cogs/audio/core/commands/queue.py
@@ -88,6 +88,7 @@ class QueueCommands(MixinMeta, metaclass=CompositeMetaClass):
             shuffle = guild_data["shuffle"]
             repeat = guild_data["repeat"]
             autoplay = guild_data["auto_play"]
+            keep_in_queue = guild_data["keep_in_queue"]
             text = ""
             text += (
                 _("Auto-Play")
@@ -111,6 +112,12 @@ class QueueCommands(MixinMeta, metaclass=CompositeMetaClass):
                 + _("Repeat Current")
                 + ": "
                 + ("\N{WHITE HEAVY CHECK MARK}" if player.repeat_current else "\N{CROSS MARK}")
+            )
+            text += (
+                (" | " if text else "")
+                + _("Keep in Queue")
+                + ": "
+                + ("\N{WHITE HEAVY CHECK MARK}" if keep_in_queue else "\N{CROSS MARK}")
             )
             embed.set_footer(text=text)
             message = await self.send_embed_msg(ctx, embed=embed)

--- a/redbot/cogs/audio/core/utilities/miscellaneous.py
+++ b/redbot/cogs/audio/core/utilities/miscellaneous.py
@@ -214,9 +214,12 @@ class MiscellaneousUtilities(MixinMeta, metaclass=CompositeMetaClass):
 
     async def queue_duration(self, ctx: commands.Context) -> int:
         player = lavalink.get_player(ctx.guild.id)
+        next_index = min(player.next_queue_position, len(player.queue))
         dur = [
             i.length
-            async for i in AsyncIter(player.queue, steps=50).filter(lambda x: not x.is_stream)
+            async for i in AsyncIter(player.queue[next_index:], steps=50).filter(
+                lambda x: not x.is_stream
+            )
         ]
         queue_dur = sum(dur)
         if not player.queue:

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -162,7 +162,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             return
 
         queue_to_append = []
-        if skip_to_track is not None and skip_to_track != 1:
+        if skip_to_track is not None:
             if skip_to_track < 1:
                 await self.send_embed_msg(
                     ctx, title=_("Track number must be equal to or greater than 1.")
@@ -176,15 +176,26 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     ),
                 )
                 return
-            embed = discord.Embed(
-                title=_("{skip_to_track} Tracks Skipped").format(skip_to_track=skip_to_track)
-            )
+            if skip_to_track - 1 >= player.next_queue_position:
+                skipped_count = skip_to_track - player.next_queue_position
+                embed = discord.Embed(
+                    title=_("{skipped_count} Tracks Skipped").format(skipped_count=skipped_count)
+                )
+            else:
+                embed = discord.Embed(
+                    title=_("Skipped to Track {skip_to_track}").format(skip_to_track=skip_to_track)
+                )
             await self.send_embed_msg(ctx, embed=embed)
-            if player.repeat:
-                queue_to_append = player.queue[0 : min(skip_to_track - 1, len(player.queue) - 1)]
-            player.queue = player.queue[
-                min(skip_to_track - 1, len(player.queue) - 1) : len(player.queue)
-            ]
+            if player.keep_in_queue:
+                player.next_queue_position = skip_to_track - 1
+            else:
+                if player.repeat:
+                    queue_to_append = player.queue[
+                        0 : min(skip_to_track - 1, len(player.queue) - 1)
+                    ]
+                player.queue = player.queue[
+                    min(skip_to_track - 1, len(player.queue) - 1) : len(player.queue)
+                ]
         else:
             embed = discord.Embed(
                 title=_("Track Skipped"),
@@ -651,10 +662,12 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
         player = lavalink.get_player(ctx.guild.id)
         shuffle = await self.config.guild(ctx.guild).shuffle()
         repeat = await self.config.guild(ctx.guild).repeat()
+        keep_in_queue = await self.config.guild(ctx.guild).keep_in_queue()
         volume = await self.config.guild(ctx.guild).volume()
         shuffle_bumped = await self.config.guild(ctx.guild).shuffle_bumped()
         player.repeat = repeat
         player.shuffle = shuffle
+        player.keep_in_queue = keep_in_queue
         player.shuffle_bumped = shuffle_bumped
         if player.volume != volume:
             await player.set_volume(volume)

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -127,6 +127,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
 
     async def _skip_action(self, ctx: commands.Context, skip_to_track: int = None) -> None:
         player = lavalink.get_player(ctx.guild.id)
+        player.repeat_current = False
         autoplay = await self.config.guild(player.guild).auto_play()
         if not player.current or (not player.queue and not autoplay):
             try:

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -455,21 +455,10 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 ):
                     log.debug("Query is not allowed in %r (%s)", ctx.guild.name, ctx.guild.id)
                     continue
-                elif guild_data["maxlength"] > 0:
-                    if self.is_track_length_allowed(track, guild_data["maxlength"]):
-                        track_len += 1
-                        track.extras.update(
-                            {
-                                "enqueue_time": int(time.time()),
-                                "vc": player.channel.id,
-                                "requester": ctx.author.id,
-                            }
-                        )
-                        player.add(ctx.author, track)
-                        self.bot.dispatch(
-                            "red_audio_track_enqueue", player.guild, track, ctx.author
-                        )
-
+                elif guild_data["maxlength"] > 0 and not self.is_track_length_allowed(
+                    track, guild_data["maxlength"]
+                ):
+                    continue
                 else:
                     track_len += 1
                     track.extras.update(
@@ -548,29 +537,11 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     return await self.send_embed_msg(
                         ctx, title=_("This track is not allowed in this server.")
                     )
-                elif guild_data["maxlength"] > 0:
-                    if self.is_track_length_allowed(single_track, guild_data["maxlength"]):
-                        single_track.extras.update(
-                            {
-                                "enqueue_time": int(time.time()),
-                                "vc": player.channel.id,
-                                "requester": ctx.author.id,
-                            }
-                        )
-                        player.add(ctx.author, single_track)
-                        player.maybe_shuffle()
-                        self.bot.dispatch(
-                            "red_audio_track_enqueue",
-                            player.guild,
-                            single_track,
-                            ctx.author,
-                        )
-                    else:
-                        self.update_player_lock(ctx, False)
-                        return await self.send_embed_msg(
-                            ctx, title=_("Track exceeds maximum length.")
-                        )
-
+                elif guild_data["maxlength"] > 0 and not self.is_track_length_allowed(
+                    single_track, guild_data["maxlength"]
+                ):
+                    self.update_player_lock(ctx, False)
+                    return await self.send_embed_msg(ctx, title=_("Track exceeds maximum length."))
                 else:
                     single_track.extras.update(
                         {

--- a/redbot/cogs/audio/core/utilities/queue.py
+++ b/redbot/cogs/audio/core/utilities/queue.py
@@ -110,6 +110,12 @@ class QueueUtilities(MixinMeta, metaclass=CompositeMetaClass):
             + ": "
             + ("\N{WHITE HEAVY CHECK MARK}" if repeat else "\N{CROSS MARK}")
         )
+        text += (
+            (" | " if text else "")
+            + _("Repeat Current")
+            + ": "
+            + ("\N{WHITE HEAVY CHECK MARK}" if player.repeat_current else "\N{CROSS MARK}")
+        )
         embed.set_footer(text=text)
         return embed
 

--- a/redbot/cogs/audio/core/utilities/queue.py
+++ b/redbot/cogs/audio/core/utilities/queue.py
@@ -32,6 +32,7 @@ class QueueUtilities(MixinMeta, metaclass=CompositeMetaClass):
         shuffle = await self.config.guild(ctx.guild).shuffle()
         repeat = await self.config.guild(ctx.guild).repeat()
         autoplay = await self.config.guild(ctx.guild).auto_play()
+        keep_in_queue = await self.config.guild(ctx.guild).keep_in_queue()
 
         queue_num_pages = math.ceil(len(queue) / 10)
         queue_idx_start = (page_num - 1) * 10
@@ -44,25 +45,26 @@ class QueueUtilities(MixinMeta, metaclass=CompositeMetaClass):
         arrow = await self.draw_time(ctx)
         pos = self.format_time(player.position)
 
-        if player.current.is_stream:
-            dur = "LIVE"
-        else:
-            dur = self.format_time(player.current.length)
+        if player.current:
+            if player.current.is_stream:
+                dur = "LIVE"
+            else:
+                dur = self.format_time(player.current.length)
 
-        query = Query.process_input(player.current, self.local_folder_current_path)
-        current_track_description = await self.get_track_description(
-            player.current, self.local_folder_current_path
-        )
-        if query.is_stream:
-            queue_list += _("**Currently livestreaming:**\n")
-            queue_list += f"{current_track_description}\n"
-            queue_list += _("Requested by: **{user}**").format(user=player.current.requester)
-            queue_list += f"\n\n{arrow}`{pos}`/`{dur}`\n\n"
-        else:
-            queue_list += _("Playing: ")
-            queue_list += f"{current_track_description}\n"
-            queue_list += _("Requested by: **{user}**").format(user=player.current.requester)
-            queue_list += f"\n\n{arrow}`{pos}`/`{dur}`\n\n"
+            query = Query.process_input(player.current, self.local_folder_current_path)
+            current_track_description = await self.get_track_description(
+                player.current, self.local_folder_current_path
+            )
+            if query.is_stream:
+                queue_list += _("**Currently livestreaming:**\n")
+                queue_list += f"{current_track_description}\n"
+                queue_list += _("Requested by: **{user}**").format(user=player.current.requester)
+                queue_list += f"\n\n{arrow}`{pos}`/`{dur}`\n\n"
+            else:
+                queue_list += _("Playing: ")
+                queue_list += f"{current_track_description}\n"
+                queue_list += _("Requested by: **{user}**").format(user=player.current.requester)
+                queue_list += f"\n\n{arrow}`{pos}`/`{dur}`\n\n"
 
         async for i, track in AsyncIter(queue[queue_idx_start:queue_idx_end]).enumerate(
             start=queue_idx_start
@@ -115,6 +117,12 @@ class QueueUtilities(MixinMeta, metaclass=CompositeMetaClass):
             + _("Repeat Current")
             + ": "
             + ("\N{WHITE HEAVY CHECK MARK}" if player.repeat_current else "\N{CROSS MARK}")
+        )
+        text += (
+            (" | " if text else "")
+            + _("Keep in Queue")
+            + ": "
+            + ("\N{WHITE HEAVY CHECK MARK}" if keep_in_queue else "\N{CROSS MARK}")
         )
         embed.set_footer(text=text)
         return embed


### PR DESCRIPTION
### Description of the changes

Add a Keep in Queue mode, where the queue acts more like a playlist and is progressed through non-destructively. This allows keeping track of what songs have previously played, shuffling without allowing repeats, and more options for curation of track order.

Currently based on #6623 and #6624 because they interact and I've only tested with the combination of all three.

Depends on https://github.com/Cog-Creators/Red-Lavalink/pull/139.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
I've been running an instance with this change (among others) for ~2.5 years; I'm in the process of organizing those changes into individual features and submitting them upstream.
