### PR TITLE
[Docs] Cleanup "About Virtual Environment" docs

### DIFF
--- a/docs/about_venv.rst
+++ b/docs/about_venv.rst
@@ -7,11 +7,10 @@ Creating a virtual environment is simple and helps prevent installation problems
 
 **What Are Virtual Environments For?**
 
-Virtual environments allow you to isolate Red's library dependencies, cog dependencies and python
-binaries from the rest of your system with no performance overhead.
-It also ensures Red and its dependencies are installed to a predictable location, which makes 
-uninstalling Red as simple as removing a single folder. Preventing any data loss 
-or breaking other things on your system.
+Virtual environments allow you to isolate Red's library dependencies, cog dependencies, and Python
+binaries from the rest of your system with no performance overhead, ensuring those dependencies 
+and Red are installed to a predictable location. This makes uninstalling Red as simple as removing 
+a single folder, preventing any data loss or breaking other things on your system.
 
 
 --------------------------------------------
@@ -35,5 +34,5 @@ Using *multiple* virtual environments for each individual or select groups of in
 .. important::
 
     Regardless of which option you choose, do not update the virtual environment while any
-    instances within that environment are running. This is especially true for Windows as 
+    instances within that environment are running. This is especially true for Windows, as 
     files are locked by the system while in use.

--- a/docs/about_venv.rst
+++ b/docs/about_venv.rst
@@ -3,16 +3,15 @@
 ==========================
 About Virtual Environments
 ==========================
-Creating a virtual environment is really easy and usually prevents many common installation
-problems.
+Creating a virtual environment is simple and helps prevent installation problems.
 
 **What Are Virtual Environments For?**
 
 Virtual environments allow you to isolate Red's library dependencies, cog dependencies and python
-binaries from the rest of your system. There is no performance overhead to using virtual environment
-and it saves you from a lot of troubles during setup. It also makes sure Red and its dependencies
-are installed to a predictable location which makes uninstalling Red as simple as removing a single folder,
-without worrying about losing your data or other things on your system becoming broken.
+binaries from the rest of your system with no performance overhead.
+It also ensures Red and its dependencies are installed to a predictable location, which makes 
+uninstalling Red as simple as removing a single folder. Preventing any loss of data 
+or breaking other things on your system.
 
 
 --------------------------------------------
@@ -21,19 +20,19 @@ Virtual Environments with Multiple Instances
 If you are running multiple instances of Red on the same machine, you have the option of either
 using the same virtual environment for all of them, or creating separate ones.
 
-.. note::
+The advantages of using a *single* virtual environment for all of your instances are:
 
-    This only applies for multiple instances of V3. If you are running a V2 instance as well,
-    you **must** use separate virtual environments.
+- When updating Red, you only need to update it once for all instances.
+    - However, you must shut down all instances before updating.
+- It will save space on your hard drive.
 
-The advantages of using a *single* virtual environment for all of your V3 instances are:
+The advantages of using *multiple* virtual environments for all of your instances are:
 
-- When updating Red, you will only need to update it once for all instances (however you will still need to restart all instances for the changes to take effect)
-- It will save space on your hard drive
-
-On the other hand, you may wish to update each of your instances individually.
+- You can update each of your instances individually.
+- Only the instances in the venv need to be shut down prior to updating.
 
 .. important::
 
-    Windows users with multiple instances should create *separate* virtual environments, as
-    updating multiple running instances at once is likely to cause errors.
+    Regardless of which option you choose, do not update the virtual environment while any
+    instance is running. This is especially true for Windows as files are locked by the 
+    system while in use.

--- a/docs/about_venv.rst
+++ b/docs/about_venv.rst
@@ -20,16 +20,17 @@ Virtual Environments with Multiple Instances
 If you are running multiple instances of Red on the same machine, you have the option of either
 using the same virtual environment for all of them, or creating separate ones.
 
-The advantages of using a *single* virtual environment for all of your instances are:
+Using a *single* virtual environment for all of your instances means you:
 
-- When updating Red, you only need to update it once for all instances.
-    - However, you must shut down all instances before updating.
-- It will save space on your hard drive.
+- Only need to update Red once for all instances.
+- Must shut down all instances prior to updating.
+- Will save space on your hard drive.
 
-The advantages of using *multiple* virtual environments for each individual or select groups of instances are:
+Using *multiple* virtual environments for each individual or select groups of instances means you:
 
-- You can update each of your instances individually or as a select group.
-- Only the instances in the virtual environment being updated need to be shut down prior to updating.
+- Need to update Red within each virtual environment separately.
+- Can update Red without needing to update all instances.
+- Only need to shut down the instance being updated.
 
 .. important::
 

--- a/docs/about_venv.rst
+++ b/docs/about_venv.rst
@@ -28,8 +28,8 @@ The advantages of using a *single* virtual environment for all of your instances
 
 The advantages of using *multiple* virtual environments for each individual or select groups of instances are:
 
-- You can update each of your instances individually.
-- Only the instances in the venv need to be shut down prior to updating.
+- You can update each of your instances individually or as a select group.
+- Only the instances in the virtual environment being updated need to be shut down prior to updating.
 
 .. important::
 

--- a/docs/about_venv.rst
+++ b/docs/about_venv.rst
@@ -26,7 +26,7 @@ The advantages of using a *single* virtual environment for all of your instances
     - However, you must shut down all instances before updating.
 - It will save space on your hard drive.
 
-The advantages of using *multiple* virtual environments for all of your instances are:
+The advantages of using *multiple* virtual environments for each individual or select groups of instances are:
 
 - You can update each of your instances individually.
 - Only the instances in the venv need to be shut down prior to updating.

--- a/docs/about_venv.rst
+++ b/docs/about_venv.rst
@@ -10,7 +10,7 @@ Creating a virtual environment is simple and helps prevent installation problems
 Virtual environments allow you to isolate Red's library dependencies, cog dependencies and python
 binaries from the rest of your system with no performance overhead.
 It also ensures Red and its dependencies are installed to a predictable location, which makes 
-uninstalling Red as simple as removing a single folder. Preventing any loss of data 
+uninstalling Red as simple as removing a single folder. Preventing any data loss 
 or breaking other things on your system.
 
 
@@ -30,10 +30,10 @@ Using *multiple* virtual environments for each individual or select groups of in
 
 - Need to update Red within each virtual environment separately.
 - Can update Red without needing to update all instances.
-- Only need to shut down the instance being updated.
+- Only need to shut down the instance(s) being updated.
 
 .. important::
 
     Regardless of which option you choose, do not update the virtual environment while any
-    instance is running. This is especially true for Windows as files are locked by the 
-    system while in use.
+    instances within that environment are running. This is especially true for Windows as 
+    files are locked by the system while in use.

--- a/docs/about_venv.rst
+++ b/docs/about_venv.rst
@@ -24,12 +24,14 @@ Using a *single* virtual environment for all of your instances means you:
 - Only need to update Red once for all instances.
 - Must shut down all instances prior to updating.
 - Will save space on your hard drive.
+- Want all instances to share the same version/dependencies.
 
 Using *multiple* virtual environments for each individual or select groups of instances means you:
 
 - Need to update Red within each virtual environment separately.
 - Can update Red without needing to update all instances.
 - Only need to shut down the instance(s) being updated.
+- Want different Red/dependency versions on different instances.
 
 .. important::
 

--- a/docs/about_venv.rst
+++ b/docs/about_venv.rst
@@ -33,6 +33,5 @@ Using *multiple* virtual environments for each individual or select groups of in
 
 .. important::
 
-    Regardless of which option you choose, do not update the virtual environment while any
-    instances within that environment are running. This is especially true for Windows, as 
-    files are locked by the system while in use.
+    Regardless of which option you choose, do not update while any instances within that virtual 
+    environment are running. This is especially true for Windows, as files are locked by the system while in use.


### PR DESCRIPTION
### Description of the changes
- More concise and cleaner reading for "About Virtual Environments" doc section.
- Remove Red V2 references as Red V2 was expired over six years ago.
- Standardize single/multiple virtual environment caveats (advantages and disadvantages).
- Clarify to never update while running, while maintaining Windows-specific behavior advisory from previous doc version (but with more detail).
- Misc grammatical fixes.

Pending docs build for further fixes/updates, remaining as draft in meantime.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
