### PR TITLE
Allow docs images to be in PRs marked as Docs-only

### DIFF
--- a/.github/workflows/auto_labeler_pr.yml
+++ b/.github/workflows/auto_labeler_pr.yml
@@ -25,3 +25,9 @@ jobs:
         uses: Jackenmen/label-doconly-changes@v1
         env:
           LDC_LABELS: Docs-only
+          LDC_HOOK_UNCONDITIONAL__FILES: |-
+            # default list of unconditionally allowed files
+            *.rst
+            *.md
+            # Red-specific includes
+            docs/.resources/*


### PR DESCRIPTION
### Description of the changes

Default value taken from https://github.com/Jackenmen/label-doconly-changes#unconditional

### Have the changes in this PR been tested?

No