### PR TITLE
Address shutdown behavior

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -212,6 +212,7 @@
   - redbot/core/_cli.py
   - redbot/core/_debuginfo.py
   - redbot/setup.py
+  - tests/core/test_dry_run.py
 "Category: Core - Help":
   - redbot/core/commands/help.py
 "Category: Core - i18n":

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -2282,7 +2282,7 @@ class Red(
                 # The client never finished starting up, so the queue was never created.
                 pass
             else:
-                raise e  # Reraise the exception if it's not the one you expect
+                raise e
 
         await _drivers.get_driver_class().teardown()
         try:

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -2277,8 +2277,13 @@ class Red(
         """Logs out of Discord and closes all connections."""
         try:
             await super().close()
-        except AttributeError:
-            pass
+        except AttributeError as e:
+            if "'Red' object has no attribute '_AutoShardedClient__queue'" in str(e):
+                # The client never finished starting up, so the queue was never created.
+                pass
+            else:
+                raise e  # Reraise the exception if it's not the one you expect
+
         await _drivers.get_driver_class().teardown()
         try:
             if self.rpc_enabled:

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -2275,7 +2275,10 @@ class Red(
 
     async def close(self):
         """Logs out of Discord and closes all connections."""
-        await super().close()
+        try:
+            await super().close()
+        except AttributeError:
+            pass
         await _drivers.get_driver_class().teardown()
         try:
             if self.rpc_enabled:

--- a/tests/core/test_dry_run.py
+++ b/tests/core/test_dry_run.py
@@ -1,0 +1,36 @@
+"""Integration test ensuring `redbot --dry-run` exits cleanly."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_dry_run_exits_cleanly():
+    """Running `redbot --dry-run` should exit with code 0 and without AttributeError."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "redbot",
+            "--no-instance",
+            "--dry-run",
+            "--no-prompt",
+            "--token",
+            "dummy_token_for_testing",
+            "--prefix",
+            "!",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, (
+        "Expected redbot dry-run to exit with code 0, "
+        f"got {result.returncode}.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    assert "AttributeError" not in result.stderr, (
+        "redbot dry-run emitted AttributeError on stderr, indicating shutdown guard failed.\n"
+        f"STDERR:\n{result.stderr}"
+    )


### PR DESCRIPTION
<details>
  <summary>Analysis of the problem</summary>

## Problem Analysis

Based on the error traceback and codebase investigation, here's what's happening:

### The Error

```
AttributeError: 'Red' object has no attribute '_AutoShardedClient__queue'. Did you mean: '_AutoShardedClient__shards'?
```

This error occurs during the bot shutdown process when red.close() is called. The issue is that the Red class (which inherits from discord.ext.commands.AutoShardedBot) is trying to access an internal attribute __queue that doesn't exist.

### Root Cause

The problem stems from the **mixin initialization order** in the Red class:

```python
class Red(
    commands.GroupMixin, RPCMixin, dpy_commands.bot.AutoShardedBot
):
```

Looking at the initialization chain:

1. **Red.__init__** (line 104-241 in bot.py) does extensive setup work BEFORE calling super().__init__() at line 241
    
2. **RPCMixin.__init__** (line 144-146 in _rpc.py) calls super().__init__(**kwargs)
    
3. **commands.GroupMixin** doesn't define __init__, so it passes through
    
4. Finally reaches **AutoShardedBot.__init__** which sets up internal attributes like __queue
    

The issue is that during the --dry-run execution:

- The bot starts initialization
    
- At line 366 in __main__.py, when --dry-run is detected, it calls sys.exit(ExitCodes.SHUTDOWN)
    
- This triggers the shutdown handler at line 539
    
- The shutdown handler calls await red.close() at line 441
    
- But red.close() → super().close() (line 2278 in bot.py) tries to access AutoShardedClient's internal __queue attribute
    
- This attribute was never properly initialized because the initialization was interrupted
    

### Why This Happens Specifically with --dry-run

The --dry-run flag causes an early exit at line 365-366 in __main__.py:

```python
if cli_flags.dry_run:
    sys.exit(ExitCodes.SHUTDOWN)
```

This happens **before** await red.start(token) is called (line 369), which means:

- The bot's connection lifecycle never begins
    
- Discord.py's internal sharding infrastructure (including __queue) is never fully initialized
    
- But the shutdown handler still tries to call close() which expects these internals to exist

</details>

try, catch might not be the best solution but I can't think of a better one. This only happens when it is not fully initialized and thus sharding is not possible.

closes #6572 
the original issue is also addressed.
```pwsh
PS C:\privat\codex\Red-DiscordBot> python -m redbot --no-prompt
Error: No instance name was provided!
PS C:\privat\codex\Red-DiscordBot> python -m redbot --no-prompt tinkerer
Instance with name 'tinkerer' doesn't exist. You can create new instance using `redbot-setup` prior to running the bot.
```
