### PR TITLE
Add version pins to older Update Red instructions

### DIFF
--- a/docs/update_red.rst
+++ b/docs/update_red.rst
@@ -88,7 +88,7 @@ If you have a Red version between 3.5.0 and 3.5.24, you can upgrade by following
     .. prompt:: batch
         :prompts: (redenv) C:\\>
 
-        python -m pip install -U Red-DiscordBot
+        python -m pip install -U "Red-DiscordBot==3.5.25"
 
     .. attention::
 
@@ -115,7 +115,7 @@ If you have a Red version between 3.5.0 and 3.5.24, you can upgrade by following
     .. prompt:: bash
         :prompts: (redenv) $
 
-        python -m pip install -U Red-DiscordBot
+        python -m pip install -U 'Red-DiscordBot==3.5.25'
 
     .. attention::
 
@@ -142,7 +142,7 @@ If you have a Red version between 3.2.0 and 3.4.19, you can upgrade by following
     .. prompt:: batch
         :prompts: (redenv) C:\\>
 
-        python -m pip install -U Red-DiscordBot
+        python -m pip install -U "Red-DiscordBot==3.5.25"
 
     .. attention::
 
@@ -181,7 +181,7 @@ If you have a Red version between 3.2.0 and 3.4.19, you can upgrade by following
     .. prompt:: bash
         :prompts: (redenv) $
 
-        python -m pip install -U Red-DiscordBot
+        python -m pip install -U 'Red-DiscordBot==3.5.25'
 
     .. attention::
 


### PR DESCRIPTION
### Description of the changes

This is what #6734 should have updated the older docs to, but I forgot. Forces the update to specifically be to 3.5.25. This only makes sense once there's no release newer than 3.5.25 - we'll have to update these docs again once another version is released, see #6754.

### Have the changes in this PR been tested?

Yes
