### PR TITLE
Fix files perms in send_interactive

### DIFF
--- a/redbot/core/bot.py
+++ b/redbot/core/bot.py
@@ -2545,7 +2545,7 @@ class Red(
             ret.append(msg)
             n_remaining = len(messages) - idx
             files_perm = (
-                isinstance(channel, discord.abc.User)
+                isinstance(channel, discord.channel.DMChannel)
                 or channel.permissions_for(channel.guild.me).attach_files
             )
             options = ("more", "file") if files_perm else ("more",)


### PR DESCRIPTION
### Description of the changes

So I found a bug when doing `[p]eval` in a DM where it would respond, the immediately give an error message on the file perms check. DM channels are in fact `discord.channel.DMChannel`, not `discord.abc.User` it seems.

I have not tested this yet though
