### PR TITLE
Fix `set api` modal not submitting

### DIFF
--- a/redbot/core/utils/views.py
+++ b/redbot/core/utils/views.py
@@ -442,7 +442,7 @@ class SetApiModal(discord.ui.Modal):
             converter = get_dict_converter(*self.default_keys, delims=[";", ",", " "])
         else:
             converter = get_dict_converter(delims=[";", ",", " "])
-        tokens = " ".join(self.token_input.value.split("\n")).rstrip()
+        tokens = " ".join(self.token_input.component.value.split("\n")).rstrip()
 
         try:
             tokens = await converter().convert(None, tokens)
@@ -459,7 +459,7 @@ class SetApiModal(discord.ui.Modal):
                 ephemeral=True,
             )
         else:
-            service = self.service_input.value.lower()
+            service = self.service_input.component.value.lower()
             await interaction.client.set_shared_api_tokens(service, **tokens)
             return await interaction.response.send_message(
                 _("`{service}` API tokens have been set.").format(service=service),


### PR DESCRIPTION
### Description of the changes
Resolves the following traceback
```
Oct 12 02:40:54 bot python[64760]: [2025-10-12 02:40:54] [ERROR] discord.ui.modal: Ignoring exception in modal <SetApiModal timeout=None children=2>:
Oct 12 02:40:54 bot python[64760]: Traceback (most recent call last):
Oct 12 02:40:54 bot python[64760]:   File "/home/itazura/redenv/lib/python3.11/site-packages/discord/ui/modal.py", line 193, in _scheduled_task
Oct 12 02:40:54 bot python[64760]:     await self.on_submit(interaction)
Oct 12 02:40:54 bot python[64760]:   File "/home/itazura/redenv/lib/python3.11/site-packages/redbot/core/utils/views.py", line 445, in on_submit
Oct 12 02:40:54 bot python[64760]:     tokens = " ".join(self.token_input.value.split("\n")).rstrip()
Oct 12 02:40:54 bot python[64760]:                       ^^^^^^^^^^^^^^^^^^^^^^
Oct 12 02:40:54 bot python[64760]: AttributeError: 'Label' object has no attribute 'value'
```


### Have the changes in this PR been tested?

Yes
