### PR TITLE
Fix deprecated use of shutdown_timeout kwarg in TCPSite

### DIFF
--- a/redbot/core/_rpc.py
+++ b/redbot/core/_rpc.py
@@ -97,9 +97,6 @@ class RPC:
                     self._runner,
                     host="127.0.0.1",
                     port=port,
-                    shutdown_timeout=120
-                    # Give the RPC server 2 minutes to finish up, else slap it!
-                    # Seems like a reasonable time. See Red#6391
                 ),
             )
         except Exception as exc:


### PR DESCRIPTION
### Description of the changes

Fixes:
```
[py.warnings] /home/ubuntu/work/Red-DiscordBot/.venv/lib/python3.8/site-packages/aiohttp/web_runner.py:95: DeprecationWarning: shutdown_timeout should be set on BaseRunner
  super().__init__(
```

The kwarg was moved to the AppRunner *but* I opted to simply remove it since its default value is already 60 seconds, which is more than enough. The important part about #6391 was changing it **from zero**, the exact value wasn't meaningful.

### Have the changes in this PR been tested?

Yes