### PR TITLE
[Alias]: Fix Command Parsing with JSON data.

### DIFF
--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -19,8 +19,6 @@ _ = Translator("Alias", __file__)
 log = logging.getLogger("red.cogs.alias")
 
 
-
-
 @cog_i18n(_)
 class Alias(commands.Cog):
     """Create aliases for commands.

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -1,33 +1,24 @@
 import asyncio
 import logging
 from copy import copy
-from re import search
-from string import Formatter
+from re import search, sub
 from typing import List, Literal
 
 import discord
+
 from redbot.core import Config, commands
+from redbot.core.bot import Red
 from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils.chat_formatting import box, pagify
 from redbot.core.utils.menus import menu
 
-from redbot.core.bot import Red
-from .alias_entry import AliasEntry, AliasCache, ArgParseError
+from .alias_entry import AliasCache, AliasEntry, ArgParseError
 
 _ = Translator("Alias", __file__)
 
 log = logging.getLogger("red.cogs.alias")
 
 
-class _TrackingFormatter(Formatter):
-    def __init__(self):
-        super().__init__()
-        self.max = -1
-
-    def get_value(self, key, args, kwargs):
-        if isinstance(key, int):
-            self.max = max((key, self.max))
-        return super().get_value(key, args, kwargs)
 
 
 @cog_i18n(_)
@@ -165,12 +156,19 @@ class Alias(commands.Cog):
         except commands.BadArgument:
             return
 
-        trackform = _TrackingFormatter()
-        command = trackform.format(alias.command, *args)
+        max_index = -1
+
+        def replace_positional(m):
+            nonlocal max_index
+            n = int(m.group(1))
+            max_index = max(max_index, n)
+            return args[n] if n < len(args) else m.group(0)
+
+        command = sub(r"\{(\d+)\}", replace_positional, alias.command)
 
         # noinspection PyDunderSlots
         new_message.content = "{}{} {}".format(
-            prefix, command, " ".join(args[trackform.max + 1 :])
+            prefix, command, " ".join(args[max_index + 1 :])
         ).strip()
 
         return new_message

--- a/redbot/cogs/alias/alias_entry.py
+++ b/redbot/cogs/alias/alias_entry.py
@@ -1,9 +1,10 @@
-from typing import Tuple, Dict, Optional, List, Union
-from re import findall
+from re import findall, sub
+from typing import Dict, List, Optional, Tuple, Union
 
 import discord
 from discord.ext.commands.view import StringView  # DEP-WARN
-from redbot.core import commands, Config
+
+from redbot.core import Config, commands
 from redbot.core.i18n import Translator
 from redbot.core.utils import AsyncIter
 
@@ -207,7 +208,9 @@ class AliasCache:
                     _("Arguments must be sequential. Missing arguments: ")
                     + ", ".join(str(i + low) for i in gaps)
                 )
-            command = command.format(*(f"{{{i}}}" for i in range(-low, high + low + 1)))
+            safe = command.replace("{", "{{").replace("}", "}}")
+            safe = sub(r"\{\{(\d+)\}\}", r"{\1}", safe)
+            command = safe.format(*(f"{{{i}}}" for i in range(-low, high + low + 1)))
         return command
 
     async def add_alias(


### PR DESCRIPTION
### Description of the changes

Fixes #6524

Been a while I had this in head, and locally on a cog directory, so I am finally decided to release the PR

Fixes a `KeyError` when an alias command contains JSON-like `{}` content. Replaced `_TrackingFormatter` / `str.format()` with a regex substitution that only targets numeric placeholders like `{0}`, `{1}`

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
