### PR TITLE
Handle responding to interactions in help formatter for hybrids

### DIFF
--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -872,7 +872,7 @@ class RedHelpFormatter(HelpFormatterABC):
             and help_settings.use_menus is HelpMenuSetting.reactions
         ):
             use_DMs = help_settings.max_pages_in_guild == 0
-            destination = ctx.author if use_DMs else ctx.channel
+            destination = ctx.author if use_DMs and ctx.interaction is None else ctx
             # Specifically ensuring the menu's message is sent prior to returning
             m = await (destination.send(embed=pages[0]) if embed else destination.send(pages[0]))
             c = menus.DEFAULT_CONTROLS if len(pages) > 1 else {"\N{CROSS MARK}": menus.close_menu}
@@ -892,15 +892,13 @@ class RedHelpFormatter(HelpFormatterABC):
             delete_delay = help_settings.delete_delay
 
             messages: List[discord.Message] = []
-            for i, page in enumerate(pages):
+            page_destination = ctx if ctx.interaction and not use_DMs else destination
+            for page in pages:
                 try:
-                    use_ctx_send = ctx.interaction and not use_DMs and i == 0
                     if embed:
-                        msg = await (
-                            ctx.send(embed=page) if use_ctx_send else destination.send(embed=page)
-                        )
+                        msg = await page_destination.send(embed=page)
                     else:
-                        msg = await (ctx.send(page) if use_ctx_send else destination.send(page))
+                        msg = await page_destination.send(page)
                 except discord.Forbidden:
                     return await ctx.send(
                         _(
@@ -910,8 +908,9 @@ class RedHelpFormatter(HelpFormatterABC):
                     )
                 else:
                     messages.append(msg)
+                    page_destination = destination
             if ctx.interaction and use_DMs:
-                await ctx.interaction.response.send_message(
+                await ctx.send(
                     _("I have sent the help message to your DMs."), ephemeral=True
                 )
             elif use_DMs and help_settings.use_tick:

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -890,14 +890,19 @@ class RedHelpFormatter(HelpFormatterABC):
             use_DMs = len(pages) > max_pages_in_guild
             destination = ctx.author if use_DMs else ctx.channel
             delete_delay = help_settings.delete_delay
+            is_interaction = ctx.interaction is not None
+            if is_interaction and use_DMs:
+                if not ctx.interaction.response.is_done():
+                    await ctx.defer(ephemeral=True)
 
             messages: List[discord.Message] = []
-            for page in pages:
+            for i, page in enumerate(pages):
                 try:
+                    use_ctx_send = is_interaction and not use_DMs and i == 0
                     if embed:
-                        msg = await destination.send(embed=page)
+                        msg = await (ctx.send(embed=page) if use_ctx_send else destination.send(embed=page))
                     else:
-                        msg = await destination.send(page)
+                        msg = await (ctx.send(page) if use_ctx_send else destination.send(page))
                 except discord.Forbidden:
                     return await ctx.send(
                         _(

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -900,7 +900,9 @@ class RedHelpFormatter(HelpFormatterABC):
                 try:
                     use_ctx_send = is_interaction and not use_DMs and i == 0
                     if embed:
-                        msg = await (ctx.send(embed=page) if use_ctx_send else destination.send(embed=page))
+                        msg = await (
+                            ctx.send(embed=page) if use_ctx_send else destination.send(embed=page)
+                        )
                     else:
                         msg = await (ctx.send(page) if use_ctx_send else destination.send(page))
                 except discord.Forbidden:

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -910,9 +910,7 @@ class RedHelpFormatter(HelpFormatterABC):
                     messages.append(msg)
                     page_destination = destination
             if ctx.interaction and use_DMs:
-                await ctx.send(
-                    _("I have sent the help message to your DMs."), ephemeral=True
-                )
+                await ctx.send(_("I have sent the help message to your DMs."), ephemeral=True)
             elif use_DMs and help_settings.use_tick:
                 await ctx.tick()
             # The if statement takes into account that 'destination' will be

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -890,15 +890,11 @@ class RedHelpFormatter(HelpFormatterABC):
             use_DMs = len(pages) > max_pages_in_guild
             destination = ctx.author if use_DMs else ctx.channel
             delete_delay = help_settings.delete_delay
-            is_interaction = ctx.interaction is not None
-            if is_interaction and use_DMs:
-                if not ctx.interaction.response.is_done():
-                    await ctx.defer(ephemeral=True)
 
             messages: List[discord.Message] = []
             for i, page in enumerate(pages):
                 try:
-                    use_ctx_send = is_interaction and not use_DMs and i == 0
+                    use_ctx_send = ctx.interaction and not use_DMs and i == 0
                     if embed:
                         msg = await (
                             ctx.send(embed=page) if use_ctx_send else destination.send(embed=page)
@@ -914,7 +910,11 @@ class RedHelpFormatter(HelpFormatterABC):
                     )
                 else:
                     messages.append(msg)
-            if use_DMs and help_settings.use_tick:
+            if ctx.interaction and use_DMs:
+                await ctx.interaction.response.send_message(
+                    _("I have sent the help message to your DMs."), ephemeral=True
+                )
+            elif use_DMs and help_settings.use_tick:
                 await ctx.tick()
             # The if statement takes into account that 'destination' will be
             # the context channel in non-DM context.

--- a/redbot/core/commands/help.py
+++ b/redbot/core/commands/help.py
@@ -909,10 +909,11 @@ class RedHelpFormatter(HelpFormatterABC):
                 else:
                     messages.append(msg)
                     page_destination = destination
-            if ctx.interaction and use_DMs:
-                await ctx.send(_("I have sent the help message to your DMs."), ephemeral=True)
-            elif use_DMs and help_settings.use_tick:
-                await ctx.tick()
+            if use_DMs:
+                if ctx.interaction:
+                    await ctx.send(_("I have sent the help message to your DMs."), ephemeral=True)
+                elif help_settings.use_tick:
+                    await ctx.tick()
             # The if statement takes into account that 'destination' will be
             # the context channel in non-DM context.
             if (


### PR DESCRIPTION
### Description of the changes

Fixes #5916 

This PR fixes an issue when using `ctx.send_help()` in a hybrid command's slash command, it causes a timeout if the help menu is set to not use menus. We are simply sending with `ctx.send()` instead of `destination.send()` on first page when it's an interaction and bot does not send help through dms.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
