### PR TITLE
[Mute]: Make `unmute` dms independant of `mute` dms.

### DIFF
--- a/docs/cog_guides/mutes.rst
+++ b/docs/cog_guides/mutes.rst
@@ -294,9 +294,9 @@ Decide whether the name of the moderator muting a user should be included in the
 
 .. _mutes-command-muteset-unmutesenddm:
 
-""""""""""""""""""""""
+""""""""""""""""""""
 muteset unmutesenddm
-""""""""""""""""""""""
+""""""""""""""""""""
 
 .. note:: |mod-lock|
 

--- a/docs/cog_guides/mutes.rst
+++ b/docs/cog_guides/mutes.rst
@@ -39,7 +39,7 @@ activemutes
 
 .. code-block:: none
 
-    [p]activemutes 
+    [p]activemutes
 
 **Description**
 
@@ -113,7 +113,7 @@ muteset
 
 .. code-block:: none
 
-    [p]muteset 
+    [p]muteset
 
 **Description**
 
@@ -219,8 +219,8 @@ Sets the role to be applied when muting a user.
 If no role is setup the bot will attempt to mute a user
 by utilizing server timeouts.
 
-.. Note:: 
-    
+.. Note::
+
     If no role is setup a user may be able to leave the server
     and rejoin no longer being muted.
 
@@ -262,7 +262,7 @@ muteset settings
 
 .. code-block:: none
 
-    [p]muteset settings 
+    [p]muteset settings
 
 .. tip:: Alias: ``muteset showsettings``
 
@@ -287,6 +287,31 @@ muteset showmoderator
 **Description**
 
 Decide whether the name of the moderator muting a user should be included in the DM to that user.
+
+**Arguments**
+
+* ``<true_or_false>``: Whether to enable or disable this setting, must provide ``true`` or ``false``.
+
+.. _mutes-command-muteset-unmutesenddm:
+
+""""""""""""""""""""""
+muteset unmutesenddm
+""""""""""""""""""""""
+
+.. note:: |mod-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]muteset unmutesenddm <true_or_false>
+
+**Description**
+
+Set whether unmute notifications should be sent to users in DMs.
+
+This setting is independent of ``[p]muteset senddm``, which controls
+DM notifications for mutes. Both can be toggled separately.
 
 **Arguments**
 

--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -98,6 +98,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
             "muted_users": {},
             "default_time": 0,
             "dm": False,
+            "dm_on_unmute": True,
             "show_mod": False,
         }
         self.config.register_global(schema_version=0)
@@ -345,7 +346,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
                 until=None,
             )
             await self._send_dm_notification(
-                member, author, guild, _("Server unmute"), _("Automatic unmute")
+                member, author, guild, _("Server unmute"), _("Automatic unmute"), is_unmute=True
             )
         else:
             chan_id = await self.config.guild(guild).notification_channel()
@@ -453,7 +454,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
             until=None,
         )
         await self._send_dm_notification(
-            member, author, guild, _("Server unmute"), _("Automatic unmute")
+            member, author, guild, _("Server unmute"), _("Automatic unmute"), is_unmute=True
         )
         self._channel_mute_events[guild.id].set()
         if any(results):
@@ -532,7 +533,12 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
                     channel=channel,
                 )
                 await self._send_dm_notification(
-                    member, author, channel.guild, notification_title, _("Automatic unmute")
+                    member,
+                    author,
+                    channel.guild,
+                    notification_title,
+                    _("Automatic unmute"),
+                    is_unmute=True,
                 )
             return None
         else:
@@ -562,11 +568,16 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
         mute_type: str,
         reason: Optional[str],
         duration=None,
+        *,
+        is_unmute: bool = False,
     ):
         if user.bot:
             return
 
-        if not await self.config.guild(guild).dm():
+        if is_unmute:
+            if not await self.config.guild(guild).dm_on_unmute():
+                return
+        elif not await self.config.guild(guild).dm():
             return
 
         show_mod = await self.config.guild(guild).show_mod()
@@ -654,7 +665,12 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
                 del self._server_mutes[guild.id][after.id]
                 should_save = True
                 await self._send_dm_notification(
-                    after, None, guild, _("Server unmute"), _("Manually removed mute role")
+                    after,
+                    None,
+                    guild,
+                    _("Server unmute"),
+                    _("Manually removed mute role"),
+                    is_unmute=True,
                 )
         elif mute_role in roles_added:
             # send modlog case for mute and add to cache
@@ -742,6 +758,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
                             after.guild,
                             notification_title,
                             _("Manually removed channel overwrites"),
+                            is_unmute=True,
                         )
                     await modlog.create_case(
                         self.bot,
@@ -802,6 +819,19 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
         else:
             await ctx.send(_("Mute notifications will no longer be sent to users DMs."))
 
+    @muteset.command(name="unmutesenddm")
+    @commands.guild_only()
+    @commands.mod_or_permissions(manage_channels=True)
+    async def unmutesenddm(self, ctx: commands.Context, true_or_false: bool):
+        """Set whether unmute notifications should be sent to users in DMs.
+
+        This is independent of `[p]muteset senddm` which controls mute DMs."""
+        await self.config.guild(ctx.guild).dm_on_unmute.set(true_or_false)
+        if true_or_false:
+            await ctx.send(_("I will now try to send unmute notifications to users DMs."))
+        else:
+            await ctx.send(_("Unmute notifications will no longer be sent to users DMs."))
+
     @muteset.command()
     @commands.guild_only()
     @commands.mod_or_permissions(manage_channels=True)
@@ -837,12 +867,14 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
             "Notification Channel: {channel}\n"
             "Default Time: {time}\n"
             "Send DM: {dm}\n"
+            "Send Unmute DM: {dm_on_unmute}\n"
             "Show moderator: {show_mod}"
         ).format(
             role=mute_role.mention if mute_role else _("None"),
             channel=notification_channel.mention if notification_channel else _("None"),
             time=humanize_timedelta(timedelta=default_time) if default_time else _("None"),
             dm=data["dm"],
+            dm_on_unmute=data["dm_on_unmute"],
             show_mod=data["show_mod"],
         )
         await ctx.maybe_send_embed(msg)
@@ -1507,7 +1539,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
                         until=None,
                     )
                     await self._send_dm_notification(
-                        user, author, guild, _("Server unmute"), reason
+                        user, author, guild, _("Server unmute"), reason, is_unmute=True
                     )
                 else:
                     issue_list.append(response)
@@ -1581,7 +1613,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
                         until=None,
                     )
                     await self._send_dm_notification(
-                        user, author, guild, _("Server unmute"), reason
+                        user, author, guild, _("Server unmute"), reason, is_unmute=True
                     )
                 await self.config.member(user).clear()
 
@@ -1650,7 +1682,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
                         channel=channel,
                     )
                     await self._send_dm_notification(
-                        user, author, guild, _("Channel unmute"), reason
+                        user, author, guild, _("Channel unmute"), reason, is_unmute=True
                     )
                 else:
                     issue_list.append(response)

--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -98,7 +98,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
             "muted_users": {},
             "default_time": 0,
             "dm": False,
-            "dm_on_unmute": True,
+            "dm_on_unmute": False,
             "show_mod": False,
         }
         self.config.register_global(schema_version=0)
@@ -189,6 +189,11 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
             schema_version += 1
             await self.config.schema_version.set(schema_version)
 
+        if schema_version == 1:
+            await self._schema_1_to_2()
+            schema_version += 1
+            await self.config.schema_version.set(schema_version)
+
     async def _schema_0_to_1(self):
         """This contains conversion that adds guild ID to channel mutes data."""
         all_channels = await self.config.all_channels()
@@ -213,6 +218,14 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
             "Config conversion to schema_version 1 done. It took %s to proceed.",
             datetime.now() - start,
         )
+
+    async def _schema_1_to_2(self):
+        """This migration sets dm_on_unmute to True for guilds that previously had dm enabled,
+        preserving the existing unmute DM behaviour for those guilds."""
+        all_guilds = await self.config.all_guilds()
+        for guild_id, guild_data in all_guilds.items():
+            if guild_data.get("dm", False):
+                await self.config.guild_from_id(guild_id).dm_on_unmute.set(True)
 
     async def cog_before_invoke(self, ctx: commands.Context):
         if not self._ready.is_set():

--- a/redbot/cogs/mutes/voicemutes.py
+++ b/redbot/cogs/mutes/voicemutes.py
@@ -221,7 +221,7 @@ class VoiceMutes(MixinMeta):
                         channel=channel,
                     )
                     await self._send_dm_notification(
-                        user, author, guild, _("Voice unmute"), reason
+                        user, author, guild, _("Voice unmute"), reason, is_unmute=True
                     )
                 else:
                     issue_list.append((user, result.reason))


### PR DESCRIPTION
### Description of the changes

Fixes #6262 

This PR introduces a new feature - mute dms and unmute dms fully independent toggles

## New command :
`[p]muteset unmutesenddm true/false` - controls unmute dms independently

`dm_on_unmute` defaults to `True` so existing behavior is preserved for guilds that had `dm=True`

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
