### PR TITLE
Add support for a built-in cipher server

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -45,6 +45,13 @@ from .utils import (
 )
 from ...core.utils import AsyncIter
 
+try:
+    from red_yt_cipher_solver import SolverServerProcess
+except ModuleNotFoundError:
+    _HAS_CIPHER_SOLVER = False
+else:
+    _HAS_CIPHER_SOLVER = True
+
 if TYPE_CHECKING:
     from . import Audio
 
@@ -146,6 +153,8 @@ class ServerManager:
         self._args = []
         self._pipe_task = None
         self.plugins: dict[str, str] = {}
+        self.cipher_server: Optional[SolverServerProcess] = None
+        self.cipher_server_task: Optional[asyncio.Task] = None
 
     @property
     def lavalink_download_dir(self) -> pathlib.Path:
@@ -205,6 +214,17 @@ class ServerManager:
                 raise ManagedLavalinkPreviouslyShutdownException(
                     "Server manager has already been used - create another one"
                 )
+
+        if _HAS_CIPHER_SOLVER:
+            self.cipher_server = SolverServerProcess(
+                log_file=self.lavalink_download_dir / "logs" / "solver-server.log"
+            )
+            # TODO: monitor the task
+            self.cipher_server_task = asyncio.create_task(self.cipher_server.run())
+            if not await self.cipher_server.wait_for_startup():
+                log.warning("Failed to start the cipher server. Will continue without one.")
+                self.cipher_server = None
+
         await self.process_settings()
         await self.maybe_download_jar()
         args, msg = await self._get_jar_args()
@@ -245,6 +265,10 @@ class ServerManager:
 
     async def process_settings(self):
         data = managed_node.generate_server_config(await self._config.yaml.all())
+        if self.cipher_server is not None:
+            plugin_config = data.setdefault("plugins", {}).setdefault("youtube", {})
+            cipher_config = plugin_config.setdefault("remoteCipher", {})
+            cipher_config["url"] = self.cipher_server.base_url
 
         with open(self.lavalink_app_yml, "w", encoding="utf-8") as f:
             yaml.safe_dump(data, f)
@@ -378,6 +402,10 @@ class ServerManager:
         if self.start_monitor_task is not None:
             self.start_monitor_task.cancel()
         await self._partial_shutdown()
+        if self.cipher_server:
+            await self.cipher_server.close()
+            if self.cipher_server_task:
+                await self.cipher_server_task
 
     async def _partial_shutdown(self) -> None:
         self.ready.clear()

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -18,6 +18,7 @@ schema
 typing_extensions
 yarl
 distro; sys_platform == "linux"
+Red-YT-Cipher-Solver; python_version >= '3.10' and ((sys_platform == 'win32' and platform_machine == 'AMD64') or (sys_platform == 'linux' and (platform_machine == 'x86_64' or platform_machine == 'aarch64')) or (sys_platform == 'darwin' and (platform_machine == 'x86_64' or platform_machine == 'arm64')))
 # https://github.com/MagicStack/uvloop/issues/702
 uvloop>=0.21.0,!=0.22.0,!=0.22.1; sys_platform != "win32" and platform_python_implementation == "CPython"
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -82,13 +82,19 @@ async-timeout==4.0.3; python_version != "3.11"
     # via aiohttp
 colorama==0.4.6; sys_platform == "win32"
     # via click
+deno==2.7.2; python_version >= '3.10' and ((sys_platform == 'win32' and platform_machine == 'AMD64') or (sys_platform == 'linux' and (platform_machine == 'x86_64' or platform_machine == 'aarch64')) or (sys_platform == 'darwin' and (platform_machine == 'x86_64' or platform_machine == 'arm64')))
+    # via red-yt-cipher-solver
 distro==1.9.0; sys_platform == "linux" and sys_platform == "linux"
     # via -r base.in
 importlib-metadata==8.5.0; python_version != "3.10" and python_version != "3.11"
     # via markdown
 pytz==2026.1.post1; python_version == "3.8"
     # via babel
+red-yt-cipher-solver==0.3.0; python_version >= '3.10' and ((sys_platform == 'win32' and platform_machine == 'AMD64') or (sys_platform == 'linux' and (platform_machine == 'x86_64' or platform_machine == 'aarch64')) or (sys_platform == 'darwin' and (platform_machine == 'x86_64' or platform_machine == 'arm64')))
+    # via -r base.in
 uvloop==0.21.0; (sys_platform != "win32" and platform_python_implementation == "CPython") and sys_platform != "win32"
     # via -r base.in
+yt-dlp-ejs==0.5.0; python_version >= '3.10' and ((sys_platform == 'win32' and platform_machine == 'AMD64') or (sys_platform == 'linux' and (platform_machine == 'x86_64' or platform_machine == 'aarch64')) or (sys_platform == 'darwin' and (platform_machine == 'x86_64' or platform_machine == 'arm64')))
+    # via red-yt-cipher-solver
 zipp==3.20.2; python_version != "3.10" and python_version != "3.11"
     # via importlib-metadata


### PR DESCRIPTION
### Description of the changes

Technically works, but it's very bare. Only does anything when running Python 3.10+ on platforms supported by Deno (Windows x86_64, macOS x86_64/ARM64, Linux x86_64/aarch64).

### Have the changes in this PR been tested?

Yes
