### PR TITLE
Bump Lavalink version to 3.7.13+red.5

### DIFF
--- a/redbot/cogs/audio/managed_node/version_pins.py
+++ b/redbot/cogs/audio/managed_node/version_pins.py
@@ -11,7 +11,7 @@ __all__ = (
 )
 
 
-JAR_VERSION: Final[LavalinkVersion] = LavalinkVersion(3, 7, 13, red=3)
+JAR_VERSION: Final[LavalinkVersion] = LavalinkVersion(3, 7, 13, red=5)
 YT_PLUGIN_VERSION: Final[str] = "1.18.0"
 # keep this sorted from oldest to latest
 SUPPORTED_JAVA_VERSIONS: Final[Tuple[int, ...]] = (17, 21)


### PR DESCRIPTION
### Description of the changes

See:
https://github.com/Cog-Creators/Lavalink-Jars/releases/tag/3.7.13%2Bred.5

### Have the changes in this PR been tested?

Yes