### PR TITLE
[Audio]: Allow certain users to queue songs longer than the maxlength.

### DIFF
--- a/redbot/cogs/audio/apis/interface.py
+++ b/redbot/cogs/audio/apis/interface.py
@@ -455,6 +455,7 @@ class AudioAPIInterface:
         try:
             current_cache_level = CacheLevel(await self.config.cache_level())
             guild_data = await self.config.guild(ctx.guild).all()
+            can_skip = await self.cog._can_instaskip(ctx, ctx.author)
             enqueued_tracks = 0
             consecutive_fails = 0
             queue_dur = await self.cog.queue_duration(ctx)
@@ -624,7 +625,7 @@ class AudioAPIInterface:
                 if enqueue:
                     if len(player.queue) >= 10000:
                         continue
-                    if guild_data["maxlength"] > 0:
+                    if guild_data["maxlength"] > 0 and not can_skip:
                         if self.cog.is_track_length_allowed(single_track, guild_data["maxlength"]):
                             enqueued_tracks += 1
                             single_track.extras.update(

--- a/redbot/cogs/audio/core/__init__.py
+++ b/redbot/cogs/audio/core/__init__.py
@@ -129,6 +129,7 @@ class Audio(
             jukebox=False,
             jukebox_price=0,
             maxlength=0,
+            maxlength_bypass=True,
             max_volume=150,
             notify=False,
             prefer_lyrics=False,

--- a/redbot/cogs/audio/core/commands/audioset.py
+++ b/redbot/cogs/audio/core/commands/audioset.py
@@ -893,6 +893,19 @@ class AudioSetCommands(MixinMeta, metaclass=CompositeMetaClass):
             )
         await self.config.guild(ctx.guild).maxlength.set(seconds)
 
+    @command_audioset.command(name="maxlengthbypass")
+    @commands.admin_or_permissions(manage_guild=True)
+    async def audioset_maxlength_bypass(self, ctx: commands.Context):
+        """Toggle whether mods/admins/DJs can bypass the max track length."""
+        bypass = await self.config.guild(ctx.guild).maxlength_bypass()
+        await self.config.guild(ctx.guild).maxlength_bypass.set(not bypass)
+        if not bypass:
+            await self.send_embed_msg(
+                ctx, title=_("Mods and DJs can now bypass the max track length.")
+            )
+        else:
+            await self.send_embed_msg(ctx, title=_("Max track length now applies to everyone."))
+
     @command_audioset.command(name="notify")
     @commands.guild_only()
     @commands.mod_or_permissions(manage_guild=True)

--- a/redbot/cogs/audio/core/commands/player.py
+++ b/redbot/cogs/audio/core/commands/player.py
@@ -295,7 +295,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                 title=_("Unable To Play Tracks"),
                 description=_("This track is not allowed in this server."),
             )
-        elif guild_data["maxlength"] > 0:
+        elif guild_data["maxlength"] > 0 and not can_skip:
             if self.is_track_length_allowed(single_track, guild_data["maxlength"]):
                 single_track.requester = ctx.author
                 single_track.extras.update(
@@ -821,7 +821,7 @@ class PlayerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     ):
                         log.debug("Query is not allowed in %r (%s)", ctx.guild.name, ctx.guild.id)
                         continue
-                    elif guild_data["maxlength"] > 0:
+                    elif guild_data["maxlength"] > 0 and not can_skip:
                         if self.is_track_length_allowed(track, guild_data["maxlength"]):
                             track_len += 1
                             track.extras.update(

--- a/redbot/cogs/audio/core/commands/playlists.py
+++ b/redbot/cogs/audio/core/commands/playlists.py
@@ -1511,7 +1511,11 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                             pass
                         if not local_path.exists() and not local_path.is_file():
                             continue
-                    if maxlength > 0 and not can_skip and not self.is_track_length_allowed(track, maxlength):
+                    if (
+                        maxlength > 0
+                        and not can_skip
+                        and not self.is_track_length_allowed(track, maxlength)
+                    ):
                         continue
                     track.extras.update(
                         {

--- a/redbot/cogs/audio/core/commands/playlists.py
+++ b/redbot/cogs/audio/core/commands/playlists.py
@@ -1485,6 +1485,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                 ctx.command.reset_cooldown(ctx)
                 return
             maxlength = await self.config.guild(ctx.guild).maxlength()
+            can_skip = await self._can_instaskip(ctx, ctx.author)
             author_obj = self.bot.get_user(ctx.author.id)
             track_len = 0
             try:
@@ -1510,7 +1511,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                             pass
                         if not local_path.exists() and not local_path.is_file():
                             continue
-                    if maxlength > 0 and not self.is_track_length_allowed(track, maxlength):
+                    if maxlength > 0 and not can_skip and not self.is_track_length_allowed(track, maxlength):
                         continue
                     track.extras.update(
                         {

--- a/redbot/cogs/audio/core/commands/playlists.py
+++ b/redbot/cogs/audio/core/commands/playlists.py
@@ -4,11 +4,10 @@ import math
 import os
 import tarfile
 import time
-
 from io import BytesIO
 from pathlib import Path
-from urllib.parse import urlparse
 from typing import cast
+from urllib.parse import urlparse
 
 import discord
 import lavalink
@@ -24,7 +23,12 @@ from redbot.core.utils.menus import menu
 from redbot.core.utils.predicates import MessagePredicate
 
 from ...apis.api_utils import FakePlaylist
-from ...apis.playlist_interface import Playlist, create_playlist, delete_playlist, get_all_playlist
+from ...apis.playlist_interface import (
+    Playlist,
+    create_playlist,
+    delete_playlist,
+    get_all_playlist,
+)
 from ...audio_dataclasses import LocalPath, Query
 from ...converters import ComplexScopeParser, ScopeParser
 from ...errors import MissingGuild, TooManyMatches, TrackEnqueueError
@@ -1485,6 +1489,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                 ctx.command.reset_cooldown(ctx)
                 return
             maxlength = await self.config.guild(ctx.guild).maxlength()
+            maxlength_bypass = await self.config.guild(ctx.guild).maxlength_bypass()
             can_skip = await self._can_instaskip(ctx, ctx.author)
             author_obj = self.bot.get_user(ctx.author.id)
             track_len = 0
@@ -1499,7 +1504,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                     if not await self.is_query_allowed(
                         self.config,
                         ctx,
-                        f"{track.title} {track.author} {track.uri} " f"{str(query)}",
+                        f"{track.title} {track.author} {track.uri} {str(query)}",
                         query_obj=query,
                     ):
                         log.debug("Query is not allowed in %r (%s)", ctx.guild.name, ctx.guild.id)
@@ -1513,7 +1518,7 @@ class PlaylistCommands(MixinMeta, metaclass=CompositeMetaClass):
                             continue
                     if (
                         maxlength > 0
-                        and not can_skip
+                        and not (can_skip and maxlength_bypass)
                         and not self.is_track_length_allowed(track, maxlength)
                     ):
                         continue

--- a/redbot/cogs/audio/core/utilities/formatting.py
+++ b/redbot/cogs/audio/core/utilities/formatting.py
@@ -111,6 +111,7 @@ class FormattingUtilities(MixinMeta, metaclass=CompositeMetaClass):
         player = lavalink.get_player(ctx.guild.id)
         player.store("notify_channel", ctx.channel.id)
         guild_data = await self.config.guild(ctx.guild).all()
+        can_skip = await self._can_instaskip(ctx, ctx.author)
         if len(player.queue) >= 10000:
             return await self.send_embed_msg(
                 ctx, title=_("Unable To Play Tracks"), description=_("Queue size limit reached.")
@@ -167,7 +168,7 @@ class FormattingUtilities(MixinMeta, metaclass=CompositeMetaClass):
             return await self.send_embed_msg(
                 ctx, title=_("This track is not allowed in this server.")
             )
-        elif guild_data["maxlength"] > 0:
+        elif guild_data["maxlength"] > 0 and not can_skip:
             if self.is_track_length_allowed(search_choice, guild_data["maxlength"]):
                 search_choice.extras.update(
                     {

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -366,6 +366,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
         except KeyError:
             self.update_player_lock(ctx, True)
         guild_data = await self.config.guild(ctx.guild).all()
+        can_skip = await self._can_instaskip(ctx, ctx.author)
         first_track_only = False
         single_track = None
         index = None
@@ -454,7 +455,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 ):
                     log.debug("Query is not allowed in %r (%s)", ctx.guild.name, ctx.guild.id)
                     continue
-                elif guild_data["maxlength"] > 0:
+                elif guild_data["maxlength"] > 0 and not can_skip:
                     if self.is_track_length_allowed(track, guild_data["maxlength"]):
                         track_len += 1
                         track.extras.update(
@@ -547,7 +548,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     return await self.send_embed_msg(
                         ctx, title=_("This track is not allowed in this server.")
                     )
-                elif guild_data["maxlength"] > 0:
+                elif guild_data["maxlength"] > 0 and not can_skip:
                     if self.is_track_length_allowed(single_track, guild_data["maxlength"]):
                         single_track.extras.update(
                             {

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -65,12 +65,16 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             playing_servers = 0
         return get_single_title, playing_servers
 
-    async def update_bot_presence(self, track: Optional[str], playing_servers: int) -> None:
+    async def update_bot_presence(
+        self, track: Optional[str], playing_servers: int
+    ) -> None:
         if playing_servers == 0:
             await self.bot.change_presence(activity=None)
         elif playing_servers == 1:
             await self.bot.change_presence(
-                activity=discord.Activity(name=track, type=discord.ActivityType.listening)
+                activity=discord.Activity(
+                    name=track, type=discord.ActivityType.listening
+                )
             )
         elif playing_servers > 1:
             await self.bot.change_presence(
@@ -80,7 +84,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 )
             )
 
-    async def _can_instaskip(self, ctx: commands.Context, member: discord.Member) -> bool:
+    async def _can_instaskip(
+        self, ctx: commands.Context, member: discord.Member
+    ) -> bool:
         dj_enabled = self._dj_status_cache.setdefault(
             ctx.guild.id, await self.config.guild(ctx.guild).dj_enabled()
         )
@@ -128,7 +134,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             log.trace("Caught error in `is_requester`", exc_info=exc)
         return False
 
-    async def _skip_action(self, ctx: commands.Context, skip_to_track: int = None) -> None:
+    async def _skip_action(
+        self, ctx: commands.Context, skip_to_track: int = None
+    ) -> None:
         player = lavalink.get_player(ctx.guild.id)
         autoplay = await self.config.guild(player.guild).auto_play()
         if not player.current or (not player.queue and not autoplay):
@@ -141,7 +149,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             if player.current.is_stream:
                 embed = discord.Embed(title=_("There's nothing in the queue."))
                 embed.set_footer(
-                    text=_("Currently livestreaming {track}").format(track=player.current.title)
+                    text=_("Currently livestreaming {track}").format(
+                        track=player.current.title
+                    )
                 )
             else:
                 embed = discord.Embed(title=_("There's nothing in the queue."))
@@ -179,11 +189,15 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 )
                 return
             embed = discord.Embed(
-                title=_("{skip_to_track} Tracks Skipped").format(skip_to_track=skip_to_track)
+                title=_("{skip_to_track} Tracks Skipped").format(
+                    skip_to_track=skip_to_track
+                )
             )
             await self.send_embed_msg(ctx, embed=embed)
             if player.repeat:
-                queue_to_append = player.queue[0 : min(skip_to_track - 1, len(player.queue) - 1)]
+                queue_to_append = player.queue[
+                    0 : min(skip_to_track - 1, len(player.queue) - 1)
+                ]
             player.queue = player.queue[
                 min(skip_to_track - 1, len(player.queue) - 1) : len(player.queue)
             ]
@@ -195,7 +209,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 ),
             )
             await self.send_embed_msg(ctx, embed=embed)
-        self.bot.dispatch("red_audio_skip_track", player.guild, player.current, ctx.author)
+        self.bot.dispatch(
+            "red_audio_skip_track", player.guild, player.current, ctx.author
+        )
         await player.play()
         player.queue += queue_to_append
 
@@ -231,7 +247,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             enqueue_tracks = False
         player = lavalink.get_player(ctx.guild.id)
         api_data = await self._check_api_tokens()
-        if any([not api_data["spotify_client_id"], not api_data["spotify_client_secret"]]):
+        if any(
+            [not api_data["spotify_client_id"], not api_data["spotify_client_secret"]]
+        ):
             return await self.send_embed_msg(
                 ctx,
                 title=_("Invalid Environment"),
@@ -268,7 +286,10 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 if not res:
                     title = _("Nothing found.")
                     embed = discord.Embed(title=title)
-                    if query.is_local and query.suffix in _PARTIALLY_SUPPORTED_MUSIC_EXT:
+                    if (
+                        query.is_local
+                        and query.suffix in _PARTIALLY_SUPPORTED_MUSIC_EXT
+                    ):
                         title = _("Track is not playable.")
                         description = _(
                             "**{suffix}** is not a fully supported "
@@ -287,7 +308,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             self.update_player_lock(ctx, False)
             try:
                 if enqueue_tracks:
-                    new_query = Query.process_input(res[0], self.local_folder_current_path)
+                    new_query = Query.process_input(
+                        res[0], self.local_folder_current_path
+                    )
                     new_query.start_time = query.start_time
                     return await self._enqueue_tracks(ctx, new_query)
                 else:
@@ -309,7 +332,10 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     tracks = result.tracks
                     if not tracks:
                         embed = discord.Embed(title=_("Nothing found."))
-                        if query.is_local and query.suffix in _PARTIALLY_SUPPORTED_MUSIC_EXT:
+                        if (
+                            query.is_local
+                            and query.suffix in _PARTIALLY_SUPPORTED_MUSIC_EXT
+                        ):
                             embed = discord.Embed(title=_("Track is not playable."))
                             embed.description = _(
                                 "**{suffix}** is not a fully supported format and some "
@@ -352,7 +378,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             return await self.send_embed_msg(
                 ctx,
                 title=_("Unable To Find Tracks"),
-                description=_("This doesn't seem to be a supported Spotify URL or code."),
+                description=_(
+                    "This doesn't seem to be a supported Spotify URL or code."
+                ),
             )
 
     async def _enqueue_tracks(
@@ -378,9 +406,13 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
         playlist_url = None
         seek = 0
         if type(query) is not list:
-            if not await self.is_query_allowed(self.config, ctx, f"{query}", query_obj=query):
+            if not await self.is_query_allowed(
+                self.config, ctx, f"{query}", query_obj=query
+            ):
                 raise QueryUnauthorized(
-                    _("{query} is not an allowed query.").format(query=query.to_string_user())
+                    _("{query} is not an allowed query.").format(
+                        query=query.to_string_user()
+                    )
                 )
             if query.single_track:
                 first_track_only = True
@@ -390,7 +422,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             if query.is_url:
                 playlist_url = query.uri
             try:
-                result, called_api = await self.api_interface.fetch_track(ctx, player, query)
+                result, called_api = await self.api_interface.fetch_track(
+                    ctx, player, query
+                )
             except TrackEnqueueError:
                 self.update_player_lock(ctx, False)
                 return await self.send_embed_msg(
@@ -416,7 +450,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     if "Status Code" in result.exception_message:
                         embed.set_footer(text=result.exception_message[:2000])
                     else:
-                        embed.set_footer(text=result.exception_message[:2000].replace("\n", ""))
+                        embed.set_footer(
+                            text=result.exception_message[:2000].replace("\n", "")
+                        )
                 if await self.config.use_external_lavalink() and query.is_local:
                     embed.description = _(
                         "Local tracks will not work "
@@ -444,7 +480,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             # url where Lavalink handles providing all Track objects to use, like a
             # YouTube or SoundCloud playlist
             if len(player.queue) >= 10000:
-                return await self.send_embed_msg(ctx, title=_("Queue size limit reached."))
+                return await self.send_embed_msg(
+                    ctx, title=_("Queue size limit reached.")
+                )
             track_len = 0
             empty_queue = not player.queue
             async for track in AsyncIter(tracks):
@@ -457,9 +495,13 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     f"{track.title} {track.author} {track.uri} {str(track_query)}",
                     query_obj=track_query,
                 ):
-                    log.debug("Query is not allowed in %r (%s)", ctx.guild.name, ctx.guild.id)
+                    log.debug(
+                        "Query is not allowed in %r (%s)", ctx.guild.name, ctx.guild.id
+                    )
                     continue
-                elif guild_data["maxlength"] > 0 and not (can_skip and maxlength_bypass):
+                elif guild_data["maxlength"] > 0 and not (
+                    can_skip and maxlength_bypass
+                ):
                     if self.is_track_length_allowed(track, guild_data["maxlength"]):
                         track_len += 1
                         track.extras.update(
@@ -484,7 +526,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                         }
                     )
                     player.add(ctx.author, track)
-                    self.bot.dispatch("red_audio_track_enqueue", player.guild, track, ctx.author)
+                    self.bot.dispatch(
+                        "red_audio_track_enqueue", player.guild, track, ctx.author
+                    )
             player.maybe_shuffle(0 if empty_queue else 1)
 
             if len(tracks) > track_len:
@@ -496,7 +540,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             playlist_name = escape(
                 playlist_data.name if playlist_data else _("No Title"), formatting=True
             )
-            title = _("Playlist Enqueued") if not query.is_album else _("Album Enqueued")
+            title = (
+                _("Playlist Enqueued") if not query.is_album else _("Album Enqueued")
+            )
             embed = discord.Embed(
                 description=bold(f"[{playlist_name}]({playlist_url})", False)
                 if playlist_url
@@ -512,7 +558,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 embed.set_footer(
                     text=_(
                         "{time} until start of playlist playback: starts at #{position} in queue"
-                    ).format(time=queue_total_duration, position=before_queue_length + 1)
+                    ).format(
+                        time=queue_total_duration, position=before_queue_length + 1
+                    )
                 )
             if not player.current:
                 await player.play()
@@ -526,7 +574,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             # or this is a localtrack item
             try:
                 if len(player.queue) >= 10000:
-                    return await self.send_embed_msg(ctx, title=_("Queue size limit reached."))
+                    return await self.send_embed_msg(
+                        ctx, title=_("Queue size limit reached.")
+                    )
 
                 single_track = (
                     tracks
@@ -537,7 +587,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 )
                 if seek and seek > 0:
                     single_track.start_timestamp = seek * 1000
-                query = Query.process_input(single_track, self.local_folder_current_path)
+                query = Query.process_input(
+                    single_track, self.local_folder_current_path
+                )
                 if not await self.is_query_allowed(
                     self.config,
                     ctx,
@@ -547,13 +599,19 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     ),
                     query_obj=query,
                 ):
-                    log.debug("Query is not allowed in %r (%s)", ctx.guild.name, ctx.guild.id)
+                    log.debug(
+                        "Query is not allowed in %r (%s)", ctx.guild.name, ctx.guild.id
+                    )
                     self.update_player_lock(ctx, False)
                     return await self.send_embed_msg(
                         ctx, title=_("This track is not allowed in this server.")
                     )
-                elif guild_data["maxlength"] > 0 and not (can_skip and maxlength_bypass):
-                    if self.is_track_length_allowed(single_track, guild_data["maxlength"]):
+                elif guild_data["maxlength"] > 0 and not (
+                    can_skip and maxlength_bypass
+                ):
+                    if self.is_track_length_allowed(
+                        single_track, guild_data["maxlength"]
+                    ):
                         single_track.extras.update(
                             {
                                 "enqueue_time": int(time.time()),
@@ -586,7 +644,10 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     player.add(ctx.author, single_track)
                     player.maybe_shuffle()
                     self.bot.dispatch(
-                        "red_audio_track_enqueue", player.guild, single_track, ctx.author
+                        "red_audio_track_enqueue",
+                        player.guild,
+                        single_track,
+                        ctx.author,
                     )
             except IndexError:
                 self.update_player_lock(ctx, False)
@@ -699,7 +760,8 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             return False
         try:
             in_channel = sum(
-                not m.bot for m in ctx.guild.get_member(self.bot.user.id).voice.channel.members
+                not m.bot
+                for m in ctx.guild.get_member(self.bot.user.id).voice.channel.members
             )
         except AttributeError:
             return False
@@ -718,7 +780,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             ):
                 await player.move_to(
                     user_channel,
-                    self_deaf=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
+                    self_deaf=await self.config.guild_from_id(
+                        ctx.guild.id
+                    ).auto_deafen(),
                 )
                 return True
         else:

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -65,16 +65,12 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             playing_servers = 0
         return get_single_title, playing_servers
 
-    async def update_bot_presence(
-        self, track: Optional[str], playing_servers: int
-    ) -> None:
+    async def update_bot_presence(self, track: Optional[str], playing_servers: int) -> None:
         if playing_servers == 0:
             await self.bot.change_presence(activity=None)
         elif playing_servers == 1:
             await self.bot.change_presence(
-                activity=discord.Activity(
-                    name=track, type=discord.ActivityType.listening
-                )
+                activity=discord.Activity(name=track, type=discord.ActivityType.listening)
             )
         elif playing_servers > 1:
             await self.bot.change_presence(
@@ -84,9 +80,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 )
             )
 
-    async def _can_instaskip(
-        self, ctx: commands.Context, member: discord.Member
-    ) -> bool:
+    async def _can_instaskip(self, ctx: commands.Context, member: discord.Member) -> bool:
         dj_enabled = self._dj_status_cache.setdefault(
             ctx.guild.id, await self.config.guild(ctx.guild).dj_enabled()
         )
@@ -134,9 +128,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             log.trace("Caught error in `is_requester`", exc_info=exc)
         return False
 
-    async def _skip_action(
-        self, ctx: commands.Context, skip_to_track: int = None
-    ) -> None:
+    async def _skip_action(self, ctx: commands.Context, skip_to_track: int = None) -> None:
         player = lavalink.get_player(ctx.guild.id)
         autoplay = await self.config.guild(player.guild).auto_play()
         if not player.current or (not player.queue and not autoplay):
@@ -149,9 +141,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             if player.current.is_stream:
                 embed = discord.Embed(title=_("There's nothing in the queue."))
                 embed.set_footer(
-                    text=_("Currently livestreaming {track}").format(
-                        track=player.current.title
-                    )
+                    text=_("Currently livestreaming {track}").format(track=player.current.title)
                 )
             else:
                 embed = discord.Embed(title=_("There's nothing in the queue."))
@@ -189,15 +179,11 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 )
                 return
             embed = discord.Embed(
-                title=_("{skip_to_track} Tracks Skipped").format(
-                    skip_to_track=skip_to_track
-                )
+                title=_("{skip_to_track} Tracks Skipped").format(skip_to_track=skip_to_track)
             )
             await self.send_embed_msg(ctx, embed=embed)
             if player.repeat:
-                queue_to_append = player.queue[
-                    0 : min(skip_to_track - 1, len(player.queue) - 1)
-                ]
+                queue_to_append = player.queue[0 : min(skip_to_track - 1, len(player.queue) - 1)]
             player.queue = player.queue[
                 min(skip_to_track - 1, len(player.queue) - 1) : len(player.queue)
             ]
@@ -209,9 +195,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 ),
             )
             await self.send_embed_msg(ctx, embed=embed)
-        self.bot.dispatch(
-            "red_audio_skip_track", player.guild, player.current, ctx.author
-        )
+        self.bot.dispatch("red_audio_skip_track", player.guild, player.current, ctx.author)
         await player.play()
         player.queue += queue_to_append
 
@@ -247,9 +231,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             enqueue_tracks = False
         player = lavalink.get_player(ctx.guild.id)
         api_data = await self._check_api_tokens()
-        if any(
-            [not api_data["spotify_client_id"], not api_data["spotify_client_secret"]]
-        ):
+        if any([not api_data["spotify_client_id"], not api_data["spotify_client_secret"]]):
             return await self.send_embed_msg(
                 ctx,
                 title=_("Invalid Environment"),
@@ -286,10 +268,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 if not res:
                     title = _("Nothing found.")
                     embed = discord.Embed(title=title)
-                    if (
-                        query.is_local
-                        and query.suffix in _PARTIALLY_SUPPORTED_MUSIC_EXT
-                    ):
+                    if query.is_local and query.suffix in _PARTIALLY_SUPPORTED_MUSIC_EXT:
                         title = _("Track is not playable.")
                         description = _(
                             "**{suffix}** is not a fully supported "
@@ -308,9 +287,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             self.update_player_lock(ctx, False)
             try:
                 if enqueue_tracks:
-                    new_query = Query.process_input(
-                        res[0], self.local_folder_current_path
-                    )
+                    new_query = Query.process_input(res[0], self.local_folder_current_path)
                     new_query.start_time = query.start_time
                     return await self._enqueue_tracks(ctx, new_query)
                 else:
@@ -332,10 +309,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     tracks = result.tracks
                     if not tracks:
                         embed = discord.Embed(title=_("Nothing found."))
-                        if (
-                            query.is_local
-                            and query.suffix in _PARTIALLY_SUPPORTED_MUSIC_EXT
-                        ):
+                        if query.is_local and query.suffix in _PARTIALLY_SUPPORTED_MUSIC_EXT:
                             embed = discord.Embed(title=_("Track is not playable."))
                             embed.description = _(
                                 "**{suffix}** is not a fully supported format and some "
@@ -378,9 +352,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             return await self.send_embed_msg(
                 ctx,
                 title=_("Unable To Find Tracks"),
-                description=_(
-                    "This doesn't seem to be a supported Spotify URL or code."
-                ),
+                description=_("This doesn't seem to be a supported Spotify URL or code."),
             )
 
     async def _enqueue_tracks(
@@ -406,13 +378,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
         playlist_url = None
         seek = 0
         if type(query) is not list:
-            if not await self.is_query_allowed(
-                self.config, ctx, f"{query}", query_obj=query
-            ):
+            if not await self.is_query_allowed(self.config, ctx, f"{query}", query_obj=query):
                 raise QueryUnauthorized(
-                    _("{query} is not an allowed query.").format(
-                        query=query.to_string_user()
-                    )
+                    _("{query} is not an allowed query.").format(query=query.to_string_user())
                 )
             if query.single_track:
                 first_track_only = True
@@ -422,9 +390,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             if query.is_url:
                 playlist_url = query.uri
             try:
-                result, called_api = await self.api_interface.fetch_track(
-                    ctx, player, query
-                )
+                result, called_api = await self.api_interface.fetch_track(ctx, player, query)
             except TrackEnqueueError:
                 self.update_player_lock(ctx, False)
                 return await self.send_embed_msg(
@@ -450,9 +416,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     if "Status Code" in result.exception_message:
                         embed.set_footer(text=result.exception_message[:2000])
                     else:
-                        embed.set_footer(
-                            text=result.exception_message[:2000].replace("\n", "")
-                        )
+                        embed.set_footer(text=result.exception_message[:2000].replace("\n", ""))
                 if await self.config.use_external_lavalink() and query.is_local:
                     embed.description = _(
                         "Local tracks will not work "
@@ -480,9 +444,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             # url where Lavalink handles providing all Track objects to use, like a
             # YouTube or SoundCloud playlist
             if len(player.queue) >= 10000:
-                return await self.send_embed_msg(
-                    ctx, title=_("Queue size limit reached.")
-                )
+                return await self.send_embed_msg(ctx, title=_("Queue size limit reached."))
             track_len = 0
             empty_queue = not player.queue
             async for track in AsyncIter(tracks):
@@ -495,13 +457,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     f"{track.title} {track.author} {track.uri} {str(track_query)}",
                     query_obj=track_query,
                 ):
-                    log.debug(
-                        "Query is not allowed in %r (%s)", ctx.guild.name, ctx.guild.id
-                    )
+                    log.debug("Query is not allowed in %r (%s)", ctx.guild.name, ctx.guild.id)
                     continue
-                elif guild_data["maxlength"] > 0 and not (
-                    can_skip and maxlength_bypass
-                ):
+                elif guild_data["maxlength"] > 0 and not (can_skip and maxlength_bypass):
                     if self.is_track_length_allowed(track, guild_data["maxlength"]):
                         track_len += 1
                         track.extras.update(
@@ -526,9 +484,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                         }
                     )
                     player.add(ctx.author, track)
-                    self.bot.dispatch(
-                        "red_audio_track_enqueue", player.guild, track, ctx.author
-                    )
+                    self.bot.dispatch("red_audio_track_enqueue", player.guild, track, ctx.author)
             player.maybe_shuffle(0 if empty_queue else 1)
 
             if len(tracks) > track_len:
@@ -540,9 +496,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             playlist_name = escape(
                 playlist_data.name if playlist_data else _("No Title"), formatting=True
             )
-            title = (
-                _("Playlist Enqueued") if not query.is_album else _("Album Enqueued")
-            )
+            title = _("Playlist Enqueued") if not query.is_album else _("Album Enqueued")
             embed = discord.Embed(
                 description=bold(f"[{playlist_name}]({playlist_url})", False)
                 if playlist_url
@@ -558,9 +512,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 embed.set_footer(
                     text=_(
                         "{time} until start of playlist playback: starts at #{position} in queue"
-                    ).format(
-                        time=queue_total_duration, position=before_queue_length + 1
-                    )
+                    ).format(time=queue_total_duration, position=before_queue_length + 1)
                 )
             if not player.current:
                 await player.play()
@@ -574,9 +526,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             # or this is a localtrack item
             try:
                 if len(player.queue) >= 10000:
-                    return await self.send_embed_msg(
-                        ctx, title=_("Queue size limit reached.")
-                    )
+                    return await self.send_embed_msg(ctx, title=_("Queue size limit reached."))
 
                 single_track = (
                     tracks
@@ -587,9 +537,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 )
                 if seek and seek > 0:
                     single_track.start_timestamp = seek * 1000
-                query = Query.process_input(
-                    single_track, self.local_folder_current_path
-                )
+                query = Query.process_input(single_track, self.local_folder_current_path)
                 if not await self.is_query_allowed(
                     self.config,
                     ctx,
@@ -599,19 +547,13 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     ),
                     query_obj=query,
                 ):
-                    log.debug(
-                        "Query is not allowed in %r (%s)", ctx.guild.name, ctx.guild.id
-                    )
+                    log.debug("Query is not allowed in %r (%s)", ctx.guild.name, ctx.guild.id)
                     self.update_player_lock(ctx, False)
                     return await self.send_embed_msg(
                         ctx, title=_("This track is not allowed in this server.")
                     )
-                elif guild_data["maxlength"] > 0 and not (
-                    can_skip and maxlength_bypass
-                ):
-                    if self.is_track_length_allowed(
-                        single_track, guild_data["maxlength"]
-                    ):
+                elif guild_data["maxlength"] > 0 and not (can_skip and maxlength_bypass):
+                    if self.is_track_length_allowed(single_track, guild_data["maxlength"]):
                         single_track.extras.update(
                             {
                                 "enqueue_time": int(time.time()),
@@ -760,8 +702,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             return False
         try:
             in_channel = sum(
-                not m.bot
-                for m in ctx.guild.get_member(self.bot.user.id).voice.channel.members
+                not m.bot for m in ctx.guild.get_member(self.bot.user.id).voice.channel.members
             )
         except AttributeError:
             return False
@@ -780,9 +721,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             ):
                 await player.move_to(
                     user_channel,
-                    self_deaf=await self.config.guild_from_id(
-                        ctx.guild.id
-                    ).auto_deafen(),
+                    self_deaf=await self.config.guild_from_id(ctx.guild.id).auto_deafen(),
                 )
                 return True
         else:

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -97,6 +97,9 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
         if await self.bot.is_owner(member):
             return True
 
+        if await self.bot.is_admin(member):
+            return True
+
         if await self.bot.is_mod(member):
             return True
 

--- a/redbot/cogs/audio/core/utilities/player.py
+++ b/redbot/cogs/audio/core/utilities/player.py
@@ -370,6 +370,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
             self.update_player_lock(ctx, True)
         guild_data = await self.config.guild(ctx.guild).all()
         can_skip = await self._can_instaskip(ctx, ctx.author)
+        maxlength_bypass = guild_data["maxlength_bypass"]
         first_track_only = False
         single_track = None
         index = None
@@ -453,12 +454,12 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                 if not await self.is_query_allowed(
                     self.config,
                     ctx,
-                    f"{track.title} {track.author} {track.uri} " f"{str(track_query)}",
+                    f"{track.title} {track.author} {track.uri} {str(track_query)}",
                     query_obj=track_query,
                 ):
                     log.debug("Query is not allowed in %r (%s)", ctx.guild.name, ctx.guild.id)
                     continue
-                elif guild_data["maxlength"] > 0 and not can_skip:
+                elif guild_data["maxlength"] > 0 and not (can_skip and maxlength_bypass):
                     if self.is_track_length_allowed(track, guild_data["maxlength"]):
                         track_len += 1
                         track.extras.update(
@@ -551,7 +552,7 @@ class PlayerUtilities(MixinMeta, metaclass=CompositeMetaClass):
                     return await self.send_embed_msg(
                         ctx, title=_("This track is not allowed in this server.")
                     )
-                elif guild_data["maxlength"] > 0 and not can_skip:
+                elif guild_data["maxlength"] > 0 and not (can_skip and maxlength_bypass):
                     if self.is_track_length_allowed(single_track, guild_data["maxlength"]):
                         single_track.extras.update(
                             {


### PR DESCRIPTION
### Description of the changes

Fixes #6447 

Allow guild owner, bot owner, mods, admins, and DJ role holders to bypass the maxlength restriction by adding a `can_skip` check before enforcing track length limits across all enqueue paths, and fix `_can_instaskip` missing `bot.is_admin()`.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
