### PR TITLE
Fix label-doconly-changes setting name

### DIFF
--- a/.github/workflows/auto_labeler_pr.yml
+++ b/.github/workflows/auto_labeler_pr.yml
@@ -25,7 +25,7 @@ jobs:
         uses: Jackenmen/label-doconly-changes@v1
         env:
           LDC_LABELS: Docs-only
-          LDC_HOOK_UNCONDITIONAL__FILES: |-
+          LDC_HOOK_UNCONDITIONAL__ALLOWED_FILES: |-
             # default list of unconditionally allowed files
             *.rst
             *.md


### PR DESCRIPTION
### Description of the changes

Turns out that the documentation was wrong and it's actually `allowed_files`, not `files` as I set it in #6769.

### Have the changes in this PR been tested?

No