### PR TITLE
Bump dependencies

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -18,7 +18,8 @@ schema
 typing_extensions
 yarl
 distro; sys_platform == "linux"
-uvloop; sys_platform != "win32" and platform_python_implementation == "CPython"
+# https://github.com/MagicStack/uvloop/issues/702
+uvloop>=0.21.0,!=0.22.0,!=0.22.1; sys_platform != "win32" and platform_python_implementation == "CPython"
 
 # Used by discord.py[speedup]. See Pull request #6587 for more info.
 Brotli

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,9 +12,9 @@ apsw==3.46.1.0
     # via -r base.in
 attrs==25.3.0
     # via aiohttp
-babel==2.17.0
+babel==2.18.0
     # via -r base.in
-brotli==1.1.0
+brotli==1.2.0
     # via -r base.in
 click==8.1.8
     # via -r base.in
@@ -26,7 +26,7 @@ frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-idna==3.10
+idna==3.11
     # via yarl
 markdown==3.7
     # via -r base.in
@@ -40,19 +40,19 @@ multidict==6.1.0
     #   yarl
 orjson==3.10.15
     # via -r base.in
-packaging==25.0
+packaging==26.0
     # via -r base.in
 platformdirs==4.3.6
     # via -r base.in
 propcache==0.2.0
     # via yarl
-psutil==7.0.0
+psutil==7.2.2
     # via -r base.in
 pygments==2.19.2
     # via rich
 python-dateutil==2.9.0.post0
     # via -r base.in
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via -r base.in
 rapidfuzz==3.9.7
     # via -r base.in
@@ -62,9 +62,9 @@ red-commons==1.0.0
     #   red-lavalink
 red-lavalink==0.11.0
     # via -r base.in
-rich==14.1.0
+rich==14.3.3
     # via -r base.in
-schema==0.7.7
+schema==0.7.8
     # via -r base.in
 six==1.17.0
     # via python-dateutil
@@ -86,7 +86,7 @@ distro==1.9.0; sys_platform == "linux" and sys_platform == "linux"
     # via -r base.in
 importlib-metadata==8.5.0; python_version != "3.10" and python_version != "3.11"
     # via markdown
-pytz==2025.2; python_version == "3.8"
+pytz==2026.1.post1; python_version == "3.8"
     # via babel
 uvloop==0.21.0; (sys_platform != "win32" and platform_python_implementation == "CPython") and sys_platform != "win32"
     # via -r base.in

--- a/requirements/extra-doc.txt
+++ b/requirements/extra-doc.txt
@@ -1,15 +1,15 @@
 alabaster==0.7.13
     # via sphinx
-certifi==2025.8.3
+certifi==2026.2.25
     # via requests
-charset-normalizer==3.4.3
+charset-normalizer==3.4.4
     # via requests
 docutils==0.20.1
     # via
     #   sphinx
     #   sphinx-prompt
     #   sphinx-rtd-theme
-imagesize==1.4.1
+imagesize==1.5.0
     # via sphinx
 importlib-metadata==8.5.0
     # via
@@ -19,7 +19,7 @@ jinja2==3.1.6
     # via sphinx
 markupsafe==2.1.5
     # via jinja2
-pytz==2025.2
+pytz==2026.1.post1
     # via
     #   -c base.txt
     #   babel
@@ -36,7 +36,7 @@ sphinx==7.1.2
     #   sphinxcontrib-trio
 sphinx-prompt==1.7.0
     # via -r extra-doc.in
-sphinx-rtd-theme==3.0.2
+sphinx-rtd-theme==3.1.0
     # via -r extra-doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -52,7 +52,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sphinxcontrib-trio==1.1.2
+sphinxcontrib-trio==1.2.0
     # via -r extra-doc.in
 urllib3==2.2.3
     # via requests

--- a/requirements/extra-style.txt
+++ b/requirements/extra-style.txt
@@ -4,5 +4,5 @@ mypy-extensions==1.1.0
     # via black
 pathspec==0.12.1
     # via black
-tomli==2.2.1
+tomli==2.4.0
     # via black

--- a/requirements/extra-test.txt
+++ b/requirements/extra-test.txt
@@ -23,9 +23,9 @@ pytest-mock==3.14.1
     # via -r extra-test.in
 tomlkit==0.13.3
     # via pylint
-exceptiongroup==1.3.0; python_version != "3.11"
+exceptiongroup==1.3.1; python_version != "3.11"
     # via pytest
-tomli==2.2.1; python_version != "3.11"
+tomli==2.4.0; python_version != "3.11"
     # via
     #   pylint
     #   pytest


### PR DESCRIPTION
### Description of the changes

The most notable thing is a uvloop bug that prevents us from upgrading. More specifically, the event policy has been deprecated, and I guess its implementation was not properly covered by tests, so a refactor in preparation for removal has broken something. For now, let's just ignore it.

### Have the changes in this PR been tested?

Yes

https://cirrus-ci.com/build/5943837475995648
https://github.com/Jackenmen/Red-Install-Tests/actions/runs/22682184113/job/65755380683