### PR TITLE
Add warning to `[p]set api` if <>s are included in secret

### DIFF
--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3715,7 +3715,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
                         " was `HREDFGWE`, make sure to run `[p]set api {service} {token_name} HREDFGWE` and not "
                         "`[p]set api {service} {token_name} <HREDFGWE>`."
                     ).format(token_name=token_name, service=service)
-                    log.warning(angle_bracket_warning)
                     break
 
             await ctx.bot.set_shared_api_tokens(service, **tokens)

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3709,7 +3709,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
             for token_name, token in tokens.items():
                 if token.startswith("<") and token.endswith(">"):
-                    angle_bracket_warning = (
+                    angle_bracket_warning = _(
                         "You may have failed to properly format your `{token_name}`. If you were told to enter a token"
                         " with an example such as `[p]set api {service} {token_name} <your_{token_name}_here>`, and your {token_name}"
                         " was `HREDFGWE`, make sure to run `[p]set api {service} {token_name} HREDFGWE` and not "

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3704,8 +3704,27 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         else:
             if ctx.bot_permissions.manage_messages:
                 await ctx.message.delete()
+
+            angle_bracket_warning = None
+
+            for api_service_name, token in tokens.items():
+                if token.startswith("<") and token.endswith(">"):
+                    angle_bracket_warning = (
+                        "You may have failed to properly format your {api_service_name}. If you were told to enter a key"
+                        " with an example such as `[p]set api {service} api_key <your_api_key_here>`, and your API key"
+                        " was `HREDFGWE`, make sure to run `[p]set api {service} api_key HREDFGWE` and not "
+                        "`[p]set api {service} api_key <HREDFGWE>`."
+                    ).format(api_service_name=api_service_name, service=service)
+                    log.warning(angle_bracket_warning)
+                    break
+
             await ctx.bot.set_shared_api_tokens(service, **tokens)
-            await ctx.send(_("`{service}` API tokens have been set.").format(service=service))
+
+            message = _("`{service}` API tokens have been set.").format(service=service)
+            if angle_bracket_warning:
+                message += "\n\n" + _("**Warning:** ") + _(angle_bracket_warning)
+
+            await ctx.send(message)
 
     @_set_api.command(name="list")
     async def _set_api_list(self, ctx: commands.Context):

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3707,14 +3707,14 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
             angle_bracket_warning = None
 
-            for api_service_name, token in tokens.items():
+            for token_name, token in tokens.items():
                 if token.startswith("<") and token.endswith(">"):
                     angle_bracket_warning = (
-                        "You may have failed to properly format your {api_service_name}. If you were told to enter a key"
-                        " with an example such as `[p]set api {service} api_key <your_api_key_here>`, and your API key"
-                        " was `HREDFGWE`, make sure to run `[p]set api {service} api_key HREDFGWE` and not "
-                        "`[p]set api {service} api_key <HREDFGWE>`."
-                    ).format(api_service_name=api_service_name, service=service)
+                        "You may have failed to properly format your `{token_name}`. If you were told to enter a key"
+                        " with an example such as `[p]set api {service} {token_name} <your_api_key_here>`, and your {token_name}"
+                        " was `HREDFGWE`, make sure to run `[p]set api {service} {token_name} HREDFGWE` and not "
+                        "`[p]set api {service} {token_name} <HREDFGWE>`."
+                    ).format(token_name=token_name, service=service)
                     log.warning(angle_bracket_warning)
                     break
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3710,8 +3710,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             for token_name, token in tokens.items():
                 if token.startswith("<") and token.endswith(">"):
                     angle_bracket_warning = (
-                        "You may have failed to properly format your `{token_name}`. If you were told to enter a key"
-                        " with an example such as `[p]set api {service} {token_name} <your_api_key_here>`, and your {token_name}"
+                        "You may have failed to properly format your `{token_name}`. If you were told to enter a token"
+                        " with an example such as `[p]set api {service} {token_name} <your_{token_name}_here>`, and your {token_name}"
                         " was `HREDFGWE`, make sure to run `[p]set api {service} {token_name} HREDFGWE` and not "
                         "`[p]set api {service} {token_name} <HREDFGWE>`."
                     ).format(token_name=token_name, service=service)

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3721,7 +3721,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
             message = _("`{service}` API tokens have been set.").format(service=service)
             if angle_bracket_warning:
-                message += "\n\n" + _("**Warning:** ") + _(angle_bracket_warning)
+                message += "\n\n" + _("**Warning:** ") + angle_bracket_warning
 
             await ctx.send(message)
 


### PR DESCRIPTION
### Description of the changes
addressed review feedback, meaning I have:
- wrapped command examples with inline code marks for readability
- moved warning text inline instead of using an embed

related to #6265 
fixes #6253 

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
