### PR TITLE
Make repo names case-insensitive

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -129,11 +129,12 @@ class Downloader(commands.Cog):
         agreed = await do_install_agreement(ctx)
         if not agreed:
             return
+        name = name.lower()
         # TODO: verify this in the Downloader APIs
         if name.startswith(".") or name.endswith("."):
             await ctx.send(_("Repo names cannot start or end with a dot."))
             return
-        if re.match(r"^[a-zA-Z0-9_\-\.]+$", name) is None:
+        if re.match(r"^[a-z0-9_\-\.]+$", name) is None:
             await ctx.send(
                 _(
                     "Repo names can only contain characters A-z, numbers, underscores, hyphens,"

--- a/redbot/core/_downloader/__init__.py
+++ b/redbot/core/_downloader/__init__.py
@@ -109,6 +109,11 @@ async def _migrate_config() -> None:
         schema_version += 1
         await _config.schema_version.set(schema_version)
 
+    if schema_version == 2:
+        await _schema_2_to_3()
+        schema_version += 1
+        await _config.schema_version.set(schema_version)
+
 
 async def _schema_0_to_1():
     """
@@ -133,6 +138,26 @@ async def _schema_0_to_1():
     await _config.clear_raw("installed")
     # no reliable way to get installed libraries (i.a. missing repo name)
     # but it only helps `[p]cog update` run faster so it's not an issue
+
+
+async def _schema_2_to_3():
+    """
+    This migrates case-sensitive repo names to be case-insensitive
+    and ensures they only contain characters valid per `[p]repo add`'s regex.
+    """
+    old_conf = await _config.installed_cogs()
+
+    repo_mgr = RepoManager()
+    name_mapping = await repo_mgr._downloader_schema_2_to_3_migrate(old_conf.keys())
+
+    new_conf = {}
+    for old_name, new_name in name_mapping.items():
+        new_conf[new_name] = {
+            cog_name: {**cog_info, "repo_name": new_name}
+            for cog_name, cog_info in old_conf.get(old_name, {}).items()
+        }
+    await _config.installed_cogs.set(new_conf)
+    await repo_mgr._downloader_schema_2_to_3_clear_old_config()
 
 
 def _create_lib_folder(*, remove_first: bool = False) -> None:

--- a/redbot/core/_downloader/repo_manager.py
+++ b/redbot/core/_downloader/repo_manager.py
@@ -1067,7 +1067,7 @@ class RepoManager:
             reverse=True,
         ):
             new_name = base_new_name
-            counter = itertools.count()
+            counter = itertools.count(2)
             # Order by name before iterating to ensure consistent order.
             for old_name in sorted(old_names):
                 if old_name in name_mapping:

--- a/redbot/core/_downloader/repo_manager.py
+++ b/redbot/core/_downloader/repo_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import itertools
 import keyword
 import os
 import pkgutil
@@ -1017,16 +1018,92 @@ class RepoManager:
 
     def __init__(self) -> None:
         self._repos: Dict[str, Repo] = {}
-        self.config = Config.get_conf(self, identifier=170708480, force_registration=True)
+        self.config = Config.get_conf(self, identifier=17070841, force_registration=True)
         self.config.register_global(repos={})
+
+    # Below schema version are Downloader's - RepoManager doesn't have a separate schema version.
+    def _get_downloader_schema_2_config(self) -> Config:
+        old_config = Config.get_conf(self, identifier=170708480, force_registration=True)
+        old_config.register_global(repos={}, new_repo_names={})
+        return old_config
+
+    async def _downloader_schema_2_to_3_migrate(
+        self, extra_repo_names: Iterable[str]
+    ) -> Dict[str, str]:
+        old_config = self._get_downloader_schema_2_config()
+        old_repos_folder = self._data_folder / "repos"
+        old_repos = await self._load_repos(
+            set_repos=False, case_sensitive=True, repos_folder=old_repos_folder, config=old_config
+        )
+        # `extra_repo_names` contains repo names from Downloader's installed cogs
+        # as repos of some of those cogs may have been removed since.
+        repo_names = set(old_repos)
+        repo_names.update(extra_repo_names)
+
+        # 1. Group repo names by their lowercase form.
+        name_groups: Dict[str, List[str]] = {}
+        # Repo names used to not be restricted in any way (GH-2827).
+        # Since we're performing a repo migration now anyway, let's strip invalid chars out now.
+        invalid_char_pattern = re.compile(r"[^a-z0-9_\-\.]")
+        for old_name in repo_names:
+            base_new_name = old_name.lower().strip(".").rstrip(".")
+            base_new_name = invalid_char_pattern.sub("", base_new_name)
+            if not base_new_name:
+                base_new_name = "repo-with-invalid-name"
+
+            name_groups.setdefault(base_new_name, []).append(old_name)
+
+        # 2. Generate a mapping of old names to new names.
+        # `old_config.new_repo_names()` will contain repo names we already assigned
+        # *if* the process was stopped while migration was being performed.
+        name_mapping = await old_config.new_repo_names()
+        used_names = set(name_mapping)
+        for base_new_name, old_names in sorted(
+            name_groups.items(),
+            # Start with the longest names first to prefer keeping the existing "name-2" repo
+            # without rename, if a different "name" repo needs to have a suffix added.
+            # When length is the same, order by name to ensure consistent order.
+            key=lambda tup: (len(tup[0]), tup[0]),
+            reverse=True,
+        ):
+            new_name = base_new_name
+            counter = itertools.count()
+            # Order by name before iterating to ensure consistent order.
+            for old_name in sorted(old_names):
+                if old_name in name_mapping:
+                    continue
+                while new_name in used_names:
+                    idx = next(counter)
+                    new_name = f"{base_new_name}-{idx}"
+                used_names.add(new_name)
+                name_mapping[old_name] = new_name
+        # Store assigned names to allow rerunning migration in case the process is stopped,
+        # while it's running.
+        await old_config.new_repo_names.set(name_mapping)
+
+        # 3. Rename repo folders.
+        # Ensure the new repos folder exists before performing any renames
+        self.repos_folder.mkdir(parents=True, exist_ok=True)
+        for repo in old_repos.values():
+            new_name = name_mapping[repo.name]
+            repo.folder_path.rename(repo.folder_path.with_name(new_name))
+            await self.config.repos.set_raw(new_name, value=repo.branch)
+
+        return name_mapping
+
+    async def _downloader_schema_2_to_3_clear_old_config(self) -> None:
+        await self._get_downloader_schema_2_config().clear_all()
 
     async def initialize(self) -> None:
         await self._load_repos(set_repos=True)
 
     @property
+    def _data_folder(self) -> Path:
+        return data_manager.cog_data_path(self)
+
+    @property
     def repos_folder(self) -> Path:
-        data_folder = data_manager.cog_data_path(self)
-        return data_folder / "repos"
+        return self._data_folder / "repos.v2"
 
     def does_repo_exist(self, name: str) -> bool:
         return name.lower() in self._repos
@@ -1205,17 +1282,34 @@ class RepoManager:
 
         return ret, failed
 
-    async def _load_repos(self, set_repos: bool = False) -> Dict[str, Repo]:
+    async def _load_repos(
+        self,
+        *,
+        set_repos: bool = False,
+        case_sensitive: bool = False,
+        repos_folder: Optional[Path] = None,
+        config: Optional[Config] = None,
+    ) -> Dict[str, Repo]:
+        # NOTE: `case_sensitive`, `repos_folder`, and `config` kwargs
+        # are only used by a schema migration.
+
+        if repos_folder is None:
+            repos_folder = self.repos_folder
+        if config is None:
+            config = self.config
+
         ret = {}
-        self.repos_folder.mkdir(parents=True, exist_ok=True)
+        repos_folder.mkdir(parents=True, exist_ok=True)
         repo_branches = await config.repos()
-        for folder in self.repos_folder.iterdir():
+        for folder in repos_folder.iterdir():
             if not folder.is_dir():
                 continue
             try:
-                repo_name = folder.name.lower()
+                repo_name = folder.name if case_sensitive else folder.name.lower()
                 branch = repo_branches.get(repo_name, default="")
                 repo = await Repo.from_folder(folder, branch)
+                if case_sensitive:
+                    repo.name = folder.name
                 ret[repo.name] = repo
             except errors.NoRemoteURL:
                 log.warning("A remote URL does not exist for repo %s", folder.name)

--- a/redbot/core/_downloader/repo_manager.py
+++ b/redbot/core/_downloader/repo_manager.py
@@ -1001,7 +1001,7 @@ class Repo(RepoJSONMixin):
 
     @classmethod
     async def from_folder(cls, folder: Path, branch: str = "") -> Repo:
-        repo = cls(name=folder.name, url="", branch=branch, commit="", folder_path=folder)
+        repo = cls(name=folder.name.lower(), url="", branch=branch, commit="", folder_path=folder)
         repo.url = await repo.current_url()
         if branch == "":
             repo.branch = await repo.current_branch()
@@ -1029,13 +1029,7 @@ class RepoManager:
         return data_folder / "repos"
 
     def does_repo_exist(self, name: str) -> bool:
-        return name in self._repos
-
-    @staticmethod
-    def validate_and_normalize_repo_name(name: str) -> str:
-        if not name.isidentifier():
-            raise errors.InvalidRepoName("Not a valid Python variable name.")
-        return name.lower()
+        return name.lower() in self._repos
 
     async def add_repo(self, url: str, name: str, branch: Optional[str] = None) -> Repo:
         """Add and clone a git repository.
@@ -1055,6 +1049,7 @@ class RepoManager:
             New Repo object representing the cloned repository.
 
         """
+        name = name.lower()
         if self.does_repo_exist(name):
             raise errors.ExistingGitRepo(
                 "That repo name you provided already exists. Please choose another."
@@ -1087,7 +1082,7 @@ class RepoManager:
             Repo object for the repository, if it exists.
 
         """
-        return self._repos.get(name, None)
+        return self._repos.get(name.lower(), None)
 
     @property
     def repos(self) -> Tuple[Repo, ...]:
@@ -1131,6 +1126,7 @@ class RepoManager:
             If the repo does not exist.
 
         """
+        name = name.lower()
         repo = self.get_repo(name)
         if repo is None:
             raise errors.MissingGitRepo(f"There is no repo with the name {name}")
@@ -1157,7 +1153,7 @@ class RepoManager:
             A 2-`tuple` with Repo object and a 2-`tuple` of `str`
             containing old and new commit hashes.
         """
-        repo = self._repos[repo_name]
+        repo = self._repos[repo_name.lower()]
         old, new = await repo.update()
         return (repo, (old, new))
 
@@ -1212,14 +1208,15 @@ class RepoManager:
     async def _load_repos(self, set_repos: bool = False) -> Dict[str, Repo]:
         ret = {}
         self.repos_folder.mkdir(parents=True, exist_ok=True)
+        repo_branches = await config.repos()
         for folder in self.repos_folder.iterdir():
             if not folder.is_dir():
                 continue
             try:
-                branch = await self.config.repos.get_raw(folder.name, default="")
-                ret[folder.name] = await Repo.from_folder(folder, branch)
-                if branch == "":
-                    await self.config.repos.set_raw(folder.name, value=ret[folder.name].branch)
+                repo_name = folder.name.lower()
+                branch = repo_branches.get(repo_name, default="")
+                repo = await Repo.from_folder(folder, branch)
+                ret[repo.name] = repo
             except errors.NoRemoteURL:
                 log.warning("A remote URL does not exist for repo %s", folder.name)
             except errors.DownloaderException as err:

--- a/redbot/core/_downloader/repo_manager.py
+++ b/redbot/core/_downloader/repo_manager.py
@@ -1086,7 +1086,7 @@ class RepoManager:
         self.repos_folder.mkdir(parents=True, exist_ok=True)
         for repo in old_repos.values():
             new_name = name_mapping[repo.name]
-            repo.folder_path.rename(repo.folder_path.with_name(new_name))
+            repo.folder_path.rename(self.repos_folder / new_name)
             await self.config.repos.set_raw(new_name, value=repo.branch)
 
         return name_mapping

--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -282,6 +282,7 @@ async def create_backup(dest: Path = Path.home()) -> Optional[Path]:
         os.path.join("Downloader", "lib", ""),
         os.path.join("CogManager", "cogs", ""),
         os.path.join("RepoManager", "repos", ""),
+        os.path.join("RepoManager", "repos.v2", ""),
         os.path.join("Audio", "logs", ""),
         # these files are created during backup so we exclude them from data path backup
         os.path.join("RepoManager", "repos.json"),

--- a/redbot/pytest/downloader.py
+++ b/redbot/pytest/downloader.py
@@ -74,7 +74,7 @@ def repo(tmp_path):
 def bot_repo(event_loop):
     cwd = Path.cwd()
     return Repo(
-        name="Red-DiscordBot",
+        name="red-discordbot",
         branch="WRONG",
         commit="",
         url="https://empty.com/something.git",

--- a/redbot/pytest/downloader.py
+++ b/redbot/pytest/downloader.py
@@ -58,7 +58,7 @@ def repo_manager(tmpdir_factory):
 
 @pytest.fixture
 def repo(tmp_path):
-    repo_folder = tmp_path / "repos" / "squid"
+    repo_folder = tmp_path / "repos.v2" / "squid"
     repo_folder.mkdir(parents=True, exist_ok=True)
 
     return Repo(

--- a/tests/core/_downloader/test_downloader.py
+++ b/tests/core/_downloader/test_downloader.py
@@ -44,7 +44,7 @@ def _mock_setup_repo(mocker: MockFixture, repo: Repo, commit: str):
 
 
 def test_existing_git_repo(tmp_path):
-    repo_folder = tmp_path / "repos" / "squid" / ".git"
+    repo_folder = tmp_path / "repos.v2" / "squid" / ".git"
     repo_folder.mkdir(parents=True, exist_ok=True)
 
     r = Repo(


### PR DESCRIPTION
### Description of the changes

This PR makes repo names in Downloader case-insensitive. This involves:
- making sure that the name of the repo is lowercase everywhere relevant (at API boundaries)
- adding a migration that updates all repos to use lowercase names, resolving any conflicts that may occur
    - `RepoManager`'s Config is completely replaced by a config with a new identifier and its repos folder is completely replaced by a new (`repos.v2`) folder - this allows us to create a mapping of old names to new names and then perform a rename in any order without overriding any existing data

Testing of this PR's changes should involve:
- testing the migration, in particular:
  - name conflict handling (i.e. add 2 repos with names `name` and `NAME` and try performing a migration)
    - note for testers: while I'd generally only expect this to be possible on Linux/macOS file systems, it might be possible to test this on Windows too by creating an empty directory as case-sensitive and then creating an instance with that dir as data path, see: https://learn.microsoft.com/en-us/windows/wsl/case-sensitivity#modify-case-sensitivity; might require WSL feature to be enabled though
    - It would be good to test that Downloader prefers not changing existing names, i.e. with 3 repos named `name`, `NAME`, and `name-2`, I'd only expect `NAME` to be renamed to `name-3`, leaving `name-2` as is
  - handling of repo names that were taken from installed cogs are have since been removed
  - exiting the migration mid-run (probably by just adding a line raising an exception in some strategic place in the repo manager migration)
  - checking that the config JSONs don't have extraneous data left after the migration and that data that is there is in the correct format post-migration
- checking that all commands correctly work when passing an uppercase name for a repo, i.e. `JackCogs` should always manage to find a repo named `jackcogs`

Fixes #6371, fixes #6631, blocked by #6741

### Have the changes in this PR been tested?

No