### PR TITLE
Fix send_interactive not working on User/Member objects

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -2487,7 +2487,8 @@ class Red(
             ret.append(msg)
             n_remaining = len(messages) - idx
             files_perm = (
-                not channel.guild or channel.permissions_for(channel.guild.me).attach_files
+                isinstance(discord.abc.User)
+                or channel.permissions_for(channel.guild.me).attach_files
             )
             options = ("more", "file") if files_perm else ("more",)
             if n_remaining > 0:

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -2487,7 +2487,7 @@ class Red(
             ret.append(msg)
             n_remaining = len(messages) - idx
             files_perm = (
-                isinstance(discord.abc.User)
+                isinstance(channel, discord.abc.User)
                 or channel.permissions_for(channel.guild.me).attach_files
             )
             options = ("more", "file") if files_perm else ("more",)


### PR DESCRIPTION
### Description of the changes

Regression introduced by #6552 - the `channel` can be any `Messageable` and some of them don't have `permissions_for` and/or `guild` attribute - `User` and `Member` (also `Context`, but that's already handled earlier)

To repro, simply run:
```py
await bot.send_interactive(ctx.author, ["test"], user=ctx.author)
```
Resulting in:
```
Traceback (most recent call last):
  File "<eval command - snippet #18>", line 1, in func
    await bot.send_interactive(ctx.author, ["test"], user=ctx.author)
  File "/home/ubuntu/red-venv/lib/python3.8/site-packages/redbot/core/bot.py", line 2481, in send_interactive
    not channel.guild or channel.permissions_for(channel.guild.me).attach_files
AttributeError: 'Member' object has no attribute 'permissions_for'
```

### Have the changes in this PR been tested?

No
