### PR TITLE
Update dota2items trivia

### DIFF
--- a/redbot/cogs/trivia/data/lists/dota2items.yaml
+++ b/redbot/cogs/trivia/data/lists/dota2items.yaml
@@ -1,24 +1,11 @@
-AUTHOR: JennJenn
+AUTHOR: JennJenn, Eternalll
 DESCRIPTION: >-
   A trivia about Dota 2 items. In this trivia, identify the item
   from the image sent. Dota 2 is a multiplayer online battle arena video game by Valve.
-What item is this? (removed from game) https://i.imgur.com/hze6GhN.png:
-- Poor Man's Shield
-- PMS
-What item is this? (removed from game) https://i.imgur.com/vXFECRh.png:
-- Iron Talon
 What item is this? https://i.imgur.com/0Li6O8N.png:
 - Refresher Orb
-What item is this? https://i.imgur.com/0nQt3on.png:
-- Flying Courier (Dire)
-- Flying Courier Dire
-What item is this? https://i.imgur.com/11IYBpl.png:
-- Power Treads (Intelligence)
-- Power Treads Intelligence
 What item is this? https://i.imgur.com/1DjDKYH.png:
 - Yasha
-What item is this? https://i.imgur.com/1GWm8o6.png:
-- Necronomicon 3
 What item is this? https://i.imgur.com/1aGrpuH.png:
 - Wraith Band
 What item is this? https://i.imgur.com/1dXNyaw.png:
@@ -43,10 +30,12 @@ What item is this? https://i.imgur.com/430kekp.png:
 - Hand of Midas
 What item is this? https://i.imgur.com/4EIKWON.png:
 - Boots of Travel 2
+- Boots of Travel Level 2
 What item is this? https://i.imgur.com/5dfDXym.png:
 - Aegis of the Immortal
 What item is this? https://i.imgur.com/5eeAXJC.png:
 - Aghanim's Scepter
+- Aghs
 What item is this? https://i.imgur.com/5hZUcQQ.png:
 - Magic Wand
 What item is this? https://i.imgur.com/6Bj6Eiz.png:
@@ -57,15 +46,14 @@ What item is this? https://i.imgur.com/6aJkxtG.png:
 - Mekansm
 What item is this? https://i.imgur.com/6uNaTtD.png:
 - Faerie Fire
-What item is this? https://i.imgur.com/77S9U75.png:
-- Tome of Knowledge
 What item is this? https://i.imgur.com/7MQvg5g.png:
-- Boots of Travel 1
+- Boots of Travel
+- BoTs
 What item is this? https://i.imgur.com/7Sp3W66.png:
 - Eul's Scepter of Divinity
+- Euls
 What item is this? https://i.imgur.com/7SvVqRK.png:
-- Ring of Basilius (Active)
-- Ring of Basilius Active
+- Ring of Basilius
 What item is this? https://i.imgur.com/7eicbbk.png:
 - Meteor Hammer
 What item is this? https://i.imgur.com/8X9936w.png:
@@ -76,17 +64,12 @@ What item is this? https://i.imgur.com/9VtRTBl.png:
 - Crimson Guard
 What item is this? https://i.imgur.com/9eAs1dm.png:
 - Sange and Yasha
-What item is this? https://i.imgur.com/9g6jw0X.png:
-- Dagon 3
 What item is this? https://i.imgur.com/AG7Ii56.png:
 - Helm of the Dominator
 What item is this? https://i.imgur.com/ASNIrpm.png:
 - Demon Edge
 What item is this? https://i.imgur.com/AWxOnXw.png:
 - Solar Crest
-What item is this? https://i.imgur.com/B4AJKcj.png:
-- Bottle (Medium)
-- Bottle Medium
 What item is this? https://i.imgur.com/BqXyEWi.png:
 - Eaglesong
 What item is this? https://i.imgur.com/C6Ch4mV.png:
@@ -99,8 +82,6 @@ What item is this? https://i.imgur.com/CqtxuPE.png:
 - Gloves of Haste
 What item is this? https://i.imgur.com/DEZQLXo.png:
 - Medallion of Courage
-What item is this? https://i.imgur.com/DHILKex.png:
-- Stout Shield
 What item is this? https://i.imgur.com/DHqdudG.png:
 - Mithril Hammer
 What item is this? https://i.imgur.com/DKAS0kV.png:
@@ -115,12 +96,6 @@ What item is this? https://i.imgur.com/EdJKpKH.png:
 - Bloodthorn
 What item is this? https://i.imgur.com/EuIAVjM.png:
 - Vitality Booster
-What item is this? https://i.imgur.com/FBRqnb9.png:
-- Bottle (Arcane)
-- Bottle Arcane
-What item is this? https://i.imgur.com/FGLZkBq.png:
-- Tranquil Boots (Inactive)
-- Tranquil Boots Inactive
 What item is this? https://i.imgur.com/Fk2AqPs.png:
 - Iron Branch
 What item is this? https://i.imgur.com/FlVerQT.png:
@@ -129,34 +104,34 @@ What item is this? https://i.imgur.com/Fmnkr53.png:
 - Claymore
 What item is this? https://i.imgur.com/GsgTiUw.png:
 - Shadow Blade
+- Lothar's Edge
+- Lothar
 What item is this? https://i.imgur.com/GvtjXIF.png:
 - Assault Cuirass
+- Assault Curiass # purposeful typo
 What item is this? https://i.imgur.com/H5nRu05.png:
 - Quelling Blade
 What item is this? https://i.imgur.com/HDu0rAD.png:
 - Bloodstone
-What item is this? https://i.imgur.com/HLr6SQb.png:
-- Diffusal Blade 2
 What item is this? https://i.imgur.com/HgJHyfk.png:
 - Void Stone
 What item is this? https://i.imgur.com/HikbhwT.png:
 - Ethereal Blade
-What item is this? https://i.imgur.com/Hm7z9Xn.png:
-- Bottle (Empty)
-- Bottle Empty
+- Eblade
+- E-Blade
 What item is this? https://i.imgur.com/HrKThmN.png:
 - Orchid Malevolence
 What item is this? https://i.imgur.com/HuUqvIf.png:
 - Scythe of Vyse
+- Sheep stick
+- Sheepstick
 What item is this? https://i.imgur.com/IL1hH1m.png:
 - Crystalys
 What item is this? https://i.imgur.com/JUbevw4.png:
 - Staff of Wizardry
-What item is this? https://i.imgur.com/JYBiGVx.png:
-- Ring of Aquila (Inactive)
-- Ring of Aquila Inactive
 What item is this? https://i.imgur.com/JbKeDUc.png:
 - Urn of Shadows
+- Urn
 What item is this? https://i.imgur.com/JpqHPSA.png:
 - Bracer
 What item is this? https://i.imgur.com/KFBNr2l.png:
@@ -165,12 +140,11 @@ What item is this? https://i.imgur.com/KFNb72Y.png:
 - Reaver
 What item is this? https://i.imgur.com/KL6jON7.png:
 - Mask of Madness
-What item is this? https://i.imgur.com/KLGzvMb.png:
-- Bottle (Small)
-- Bottle Small
+- MoM
 What item is this? https://i.imgur.com/KcW7edy.png:
 - Town Portal Scroll
 - TP Scroll
+- TP
 What item is this? https://i.imgur.com/LSVesWo.png:
 - Guardian Greaves
 What item is this? https://i.imgur.com/LVpcOnf.png:
@@ -189,15 +163,8 @@ What item is this? https://i.imgur.com/MudmQ6R.png:
 - Heart of Tarrasque
 What item is this? https://i.imgur.com/NUeLPgT.png:
 - Dragon Lance
-What item is this? https://i.imgur.com/NbeuShM.png:
-- Flying Courier (Radiant)
-- Flying Courier Radiant
 What item is this? https://i.imgur.com/NhzX71W.png:
 - Octarine Core
-What item is this? https://i.imgur.com/NkYZgr5.png:
-- Tango (Shared)
-- Tango Shared
-- Shared Tango
 What item is this? https://i.imgur.com/Nl1u43a.png:
 - Echo Sabre
 What item is this? https://i.imgur.com/NrEdGsn.png:
@@ -213,9 +180,6 @@ What item is this? https://i.imgur.com/Pote0DA.png:
 - Point Booster
 What item is this? https://i.imgur.com/QNFFGLh.png:
 - Silver Edge
-What item is this? https://i.imgur.com/RGlRQJe.png:
-- Bottle (Invisibility)
-- Bottle Invisibility
 What item is this? https://i.imgur.com/RM3sSIz.png:
 - Kaya
 What item is this? https://i.imgur.com/Re67cR1.png:
@@ -225,65 +189,43 @@ What item is this? https://i.imgur.com/TNrZvq8.png:
 - Shadow Amulet
 What item is this? https://i.imgur.com/TmZVLYT.png:
 - Lotus Orb
-What item is this? https://i.imgur.com/Tqg4c3O.png:
-- Bottle (Illusion)
-- Bottle Illusion
 What item is this? https://i.imgur.com/U9f6T8O.png:
 - Mantle of Intelligence
 What item is this? https://i.imgur.com/UJ52OSo.png:
-- Diffusal Blade 1
+- Diffusal Blade
 What item is this? https://i.imgur.com/UhHdUrz.png:
 - Energy Booster
-What item is this? https://i.imgur.com/V6kBeNh.png:
-- Dagon 2
 What item is this? https://i.imgur.com/VFdPRUD.png:
 - Divine Rapier
 What item is this? https://i.imgur.com/VNmfB2T.png:
 - Shiva's Guard
-What item is this? https://i.imgur.com/VtNBM6g.png:
-- Animal Courier (Radiant)
-- Courier Radiant
-- Animal Courier Radiant
 What item is this? https://i.imgur.com/Vu3eNfk.png:
 - Sentry Ward
 What item is this? https://i.imgur.com/VwXSKr8.png:
 - Wind Lace
+- Windlace
 What item is this? https://i.imgur.com/W2F2SUd.png:
-- Radiance (Active)
-- Radiance Active
+- Radiance
 What item is this? https://i.imgur.com/WaKy1Pj.png:
 - Tango
-What item is this? https://i.imgur.com/WwEfwWi.png:
-- Necronomicon 1
 What item is this? https://i.imgur.com/XGkphzs.png:
 - Observer and Sentry Wards
-What item is this? https://i.imgur.com/XYIEKMi.png:
-- Power Treads (Agility)
-- Power Treads Agility
 What item is this? https://i.imgur.com/YsrEZDL.png:
 - Moon Shard
 What item is this? https://i.imgur.com/ZidkeLE.png:
 - Javelin
 What item is this? https://i.imgur.com/ZjhX5T8.png:
 - Aether Lens
-What item is this? https://i.imgur.com/ZoIjUQF.png:
-- Dagon 4
 What item is this? https://i.imgur.com/aQ4ZSIi.png:
 - Sage's Mask
 What item is this? https://i.imgur.com/atVJCS9.png:
 - Rod of Atos
-What item is this? https://i.imgur.com/bdVdrp3.png:
-- Ring of Aquila (Active)
-- Ring of Aquila Active
 What item is this? https://i.imgur.com/cJ3dEwh.png:
 - Oblivion Staff
 What item is this? https://i.imgur.com/cLS2cZD.png:
 - Vanguard
 What item is this? https://i.imgur.com/cYj1mr0.png:
 - Talisman of Evasion
-What item is this? https://i.imgur.com/cmeeK2C.png:
-- Bottle (Double Damage)
-- Bottle Double Damage
 What item is this? https://i.imgur.com/cpjr5Ez.png:
 - Butterfly
 What item is this? https://i.imgur.com/cznlrpv.png:
@@ -297,8 +239,7 @@ What item is this? https://i.imgur.com/dLhmL5W.png:
 What item is this? https://i.imgur.com/dVDWnth.png:
 - Dust of Appearance
 What item is this? https://i.imgur.com/dvk1MCM.png:
-- Tranquil Boots (Active)
-- Tranquil Boots Active
+- Tranquil Boots
 What item is this? https://i.imgur.com/eOSLFWz.png:
 - Cloak
 What item is this? https://i.imgur.com/f8opJQc.png:
@@ -307,21 +248,15 @@ What item is this? https://i.imgur.com/fcLcZyE.png:
 - Sange
 What item is this? https://i.imgur.com/fhAoSOC.png:
 - Ogre Club
-What item is this? https://i.imgur.com/gjofxoF.png:
-- Necronomicon 2
-What item is this? https://i.imgur.com/h4dZ64X.png:
-- Dagon 1
 What item is this? https://i.imgur.com/h5Gu48S.png:
 - Observer Ward
+- Obs
 What item is this? https://i.imgur.com/hF3mjT1.png:
 - Drum of Endurance
 What item is this? https://i.imgur.com/haXACou.png:
 - Power Treads
 What item is this? https://i.imgur.com/iYzaR71.png:
-- Bottle (Full)
-- Bottle Full
-What item is this? https://i.imgur.com/ibmZmvS.png:
-- Banana
+- Bottle
 What item is this? https://i.imgur.com/jvUNnd1.png:
 - Pipe of Insight
 What item is this? https://i.imgur.com/kC1KzdQ.png:
@@ -330,9 +265,6 @@ What item is this? https://i.imgur.com/kMypuTg.png:
 - Ring of Regen
 What item is this? https://i.imgur.com/kW9IHvM.png:
 - Blink Dagger
-What item is this? https://i.imgur.com/kWErZRY.png:
-- Bottle (Regeneration)
-- Bottle Regeneration
 What item is this? https://i.imgur.com/kiXFzsz.png:
 - Spirit Vessel
 What item is this? https://i.imgur.com/ks3ysLe.png:
@@ -343,62 +275,36 @@ What item is this? https://i.imgur.com/lkyWMvx.png:
 - Ultimate Orb
 What item is this? https://i.imgur.com/lpyKT7r.png:
 - Glimmer Cape
-What item is this? https://i.imgur.com/lzdpgK0.png:
-- Animal Courier (Dire)
-- Courier Dire
-- Animal Courier Dire
 What item is this? https://i.imgur.com/m0U0nlL.png:
 - Platemail
-What item is this? https://i.imgur.com/m2UA7a8.png:
-- Radiance (Inactive)
-- Radiance Inactive
 What item is this? https://i.imgur.com/mGZEMpC.png:
 - Circlet
 What item is this? https://i.imgur.com/my0MEtj.png:
 - Morbid Mask
-What item is this? https://i.imgur.com/nXn8KhO.png:
-- Power Treads (Strength)
-- Power Treads Strength
 What item is this? https://i.imgur.com/oKhuvbG.png:
 - Gauntlets of Strength
 What item is this? https://i.imgur.com/oLgqHaR.png:
 - Linken's Sphere
 What item is this? https://i.imgur.com/oentyyC.png:
 - Null Talisman
-What item is this? https://i.imgur.com/owoQWNV.png:
-- Armlet of Mordiggian (Inactive)
-- Armlet of Mordiggian
 What item is this? https://i.imgur.com/pNmAlAl.png:
 - Skull Basher
 What item is this? https://i.imgur.com/paO69Se.png:
 - Clarity
-What item is this? https://i.imgur.com/qM0dRmS.png:
-- Dagon 5
-What item is this? https://i.imgur.com/rUKqmWD.png:
-- Bottle (Bounty)
-- Bottle Bounty
 What item is this? https://i.imgur.com/rr3OllO.png:
 - Ghost Scepter
 What item is this? https://i.imgur.com/sxkItEZ.png:
 - Gem of True Sight
+- Gem
 What item is this? https://i.imgur.com/u9psKe0.png:
 - Mystic Staff
 What item is this? https://i.imgur.com/uk7Z8tt.png:
 - Blade Mail
 What item is this? https://i.imgur.com/unPnQTi.png:
 - Magic Stick
-What item is this? https://i.imgur.com/unPvR9W.png:
-- Ring of Basilius (Inactive)
-- Ring of Basilius Inactive
 What item is this? https://i.imgur.com/vAEHlcZ.png:
 - Robe of the Magi
-What item is this? https://i.imgur.com/vDCqBu6.png:
-- Hood of Defiance
-What item is this? https://i.imgur.com/vg0KnIq.png:
-- Recipe Scroll
-- Recipe
 What item is this? https://i.imgur.com/vvn8qPb.png:
-- Armlet of Mordiggian (Active)
 - Armlet of Mordiggian
 What item is this? https://i.imgur.com/w6qAscb.png:
 - Healing Salve
@@ -412,6 +318,3 @@ What item is this? https://i.imgur.com/y8uW7V1.png:
 - Vladimir's Offering
 What item is this? https://i.imgur.com/ycsTV7m.png:
 - Enchanted Mango
-What item is this? https://i.imgur.com/z2OZqwa.png:
-- Bottle (Haste)
-- Bottle Haste


### PR DESCRIPTION
### Description of the changes

- Remove items that no longer appear in the game.
- Allow answering using popular abbreviations/alt names and Dota 1 item names.
- Remove questions that deal with the state or "tier" of the item (bottle qty, dagon level, etc.) unless standalone item with unique asset/imagery  (e.g. boots of travel 2).

I would add items, but was advised this would require images to be uploaded and owned by the org. So just a cleanup for now.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->

Tested by renaming file and uploading as a custom trivia list.