### PR TITLE
Use ubuntu-slim runners

### DIFF
--- a/.github/workflows/auto_labeler_issues.yml
+++ b/.github/workflows/auto_labeler_issues.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   apply_triage_label_to_issues:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Apply Triage Label
         uses: actions/github-script@v6

--- a/.github/workflows/auto_labeler_pr.yml
+++ b/.github/workflows/auto_labeler_pr.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   label_pull_requests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Apply Type Label
         uses: actions/labeler@v4

--- a/.github/workflows/check_label_pattern_exhaustiveness.yaml
+++ b/.github/workflows/check_label_pattern_exhaustiveness.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   check_label_pattern_exhaustiveness:
     name: Check label pattern exhaustiveness
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4

--- a/.github/workflows/crowdin_upload_strings.yml
+++ b/.github/workflows/crowdin_upload_strings.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   deploy:
     if: github.repository == 'Cog-Creators/Red-DiscordBot'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python

--- a/.github/workflows/lint_python.yaml
+++ b/.github/workflows/lint_python.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
   lint_python:
     name: Lint Python
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   crowdin_download_translations:
     needs: pr_stable_bump
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -68,7 +68,7 @@ jobs:
             console.log(script({github, context}));
 
   pr_stable_bump:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       milestone_number: ${{ steps.get_milestone_number.outputs.result }}
     steps:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -8,7 +8,7 @@ jobs:
   release_information:
     if: github.repository == 'Cog-Creators/Red-DiscordBot'
     name: GO HERE BEFORE APPROVING
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       # Checkout repository and install Python
       - uses: actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
       - generate_default_ll_server_config
     environment: Release
     name: Release to PyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
       id-token: write
@@ -152,7 +152,7 @@ jobs:
       pull-requests: write
     needs: release_to_pypi
     name: Update Red version number to dev
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Get base branch
         env:

--- a/.github/workflows/run_pip_compile.yaml
+++ b/.github/workflows/run_pip_compile.yaml
@@ -56,7 +56,7 @@ jobs:
   merge_requirements:
     name: Merge requirements files.
     needs: generate_requirements
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout the repository.
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description of the changes

I donno, if this will make sense, but I figured why not try?
https://github.blog/changelog/2026-01-22-1-vcpu-linux-runner-now-generally-available-in-github-actions/
IMO, almost every job our CI performs is lightweight, with the notable exception being testing and codeQL.

### Have the changes in this PR been tested?

No
