### PR TITLE
[i18n]: fix sr-SP not being accepted

### DIFF
--- a/redbot/core/_i18n.py
+++ b/redbot/core/_i18n.py
@@ -30,6 +30,10 @@ current_regional_format_default = None
 
 translators: List[Translator] = []
 
+_CROWDIN_LOCALE_OVERRIDES: dict[str, str] = {
+    "sr-SP": "sr-SP",
+}
+
 
 def _reload_locales() -> None:
     for translator in translators:
@@ -37,6 +41,8 @@ def _reload_locales() -> None:
 
 
 def _get_standardized_locale_name(language_code: str) -> str:
+    if language_code in _CROWDIN_LOCALE_OVERRIDES:
+        return _CROWDIN_LOCALE_OVERRIDES[language_code]
     try:
         locale = Locale.parse(language_code, sep="-")
     except (ValueError, UnknownLocaleError):


### PR DESCRIPTION
### Description of the changes

Fixes #5812 

As `sr-SP` is not a valid ISO 3166-1 code, Babel is throwing an UnknownLocaleError. The fix I have made makes an override to that, so `sr-SP` gets accepted now

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
