### PR TITLE
Always allow installing a pre-release if explicitly requested

### DIFF
--- a/redbot/_update/updater.py
+++ b/redbot/_update/updater.py
@@ -302,7 +302,8 @@ class Updater:
             available_versions = await fetch_available_red_versions(
                 include_prereleases=(
                     self.options.red_version.is_prerelease
-                    or common.get_current_red_version().is_prerelease
+                    if self.options.red_version is not None
+                    else common.get_current_red_version().is_prerelease
                 )
             )
             latest_major = available_versions[0]

--- a/redbot/_update/updater.py
+++ b/redbot/_update/updater.py
@@ -300,7 +300,10 @@ class Updater:
         interpreter_info = self.options.new_python_interpreter or PythonInfo.current_system()
         with self.console.status("Checking latest version..."):
             available_versions = await fetch_available_red_versions(
-                include_prereleases=common.get_current_red_version().is_prerelease
+                include_prereleases=(
+                    self.options.red_version.is_prerelease
+                    or common.get_current_red_version().is_prerelease
+                )
             )
             latest_major = available_versions[0]
 


### PR DESCRIPTION
### Description of the changes

`redbot-update --version 3.6.0rc1` should allow installation of the specified pre-release regardless of what the current version is.

### Have the changes in this PR been tested?

Yes
