### PR TITLE
Make few adjustments to [p]mywarnings and its docs

### DIFF
--- a/docs/cog_guides/warnings.rst
+++ b/docs/cog_guides/warnings.rst
@@ -347,7 +347,7 @@ warningset mywarnings sendtodms
 
 .. code-block:: none
 
-    [p]warningset mywarnings_sendtodms <true_or_false>
+    [p]warningset mywarnings sendtodms <true_or_false>
 
 **Description**
 

--- a/redbot/cogs/warnings/warnings.py
+++ b/redbot/cogs/warnings/warnings.py
@@ -648,52 +648,54 @@ class Warnings(commands.Cog):
         msg = ""
         guild_settings = await self.config.guild(ctx.guild).all()
         member_settings = self.config.member(user)
-        async with member_settings.warnings() as user_warnings:
-            if not user_warnings.keys():  # no warnings for the user
-                if guild_settings["mywarnings_in_dms"]:
-                    await ctx.tick()
+        user_warnings = await member_settings.warnings()
+        if not user_warnings:  # no warnings for the user
+            if guild_settings["mywarnings_in_dms"]:
+                try:
                     await user.send(_("You have no warnings!"))
+                except discord.Forbidden:
+                    await ctx.send(_("I could not send you a DM. Do you have DMs disabled?"))
                 else:
-                    await ctx.send(_("You have no warnings!"))
+                    await ctx.tick()
             else:
-                for key in user_warnings.keys():
-                    mod_id = user_warnings[key]["mod"]
-                    if mod_id == 0xDE1:
-                        mod = _("Deleted Moderator")
-                    elif not guild_settings["show_mod"]:
-                        mod = None
-                    else:
-                        bot = ctx.bot
-                        mod = bot.get_user(mod_id) or _("Unknown Moderator ({})").format(mod_id)
-                    msg += _("{num_points} point warning {reason_name}").format(
-                        num_points=user_warnings[key]["points"],
-                        reason_name=key,
-                    )
-                    if mod is not None:
-                        msg += _(" issued by {user}").format(user=mod)
-                    msg += _(" for {description} \n").format(
-                        description=user_warnings[key]["description"]
-                    )
+                await ctx.send(_("You have no warnings!"))
+            return
 
-                if guild_settings["mywarnings_in_dms"]:
-                    if user.dm_channel is None:
-                        await user.create_dm()
-                    try:
-                        await ctx.bot.send_interactive(
-                            channel=user.dm_channel,
-                            messages=pagify(msg, shorten_by=58),
-                            user=user,
-                            box_lang=_("Warnings for {user}").format(user=user),
-                        )
-                        await ctx.tick()
-                    except discord.Forbidden:
-                        await ctx.send(_("I could not send you a DM. Do you have DMs disabled?"))
+        for key in user_warnings:
+            mod_id = user_warnings[key]["mod"]
+            if mod_id == 0xDE1:
+                mod = _("Deleted Moderator")
+            elif not guild_settings["show_mod"]:
+                mod = None
+            else:
+                bot = ctx.bot
+                mod = bot.get_user(mod_id) or _("Unknown Moderator ({})").format(mod_id)
+            msg += _("{num_points} point warning {reason_name}").format(
+                num_points=user_warnings[key]["points"],
+                reason_name=key,
+            )
+            if mod is not None:
+                msg += _(" issued by {user}").format(user=mod)
+            msg += _(" for {description}\n").format(description=user_warnings[key]["description"])
 
-                else:
-                    await ctx.send_interactive(
-                        pagify(msg, shorten_by=58),
-                        box_lang=_("Warnings for {user}").format(user=user),
-                    )
+        if guild_settings["mywarnings_in_dms"]:
+            try:
+                await ctx.bot.send_interactive(
+                    channel=user,
+                    messages=pagify(msg, shorten_by=58),
+                    user=user,
+                    box_lang=_("Warnings for {user}").format(user=user),
+                )
+            except discord.Forbidden:
+                await ctx.send(_("I could not send you a DM. Do you have DMs disabled?"))
+            else:
+                await ctx.tick()
+
+        else:
+            await ctx.send_interactive(
+                pagify(msg, shorten_by=58),
+                box_lang=_("Warnings for {user}").format(user=user),
+            )
 
     @commands.command()
     @commands.guild_only()


### PR DESCRIPTION
### Description of the changes

Look at the diff with "Hide whitespace changes" checked to see the changes more accurately.

In summary:
- fixed incorrect command in docs
- updated config call to not use the context manager since we don't intend to modify the data
- updated "You have no warnings" case to have a try-except for Forbidden on DM send and tick only *after* DM succeeds
- updated `ctx.bot.send_interactive()` call to pass `user` as channel directly instead of calling `user.create_dm()`
    - presumably this was done like that because there was a period of time when `ctx.bot.send_interactive()` had a bug that did not allow this
- removed unnecessary whitespace between description and newline

### Have the changes in this PR been tested?

Yes

