### PR TITLE
fix: allow setting embed colour to None for theme-adaptive color

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -989,9 +989,7 @@ class Red(
         """
         await self._prefix_cache.set_prefixes(guild=guild, prefixes=prefixes)
 
-    async def get_embed_color(
-        self, location: discord.abc.Messageable
-    ) -> Optional[discord.Color]:
+    async def get_embed_color(self, location: discord.abc.Messageable) -> Optional[discord.Color]:
         """
         Get the embed color for a location. This takes into account all related settings.
 

--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -989,7 +989,9 @@ class Red(
         """
         await self._prefix_cache.set_prefixes(guild=guild, prefixes=prefixes)
 
-    async def get_embed_color(self, location: discord.abc.Messageable) -> discord.Color:
+    async def get_embed_color(
+        self, location: discord.abc.Messageable
+    ) -> Optional[discord.Color]:
         """
         Get the embed color for a location. This takes into account all related settings.
 
@@ -1000,8 +1002,8 @@ class Red(
 
         Returns
         -------
-        discord.Color
-            Embed color for the provided location.
+        Optional[discord.Color]
+            Embed color for the provided location, or ``None`` for theme color.
         """
 
         guild = getattr(location, "guild", None)
@@ -1148,7 +1150,8 @@ class Red(
 
         await self._maybe_update_config()
         self.description = await self._config.description()
-        self._color = discord.Colour(await self._config.color())
+        raw_color = await self._config.color()
+        self._color = discord.Colour(raw_color) if raw_color is not None else None
 
         init_global_checks(self)
         init_events(self, self._cli_flags)

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -195,8 +195,8 @@ class Context(DPYContext):
 
         Returns
         -------
-        discord.Colour:
-            The colour to be used
+        Optional[discord.Colour]:
+            The colour to be used, or ``None`` for theme colour.
         """
         return await self.bot.get_embed_color(self)
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -4110,9 +4110,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         try:
             colour = await commands.ColourConverter().convert(ctx, colour)
         except commands.BadColourArgument:
-            return await ctx.send(
-                _('"{}" is not a valid colour.').format(colour)
-            )
+            return await ctx.send(_('"{}" is not a valid colour.').format(colour))
         ctx.bot._color = colour
         await ctx.bot._config.color.set(colour.value)
         await ctx.send(_("The color has been set."))

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -3944,7 +3944,8 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         global_data = await ctx.bot._config.all()
         locale = global_data["locale"]
         regional_format = global_data["regional_format"] or locale
-        colour = discord.Colour(global_data["color"])
+        raw_color = global_data["color"]
+        colour = _("Theme (auto)") if raw_color is None else discord.Colour(raw_color)
 
         prefix_string = " ".join(prefixes)
         settings = _(
@@ -4074,7 +4075,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
     @_set.command(name="colour", aliases=["color"])
     @commands.is_owner()
-    async def _set_colour(self, ctx: commands.Context, *, colour: discord.Colour = None):
+    async def _set_colour(self, ctx: commands.Context, *, colour: str = None):
         """
         Sets a default colour to be used for the bot's embeds.
 
@@ -4082,20 +4083,36 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
 
         https://discordpy.readthedocs.io/en/stable/ext/commands/api.html#discord.ext.commands.ColourConverter
 
+        Use ``none`` to let embeds use the user's theme colour instead of a fixed value.
+
         **Examples:**
         - `[p]set colour dark red`
         - `[p]set colour blurple`
         - `[p]set colour 0x5DADE2`
         - `[p]set color 0x#FDFEFE`
         - `[p]set color #7F8C8D`
+        - `[p]set color none`
 
         **Arguments:**
-        - `[colour]` - The colour to use for embeds. Leave blank to set to the default value (red).
+        - `[colour]` - The colour to use for embeds. Use ``none`` for theme colour.\
+          Leave blank to set to the default value (red).
         """
         if colour is None:
             ctx.bot._color = discord.Color.red()
             await ctx.bot._config.color.set(discord.Color.red().value)
             return await ctx.send(_("The color has been reset."))
+        if colour.lower() == "none":
+            ctx.bot._color = None
+            await ctx.bot._config.color.set(None)
+            return await ctx.send(
+                _("The color has been cleared. Embeds will use the user's theme color.")
+            )
+        try:
+            colour = await commands.ColourConverter().convert(ctx, colour)
+        except commands.BadColourArgument:
+            return await ctx.send(
+                _('"{}" is not a valid colour.').format(colour)
+            )
         ctx.bot._color = colour
         await ctx.bot._config.color.set(colour.value)
         await ctx.send(_("The color has been set."))


### PR DESCRIPTION
Closes #6618

The `[p]set colour` command only accepted valid `discord.Colour` values, so passing
`none` would fail with a conversion error. This meant there was no way to set the embed
colour to null, which Discord renders as the user's theme colour.

Changes:
- Accept `none` as a special keyword in `[p]set colour` to clear the fixed colour
- Store `None` in config and propagate it through `get_embed_color` / `embed_colour`
- Show "Theme (auto)" in `[p]showsettings` when colour is unset
- Passing no argument still resets to the default (red), matching existing behavior

Following the approach suggested by Flame442 in the issue discussion.