### PR TITLE
Bump Java versions in install guides to latest available LTSes

### DIFF
--- a/docs/cog_guides/audio.rst
+++ b/docs/cog_guides/audio.rst
@@ -116,18 +116,18 @@ How can I use this playlist link with playlist commands in audio?**
     :ref:`setting up Audio for multiple bots<multibots>`. Otherwise, another process is using the 
     port, so you need to figure out what is using port 2333 and terminate/disconnect it yourself.
     
-**Q: My terminal is saying that I "must install Java 21 or 17 for Lavalink to run". How can I fix this?**
+**Q: My terminal is saying that I "must install Java 25, 21, or 17 for Lavalink to run". How can I fix this?**
 
     You are getting this error because you have a different version of Java installed, or you don't have
-    Java installed at all. As the error states, Java 21 or 17 is required, and can be installed from
-    `here <https://adoptium.net/temurin/releases/?version=21>`__.
+    Java installed at all. As the error states, Java 25, 21, or 17 is required, and can be installed from
+    `here <https://adoptium.net/temurin/releases/?version=25>`__.
     
-    If you have Java 21 or 17 installed, and are still getting this error, you will have to manually tell Audio where your Java install is located.
-    Use ``[p]llset java <path_to_java_21_or_17_executable>``, to make Audio launch Lavalink with a
+    If you have Java 25, 21, or 17 installed, and are still getting this error, you will have to manually tell Audio where your Java install is located.
+    Use ``[p]llset java <path_to_compatible_java_executable>``, to make Audio launch Lavalink with a
     specific Java binary. To do this, you will need to locate your ``java.exe``/``java`` file
-    in your **Java 21 or 17 install**.
+    in your **Java 25, 21, or 17 install**.
     
-    Alternatively, update your PATH settings so that Java 21 or 17 is the one used by ``java``. However,
+    Alternatively, update your PATH settings so that Java 25, 21, or 17 is the one used by ``java``. However,
     you should confirm that nothing other than Red is running on the machine that requires Java.
 
 .. _queue_commands:
@@ -3651,7 +3651,7 @@ This command shouldn't need to be used most of the time,
 and is only useful if the host machine has conflicting Java versions.
 
 If changing this make sure that the Java executable you set is supported by Audio.
-The current supported versions are Java 21 or 17.
+The current supported versions are Java 25, 21, and 17.
 
 **Arguments**
 

--- a/docs/install_guides/_includes/install-guide-rhel8-derivatives.rst
+++ b/docs/install_guides/_includes/install-guide-rhel8-derivatives.rst
@@ -13,13 +13,13 @@ Install them with dnf:
 
     sudo dnf -y update
     sudo dnf -y group install development
-    sudo dnf -y install python3.11 python3.11-devel java-17-openjdk-headless nano git
+    sudo dnf -y install python3.11 python3.11-devel java-25-openjdk-headless nano git
 
-Set ``java`` executable to point to Java 17:
+Set ``java`` executable to point to Java 21:
 
 .. prompt:: bash
 
-    sudo alternatives --set java "java-17-openjdk.$(uname -i)"
+    sudo alternatives --set java "java-21-openjdk.$(uname -i)"
 
 .. Include common instructions:
 

--- a/docs/install_guides/_includes/install-guide-rhel9-derivatives.rst
+++ b/docs/install_guides/_includes/install-guide-rhel9-derivatives.rst
@@ -11,7 +11,7 @@ Install them with dnf:
 
 .. prompt:: bash
 
-    sudo dnf -y install python3.11 python3.11-devel git java-17-openjdk-headless @development nano
+    sudo dnf -y install python3.11 python3.11-devel git java-25-openjdk-headless @development nano
 
 .. Include common instructions:
 

--- a/docs/install_guides/amazon-linux-2023.rst
+++ b/docs/install_guides/amazon-linux-2023.rst
@@ -17,7 +17,7 @@ them with dnf:
 
 .. prompt:: bash
 
-    sudo dnf -y install python3.11 python3.11-devel git java-17-amazon-corretto-headless @development nano
+    sudo dnf -y install python3.11 python3.11-devel git java-25-amazon-corretto-headless @development nano
 
 .. Include common instructions:
 

--- a/docs/install_guides/arch.rst
+++ b/docs/install_guides/arch.rst
@@ -16,7 +16,7 @@ Install the pre-requirements with pacman:
 
 .. prompt:: bash
 
-    sudo pacman -Syu git jre17-openjdk-headless base-devel nano
+    sudo pacman -Syu git jre25-openjdk-headless base-devel nano
 
 On Arch Linux, Python 3.11 can be installed from the Arch User Repository (AUR) from the ``python311`` package.
 

--- a/docs/install_guides/fedora.rst
+++ b/docs/install_guides/fedora.rst
@@ -19,7 +19,7 @@ them with dnf:
 
     sudo dnf -y install python3.11 python3.11-devel git adoptium-temurin-java-repository @development-tools nano
     sudo dnf config-manager setopt adoptium-temurin-java-repository.enabled=1
-    sudo dnf -y install temurin-17-jre
+    sudo dnf -y install temurin-25-jre
 
 .. Include common instructions:
 

--- a/docs/install_guides/mac.rst
+++ b/docs/install_guides/mac.rst
@@ -28,7 +28,7 @@ one-by-one:
 
     brew install python@3.11
     brew install git
-    brew install temurin@17
+    brew install temurin@25
 
 By default, Python installed through Homebrew is not added to the load path.
 To fix this, you should run these commands:

--- a/docs/install_guides/opensuse-leap-15.rst
+++ b/docs/install_guides/opensuse-leap-15.rst
@@ -17,7 +17,7 @@ with zypper:
 
 .. prompt:: bash
 
-    sudo zypper -n install python311 python311-devel git-core java-17-openjdk-headless nano
+    sudo zypper -n install python311 python311-devel git-core java-21-openjdk-headless nano
     sudo zypper -n install -t pattern devel_basis
 
 .. Include common instructions:

--- a/docs/install_guides/opensuse-tumbleweed.rst
+++ b/docs/install_guides/opensuse-tumbleweed.rst
@@ -17,7 +17,7 @@ with zypper:
 
 .. prompt:: bash
 
-    sudo zypper -n install python311 python311-devel git-core java-17-openjdk-headless nano
+    sudo zypper -n install python311 python311-devel git-core java-25-openjdk-headless nano
     sudo zypper -n install -t pattern devel_basis
 
 .. Include common instructions:

--- a/docs/install_guides/ubuntu-2204.rst
+++ b/docs/install_guides/ubuntu-2204.rst
@@ -18,7 +18,7 @@ with apt:
 .. prompt:: bash
 
     sudo apt update
-    sudo apt -y install python3.10 python3.10-dev python3.10-venv git openjdk-17-jre-headless build-essential nano
+    sudo apt -y install python3.10 python3.10-dev python3.10-venv git openjdk-25-jre-headless build-essential nano
 
 .. Include common instructions:
 

--- a/docs/install_guides/ubuntu-2404.rst
+++ b/docs/install_guides/ubuntu-2404.rst
@@ -24,7 +24,7 @@ Now install the pre-requirements with apt:
 
 .. prompt:: bash
 
-    sudo apt -y install python3.11 python3.11-dev python3.11-venv git openjdk-17-jre-headless build-essential nano
+    sudo apt -y install python3.11 python3.11-dev python3.11-venv git openjdk-25-jre-headless build-essential nano
 
 .. Include common instructions:
 

--- a/docs/install_guides/windows.rst
+++ b/docs/install_guides/windows.rst
@@ -39,7 +39,7 @@ For Audio support, you should also run the following command before exiting:
 
 .. prompt:: powershell
 
-    choco upgrade temurin17 -y
+    choco upgrade temurin25 -y
 
 
 From here, exit the prompt then continue onto `creating-venv-windows`.
@@ -66,7 +66,7 @@ Manually installing dependencies
 
 .. attention:: Please choose the option to "Git from the command line and also from 3rd-party software" in Git's setup.
 
-* `Java 17 <https://adoptium.net/temurin/releases/?version=17>`_ - needed for Audio
+* `Java 25 <https://adoptium.net/temurin/releases/?version=25>`_ - needed for Audio
 
 From here, continue onto `creating-venv-windows`.
 

--- a/redbot/cogs/audio/managed_node/version_pins.py
+++ b/redbot/cogs/audio/managed_node/version_pins.py
@@ -14,6 +14,6 @@ __all__ = (
 JAR_VERSION: Final[LavalinkVersion] = LavalinkVersion(3, 7, 13, red=5)
 YT_PLUGIN_VERSION: Final[str] = "1.18.0"
 # keep this sorted from oldest to latest
-SUPPORTED_JAVA_VERSIONS: Final[Tuple[int, ...]] = (17, 21)
+SUPPORTED_JAVA_VERSIONS: Final[Tuple[int, ...]] = (17, 21, 25)
 LATEST_SUPPORTED_JAVA_VERSION: Final = SUPPORTED_JAVA_VERSIONS[-1]
 OLDER_SUPPORTED_JAVA_VERSIONS: Final[Tuple[int, ...]] = SUPPORTED_JAVA_VERSIONS[:-1]


### PR DESCRIPTION
### Description of the changes

This PR adds Java 25 LTS to supported versions and bumps the installed version in install guides to the latest available LTS version in the repos for each system.

### Have the changes in this PR been tested?

Yes

Links:
https://github.com/Jackenmen/Red-Install-Tests/actions/runs/26060298154
https://cirrus-ci.com/build/6251970744287232