### PR TITLE
Bump YT plugin version to 1.18.1

### DIFF
--- a/redbot/cogs/audio/managed_node/version_pins.py
+++ b/redbot/cogs/audio/managed_node/version_pins.py
@@ -12,7 +12,7 @@ __all__ = (
 
 
 JAR_VERSION: Final[LavalinkVersion] = LavalinkVersion(3, 7, 13, red=5)
-YT_PLUGIN_VERSION: Final[str] = "1.18.0"
+YT_PLUGIN_VERSION: Final[str] = "1.18.1"
 # keep this sorted from oldest to latest
 SUPPORTED_JAVA_VERSIONS: Final[Tuple[int, ...]] = (17, 21)
 LATEST_SUPPORTED_JAVA_VERSION: Final = SUPPORTED_JAVA_VERSIONS[-1]


### PR DESCRIPTION
### Description of the changes

https://github.com/lavalink-devs/youtube-source/releases/tag/1.18.1

### Have the changes in this PR been tested?

Yes
