### PR TITLE
Add commands like findcog with cog and cog package as inputs

### DIFF
--- a/docs/cog_guides/downloader.rst
+++ b/docs/cog_guides/downloader.rst
@@ -359,16 +359,94 @@ findcog
 
 **Description**
 
-Find which cog a command comes from.
+Find which cog package a command comes from.
 
 This will only work with loaded cogs.
 
 Example:
     - ``[p]findcog ping``
+    - ``[p]findcog command ping``
+    - ``[p]findcog cog Audio``
+    - ``[p]findcog package audio``
 
 **Arguments**
 
 - ``<command_name>`` The command to search for.
+
+.. _downloader-command-findcog-cog:
+
+"""""""""""
+findcog cog
+"""""""""""
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]findcog cog <cog_name>
+
+**Description**
+
+Find which cog package a cog comes from.
+
+This will only work with loaded cogs.
+
+Example:
+    - ``[p]findcog cog Audio``
+
+**Arguments**
+
+- ``<cog_name>`` The cog to find the cog package for.
+
+.. _downloader-command-findcog-command:
+
+"""""""""""""""
+findcog command
+"""""""""""""""
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]findcog command <command_name>
+
+**Description**
+
+Find which cog package a command comes from.
+
+This will only work with loaded cogs.
+
+Example:
+    - ``[p]findcog command ping``
+
+**Arguments**
+
+- ``<command_name>`` The command to search for.
+
+.. _downloader-command-findcog-package:
+
+"""""""""""""""
+findcog package
+"""""""""""""""
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]findcog package <cog_pkg_name>
+
+**Description**
+
+Show details about a cog package.
+
+This will only work with loaded cogs.
+
+Example:
+    - ``[p]findcog package audio``
+
+**Arguments**
+
+- ``<cog_pkg_name>`` The package to show details for.
 
 .. _downloader-command-pipinstall:
 

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1122,7 +1122,7 @@ class Downloader(commands.Cog):
         This will only work with loaded cogs.
 
         Example:
-        - `[p]findcog ping`
+        - `[p]findcommand ping`
 
         **Arguments**
 
@@ -1146,7 +1146,7 @@ class Downloader(commands.Cog):
         This will only work with loaded cogs.
 
         Example:
-        - `[p]findcogpackage Audio`
+        - `[p]findcog Audio`
 
         **Arguments**
 

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1136,7 +1136,7 @@ class Downloader(commands.Cog):
 
         cog = command.cog
         await self._show_cog_info(
-            cog.__module__, cog_name=cog.__class__.__name__, command_name=command_name
+            ctx, cog.__module__, cog_name=cog.__class__.__name__, command_name=command_name
         )
 
     @commands.command()
@@ -1158,7 +1158,7 @@ class Downloader(commands.Cog):
             await ctx.send(_("That cog doesn't seem to exist."))
             return
 
-        await self._show_cog_package_info(cog.__module__, cog_name=cog.__class__.__name__)
+        await self._show_cog_package_info(ctx, cog.__module__, cog_name=cog.__class__.__name__)
 
     @commands.command()
     async def findcogpackage(self, ctx: commands.Context, cog_pkg_name: str) -> None:
@@ -1179,10 +1179,10 @@ class Downloader(commands.Cog):
             await ctx.send(_("That cog package doesn't seem to exist."))
             return
 
-        await self._show_cog_package_info(module.__name__)
+        await self._show_cog_package_info(ctx, module.__name__)
 
     async def _show_cog_package_info(
-        self, module_name: Optional[str], *, cog_name: str = "", command_name: str = ""
+        self, ctx, module_name: Optional[str], *, cog_name: str = "", command_name: str = ""
     ) -> None:
         if not module_name:
             msg = _("This is not provided by a cog package.")

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1116,8 +1116,8 @@ class Downloader(commands.Cog):
         return splitted[0]
 
     @commands.command()
-    async def findcog(self, ctx: commands.Context, command_name: str) -> None:
-        """Find which cog a command comes from.
+    async def findcommand(self, ctx: commands.Context, command_name: str) -> None:
+        """Find which cog package a command comes from.
 
         This will only work with loaded cogs.
 
@@ -1134,52 +1134,103 @@ class Downloader(commands.Cog):
             await ctx.send(_("That command doesn't seem to exist."))
             return
 
-        # Check if in installed cogs
         cog = command.cog
-        if cog:
-            cog_pkg_name = self.cog_name_from_instance(cog)
-            installed, cog_installable = await _downloader.is_installed(cog_pkg_name)
-            if installed:
-                made_by = (
-                    humanize_list(cog_installable.author)
-                    if cog_installable.author
-                    else _("Missing from info.json")
-                )
-                repo_url = (
-                    _("Missing from installed repos")
-                    if cog_installable.repo is None
-                    else cog_installable.repo.clean_url
-                )
-                repo_name = (
-                    _("Missing from installed repos")
-                    if cog_installable.repo is None
-                    else cog_installable.repo.name
-                )
-                cog_pkg_name = cog_installable.name
-            elif cog.__module__.startswith("redbot."):  # core commands or core cog
-                made_by = "Cog Creators"
-                repo_url = "https://github.com/Cog-Creators/Red-DiscordBot"
-                module_fragments = cog.__module__.split(".")
-                if module_fragments[1] == "core":
-                    cog_pkg_name = "N/A - Built-in commands"
-                else:
-                    cog_pkg_name = module_fragments[2]
-                repo_name = "Red-DiscordBot"
-            else:  # assume not installed via downloader
-                made_by = _("Unknown")
-                repo_url = _("None - this cog wasn't installed via downloader")
-                repo_name = _("Unknown")
-            cog_name = cog.__class__.__name__
-        else:
-            msg = _("This command is not provided by a cog.")
+        await self._show_cog_info(
+            cog.__module__, cog_name=cog.__class__.__name__, command_name=command_name
+        )
+
+    @commands.command()
+    async def findcog(self, ctx: commands.Context, cog_name: str) -> None:
+        """Find which cog package a cog comes from.
+
+        This will only work with loaded cogs.
+
+        Example:
+        - `[p]findcogpackage Audio`
+
+        **Arguments**
+
+        - `<cog_name>` The cog to find the cog package for.
+        """
+        cog = ctx.bot.cogs.get(cog_name)
+
+        if cog is None:
+            await ctx.send(_("That cog doesn't seem to exist."))
+            return
+
+        await self._show_cog_package_info(cog.__module__, cog_name=cog.__class__.__name__)
+
+    @commands.command()
+    async def findcogpackage(self, ctx: commands.Context, cog_pkg_name: str) -> None:
+        """Show details about a cog package.
+
+        This will only work with loaded cogs.
+
+        Example:
+        - `[p]findcogpackage audio`
+
+        **Arguments**
+
+        - `<cog_pkg_name>` The cog package to show details for.
+        """
+        module = ctx.bot.extensions.get(cog_pkg_name)
+
+        if module is None:
+            await ctx.send(_("That cog package doesn't seem to exist."))
+            return
+
+        await self._show_cog_package_info(module.__name__)
+
+    async def _show_cog_package_info(
+        self, module_name: Optional[str], *, cog_name: str = "", command_name: str = ""
+    ) -> None:
+        if not module_name:
+            msg = _("This is not provided by a cog package.")
             await ctx.send(msg)
             return
 
+        # Check if in installed cogs
+        splitted = module_name.split(".")
+        installed, cog_installable = await _downloader.is_installed(splitted[0])
+        if installed:
+            made_by = (
+                humanize_list(cog_installable.author)
+                if cog_installable.author
+                else _("Missing from info.json")
+            )
+            repo_url = (
+                _("Missing from installed repos")
+                if cog_installable.repo is None
+                else cog_installable.repo.clean_url
+            )
+            repo_name = (
+                _("Missing from installed repos")
+                if cog_installable.repo is None
+                else cog_installable.repo.name
+            )
+            cog_pkg_name = cog_installable.name
+        elif module_name.startswith("redbot."):  # core commands or core cog
+            made_by = "Cog Creators"
+            repo_url = "https://github.com/Cog-Creators/Red-DiscordBot"
+            module_fragments = module_name.split(".")
+            if module_fragments[1] == "core":
+                cog_pkg_name = "N/A - Built-in commands"
+            else:
+                cog_pkg_name = module_fragments[2]
+            repo_name = "Red-DiscordBot"
+        else:  # assume not installed via downloader
+            made_by = _("Unknown")
+            repo_url = _("None - this cog wasn't installed via downloader")
+            repo_name = _("Unknown")
+            cog_pkg_name = module_name
+
         if await ctx.embed_requested():
             embed = discord.Embed(color=(await ctx.embed_colour()))
-            embed.add_field(name=_("Command:"), value=command_name, inline=False)
+            if command_name:
+                embed.add_field(name=_("Command:"), value=command_name, inline=False)
+            if cog_name:
+                embed.add_field(name=_("Cog name:"), value=cog_name, inline=True)
             embed.add_field(name=_("Cog package name:"), value=cog_pkg_name, inline=True)
-            embed.add_field(name=_("Cog name:"), value=cog_name, inline=True)
             embed.add_field(name=_("Made by:"), value=made_by, inline=False)
             embed.add_field(name=_("Repo name:"), value=repo_name, inline=False)
             embed.add_field(name=_("Repo URL:"), value=repo_url, inline=False)
@@ -1190,17 +1241,18 @@ class Downloader(commands.Cog):
             await ctx.send(embed=embed)
 
         else:
-            msg = _(
-                "Command:          {command}\n"
+            msg = ""
+            if command_name:
+                msg += _("Command:          {command}\n").format(command=command_name)
+            if cog_name:
+                msg += _("Cog name:         {cog}\n").format(cog=cog_name)
+            msg += _(
                 "Cog package name: {cog_pkg}\n"
-                "Cog name:         {cog}\n"
                 "Made by:          {author}\n"
                 "Repo name:        {repo_name}\n"
                 "Repo URL:         {repo_url}\n"
             ).format(
-                command=command_name,
                 cog_pkg=cog_pkg_name,
-                cog=cog_name,
                 author=made_by,
                 repo_url=repo_url,
                 repo_name=repo_name,

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1115,14 +1115,32 @@ class Downloader(commands.Cog):
         splitted = instance.__module__.split(".")
         return splitted[0]
 
-    @commands.command()
-    async def findcommand(self, ctx: commands.Context, command_name: str) -> None:
+    @commands.group(invoke_without_command=True)
+    async def findcog(self, ctx: commands.Context, command_name: str) -> None:
+        """Find which cog package a command comes from.
+
+        This will only work with loaded cogs.
+
+        Examples:
+        - `[p]findcog ping`
+        - `[p]findcog command ping`
+        - `[p]findcog cog Audio`
+        - `[p]findcog package audio`
+
+        **Arguments**
+
+        - `<command_name>` The command to search for.
+        """
+        await self.findcog_command(ctx, command_name)
+
+    @findcog.command(name="command")
+    async def findcog_command(self, ctx: commands.Context, command_name: str) -> None:
         """Find which cog package a command comes from.
 
         This will only work with loaded cogs.
 
         Example:
-        - `[p]findcommand ping`
+        - `[p]findcog command ping`
 
         **Arguments**
 
@@ -1139,14 +1157,14 @@ class Downloader(commands.Cog):
             ctx, cog.__module__, cog_name=cog.__class__.__name__, command_name=command_name
         )
 
-    @commands.command()
-    async def findcog(self, ctx: commands.Context, cog_name: str) -> None:
+    @findcog.command(name="cog")
+    async def findcog_cog(self, ctx: commands.Context, cog_name: str) -> None:
         """Find which cog package a cog comes from.
 
         This will only work with loaded cogs.
 
         Example:
-        - `[p]findcog Audio`
+        - `[p]findcog cog Audio`
 
         **Arguments**
 
@@ -1160,14 +1178,14 @@ class Downloader(commands.Cog):
 
         await self._show_cog_package_info(ctx, cog.__module__, cog_name=cog.__class__.__name__)
 
-    @commands.command()
-    async def findcogpackage(self, ctx: commands.Context, cog_pkg_name: str) -> None:
+    @findcog.command(name="package", aliases=["cogpackage"])
+    async def findcog_package(self, ctx: commands.Context, cog_pkg_name: str) -> None:
         """Show details about a cog package.
 
         This will only work with loaded cogs.
 
         Example:
-        - `[p]findcogpackage audio`
+        - `[p]findcog package audio`
 
         **Arguments**
 

--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -1135,7 +1135,7 @@ class Downloader(commands.Cog):
             return
 
         cog = command.cog
-        await self._show_cog_info(
+        await self._show_cog_package_info(
             ctx, cog.__module__, cog_name=cog.__class__.__name__, command_name=command_name
         )
 


### PR DESCRIPTION
### Description of the changes

This PR adds new subcommands to `findcog` that allow finding a cog package using the name of the cog or cog package:
```
findcog play
findcog command play
findcog cog Audio
findcog cogpackage audio
```

### Have the changes in this PR been tested?

Yes
