### PR TITLE
Revert "strip unicode bidi control characters in `cleanup_code` (#6649)"

### DIFF
--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -42,18 +42,6 @@ _ = Translator("Dev", __file__)
 # - or "```" and potentially also strip a single "\n" if it follows it immediately
 START_CODE_BLOCK_RE = re.compile(r"^((```[\w.+\-]+\n+(?!```))|(```\n*))")
 
-REMOVE_CONTROL_CHARS = [
-    "\u2066",
-    "\u2067",
-    "\u2068",
-    "\u202A",
-    "\u202B",
-    "\u202D",
-    "\u202E",
-    "\u2069",
-    "\u202C",
-]
-
 T = TypeVar("T")
 
 
@@ -87,8 +75,6 @@ async def maybe_await(coro: Union[T, Awaitable[T], Awaitable[Awaitable[T]]]) -> 
 
 def cleanup_code(content: str) -> str:
     """Automatically removes code blocks from the code."""
-    content = content.strip("".join(REMOVE_CONTROL_CHARS))
-
     # remove ```py\n```
     if content.startswith("```") and content.endswith("```"):
         return START_CODE_BLOCK_RE.sub("", content)[:-3].rstrip("\n")


### PR DESCRIPTION
### Description of the changes

This reverts commit 01a3c17f8e886252fadd72fc117d3a3163259c3e / PR #6649.

Discord no longer does this.

### Have the changes in this PR been tested?

Yes