### PR TITLE
Cleanup *.po files before running `crowdin download`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ gettext:
 upload_translations:
 	crowdin upload sources
 download_translations:
+	# get rid of any files that are no longer on Crowdin
+	find -name '*.po' -delete 
 	crowdin download
 
 # Dependencies


### PR DESCRIPTION
### Description of the changes

Per https://github.com/Cog-Creators/Red-DiscordBot/issues/5812#issuecomment-4504763371, this will automatically clean up stale `*.po` files whenever we update translations.

### Have the changes in this PR been tested?

Yes