### PR TITLE
Add Ubuntu 26.04 guide using deadsnakes repo

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -282,7 +282,7 @@ If you want to do it, follow these steps.
 2. **Install Linux**
 
   Most of the VPS providers have tools for installing Linux automatically. If
-  you're a beginner, we recommend **Ubuntu 24.04 LTS**.
+  you're a beginner, we recommend **Ubuntu 26.04 LTS**.
 
   For Raspberry Pi users, just install `Raspbian
   <https://www.raspberrypi.org/software/>`_ on a micro-SD card.

--- a/docs/install_guides/index.rst
+++ b/docs/install_guides/index.rst
@@ -6,7 +6,7 @@ Installing Red
 The list below shows the installation guides available based on the operating system being used.
 
 If you want to host Red on a VPS and are unsure what operating system you should choose,
-we recommend **Ubuntu 24.04 LTS**.
+we recommend **Ubuntu 26.04 LTS**.
 
 .. toctree::
    :maxdepth: 1
@@ -31,4 +31,5 @@ we recommend **Ubuntu 24.04 LTS**.
    rocky-linux-9
    ubuntu-2204
    ubuntu-2404
+   ubuntu-2604
    ubuntu-non-lts

--- a/docs/install_guides/ubuntu-2604.rst
+++ b/docs/install_guides/ubuntu-2604.rst
@@ -1,0 +1,33 @@
+.. _install-ubuntu-2604:
+
+==================================
+Installing Red on Ubuntu 26.04 LTS
+==================================
+
+.. include:: _includes/supported-arch-x64+aarch64.rst
+
+.. include:: _includes/linux-preamble.rst
+
+-------------------------------
+Installing the pre-requirements
+-------------------------------
+
+We recommend adding the ``deadsnakes`` ppa to install Python 3.11:
+
+.. prompt:: bash
+
+    sudo apt update
+    sudo apt -y install software-properties-common
+    sudo add-apt-repository -y ppa:deadsnakes/ppa
+
+Now install the pre-requirements with apt:
+
+.. prompt:: bash
+
+    sudo apt -y install python3.11 python3.11-dev python3.11-venv git openjdk-17-jre-headless build-essential nano
+
+.. Include common instructions:
+
+.. include:: _includes/create-env-with-venv3.11.rst
+
+.. include:: _includes/install-and-setup-red-unix.rst

--- a/docs/install_guides/ubuntu-non-lts.rst
+++ b/docs/install_guides/ubuntu-non-lts.rst
@@ -10,4 +10,4 @@ due to lack of availability of Python 3.11 or older in its repositories.
 The support should come back once we get back on track with supporting current Python versions.
 
 We recommend usage of latest Ubuntu **LTS** versions instead, you can find
-`an install guide for Ubuntu 24.04 <ubuntu-2404>` in our docs.
+`an install guide for Ubuntu 26.04 <ubuntu-2604>` in our docs.

--- a/docs/version_guarantees.rst
+++ b/docs/version_guarantees.rst
@@ -77,6 +77,7 @@ Rocky Linux 8                      x86-64, aarch64           2029-05-31 (`End of
 Rocky Linux 9                      x86-64, aarch64           2032-05-31 (`End of Life <https://wiki.rockylinux.org/rocky/version/>`__)
 Ubuntu 22.04 LTS                   x86-64, aarch64           2027-06-30 (`End of Standard Support <https://wiki.ubuntu.com/Releases#Current>`__)
 Ubuntu 24.04 LTS                   x86-64, aarch64           2029-06-30 (`End of Standard Support <https://wiki.ubuntu.com/Releases#Current>`__)
+Ubuntu 26.04 LTS                   x86-64, aarch64           2031-05-31 (`End of Standard Support <https://wiki.ubuntu.com/Releases#Current>`__)
 ================================   =======================   ============================================================
 
 .. _developer-guarantees:


### PR DESCRIPTION
### Description of the changes

Blocked until new python3.11 build releases: https://github.com/deadsnakes/issues/issues/341
We probably won't ever actually merge this and will just add the 26.04 guide using system packages when we release 3.6.

### Have the changes in this PR been tested?

No
