### PR TITLE
Drop support for Python 3.8-3.10

### DIFF
--- a/.github/workflows/check_label_pattern_exhaustiveness.yaml
+++ b/.github/workflows/check_label_pattern_exhaustiveness.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.11"
       - name: Install script's pre-requirements
         run: |
           python -m pip install -U pip

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.8"
+        python-version: "3.11"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/crowdin_upload_strings.yml
+++ b/.github/workflows/crowdin_upload_strings.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         curl https://artifacts.crowdin.com/repo/GPG-KEY-crowdin | sudo apt-key add -

--- a/.github/workflows/lint_python.yaml
+++ b/.github/workflows/lint_python.yaml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ env.ref }}
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.11"
       - run: >
           python -m pip install
           'pyflakes @ https://github.com/pycqa/pyflakes/tarball/1911c20'

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.8'
+          python-version: '3.11'
       - name: Install dependencies
         run: |
           curl https://artifacts.crowdin.com/repo/GPG-KEY-crowdin | sudo apt-key add -
@@ -84,7 +84,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.8'
+          python-version: '3.11'
 
       # Create PR for stable version bump
       - name: Update Red version number from input

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.11'
 
       # Get version to release
       - name: Get version to release
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.11'
 
       - name: Install script's dependencies
         run: python -m pip install PyYAML
@@ -171,7 +171,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.8'
+          python-version: '3.11'
 
       # Version bump to development version
       - name: Update Red version number to dev

--- a/.github/workflows/run_pip_compile.yaml
+++ b/.github/workflows/run_pip_compile.yaml
@@ -17,30 +17,21 @@ jobs:
       - name: Checkout the repository.
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.8.
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: |
             3.11
-            3.10
-            3.9
-            3.8
 
       - name: Install dependencies on Linux/macOS
         if: matrix.os != 'windows-latest'
         run: |
           python3.11 -m pip install -U pip pip-tools
-          python3.10 -m pip install -U pip pip-tools
-          python3.9 -m pip install -U pip pip-tools
-          python3.8 -m pip install -U pip pip-tools
 
       - name: Install dependencies on Windows
         if: matrix.os == 'windows-latest'
         run: |
           py -3.11 -m pip install -U pip pip-tools
-          py -3.10 -m pip install -U pip pip-tools
-          py -3.9 -m pip install -U pip pip-tools
-          py -3.8 -m pip install -U pip pip-tools
 
       - name: Generate requirements files.
         id: compile_requirements
@@ -61,10 +52,10 @@ jobs:
       - name: Checkout the repository.
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.8.
+      - name: Set up Python 3.11.
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/scripts/compile_requirements.py
+++ b/.github/workflows/scripts/compile_requirements.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 
-EXCLUDE_STEM_RE = re.compile(r".*-3\.(?!8-)(\d+)-extra-(doc|style)")
+EXCLUDE_STEM_RE = re.compile(r".*-3\.(?!11-)(\d+)-extra-(doc|style)")
 GITHUB_OUTPUT = os.environ["GITHUB_OUTPUT"]
 REQUIREMENTS_FOLDER = Path(__file__).parents[3].absolute() / "requirements"
 os.chdir(REQUIREMENTS_FOLDER)
@@ -19,7 +19,7 @@ def pip_compile(version: str, name: str) -> None:
 
     constraint_flags = [
         arg
-        for file in REQUIREMENTS_FOLDER.glob(f"{sys.platform}-3.8-*.txt")
+        for file in REQUIREMENTS_FOLDER.glob(f"{sys.platform}-3.11-*.txt")
         for arg in ("-c", file.name)
     ]
 
@@ -41,7 +41,7 @@ def pip_compile(version: str, name: str) -> None:
     )
 
 
-for minor in range(8, 11 + 1):
+for minor in range(11, 11 + 1):
     version = f"3.{minor}"
     pip_compile(version, "base")
     shutil.copyfile(f"{sys.platform}-{version}-base.txt", "base.txt")

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,20 +15,11 @@ jobs:
       strategy:
         matrix:
           python_version:
-            - "3.8"
+            - "3.11"
           tox_env:
             - style
             - docs
           include:
-            - tox_env: py38
-              python_version: "3.8"
-              friendly_name: Python 3.8 - Tests
-            - tox_env: py39
-              python_version: "3.9"
-              friendly_name: Python 3.9 - Tests
-            - tox_env: py310
-              python_version: "3.10"
-              friendly_name: Python 3.10 - Tests
             - tox_env: py311
               python_version: "3.11"
               friendly_name: Python 3.11 - Tests
@@ -60,9 +51,6 @@ jobs:
       strategy:
         matrix:
           python_version:
-            - "3.8"
-            - "3.9"
-            - "3.10"
             - "3.11"
         fail-fast: false
       name: Tox - Postgres

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.8"
+    python: "3.11"
   jobs:
     install:
       - pip install .[doc]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ We love receiving contributions from our community. Any assistance you can provi
 
 # 2. Ground Rules
 1. Ensure cross compatibility for Windows, Mac OS and Linux.
-2. Ensure all Python features used in contributions exist and work in Python 3.8.1 and above.
+2. Ensure all Python features used in contributions exist and work in Python 3.11 and above.
 3. Create new tests for code you add or bugs you fix. It helps us help you by making sure we don't accidentally break anything :grinning:
 4. Create any issues for new features you'd like to implement and explain why this feature is useful to everyone and not just you personally.
 5. Don't add new cogs unless specifically given approval in an issue discussing said cog idea.
@@ -52,7 +52,7 @@ Red's repository is configured to follow a particular development workflow, usin
 
 ### 4.1 Setting up your development environment
 The following requirements must be installed prior to setting up:
- - Python 3.8.1 or greater
+ - Python 3.11 or greater
  - git
  - pip
  
@@ -81,7 +81,7 @@ If you're not on Windows, you should also have GNU make installed, and you can o
 We're using [tox](https://github.com/tox-dev/tox) to run all of our tests. It's extremely simple to use, and if you followed the previous section correctly, it is already installed to your virtual environment.
 
 Currently, tox does the following, creating its own virtual environments for each stage:
-- Runs all of our unit tests with [pytest](https://github.com/pytest-dev/pytest) on python 3.8 (test environment `py38`)
+- Runs all of our unit tests with [pytest](https://github.com/pytest-dev/pytest) on python 3.11 (test environment `py311`)
 - Ensures documentation builds without warnings, and all hyperlinks have a valid destination (test environment `docs`)
 - Ensures that the code meets our style guide with [black](https://github.com/psf/black) (test environment `style`)
 
@@ -105,7 +105,7 @@ You may have noticed we have a `Makefile` and a `make.bat` in the top-level dire
 
 The other make recipes are most likely for project maintainers rather than contributors.
 
-You can specify the Python executable used in the make recipes with the `PYTHON` environment variable, e.g. `make PYTHON=/usr/bin/python3.8 newenv`.
+You can specify the Python executable used in the make recipes with the `PYTHON` environment variable, e.g. `make PYTHON=/usr/bin/python3.11 newenv`.
 
 ### 4.5 Keeping your dependencies up to date
 Whenever you pull from upstream (V3/develop on the main repository) and you notice either of the files `setup.cfg` or `tools/dev-requirements.txt` have been changed, it can often mean some package dependencies have been updated, added or removed. To make sure you're testing and formatting with the most up-to-date versions of our dependencies, run `make syncenv`. You could also simply do `make newenv` to install them to a clean new virtual environment.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-PYTHON ?= python3.8
+PYTHON ?= python3.11
 
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 

--- a/docs/guide_cog_creation.rst
+++ b/docs/guide_cog_creation.rst
@@ -17,7 +17,7 @@ you in the process.
 Getting started
 ---------------
 
-To start off, be sure that you have installed Python 3.8.
+To start off, be sure that you have installed Python 3.11.
 Next, you need to decide if you want to develop against the Stable or Develop version of Red.
 Depending on what your goal is should help determine which version you need.
 
@@ -26,7 +26,7 @@ Depending on what your goal is should help determine which version you need.
     If your goal is to support both versions, make sure you build compatibility layers or use separate branches to keep compatibility until the next Red release
 
 Open a terminal or command prompt and type one of the following
-    Stable Version: :code:`python3.8 -m pip install -U Red-DiscordBot`
+    Stable Version: :code:`python3.11 -m pip install -U Red-DiscordBot`
 
 .. note::
 
@@ -43,7 +43,7 @@ Open a terminal or command prompt and type one of the following
       Red-DiscordBot @ https://github.com/Cog-Creators/Red-DiscordBot/tarball/V3/develop
 
 
-(Windows users may need to use :code:`py -3.8` or :code:`python` instead of :code:`python3.8`)
+(Windows users may need to use :code:`py -3.11` or :code:`python` instead of :code:`python3.11`)
 
 --------------------
 Setting up a package

--- a/docs/install_guides/_includes/create-env-with-venv3.10.rst
+++ b/docs/install_guides/_includes/create-env-with-venv3.10.rst
@@ -1,7 +1,0 @@
-.. include:: _includes/_create-env-with-venv-intro.rst
-
-.. prompt:: bash
-
-    python3.10 -m venv ~/redenv
-
-.. include:: _includes/_create-env-with-venv-outro.rst

--- a/docs/install_guides/_includes/create-env-with-venv3.9.rst
+++ b/docs/install_guides/_includes/create-env-with-venv3.9.rst
@@ -1,7 +1,0 @@
-.. include:: _includes/_create-env-with-venv-intro.rst
-
-.. prompt:: bash
-
-    python3.9 -m venv ~/redenv
-
-.. include:: _includes/_create-env-with-venv-outro.rst

--- a/docs/install_guides/ubuntu-2204.rst
+++ b/docs/install_guides/ubuntu-2204.rst
@@ -12,16 +12,22 @@ Installing Red on Ubuntu 22.04 LTS
 Installing the pre-requirements
 -------------------------------
 
-Ubuntu 22.04 LTS has all required packages available in official repositories. Install them
-with apt:
+We recommend adding the ``deadsnakes`` ppa to install Python 3.11:
 
 .. prompt:: bash
 
     sudo apt update
-    sudo apt -y install python3.10 python3.10-dev python3.10-venv git openjdk-17-jre-headless build-essential nano
+    sudo apt -y install software-properties-common
+    sudo add-apt-repository -y ppa:deadsnakes/ppa
+
+Now install the pre-requirements with apt:
+
+.. prompt:: bash
+
+    sudo apt -y install python3.11 python3.11-dev python3.11-venv git openjdk-17-jre-headless build-essential nano
 
 .. Include common instructions:
 
-.. include:: _includes/create-env-with-venv3.10.rst
+.. include:: _includes/create-env-with-venv3.11.rst
 
 .. include:: _includes/install-and-setup-red-unix.rst

--- a/docs/install_guides/windows.rst
+++ b/docs/install_guides/windows.rst
@@ -57,7 +57,7 @@ Manually installing dependencies
 
 * `MSVC Build tools <https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019>`_
 
-* `Python 3.8.1 - 3.11.x <https://www.python.org/downloads/windows/>`_
+* `Python 3.11.x <https://www.python.org/downloads/windows/>`_
 
 .. attention:: Please make sure that the box to add Python to PATH is CHECKED, otherwise
                you may run into issues when trying to run Red.

--- a/make.bat
+++ b/make.bat
@@ -23,7 +23,7 @@ goto:eof
 goto:eof
 
 :newenv
-py -3.8 -m venv --clear .venv
+py -3.11 -m venv --clear .venv
 "%~dp0.venv\Scripts\python" -m pip install -U pip wheel
 goto syncenv
 

--- a/make.ps1
+++ b/make.ps1
@@ -55,7 +55,7 @@ function stylediff() {
 }
 
 function newenv() {
-    py -3.8 -m venv --clear .venv
+    py -3.11 -m venv --clear .venv
     & $PSScriptRoot\.venv\Scripts\python.exe -m pip install -U pip wheel
     syncenv
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Topic :: Communications :: Chat",
 ]
@@ -45,7 +42,7 @@ red-discordbot = "redbot.pytest"
 [tool.black]
 line-length = 99
 required-version = '23'
-target-version = ['py38']
+target-version = ['py311']
 include = '\.py$'
 force-exclude = '''
 /(

--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -352,15 +352,6 @@ if not any(_re.match("^-(-debug|d+|-verbose|v+)$", i) for i in _sys.argv):
     # Individual warnings - tracked in https://github.com/Cog-Creators/Red-DiscordBot/issues/3529
     # DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
     _warnings.filterwarnings("ignore", category=DeprecationWarning, module="importlib", lineno=219)
-    # DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10
-    #   stdin, stdout, stderr = await tasks.gather(stdin, stdout, stderr,
-    # this is a bug in CPython
-    _warnings.filterwarnings(
-        "ignore",
-        category=DeprecationWarning,
-        module="asyncio",
-        message="The loop argument is deprecated since Python 3.8",
-    )
     # DEP-WARN - d.py currently uses audioop module, Danny is aware of the deprecation
     #
     # DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13

--- a/redbot/__init__.py
+++ b/redbot/__init__.py
@@ -19,7 +19,7 @@ __all__ = (
     "VersionInfo",
 )
 
-MIN_PYTHON_VERSION = (3, 8, 1)
+MIN_PYTHON_VERSION = (3, 11, 0)
 if _sys.version_info < MIN_PYTHON_VERSION:
     print(
         f"Python {'.'.join(map(str, MIN_PYTHON_VERSION))} is required to run Red, but you have "

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -431,9 +431,28 @@ async def shutdown_handler(red: Red, exit_code: int) -> None:
             await red.close()
     finally:
         # Then cancels all outstanding tasks other than ourselves
-        pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
-        [task.cancel() for task in pending]
-        await asyncio.gather(*pending, return_exceptions=True)
+        current_task = asyncio.current_task()
+        pending = [t for t in asyncio.all_tasks() if t is not current_task]
+
+        for task in pending:
+            task.cancel()
+
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+        loop = asyncio.get_running_loop()
+        for task in pending:
+            if task.cancelled():
+                continue
+            exc = task.exception()
+            if exc is not None:
+                loop.call_exception_handler(
+                    {
+                        "message": "Unhandled exception during Red shutdown",
+                        "exception": task.exception(),
+                        "task": task,
+                    }
+                )
 
 
 def global_exception_handler(red, loop, context):
@@ -534,15 +553,7 @@ def main():
             loop.run_until_complete(shutdown_handler(red, ExitCodes.CRITICAL))
     finally:
         # Allows transports to close properly, and prevent new ones from being opened.
-        # Transports may still not be closed correctly on windows, see below
         loop.run_until_complete(loop.shutdown_asyncgens())
-        # *we* aren't cleaning up more here, but it prevents
-        # a runtime error at the event loop on windows
-        # with resources which require longer to clean up.
-        # With other event loops, a failure to cleanup prior to here
-        # results in a resource warning instead
-        log.info("Please wait, cleaning up a bit more")
-        loop.run_until_complete(asyncio.sleep(2))
         asyncio.set_event_loop(None)
         loop.stop()
         loop.close()

--- a/redbot/__main__.py
+++ b/redbot/__main__.py
@@ -257,11 +257,7 @@ def _copy_data(data):
     if Path(data["DATA_PATH"]).exists():
         if any(os.scandir(data["DATA_PATH"])):
             return False
-        else:
-            # this is needed because copytree doesn't work when destination folder exists
-            # Python 3.8 has `dirs_exist_ok` option for that
-            os.rmdir(data["DATA_PATH"])
-    shutil.copytree(data_manager.basic_config["DATA_PATH"], data["DATA_PATH"])
+    shutil.copytree(data_manager.basic_config["DATA_PATH"], data["DATA_PATH"], dirs_exist_ok=True)
     return True
 
 

--- a/redbot/core/_cli.py
+++ b/redbot/core/_cli.py
@@ -331,18 +331,12 @@ def parse_cli_flags(args):
         default=None,
         help="Forcefully disables the Rich logging handlers.",
     )
-    # DEP-WARN: use argparse.BooleanOptionalAction when we drop support for Python 3.8
     parser.add_argument(
         "--rich-tracebacks",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=False,
         help="Format the Python exception tracebacks using Rich (with syntax highlighting)."
         " *May* be useful to increase traceback readability during development.",
-    )
-    parser.add_argument(
-        "--no-rich-tracebacks",
-        action="store_false",
-        dest="rich_tracebacks",
     )
     parser.add_argument(
         "--rich-traceback-extra-lines",

--- a/redbot/core/_cog_manager.py
+++ b/redbot/core/_cog_manager.py
@@ -385,9 +385,8 @@ class CogManagerUI(commands.Cog):
 
         path = path.resolve()
 
-        # Path.is_relative_to() is 3.9+
         bot_data_path = data_path()
-        if path == bot_data_path or bot_data_path in path.parents:
+        if path.is_relative_to(bot_data_path):
             await ctx.send(
                 _("A cog path cannot be part of bot's data path ({bot_data_path}).").format(
                     bot_data_path=inline(str(bot_data_path))
@@ -395,9 +394,8 @@ class CogManagerUI(commands.Cog):
             )
             return
 
-        # Path.is_relative_to() is 3.9+
         core_path = ctx.bot._cog_mgr.CORE_PATH
-        if path == core_path or core_path in path.parents:
+        if path.is_relative_to(core_path):
             await ctx.send(
                 _("A cog path cannot be part of bot's core path ({core_path}).").format(
                     core_path=inline(str(core_path))

--- a/redbot/core/_debuginfo.py
+++ b/redbot/core/_debuginfo.py
@@ -143,11 +143,7 @@ class DebugInfo:
         parts = [f"Instance name: {instance_name}"]
 
         if self.bot is not None:
-            # sys.original_argv is available since 3.10 and shows the actual command line arguments
-            # rather than a Python-transformed version (i.e. with '-c' or path to `__main__.py`
-            # as first element). We could just not show the first argument for consistency
-            # but it can be useful.
-            cli_args = getattr(sys, "orig_argv", sys.argv).copy()
+            cli_args = sys.orig_argv.copy()
             # best effort attempt to expunge a token argument
             for idx, arg in enumerate(cli_args):
                 if not arg.startswith("--to"):

--- a/redbot/core/dev_commands.py
+++ b/redbot/core/dev_commands.py
@@ -349,7 +349,6 @@ class DevOutput:
                         exc.end_lineno -= line_offset
 
         top_traceback_exc = traceback.TracebackException(exc_type, exc, tb)
-        py311_or_above = sys.version_info >= (3, 11)
         queue = [  # actually a stack but 'stack' is easy to confuse with actual traceback stack
             top_traceback_exc,
         ]
@@ -357,10 +356,8 @@ class DevOutput:
         while queue:
             traceback_exc = queue.pop()
 
-            # handle exception groups; this uses getattr() to support `exceptiongroup` backport lib
-            exceptions: List[traceback.TracebackException] = (
-                getattr(traceback_exc, "exceptions", None) or []
-            )
+            # handle exception groups
+            exceptions = traceback_exc.exceptions or []
             # handle exception chaining
             if traceback_exc.__cause__ is not None:
                 exceptions.append(traceback_exc.__cause__)
@@ -389,23 +386,18 @@ class DevOutput:
                     continue
                 lineno -= line_offset
                 # support for enhanced error locations in tracebacks
-                if py311_or_above:
-                    end_lineno = frame_summary.end_lineno
-                    if end_lineno is not None:
-                        end_lineno -= line_offset
-                    frame_summary = traceback.FrameSummary(
-                        frame_summary.filename,
-                        lineno,
-                        frame_summary.name,
-                        line=line,
-                        end_lineno=end_lineno,
-                        colno=frame_summary.colno,
-                        end_colno=frame_summary.end_colno,
-                    )
-                else:
-                    frame_summary = traceback.FrameSummary(
-                        frame_summary.filename, lineno, frame_summary.name, line=line
-                    )
+                end_lineno = frame_summary.end_lineno
+                if end_lineno is not None:
+                    end_lineno -= line_offset
+                frame_summary = traceback.FrameSummary(
+                    frame_summary.filename,
+                    lineno,
+                    frame_summary.name,
+                    line=line,
+                    end_lineno=end_lineno,
+                    colno=frame_summary.colno,
+                    end_colno=frame_summary.end_colno,
+                )
                 stack_summary[idx] = frame_summary
 
         return "".join(top_traceback_exc.format())

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -78,17 +78,9 @@ yarl==1.15.2
     #   aiohttp
 zstandard==0.23.0
     # via -r base.in
-async-timeout==4.0.3; python_version != "3.11"
-    # via aiohttp
 colorama==0.4.6; sys_platform == "win32"
     # via click
 distro==1.9.0; sys_platform == "linux" and sys_platform == "linux"
     # via -r base.in
-importlib-metadata==8.5.0; python_version != "3.10" and python_version != "3.11"
-    # via markdown
-pytz==2026.1.post1; python_version == "3.8"
-    # via babel
 uvloop==0.21.0; (sys_platform != "win32" and platform_python_implementation == "CPython") and sys_platform != "win32"
     # via -r base.in
-zipp==3.20.2; python_version != "3.10" and python_version != "3.11"
-    # via importlib-metadata

--- a/requirements/extra-doc.txt
+++ b/requirements/extra-doc.txt
@@ -34,7 +34,7 @@ sphinx==7.1.2
     #   sphinx-rtd-theme
     #   sphinxcontrib-jquery
     #   sphinxcontrib-trio
-sphinx-prompt==1.7.0
+sphinx-prompt==1.8.0
     # via -r extra-doc.in
 sphinx-rtd-theme==3.1.0
     # via -r extra-doc.in

--- a/requirements/extra-test.txt
+++ b/requirements/extra-test.txt
@@ -23,9 +23,3 @@ pytest-mock==3.14.1
     # via -r extra-test.in
 tomlkit==0.13.3
     # via pylint
-exceptiongroup==1.3.1; python_version != "3.11"
-    # via pytest
-tomli==2.4.0; python_version != "3.11"
-    # via
-    #   pylint
-    #   pytest

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ extras_require["dev"] = extras_combined()
 extras_require["all"] = extras_combined("postgres")
 
 
-python_requires = ">=3.8.1"
+python_requires = ">=3.11"
 if not os.getenv("TOX_RED", False) or sys.version_info < (3, 12):
     python_requires += ",<3.12"
 

--- a/tests/core/test_dev_commands.py
+++ b/tests/core/test_dev_commands.py
@@ -187,20 +187,12 @@ async def _run_dev_output(
         assert not output.ctx.mock_calls
 
 
-EXPRESSION_TESTS = {
-    # invalid syntax
-    "12x\n": (
+@pytest.mark.parametrize(
+    "source,result",
+    (
+        # invalid syntax
         (
-            lambda v: v < (3, 10),
-            """\
-              File "<test run - snippet #0>", line 1
-                12x
-                  ^
-            SyntaxError: invalid syntax
-            """,
-        ),
-        (
-            lambda v: v >= (3, 10),
+            "12x\n",
             """\
               File "<test run - snippet #0>", line 1
                 12x
@@ -208,19 +200,8 @@ EXPRESSION_TESTS = {
             SyntaxError: invalid decimal literal
             """,
         ),
-    ),
-    "foo(x, z for z in range(10), t, w)": (
         (
-            lambda v: v < (3, 10),
-            """\
-              File "<test run - snippet #0>", line 1
-                foo(x, z for z in range(10), t, w)
-                       ^
-            SyntaxError: Generator expression must be parenthesized
-            """,
-        ),
-        (
-            lambda v: v >= (3, 10),
+            "foo(x, z for z in range(10), t, w)",
             """\
               File "<test run - snippet #0>", line 1
                 foo(x, z for z in range(10), t, w)
@@ -228,20 +209,9 @@ EXPRESSION_TESTS = {
             SyntaxError: Generator expression must be parenthesized
             """,
         ),
-    ),
-    # exception raised
-    "abs(1 / 0)": (
+        # exception raised
         (
-            lambda v: v < (3, 11),
-            """\
-            Traceback (most recent call last):
-              File "<test run - snippet #0>", line 1, in <module>
-                abs(1 / 0)
-            ZeroDivisionError: division by zero
-            """,
-        ),
-        (
-            lambda v: v >= (3, 11),
+            "abs(1 / 0)",
             """\
             Traceback (most recent call last):
               File "<test run - snippet #0>", line 1, in <module>
@@ -251,24 +221,22 @@ EXPRESSION_TESTS = {
             """,
         ),
     ),
-}
-STATEMENT_TESTS = {
-    # invalid syntax
-    """\
-    def x():
-        12x
-    """: (
+)
+async def test_format_exception_expressions(
+    monkeypatch: pytest.MonkeyPatch, source: str, result: str
+) -> None:
+    await _run_dev_output(monkeypatch, source, result, debug=True, repl=True)
+
+
+@pytest.mark.parametrize(
+    "source,result",
+    (
+        # invalid syntax
         (
-            lambda v: v < (3, 10),
             """\
-              File "<test run - snippet #0>", line 2
+            def x():
                 12x
-                  ^
-            SyntaxError: invalid syntax
             """,
-        ),
-        (
-            lambda v: v >= (3, 10),
             """\
               File "<test run - snippet #0>", line 2
                 12x
@@ -276,22 +244,11 @@ STATEMENT_TESTS = {
             SyntaxError: invalid decimal literal
             """,
         ),
-    ),
-    """\
-    def x():
-        foo(x, z for z in range(10), t, w)
-    """: (
         (
-            lambda v: v < (3, 10),
             """\
-              File "<test run - snippet #0>", line 2
+            def x():
                 foo(x, z for z in range(10), t, w)
-                       ^
-            SyntaxError: Generator expression must be parenthesized
             """,
-        ),
-        (
-            lambda v: v >= (3, 10),
             """\
               File "<test run - snippet #0>", line 2
                 foo(x, z for z in range(10), t, w)
@@ -299,27 +256,15 @@ STATEMENT_TESTS = {
             SyntaxError: Generator expression must be parenthesized
             """,
         ),
-    ),
-    # exception raised
-    """\
-    print(123)
-    try:
-        abs(1 / 0)
-    except ValueError:
-        pass
-    """: (
+        # exception raised
         (
-            lambda v: v < (3, 11),
             """\
-            123
-            Traceback (most recent call last):
-              File "<test run - snippet #0>", line 3, in <module>
+            print(123)
+            try:
                 abs(1 / 0)
-            ZeroDivisionError: division by zero
+            except ValueError:
+                pass
             """,
-        ),
-        (
-            lambda v: v >= (3, 11),
             """\
             123
             Traceback (most recent call last):
@@ -329,42 +274,17 @@ STATEMENT_TESTS = {
             ZeroDivisionError: division by zero
             """,
         ),
-    ),
-    # exception chaining
-    """\
-    try:
-        1 / 0
-    except ZeroDivisionError as exc:
-        try:
-            raise RuntimeError("direct cause") from exc
-        except RuntimeError:
-            raise ValueError("indirect cause")
-    """: (
+        # exception chaining
         (
-            lambda v: v < (3, 11),
             """\
-            Traceback (most recent call last):
-              File "<test run - snippet #0>", line 2, in <module>
+            try:
                 1 / 0
-            ZeroDivisionError: division by zero
-
-            The above exception was the direct cause of the following exception:
-
-            Traceback (most recent call last):
-              File "<test run - snippet #0>", line 5, in <module>
-                raise RuntimeError("direct cause") from exc
-            RuntimeError: direct cause
-
-            During handling of the above exception, another exception occurred:
-
-            Traceback (most recent call last):
-              File "<test run - snippet #0>", line 7, in <module>
-                raise ValueError("indirect cause")
-            ValueError: indirect cause
+            except ZeroDivisionError as exc:
+                try:
+                    raise RuntimeError("direct cause") from exc
+                except RuntimeError:
+                    raise ValueError("indirect cause")
             """,
-        ),
-        (
-            lambda v: v >= (3, 11),
             """\
             Traceback (most recent call last):
               File "<test run - snippet #0>", line 2, in <module>
@@ -387,28 +307,26 @@ STATEMENT_TESTS = {
             ValueError: indirect cause
             """,
         ),
-    ),
-    # exception groups
-    """\
-    def f(v):
-        try:
-            1 / 0
-        except ZeroDivisionError:
-            try:
-                raise ValueError(v)
-            except ValueError as e:
-                return e
-    try:
-        raise ExceptionGroup("one", [f(1)])
-    except ExceptionGroup as e:
-        eg = e
-    try:
-        raise ExceptionGroup("two", [f(2), eg])
-    except ExceptionGroup as e:
-        raise RuntimeError("wrapping") from e
-    """: (
+        # exception groups
         (
-            lambda v: v >= (3, 11),
+            """\
+            def f(v):
+                try:
+                    1 / 0
+                except ZeroDivisionError:
+                    try:
+                        raise ValueError(v)
+                    except ValueError as e:
+                        return e
+            try:
+                raise ExceptionGroup("one", [f(1)])
+            except ExceptionGroup as e:
+                eg = e
+            try:
+                raise ExceptionGroup("two", [f(2), eg])
+            except ExceptionGroup as e:
+                raise RuntimeError("wrapping") from e
+            """,
             """\
               + Exception Group Traceback (most recent call last):
               |   File "<test run - snippet #0>", line 14, in <module>
@@ -456,32 +374,6 @@ STATEMENT_TESTS = {
             """,
         ),
     ),
-}
-
-
-@pytest.mark.parametrize(
-    "source,result",
-    [
-        (source, result)
-        for source, results in EXPRESSION_TESTS.items()
-        for condition, result in results
-        if condition(sys.version_info)
-    ],
-)
-async def test_format_exception_expressions(
-    monkeypatch: pytest.MonkeyPatch, source: str, result: str
-) -> None:
-    await _run_dev_output(monkeypatch, source, result, debug=True, repl=True)
-
-
-@pytest.mark.parametrize(
-    "source,result",
-    [
-        (source, result)
-        for source, results in STATEMENT_TESTS.items()
-        for condition, result in results
-        if condition(sys.version_info)
-    ],
 )
 async def test_format_exception_statements(
     monkeypatch: pytest.MonkeyPatch, source: str, result: str

--- a/tools/edit_testrepo.py
+++ b/tools/edit_testrepo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.8
+#!/usr/bin/env python3.11
 """Script to edit test repo used by Downloader git integration tests.
 
 This script aims to help update the human-readable version of repo

--- a/tools/release_helper.py
+++ b/tools/release_helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.8
+#!/usr/bin/env python3.11
 """Script helping with making releases.
 
 This script mostly aims to help with the changelog-related tasks but it does also guide you

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ allowlist_externals =
 setenv =
     # This is just for Windows
     # Prioritise make.bat over any make.exe which might be on PATH
-    PATHEXT=.BAT;.EXE
+    PATHEXT=.BAT\;.EXE
 basepython = python3.11
 extras = doc
 commands =
@@ -64,7 +64,7 @@ allowlist_externals =
 setenv =
     # This is just for Windows
     # Prioritise make.bat over any make.exe which might be on PATH
-    PATHEXT=.BAT;.EXE
+    PATHEXT=.BAT\;.EXE
 basepython = python3.11
 extras = style
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,6 @@
 
 [tox]
 envlist =
-    py38
-    py39
-    py310
     py311
     docs
     style
@@ -54,7 +51,7 @@ setenv =
     # This is just for Windows
     # Prioritise make.bat over any make.exe which might be on PATH
     PATHEXT=.BAT;.EXE
-basepython = python3.8
+basepython = python3.11
 extras = doc
 commands =
     sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out/html" -W --keep-going -bhtml
@@ -68,7 +65,7 @@ setenv =
     # This is just for Windows
     # Prioritise make.bat over any make.exe which might be on PATH
     PATHEXT=.BAT;.EXE
-basepython = python3.8
+basepython = python3.11
 extras = style
 commands =
     make stylediff


### PR DESCRIPTION
### Description of the changes

One of the things we'll be doing for Red 3.6. Of course, we'll be adding support for newer Python versions as well, but this PR just focuses on doing the minimal work for dropping older Python versions.

### Have the changes in this PR been tested?

No