### PR TITLE
Add --no-debug flag for resetting the verbosity level

### DIFF
--- a/redbot/core/_cli.py
+++ b/redbot/core/_cli.py
@@ -244,6 +244,14 @@ def parse_cli_flags(args):
         dest="logging_level",
         help="Increase the verbosity of the logs, each usage of this flag increases the verbosity level by 1.",
     )
+    parser.add_argument(
+        "--no-verbose",
+        "--no-debug",
+        action="store_const",
+        const=0,
+        dest="logging_level",
+        help="Set the verbosity level to 0.",
+    )
     parser.add_argument("--dev", action="store_true", help="Enables developer mode")
     parser.add_argument(
         "--mentionable",


### PR DESCRIPTION
### Description of the changes

I was a tad bit surprised that the `--debug` flag does not have a `--no-debug` counterpart. This PR implements one such that it resets the set verbosity level back to 0.

### Have the changes in this PR been tested?

Yes
