### PR TITLE
Replace direct RepoManager use in backup process

### DIFF
--- a/redbot/core/utils/_internal_utils.py
+++ b/redbot/core/utils/_internal_utils.py
@@ -290,12 +290,13 @@ async def create_backup(dest: Path = Path.home()) -> Optional[Path]:
     ]
 
     # Avoiding circular imports
-    from redbot.core._downloader.repo_manager import RepoManager
+    from redbot.core import _downloader
+    from redbot.core._cog_manager import CogManager
 
-    repo_mgr = RepoManager()
-    await repo_mgr.initialize()
+    await _downloader._init_without_bot(CogManager())
+
     repo_output = []
-    for repo in repo_mgr.repos:
+    for repo in _downloader._repo_manager.repos:
         repo_output.append({"url": repo.url, "name": repo.name, "branch": repo.branch})
 
     with rich.progress.Progress(


### PR DESCRIPTION
### Description of the changes

Since we now have an internal Downloader API, it's safer to use it over manually instantiating RepoManager. This will become especially important when we have schema migrations affecting the repo manager, such as in #6750 though there's no reason we shouldn't already be doing it.

### Have the changes in this PR been tested?

No
