### PR TITLE
[Core]: Allow setting embed color to none.

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -989,7 +989,7 @@ class Red(
         """
         await self._prefix_cache.set_prefixes(guild=guild, prefixes=prefixes)
 
-    async def get_embed_color(self, location: discord.abc.Messageable) -> discord.Color:
+    async def get_embed_color(self, location: discord.abc.Messageable) -> Optional[discord.Color]:
         """
         Get the embed color for a location. This takes into account all related settings.
 
@@ -1001,7 +1001,7 @@ class Red(
         Returns
         -------
         discord.Color
-            Embed color for the provided location.
+            Embed color for the provided location, or ``None`` for theme colour.
         """
 
         guild = getattr(location, "guild", None)
@@ -1148,7 +1148,8 @@ class Red(
 
         await self._maybe_update_config()
         self.description = await self._config.description()
-        self._color = discord.Colour(await self._config.color())
+        color_value = await self._config.color()
+        self._color = discord.Colour(color_value) if color_value is not None else None
 
         init_global_checks(self)
         init_events(self, self._cli_flags)

--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -189,14 +189,14 @@ class Context(DPYContext):
             join_character=join_character,
         )
 
-    async def embed_colour(self):
+    async def embed_colour(self) -> Optional[discord.Colour]:
         """
         Helper function to get the colour for an embed.
 
         Returns
         -------
-        discord.Colour:
-            The colour to be used
+        Optional[discord.Colour]:
+            The colour to be used, or ``None`` for theme colour.
         """
         return await self.bot.get_embed_color(self)
 

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -4120,9 +4120,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         **Example:**
         - `[p]set colour reset`
         """
-        default_color = discord.Color(15158332)
+        await ctx.bot._config.color.clear()
+        default_color = await ctx.bot._config.color()
         ctx.bot._color = default_color
-        await ctx.bot._config.color.set(default_color.value)
         await ctx.send(_("The embed colour has been reset to the default."))
 
     @_set.command(

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -4089,10 +4089,6 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         - `[p]set color 0x#FDFEFE`
         - `[p]set color #7F8C8D`
 
-        **Subcommands:**
-        - `[p]set colour theme` - Use Discord's default embed colour (no colour set).
-        - `[p]set colour reset` - Reset to Red's default colour.
-
         **Arguments:**
         - `<colour>` - The colour to use for embeds.
         """

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -4122,7 +4122,7 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         """
         await ctx.bot._config.color.clear()
         default_color = await ctx.bot._config.color()
-        ctx.bot._color = default_color
+        ctx.bot._color = discord.Colour(default_color) if default_color is not None else None
         await ctx.send(_("The embed colour has been reset to the default."))
 
     @_set.command(

--- a/redbot/core/core_commands.py
+++ b/redbot/core/core_commands.py
@@ -4072,9 +4072,9 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
             )
         )
 
-    @_set.command(name="colour", aliases=["color"])
+    @_set.group(name="colour", aliases=["color"], invoke_without_command=True)
     @commands.is_owner()
-    async def _set_colour(self, ctx: commands.Context, *, colour: discord.Colour = None):
+    async def _set_colour(self, ctx: commands.Context, *, colour: discord.Colour):
         """
         Sets a default colour to be used for the bot's embeds.
 
@@ -4089,16 +4089,45 @@ class Core(commands.commands._RuleDropper, commands.Cog, CoreLogic):
         - `[p]set color 0x#FDFEFE`
         - `[p]set color #7F8C8D`
 
+        **Subcommands:**
+        - `[p]set colour theme` - Use Discord's default embed colour (no colour set).
+        - `[p]set colour reset` - Reset to Red's default colour.
+
         **Arguments:**
-        - `[colour]` - The colour to use for embeds. Leave blank to set to the default value (red).
+        - `<colour>` - The colour to use for embeds.
         """
-        if colour is None:
-            ctx.bot._color = discord.Color.red()
-            await ctx.bot._config.color.set(discord.Color.red().value)
-            return await ctx.send(_("The color has been reset."))
         ctx.bot._color = colour
         await ctx.bot._config.color.set(colour.value)
         await ctx.send(_("The color has been set."))
+
+    @_set_colour.command(name="theme")
+    @commands.is_owner()
+    async def _set_colour_theme(self, ctx: commands.Context):
+        """
+        Sets the bot's embed colour to Discord's default (no colour).
+
+        This makes embeds use Discord's built-in theme colour instead of a custom one.
+
+        **Example:**
+        - `[p]set colour theme`
+        """
+        ctx.bot._color = None
+        await ctx.bot._config.color.set(None)
+        await ctx.send(_("The embed colour has been set to Discord's default theme colour."))
+
+    @_set_colour.command(name="reset")
+    @commands.is_owner()
+    async def _set_colour_reset(self, ctx: commands.Context):
+        """
+        Resets the bot's embed colour to Red's default.
+
+        **Example:**
+        - `[p]set colour reset`
+        """
+        default_color = discord.Color(15158332)
+        ctx.bot._color = default_color
+        await ctx.bot._config.color.set(default_color.value)
+        await ctx.send(_("The embed colour has been reset to the default."))
 
     @_set.command(
         name="prefix",


### PR DESCRIPTION
### Description of the changes

Fixes #6618
Rewrite of AI-looking PR #6702 

- `[p]set colour` converted to a group so missing args now errors instead of silently resetting to red
- `[p]set colour theme` sets embed colour to `None` (Discord's default theme colour)
- `[p]set colour reset` explicitly resets to Red's default (Flame Red, `0xE74C3C`, or `15158332`)
- `get_embed_color` and `embed_colour` return type updated to `Optional[discord.Colour]`
- `_pre_login` guarded against `None` color value to prevent crash on startup

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
