### PR TITLE
Add basic backcompat for people using Downloader internals

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -50,6 +50,17 @@ class Downloader(commands.Cog):
         """Nothing to delete"""
         return
 
+    # This is a compatibility shim for people using Downloader internal pre-3.5.25.
+    # It will probably get removed in Red 3.6.
+    @property
+    def _repo_manager(self):
+        return _downloader._repo_manager
+
+    # This is a compatibility shim for people using Downloader internal pre-3.5.25.
+    # It will probably get removed in Red 3.6.
+    async def installed_cogs(self) -> Tuple[InstalledModule, ...]:
+        return await _downloader.installed_cogs()
+
     @staticmethod
     async def send_pagified(target: discord.abc.Messageable, content: str) -> None:
         for page in pagify(content):

--- a/redbot/cogs/downloader/repo_manager.py
+++ b/redbot/cogs/downloader/repo_manager.py
@@ -1,0 +1,8 @@
+# This is a compatibility shim for people using Downloader internal pre-3.5.25.
+# It will probably get removed in Red 3.6.
+
+# import everything from repo_manager module
+from redbot.core._downloader.repo_manager import *
+
+# use Repo subclass with `convert()` method instead of Repo from repo_manager module
+from .converters import Repo


### PR DESCRIPTION
### Description of the changes

This PR readds internals that are commonly used by 3rd-party cogs, which were removed by #6706. This covers the majority of use with minimal work for us.

### Have the changes in this PR been tested?

No
