### PR TITLE
Add `[p]bank add/sub` subcommands

### DIFF
--- a/docs/cog_guides/economy.rst
+++ b/docs/cog_guides/economy.rst
@@ -38,7 +38,7 @@ bank
 
 .. code-block:: none
 
-    [p]bank 
+    [p]bank
 
 **Description**
 
@@ -67,6 +67,32 @@ Example:
 **Arguments**
 
 - ``<user>`` The user to check the balance of. If omitted, defaults to your own balance.
+
+.. _economy-command-bank-add:
+
+""""""""
+bank add
+""""""""
+
+.. note:: |admin-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]bank add <to> <creds>
+
+**Description**
+
+Add currency to a user's bank account.
+
+Example:
+    - ``[p]bank add @Twentysix 100``
+
+**Arguments**
+
+- ``<to>`` The user to give currency to.
+- ``<creds>`` The amount of currency to add.
 
 .. _economy-command-bank-set:
 
@@ -97,6 +123,32 @@ Examples:
 
 - ``<to>`` The user to set the currency of.
 - ``<creds>`` The amount of currency to set their balance to.
+
+.. _economy-command-bank-sub:
+
+""""""""
+bank sub
+""""""""
+
+.. note:: |admin-lock|
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]bank sub <to> <creds>
+
+**Description**
+
+Remove currency from a user's bank account.
+
+Example:
+    - ``[p]bank sub @Twentysix 50``
+
+**Arguments**
+
+- ``<to>`` The user to remove currency from.
+- ``<creds>`` The amount of currency to remove.
 
 .. _economy-command-bank-transfer:
 
@@ -136,7 +188,7 @@ economyset
 
 .. code-block:: none
 
-    [p]economyset 
+    [p]economyset
 
 **Description**
 
@@ -228,7 +280,7 @@ economyset showsettings
 
 .. code-block:: none
 
-    [p]economyset showsettings 
+    [p]economyset showsettings
 
 **Description**
 
@@ -343,7 +395,7 @@ payday
 
 .. code-block:: none
 
-    [p]payday 
+    [p]payday
 
 **Description**
 
@@ -361,7 +413,7 @@ payouts
 
 .. code-block:: none
 
-    [p]payouts 
+    [p]payouts
 
 **Description**
 

--- a/docs/cog_guides/economy.rst
+++ b/docs/cog_guides/economy.rst
@@ -44,30 +44,6 @@ bank
 
 Base command to manage the bank.
 
-.. _economy-command-bank-balance:
-
-""""""""""""
-bank balance
-""""""""""""
-
-**Syntax**
-
-.. code-block:: none
-
-    [p]bank balance [user]
-
-**Description**
-
-Show the user's account balance.
-
-Example:
-    - ``[p]bank balance``
-    - ``[p]bank balance @Twentysix``
-
-**Arguments**
-
-- ``<user>`` The user to check the balance of. If omitted, defaults to your own balance.
-
 .. _economy-command-bank-add:
 
 """"""""
@@ -93,6 +69,30 @@ Example:
 
 - ``<to>`` The user to give currency to.
 - ``<creds>`` The amount of currency to add.
+
+.. _economy-command-bank-balance:
+
+""""""""""""
+bank balance
+""""""""""""
+
+**Syntax**
+
+.. code-block:: none
+
+    [p]bank balance [user]
+
+**Description**
+
+Show the user's account balance.
+
+Example:
+    - ``[p]bank balance``
+    - ``[p]bank balance @Twentysix``
+
+**Arguments**
+
+- ``<user>`` The user to check the balance of. If omitted, defaults to your own balance.
 
 .. _economy-command-bank-set:
 

--- a/docs/cog_guides/economy.rst
+++ b/docs/cog_guides/economy.rst
@@ -87,7 +87,7 @@ bank add
 Add currency to a user's bank account.
 
 Example:
-    - ``[p]bank add @Twentysix 100``
+    - ``[p]bank add @Twentysix 100`` - Increases balance by 100
 
 **Arguments**
 
@@ -143,7 +143,7 @@ bank sub
 Remove currency from a user's bank account.
 
 Example:
-    - ``[p]bank sub @Twentysix 50``
+    - ``[p]bank sub @Twentysix 50`` - Decreases balance by 50
 
 **Arguments**
 

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -319,7 +319,7 @@ class Economy(commands.Cog):
 
     @bank.is_owner_if_bank_global()
     @commands.admin_or_permissions(manage_guild=True)
-    @_bank.command(name="sub")
+    @_bank.command(name="sub", aliases=["subtract"])
     async def _sub(self, ctx: commands.Context, to: discord.Member, creds: positive_int):
         """Remove currency from a user's bank account.
 

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -286,6 +286,68 @@ class Economy(commands.Cog):
         else:
             await ctx.send(msg)
 
+    @bank.is_owner_if_bank_global()
+    @commands.admin_or_permissions(manage_guild=True)
+    @_bank.command(name="add")
+    async def _add(self, ctx: commands.Context, to: discord.Member, creds: positive_int):
+        """Add currency to a user's bank account.
+
+        Example:
+        - `[p]bank add @Twentysix 100`
+
+        **Arguments**
+
+        - `<to>` The user to give currency to.
+        - `<creds>` The amount of currency to add.
+        """
+        author = ctx.author
+        currency = await bank.get_currency_name(ctx.guild)
+
+        try:
+            await bank.deposit_credits(to, creds)
+        except (ValueError, errors.BalanceTooHigh) as e:
+            await ctx.send(str(e))
+        else:
+            await ctx.send(
+                _("{author} added {num} {currency} to {user}'s account.").format(
+                    author=author.display_name,
+                    num=humanize_number(creds),
+                    currency=currency,
+                    user=to.display_name,
+                )
+            )
+
+    @bank.is_owner_if_bank_global()
+    @commands.admin_or_permissions(manage_guild=True)
+    @_bank.command(name="sub")
+    async def _sub(self, ctx: commands.Context, to: discord.Member, creds: positive_int):
+        """Remove currency from a user's bank account.
+
+        Example:
+        - `[p]bank sub @Twentysix 50`
+
+        **Arguments**
+
+        - `<to>` The user to remove currency from.
+        - `<creds>` The amount of currency to remove.
+        """
+        author = ctx.author
+        currency = await bank.get_currency_name(ctx.guild)
+
+        try:
+            await bank.withdraw_credits(to, creds)
+        except ValueError as e:
+            await ctx.send(str(e))
+        else:
+            await ctx.send(
+                _("{author} removed {num} {currency} from {user}'s account.").format(
+                    author=author.display_name,
+                    num=humanize_number(creds),
+                    currency=currency,
+                    user=to.display_name,
+                )
+            )
+
     @guild_only_check()
     @commands.command()
     async def payday(self, ctx: commands.Context):

--- a/redbot/cogs/economy/economy.py
+++ b/redbot/cogs/economy/economy.py
@@ -293,7 +293,7 @@ class Economy(commands.Cog):
         """Add currency to a user's bank account.
 
         Example:
-        - `[p]bank add @Twentysix 100`
+        - `[p]bank add @Twentysix 100` - Increases balance by 100
 
         **Arguments**
 
@@ -324,7 +324,7 @@ class Economy(commands.Cog):
         """Remove currency from a user's bank account.
 
         Example:
-        - `[p]bank sub @Twentysix 50`
+        - `[p]bank sub @Twentysix 50` - Decreases balance by 50
 
         **Arguments**
 


### PR DESCRIPTION
### Description of the changes

Adds `[p]bank add` and `[p]bank sub` subcommands as a more intuitive alternative to `[p]bank set` with `+/-` prefix.

Discussed in https://discord.com/channels/133049272517001216/133049878837329920/1491377608510931018 ; Accepted by Jackenmen.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No, I do not use economy on my bots
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
