### PR TITLE
Fix redbot-update's pretend version not affecting version list

### DIFF
--- a/redbot/_update/cmd/cog_compatibility.py
+++ b/redbot/_update/cmd/cog_compatibility.py
@@ -89,7 +89,9 @@ async def _check_cog_compatibility_command_impl(
     console = common.get_console()
     if red_version is None or python_version is None:
         with console.status("Checking latest version..."):
-            latest = await fetch_latest_red_version()
+            latest = await fetch_latest_red_version(
+                include_prereleases=common.get_current_red_version().is_prerelease
+            )
             red_version = latest.version
 
         python_version = Version(".".join(map(str, sys.version_info[:3])))

--- a/redbot/_update/updater.py
+++ b/redbot/_update/updater.py
@@ -299,7 +299,9 @@ class Updater:
     async def _prepare_metadata(self) -> None:
         interpreter_info = self.options.new_python_interpreter or PythonInfo.current_system()
         with self.console.status("Checking latest version..."):
-            available_versions = await fetch_available_red_versions()
+            available_versions = await fetch_available_red_versions(
+                include_prereleases=common.get_current_red_version().is_prerelease
+            )
             latest_major = available_versions[0]
 
         self.metadata = UpdaterMetadata(


### PR DESCRIPTION
### Description of the changes

`fetch_available_red_versions()` automatically determines whether to include prereleases in the list by checking `__version__`. In case of `redbot-update`, however, we have a pretend version that we need to check against instead. This only affects devs testing changes to `redbot-update` since `_RED_UPDATE_PRETEND_VERSION` is not something we support users using.

### Have the changes in this PR been tested?

Yes