### PR TITLE
Prefer using repr() on the Dev cog results (excl. str instances)

### DIFF
--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -158,7 +158,7 @@ class DevOutput:
             output.append(self.formatted_exc)
         elif self.always_include_result or self.result is not None:
             try:
-                result = str(self.result)
+                result = str(self.result) if isinstance(self.result, str) else repr(self.result)
                 # ensure that the result can be encoded (GH-6485)
                 result.encode("utf-8")
             except Exception as exc:


### PR DESCRIPTION
### Description of the changes

This has been an annoyance for ages, and the simpler alternative of *always* using `repr()` on the object was rejected due to practicality of `return "some\nstring"`, sending back:
```
some
string
```
rather than `"some\nstring"`. That's why this PR special cases `str` instances.

### Have the changes in this PR been tested?

No