### PR TITLE
strip unicode bidi control characters in `cleanup_code`

### DIFF
--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -42,6 +42,8 @@ _ = Translator("Dev", __file__)
 # - or "```" and potentially also strip a single "\n" if it follows it immediately
 START_CODE_BLOCK_RE = re.compile(r"^((```[\w.+\-]+\n+(?!```))|(```\n*))")
 
+REMOVE_CONTROL_CHARS = ["\u2066", "\u2067", "\u2068", "\u202A", "\u202B", "\u202D", "\u202E", "\u2069", "\u202C"]
+
 T = TypeVar("T")
 
 
@@ -75,6 +77,8 @@ async def maybe_await(coro: Union[T, Awaitable[T], Awaitable[Awaitable[T]]]) -> 
 
 def cleanup_code(content: str) -> str:
     """Automatically removes code blocks from the code."""
+    content = content.strip(''.join(REMOVE_CONTROL_CHARS))
+    
     # remove ```py\n```
     if content.startswith("```") and content.endswith("```"):
         return START_CODE_BLOCK_RE.sub("", content)[:-3].rstrip("\n")

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -42,7 +42,17 @@ _ = Translator("Dev", __file__)
 # - or "```" and potentially also strip a single "\n" if it follows it immediately
 START_CODE_BLOCK_RE = re.compile(r"^((```[\w.+\-]+\n+(?!```))|(```\n*))")
 
-REMOVE_CONTROL_CHARS = ["\u2066", "\u2067", "\u2068", "\u202A", "\u202B", "\u202D", "\u202E", "\u2069", "\u202C"]
+REMOVE_CONTROL_CHARS = [
+    "\u2066",
+    "\u2067",
+    "\u2068",
+    "\u202A",
+    "\u202B",
+    "\u202D",
+    "\u202E",
+    "\u2069",
+    "\u202C",
+]
 
 T = TypeVar("T")
 
@@ -77,8 +87,8 @@ async def maybe_await(coro: Union[T, Awaitable[T], Awaitable[Awaitable[T]]]) -> 
 
 def cleanup_code(content: str) -> str:
     """Automatically removes code blocks from the code."""
-    content = content.strip(''.join(REMOVE_CONTROL_CHARS))
-    
+    content = content.strip("".join(REMOVE_CONTROL_CHARS))
+
     # remove ```py\n```
     if content.startswith("```") and content.endswith("```"):
         return START_CODE_BLOCK_RE.sub("", content)[:-3].rstrip("\n")


### PR DESCRIPTION
### Description of the changes

discord recently started wrapping codeblocks in bi-directional control characters, and this broke the eval command when used with a codeblock. this fixes that (and hopefully doesn't break anything else)

only tested with codeblocks on an english bot

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
