### PR TITLE
Fix remaining issues with internal Downloader API

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -474,15 +474,20 @@ class Downloader(commands.Cog):
                     )
                     + message
                 )
-        # "---" added to separate cog install messages from Downloader's message
-        await self.send_pagified(ctx, f"{message}{deprecation_notice}\n---")
-        for cog in install_result.installed_cogs:
-            if cog.install_msg:
-                await ctx.send(
-                    cog.install_msg.replace("[p]", ctx.clean_prefix).replace(
-                        "[botname]", ctx.me.display_name
-                    )
+
+        message += deprecation_notice
+        cogs_with_install_msg = [cog for cog in install_result.installed_cogs if cog.install_msg]
+        if cogs_with_install_msg:
+            # "---" added to separate cog install messages from Downloader's message
+            message += "\n---"
+        await self.send_pagified(ctx, message)
+
+        for cog in cogs_with_install_msg:
+            await ctx.send(
+                cog.install_msg.replace("[p]", ctx.clean_prefix).replace(
+                    "[botname]", ctx.me.display_name
                 )
+            )
 
     @cog.command(name="uninstall", require_var_positional=True)
     async def _cog_uninstall(self, ctx: commands.Context, *cogs: InstalledCog) -> None:

--- a/redbot/core/_downloader/__init__.py
+++ b/redbot/core/_downloader/__init__.py
@@ -20,6 +20,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import (
     Dict,
+    FrozenSet,
     Iterable,
     List,
     Literal,
@@ -486,7 +487,7 @@ async def _get_cogs_to_check(
     cogs: Optional[Iterable[InstalledModule]] = None,
     update_repos: bool = True,
 ) -> Tuple[Set[InstalledModule], List[str]]:
-    failed = []
+    failed: List[str] = []
     if not (cogs or repos):
         if update_repos:
             __, failed = await _repo_manager.update_repos()
@@ -528,7 +529,7 @@ async def pip_install(*deps: str) -> bool:
     return await repo.install_raw_requirements(deps, LIB_PATH)
 
 
-async def reinstall_requirements() -> tuple[List[str], List[str]]:
+async def reinstall_requirements() -> Tuple[Tuple[str, ...], Tuple[Installable, ...]]:
     _create_lib_folder(remove_first=True)
     _installed_cogs = await installed_cogs()
     cogs = []
@@ -548,7 +549,7 @@ async def reinstall_requirements() -> tuple[List[str], List[str]]:
         all_installed_libs += installed_libs
         all_failed_libs += failed_libs
 
-    return failed_reqs, all_failed_libs
+    return failed_reqs, tuple(all_failed_libs)
 
 
 async def install_cogs(
@@ -713,7 +714,7 @@ async def update_repo_cogs(
 
 
 async def _update_cogs(
-    cogs_to_check: Set[InstalledModule], *, failed_repos: Sequence[Repo]
+    cogs_to_check: Set[InstalledModule], *, failed_repos: Sequence[str]
 ) -> CogUpdateResult:
     pinned_cogs = {cog for cog in cogs_to_check if cog.pinned}
     cogs_to_check -= pinned_cogs
@@ -824,7 +825,7 @@ class CogUpdateCheckResult:
     outdated_cogs: Tuple[Installable, ...]
     outdated_libs: Tuple[Installable, ...]
     updatable_cogs: Tuple[Installable, ...]
-    failed_repos: Tuple[Repo, ...]
+    failed_repos: Tuple[str, ...]
     incompatible_python_version: Tuple[Installable, ...]
     incompatible_bot_version: Tuple[Installable, ...]
 
@@ -845,8 +846,8 @@ class CogUpdateCheckResult:
 @dataclasses.dataclass
 class CogUpdateResult(CogUpdateCheckResult):
     # checked_cogs contains old modules, before update
-    checked_cogs: Set[InstalledModule]
-    pinned_cogs: Set[InstalledModule]
+    checked_cogs: FrozenSet[InstalledModule]
+    pinned_cogs: FrozenSet[InstalledModule]
     updated_cogs: Tuple[InstalledModule, ...]
     updated_libs: Tuple[InstalledModule, ...]
     failed_cogs: Tuple[Installable, ...]

--- a/redbot/core/_downloader/__init__.py
+++ b/redbot/core/_downloader/__init__.py
@@ -701,7 +701,7 @@ async def update_repo_cogs(
     try:
         await repo.update()
     except errors.UpdateError:
-        return await _update_cogs(set(), failed_repos=[repo])
+        return await _update_cogs(set(), failed_repos=(repo.name,))
 
     # TODO: should this be set to `repo.branch` when `rev` is None?
     commit = None


### PR DESCRIPTION
### Description of the changes

Fixes regressions from #6706:
- "---" being appended when all cogs failed to install
	- The prefix will also no longer be shown when none of the cogs has an install message, though that was not part of the regression
- Incorrect type hints
- Wrong argument being passed to `_update_cogs()` when repo fails to update in `cog updatetoversion`

### Have the changes in this PR been tested?

Yes