### PR TITLE
Make `untranslated` a positional-only argument in `Translator()`.

### DIFF
--- a/redbot/core/i18n.py
+++ b/redbot/core/i18n.py
@@ -279,7 +279,7 @@ class Translator(Callable[[str], str]):
 
         self.load_translations()
 
-    def __call__(self, untranslated: str) -> str:
+    def __call__(self, untranslated: str, /) -> str:
         """Translate the given string.
 
         This will look for the string in the translator's :code:`.pot` file,


### PR DESCRIPTION
### Description of the changes

This PR changes the signature of `redbot.core.i18n.Translator.__call__()` from `self, untranslated: str` to `self, untranslated: str, /`, making `untranslated` a positional-only argument.

This works around an issue in `redgettext`, where using `_("text")` works fine, but `_(untranslated="text")` causes `untranslated=` to be detected as an unexpected token. Considering this function is a single-argument function, and nothing would be gained from using the keyword argument, I believe marking it as positional-only is the correct solution, rather than making a change in `redgettext`. This is technically a breaking change though.

This also has the small but notable side effect of removing `untranslated=` from calls in editors that show inline keyword arguments, such as basedpyright's `basedpyright.analysis.inlayHints.callArgumentNames` VSCode setting, or similar settings in other extensions. This cuts down on wasted space in the editor without disabling an otherwise useful feature.

<img width="535" height="19" alt="image" src="https://github.com/user-attachments/assets/915be4c3-b250-4ee6-b690-f7c2194192e1" />

See the related discussion in [`#coding`](https://discord.com/channels/133049272517001216/160386989819035648/1453030635756191866).

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
