### PR TITLE
[Docs] Red backup and restore instructions.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -273,6 +273,7 @@
   - docs/bot_application_guide.rst
   - docs/install_guides/**/*
   - docs/update_red.rst
+  - docs/backup_red.rst
 "Category: Docs - Other":
   - docs/host-list.rst
   - docs/index.rst

--- a/docs/backup_red.rst
+++ b/docs/backup_red.rst
@@ -1,3 +1,5 @@
+.. _backup-red:
+
 ============================
 Backing Up and Restoring Red
 ============================

--- a/docs/backup_red.rst
+++ b/docs/backup_red.rst
@@ -2,9 +2,9 @@
 Backing Up and Restoring Red
 ============================
 
-Red can be backed up and restored to any device as long as it is supported operating system. See page: `version_guarantees`.
+Red can be backed up and restored to any device as long as it is supported operating system. See page: :ref:`end-user-guarantees`.
 
-Backup steps must be done correctly to ensure that it can be restored without any issues occurring.
+Backup steps are to be done in order and carefully to avoid any issues.
 
 #. Take note of the installed cogs and cog repositories with ``[p]cogs``, then ``[p]load downloader``, then ``[p]repo list`` (``[p]`` is considered as your bot's prefix).
 #. Stop the bot, ideally with ``[p]shutdown``.
@@ -21,3 +21,13 @@ Backup steps must be done correctly to ensure that it can be restored without an
     .. note::
 
         The config (data) from cogs has been saved, but not the code itself.
+
+    .. tip::
+
+        You can fix permissions (if needed) on your directory using:
+
+        .. code-block:: bash
+
+            sudo chown -R <user>:<user> ~/.local
+
+        Replace ``<user>`` with your actual username.

--- a/docs/backup_red.rst
+++ b/docs/backup_red.rst
@@ -2,9 +2,9 @@
 Backing Up and Restoring Red
 ============
 
-Red can be backed up and restored to any device, regardless of operating system, as long as it is supported.
+Red can be backed up and restored to any device as long as it is supported operating system. See page: `version_guarantees`.
 
-However, backup steps must be done correctly to ensure that it can be restored without issue and minimal downtime.
+Backup steps must be done correctly to ensure that it can be restored without any issues occurring.
 
 #. Take note of the installed cogs and cog repositories with ``[p]cogs``, then ``[p]load downloader``, then ``[p]repo list`` (``[p]`` is considered as your bot's prefix).
 #. Stop the bot, ideally with ``[p]shutdown``.

--- a/docs/backup_red.rst
+++ b/docs/backup_red.rst
@@ -1,0 +1,23 @@
+============
+Backing Up and Restoring Red
+============
+
+Red can be backed up and restored to any device, regardless of operating system, as long as it is supported.
+
+However, backup steps must be done correctly to ensure that it can be restored without issue and minimal downtime.
+
+#. Take note of the installed cogs and cog repositories with ``[p]cogs``, then ``[p]load downloader``, then ``[p]repo list`` (``[p]`` is considered as your bot's prefix).
+#. Stop the bot, ideally with ``[p]shutdown``.
+#. Activate your venv, and run ``redbot-setup backup <instancename>`` replacing ``<instancename>`` with the name of your instance.
+#. Copy your backup file to the new machine/location.
+#. Extract the file to a location of your choice (remember the full path and make sure that the user you are going to install/run Red under can access this path).
+#. Install Red as normal on the new machine/location
+#. Run ``redbot-setup`` in your venv to create a new instance, except use the path you remembered above as your data path.
+#. Start your new instance.
+#. Re-add the Repos using the same names as before
+#. Do ``[p]cog update``
+#. Re-add any cogs that were not re-installed (you may have to uninstall them first as Downloader may think they are still installed)
+
+    .. note::
+
+        The config (data) from cogs has been saved, but not the code itself.

--- a/docs/backup_red.rst
+++ b/docs/backup_red.rst
@@ -6,17 +6,17 @@ Red can be backed up and restored to any device as long as it is supported opera
 
 Backup steps are to be done in order and carefully to avoid any issues.
 
-#. Take note of the installed cogs and cog repositories with ``[p]cogs``, then ``[p]load downloader``, then ``[p]repo list`` (``[p]`` is considered as your bot's prefix).
+#. Take note of the installed cogs with ``[p]cogs``; and cog repositories with ``[p]load downloader``, then ``[p]repo list`` (``[p]`` is your bot's prefix).
 #. Stop the bot, ideally with ``[p]shutdown``.
-#. Activate your venv, and run ``redbot-setup backup <instancename>`` replacing ``<instancename>`` with the name of your instance.
+#. Activate your venv, and run ``redbot-setup backup <instancename>``, replacing ``<instancename>`` with the name of your instance.
 #. Copy your backup file to the new machine/location.
 #. Extract the file to a location of your choice (remember the full path and make sure that the user you are going to install/run Red under can access this path).
-#. Install Red as normal on the new machine/location
-#. Run ``redbot-setup`` in your venv to create a new instance, except use the path you remembered above as your data path.
+#. :ref:`Install Red <install_guides/index>` as normal on the new machine/location.
+#. Run ``redbot-setup`` in your venv to create a new instance, using the path you remembered above as your data path.
 #. Start your new instance.
-#. Re-add the Repos using the same names as before
-#. Do ``[p]cog update``
-#. Re-add any cogs that were not re-installed (you may have to uninstall them first as Downloader may think they are still installed)
+#. Re-add the cog repositories using the same names as before.
+#. Do ``[p]cog update``.
+#. Re-add any cogs that were not re-installed (you may have to uninstall them first as Downloader may think they are still installed).
 
     .. note::
 

--- a/docs/backup_red.rst
+++ b/docs/backup_red.rst
@@ -1,6 +1,6 @@
-============
+============================
 Backing Up and Restoring Red
-============
+============================
 
 Red can be backed up and restored to any device as long as it is supported operating system. See page: `version_guarantees`.
 

--- a/docs/backup_red.rst
+++ b/docs/backup_red.rst
@@ -11,7 +11,7 @@ Backup steps are to be done in order and carefully to avoid any issues.
 #. Activate your venv, and run ``redbot-setup backup <instancename>``, replacing ``<instancename>`` with the name of your instance.
 #. Copy your backup file to the new machine/location.
 #. Extract the file to a location of your choice (remember the full path and make sure that the user you are going to install/run Red under can access this path).
-#. :ref:`Install Red <install_guides/index>` as normal on the new machine/location.
+#. :ref:`Install Red <install-guides>` as normal on the new machine/location.
 #. Run ``redbot-setup`` in your venv to create a new instance, using the path you remembered above as your data path.
 #. Start your new instance.
 #. Re-add the cog repositories using the same names as before.

--- a/docs/host-list.rst
+++ b/docs/host-list.rst
@@ -32,12 +32,11 @@ First, we would like to make something clear:
 Hosting on a VPS or Dedicated Server
 ------------------------------------
 
-| You can host Red in a VPS running Linux or Windows. Using a Linux VPS is the
+| You can host Red on a VPS running Linux or Windows. Using a Linux VPS is the
   recommended option. Dedicated servers also work but are overpowered and cost 
   ineffective unless one plans to run a very large bot or use their server for 
   more than just hosting Red. If you have already created an instance, Red can be moved to a different 
-  server for hosting with a backup/restore process. More information and guidance
-  about this process is available in the `Red Support Server <https://discord.com/invite/red>`_.
+  server for hosting using the :ref:`backup/restore process <backup-red>`.
 
 .. warning::
     Please be aware that a Linux server is controlled through a command line.

--- a/docs/host-list.rst
+++ b/docs/host-list.rst
@@ -36,7 +36,7 @@ Hosting on a VPS or Dedicated Server
   recommended option. Dedicated servers also work but are overpowered and cost 
   ineffective unless one plans to run a very large bot or use their server for 
   more than just hosting Red. If you have already created an instance, Red can be moved to a different 
-  server for hosting using the :ref:`backup/restore process <backup-red>`.
+  server for hosting using the :ref:`backup/restore process <backup_red>`.
 
 .. warning::
     Please be aware that a Linux server is controlled through a command line.

--- a/docs/host-list.rst
+++ b/docs/host-list.rst
@@ -36,7 +36,7 @@ Hosting on a VPS or Dedicated Server
   recommended option. Dedicated servers also work but are overpowered and cost 
   ineffective unless one plans to run a very large bot or use their server for 
   more than just hosting Red. If you have already created an instance, Red can be moved to a different 
-  server for hosting using the :ref:`backup/restore process <backup_red>`.
+  server for hosting using the :doc:`backup/restore process </backup_red>`.
 
 .. warning::
     Please be aware that a Linux server is controlled through a command line.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Welcome to Red - Discord Bot's documentation!
     install_guides/index
     bot_application_guide
     update_red
+    backup_red
     about_venv
     autostart_windows
     autostart_mac

--- a/docs/install_guides/_includes/linux-preamble.rst
+++ b/docs/install_guides/_includes/linux-preamble.rst
@@ -2,4 +2,4 @@
 
     For safety reasons, DO NOT install Red with a root user. If you are unsure how to create
     a new user on Linux, see `DigitalOcean's tutorial: How To Create a New Sudo-enabled User
-    <https://www.digitalocean.com/community/tutorials/how-to-create-a-new-sudo-enabled-user-on-ubuntu-20-04-quickstart>`_.
+    <https://www.digitalocean.com/community/tutorials/how-to-create-a-new-sudo-enabled-user-on-ubuntu>`_.


### PR DESCRIPTION
### Description of the changes

This change adds backup and restore instructions to the Red docs. Uses the `?backup` customcom instruction as an approved basic instruction for backup and restoring the bot onto a new machine.

- Also updates the DigitalOcean URL in the linux preamble to the new address.

Closes https://github.com/Cog-Creators/Red-DiscordBot/issues/3421

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->