### PR TITLE
Update uvloop to 0.22.1

### DIFF
--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -289,19 +289,6 @@ class VersionInfo:
         return version("Red-DiscordBot")
 
 
-def _update_event_loop_policy():
-    if _sys.implementation.name == "cpython":
-        # Let's not force this dependency, uvloop is much faster on cpython
-        try:
-            import uvloop
-        except ImportError:
-            pass
-        else:
-            import asyncio
-
-            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
-
-
 def _ensure_no_colorama():
     # a hacky way to ensure that nothing initialises colorama
     # if we're not running with legacy Windows command line mode
@@ -334,7 +321,6 @@ def _early_init():
     # This function replaces logger so we preferably (though not necessarily) want that to happen
     # before importing anything that calls `logging.getLogger()`, i.e. `asyncio`.
     _update_logger_class()
-    _update_event_loop_policy()
     _ensure_no_colorama()
 
 

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -25,7 +25,7 @@ import rich
 import redbot.logging
 from redbot import __version__
 from redbot.core.bot import Red, ExitCodes, _NoOwnerSet
-from redbot.core._cli import interactive_config, confirm, parse_cli_flags
+from redbot.core._cli import interactive_config, confirm, parse_cli_flags, new_event_loop
 from redbot.setup import get_data_dir, get_name, save_config
 from redbot.core import data_manager, _drivers
 from redbot.core._debuginfo import DebugInfo
@@ -272,7 +272,7 @@ def early_exit_runner(
     """
     This one exists to not log all the things like it's a full run of the bot.
     """
-    loop = asyncio.new_event_loop()
+    loop = new_event_loop()
     asyncio.set_event_loop(loop)
     try:
         if not cli_flags.instance_name:
@@ -478,7 +478,7 @@ def main():
         early_exit_runner(cli_flags, edit_instance)
         return
     try:
-        loop = asyncio.new_event_loop()
+        loop = new_event_loop()
         asyncio.set_event_loop(loop)
 
         if cli_flags.no_instance:

--- a/redbot/core/_cli.py
+++ b/redbot/core/_cli.py
@@ -3,12 +3,14 @@ import asyncio
 import logging
 import sys
 from enum import IntEnum
-from typing import Optional
+from typing import Any, Coroutine, Optional, TypeVar
 
 import discord
 from discord import __version__ as discord_version
 
 from redbot.core.utils._internal_utils import cli_level_to_log_level
+
+_T = TypeVar("_T")
 
 
 # This needs to be an int enum to be used
@@ -368,3 +370,32 @@ def parse_cli_flags(args):
     args.logging_level = cli_level_to_log_level(args.logging_level)
 
     return args
+
+
+def asyncio_run(main: Coroutine[Any, Any, _T]) -> _T:
+    if sys.version_info >= (3, 12):
+        return asyncio.run(main, loop_factory=new_event_loop)
+
+    if sys.implementation.name == "cpython":
+        # Let's not force this dependency, uvloop is much faster on cpython
+        try:
+            import uvloop
+        except ImportError:
+            pass
+        else:
+            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
+    return asyncio.run(main)
+
+
+def new_event_loop() -> asyncio.AbstractEventLoop:
+    if sys.implementation.name == "cpython":
+        # Let's not force this dependency, uvloop is much faster on cpython
+        try:
+            import uvloop
+        except ImportError:
+            pass
+        else:
+            return uvloop.new_event_loop()
+
+    return asyncio.new_event_loop()

--- a/redbot/core/_cli.py
+++ b/redbot/core/_cli.py
@@ -372,9 +372,10 @@ def parse_cli_flags(args):
     return args
 
 
-def asyncio_run(main: Coroutine[Any, Any, _T]) -> _T:
-    if sys.version_info >= (3, 12):
-        return asyncio.run(main, loop_factory=new_event_loop)
+def asyncio_run(coro: Coroutine[Any, Any, _T]) -> _T:
+    if sys.version_info >= (3, 11):
+        with asyncio.Runner(loop_factory=new_event_loop) as runner:
+            return runner.run(coro)
 
     if sys.implementation.name == "cpython":
         # Let's not force this dependency, uvloop is much faster on cpython
@@ -385,7 +386,7 @@ def asyncio_run(main: Coroutine[Any, Any, _T]) -> _T:
         else:
             asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
-    return asyncio.run(main)
+    return asyncio.run(coro)
 
 
 def new_event_loop() -> asyncio.AbstractEventLoop:

--- a/redbot/setup.py
+++ b/redbot/setup.py
@@ -22,7 +22,7 @@ from redbot.core.utils._internal_utils import (
 )
 from redbot.core import config, data_manager
 from redbot.core._config import migrate
-from redbot.core._cli import ExitCodes
+from redbot.core._cli import ExitCodes, asyncio_run
 from redbot.core.data_manager import appdir, config_dir, config_file
 from redbot.core._drivers import (
     BackendType,
@@ -514,7 +514,7 @@ def delete(
     remove_datapath: Optional[bool],
 ) -> None:
     """Removes an instance."""
-    asyncio.run(
+    asyncio_run(
         remove_instance(
             instance, interactive, delete_data, _create_backup, drop_db, remove_datapath
         )
@@ -536,7 +536,7 @@ def convert(instance: str, backend: str) -> None:
     if current_backend == BackendType.MONGOV1:
         raise RuntimeError("Please see the 3.2 release notes for upgrading a bot using mongo.")
     else:
-        new_storage_details = asyncio.run(do_migration(current_backend, target))
+        new_storage_details = asyncio_run(do_migration(current_backend, target))
 
     if new_storage_details is not None:
         default_dirs["STORAGE_TYPE"] = target.value
@@ -560,7 +560,7 @@ def convert(instance: str, backend: str) -> None:
 )
 def backup(instance: str, destination_folder: Path) -> None:
     """Backup instance's data."""
-    asyncio.run(create_backup(instance, destination_folder))
+    asyncio_run(create_backup(instance, destination_folder))
 
 
 def run_cli():

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -19,7 +19,7 @@ typing_extensions
 yarl
 distro; sys_platform == "linux"
 # https://github.com/MagicStack/uvloop/issues/702
-uvloop>=0.21.0,!=0.22.0,!=0.22.1; sys_platform != "win32" and platform_python_implementation == "CPython"
+uvloop; sys_platform != "win32" and platform_python_implementation == "CPython"
 
 # Used by discord.py[speedup]. See Pull request #6587 for more info.
 Brotli

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -88,7 +88,7 @@ importlib-metadata==8.5.0; python_version != "3.10" and python_version != "3.11"
     # via markdown
 pytz==2026.1.post1; python_version == "3.8"
     # via babel
-uvloop==0.21.0; (sys_platform != "win32" and platform_python_implementation == "CPython") and sys_platform != "win32"
+uvloop==0.22.1; (sys_platform != "win32" and platform_python_implementation == "CPython") and sys_platform != "win32"
     # via -r base.in
 zipp==3.20.2; python_version != "3.10" and python_version != "3.11"
     # via importlib-metadata

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,16 +3,14 @@ import os
 
 import pytest
 
-from redbot import _update_event_loop_policy
 from redbot.core import _drivers, data_manager
-
-_update_event_loop_policy()
+from redbot.core._cli import new_event_loop
 
 
 @pytest.fixture(scope="session")
 def event_loop(request):
     """Create an instance of the default event loop for entire session."""
-    loop = asyncio.new_event_loop()
+    loop = new_event_loop()
     asyncio.set_event_loop(loop)
     yield loop
     asyncio.set_event_loop(None)


### PR DESCRIPTION
### Description of the changes

Due to the deprecation of event loop policies, we now avoid using them whenever possible. The only time a policy still needs to be set is whenever `asyncio.run` is called in versions older than Python 3.12, as those don't have a `loop_factory` argument.

### Have the changes in this PR been tested?

Yes