### PR TITLE
Update dota2abilities trivia

### DIFF
--- a/redbot/cogs/trivia/data/lists/dota2abilities.yaml
+++ b/redbot/cogs/trivia/data/lists/dota2abilities.yaml
@@ -811,7 +811,7 @@ What ability is this? https://i.imgur.com/yRs0y6A.png:
 # What ability is this? https://i.imgur.com/0000000: # [ULT]
 # - Arena of Blood
 # Medusa
-What innate ability is this? https://i.imgur.com/vjN869j.png: # [INT]
+What innate ability is this? https://i.imgur.com/vjN869j.png: # [IN]
 - Mana Shield
 What ability is this? https://i.imgur.com/K38Heb1.png: # [1]
 - Split Shot
@@ -1726,7 +1726,7 @@ What ability is this? https://i.imgur.com/scUQ1Vx.png: # [3]
 # What ability is this? https://i.imgur.com/0000000: # [ULT]
 # - Reincarnation
 # Zeus
-What innate ability is this? https://i.imgur.com/oElP1im.png: # [INT]
+What innate ability is this? https://i.imgur.com/oElP1im.png: # [IN]
 - Static Field
 What ability is this? https://i.imgur.com/eaEmrUO.png: # [1]
 - Arc Lightning

--- a/redbot/cogs/trivia/data/lists/dota2abilities.yaml
+++ b/redbot/cogs/trivia/data/lists/dota2abilities.yaml
@@ -11,7 +11,7 @@ What ability is this? https://i.imgur.com/RHRZzj6.png: # [2]
 - Aphotic Shield
 What ability is this? https://i.imgur.com/g42pVks.png: # [3]
 - Curse of Avernus
-What ability is this? https://i.imgur.com/g8vFvN6.png: # [4]
+What ability is this? https://i.imgur.com/g8vFvN6.png: # [ULT]
 - Borrowed Time
 # Alchemist
 What innate ability is this? https://i.imgur.com/J97FNqg.png: # [IN]
@@ -24,10 +24,10 @@ What ability is this? https://i.imgur.com/ORiUzGL.png: # [2](Alt)
 - Unstable Concoction Throw
 # What ability is this? https://i.imgur.com/0000000: # [3]
 #- Corrosive Weaponry
-What ability is this? https://i.imgur.com/DJzNANM.png: # [4]
-- Chemical Rage
-# What ability is this? https://i.imgur.com/0000000: # [5]
+# What ability is this? https://i.imgur.com/0000000: # [4]
 #- Berserk Potion
+What ability is this? https://i.imgur.com/DJzNANM.png: # [ULT]
+- Chemical Rage
 # Ancient Apparition
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
 # - Bone Chill
@@ -35,7 +35,7 @@ What ability is this? https://i.imgur.com/PKZ2cTp.png: # [1]
 - Cold Feet
 What ability is this? https://i.imgur.com/7wfVN6a.png: # [2]
 - Ice Vortex
-What ability is this? https://i.imgur.com/5lkslhd.png: # [4]
+What ability is this? https://i.imgur.com/5lkslhd.png: # [ULT]
 - Ice Blast
 # Anti-Mage
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
@@ -48,7 +48,7 @@ What ability is this? https://i.imgur.com/j6tX9kQ.png: # [2]
 - Anti-Mage Blink
 What ability is this? https://i.imgur.com/Dz7G2Ma.png: # [3] - image is a little out of date
 - Counterspell
-What ability is this? https://i.imgur.com/BLCIY3v.png: # [4]
+What ability is this? https://i.imgur.com/BLCIY3v.png: # [ULT]
 - Mana Void
 # Arc Warden
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
@@ -59,7 +59,7 @@ What ability is this? https://i.imgur.com/e9ipnhZ.png: # [2]
 - Magnetic Field
 What ability is this? https://i.imgur.com/syRZuJG.png: # [3]
 - Spark Wraith
-What ability is this? https://i.imgur.com/sbiDRM8.png: # [4]
+What ability is this? https://i.imgur.com/sbiDRM8.png: # [ULT]
 - Tempest Double
 # Axe
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
@@ -70,7 +70,7 @@ What ability is this? https://i.imgur.com/FZML9xq.png: # [2]
 - Battle Hunger
 What ability is this? https://i.imgur.com/acHDcF3.png: # [3]
 - Counter Helix
-What ability is this? https://i.imgur.com/QPkeKvK.png: # [4]
+What ability is this? https://i.imgur.com/QPkeKvK.png: # [ULT]
 - Culling Blade
 # Bane
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
@@ -83,7 +83,7 @@ What ability is this? https://i.imgur.com/ostwLWM.png: # [3]
 - Nightmare
 What ability is this? https://i.imgur.com/4U35Jam.png: # [3](Alt)
 - Nightmare End
-What ability is this? https://i.imgur.com/5mUEdUT.png: # [4]
+What ability is this? https://i.imgur.com/5mUEdUT.png: # [ULT]
 - Fiend's Grip
 # Batrider
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
@@ -94,7 +94,7 @@ What ability is this? https://i.imgur.com/ea88e97.png: # [2]
 - Flamebreak
 What ability is this? https://i.imgur.com/c6WTDXX.png: # [3]
 - Firefly
-What ability is this? https://i.imgur.com/5VYGT2S.png: # [4]
+What ability is this? https://i.imgur.com/5VYGT2S.png: # [ULT]
 - Flaming Lasso
 # Beastmaster
 What innate ability is this? https://i.imgur.com/4AoRrcX.png:
@@ -105,85 +105,577 @@ What ability is this? https://i.imgur.com/3BaLwBw.png: # [2]
 - Summon Razorback
 What ability is this? https://i.imgur.com/GaGZzRK.png: # [3]
 - Summon Raptors
-What ability is this? https://i.imgur.com/Lh00eYb.png: # [4]
-- Primal Roar
-# What ability is this? https://i.imgur.com/0000000: # [5]
+# What ability is this? https://i.imgur.com/0000000: # [4]
 # - Drums of Slom
+What ability is this? https://i.imgur.com/Lh00eYb.png: # [ULT]
+- Primal Roar
 # Bloodseeker
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Sanguivore
+What ability is this? https://i.imgur.com/DIto2eL.png: # [1]
+- Bloodrage
+What ability is this? https://i.imgur.com/XzPyTGf.png: # [2]
+- Blood Rite
+What ability is this? https://i.imgur.com/TjIASfx.png: # [3]
+- Thirst
+What ability is this? https://i.imgur.com/b5IrqkC.png: # [ULT]
+- Rupture
 # Bounty Hunter
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Big Game Hunter
+What ability is this? https://i.imgur.com/jMwUoNI.png: # [1]
+- Shuriken Toss
+What ability is this? https://i.imgur.com/8c1qrax.png: # [2]
+- Jinada
+What ability is this? https://i.imgur.com/eAwNPER.png: # [3]
+- Shadow Walk
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Friendly Shadow
+What ability is this? https://i.imgur.com/GST8fid.png: # [ULT]
+- Track
 # Brewmaster
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Liquid Courage
+What ability is this? https://i.imgur.com/Xwolrjn.png: # [1]
+- Thunder Clap
 What ability is this? https://i.imgur.com/70eq5fC.png: # [2]
 - Cinder Brew
+What ability is this? https://i.imgur.com/SwcSLVf.png: # [3]
+- Drunken Brawler
+What ability is this? https://i.imgur.com/E96ZJl3.png:
+- Primal Split
 # Bristleback
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Prickly
 What ability is this? https://i.imgur.com/0YpdsNT.png: # [1]
 - Viscous Nasal Goo
+What ability is this? https://i.imgur.com/XPmJF9W.png: # [2]
+- Quill Spray
 What ability is this? https://i.imgur.com/1LmjfoY.png: # [3]
 - Bristleback
-What ability is this? https://i.imgur.com/2T8w9q2.png: # [4]
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Hairball
+What ability is this? https://i.imgur.com/2T8w9q2.png: # [ULT]
 - Warpath
 # Broodmother
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Spider's Milk
+What ability is this? https://i.imgur.com/xN1TWZh.png: # [1]
+- Insatiable Hunger
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Spin Web
+What ability is this? https://i.imgur.com/PNH7ytm.png: # [3]
+- Incapacitating Bite
+What ability is this? https://i.imgur.com/G3yMjte.png: # [4]
+- Spinner's Snare
+What ability is this? https://i.imgur.com/B7bhmxH.png: # [ULT]
+- Spawn Spiderlings
 # Centaur Warrunner
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Horsepower
+What ability is this? https://i.imgur.com/rVxgLdC.png: # [1]
+- Hoof Stomp
+What ability is this? https://i.imgur.com/A4AbG8P.png: # [2]
+- Double Edge
+What ability is this? https://i.imgur.com/xeBkssG.png: # [3]
+- Retaliate
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Work Horse
+What ability is this? https://i.imgur.com/i1JiCuX.png: # [ULT]
+- Stampede
 # Chaos Knight
-What ability is this? https://i.imgur.com/0A8C7wM.png: # [1]
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Fundamental Forging
+What ability is this? https://i.imgur.com/VEY99cQ.png: # [1]
+- Chaos Bolt
+What ability is this? https://i.imgur.com/nlhSakJ.png: # [2]
+- Reality Rift
+What ability is this? https://i.imgur.com/0A8C7wM.png: # [3]
 - Chaos Strike
+What ability is this? https://i.imgur.com/wE3EDdL.png: # [4]
+- Phantasm
 # Chen
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Zealot
+What ability is this? https://i.imgur.com/Kz1H0SU.png: # [1]
+- Penitence
+What ability is this? https://i.imgur.com/TreGmRD.png: # [2]
+- Holy Persuasion
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Divine Favor
+What ability is this? https://i.imgur.com/gfXcapt.png: # [ULT]
+- Hand of God
 # Clinkz
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Infernal Shred
+What ability is this? https://i.imgur.com/Q5IWZ8w.png: # [1]
+- Strafe
+What ability is this? https://i.imgur.com/FhPo2Dv.png: # [2]
+- Searing Arrows
+What ability is this? https://i.imgur.com/o2qAqkE.png: # [3]
+- Death Pact
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Burning Army
+# What ability is this? https://i.imgur.com/0000000: # [5]
+# - Burning Barrage
+What ability is this? https://i.imgur.com/DcA2Vez.png: # [ULT]
+- Skeleton Walk
 # Clockwork
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Armor Power
+What ability is this? https://i.imgur.com/yqbbjpH.png: # [1]
+- Battery Assault
+What ability is this? https://i.imgur.com/BMod0Q4.png: # [2]
+- Power Cogs
+What ability is this? https://i.imgur.com/kOlC0Gh.png: # [3]
+- Rocket Flare
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Overclocking
+# What ability is this? https://i.imgur.com/0000000: # [5]
+# - Jetpack
+What ability is this? https://i.imgur.com/mIV1Ekb.png: # [ULT]
+- Hookshot
 # Crystal Maiden
-What ability is this? https://i.imgur.com/17LrPpY.png: # [4]
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Glacial Guard
+What ability is this? https://i.imgur.com/e8NkVgl.png: # [1]
+- Crystal Nova
+What ability is this? https://i.imgur.com/QpZ8h6A.png: # [2]
+- Frostbite
+What ability is this? https://i.imgur.com/EwdOxlc.png: # [3]
+- Arcane Aura
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Crystal Clone
+What ability is this? https://i.imgur.com/17LrPpY.png: # [ULT]
 - Freezing Field
 # Dark Seer
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Quick Wit
+What ability is this? https://i.imgur.com/UqFDO1o.png: # [1]
+- Vacuum
+What ability is this? https://i.imgur.com/mjKcsMe.png: # [2]
+- Ion Shell
+What ability is this? https://i.imgur.com/SPqUual.png: # [3]
+- Surge
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Normal Punch
+What ability is this? https://i.imgur.com/dwI4ZYX.png: # [ULT]
+- Wall of Replica
 # Dark Willow
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Pixie Dust
+What ability is this? https://i.imgur.com/IlLBqSY.png: # [1]
+- Bramble Maze
+What ability is this? https://i.imgur.com/clAB5hr.png: # [2]
+- Shadow Realm
+What ability is this? https://i.imgur.com/bvSHdHA.png: # [3]
+- Cursed Crown
+What ability is this? https://i.imgur.com/KcsKin0.png: # [4]
+- Bedlam
+What ability is this? https://i.imgur.com/ai8I1Lr.png: # [5]
+- Terrorize
 # Dawnbreaker
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Break of Dawn
+# What ability is this? https://i.imgur.com/0000000: # [1]
+# - Starbreaker
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Celestial Hammer
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Luminosity
+# What ability is this? https://i.imgur.com/0000000: # [ULT]
+# - Solar Guardian
 # Dazzle
+What innate ability is this? https://i.imgur.com/TYIYW4D.png: # [IN]
+- Weave
+What ability is this? https://i.imgur.com/MrZR4Fk.png: # [1]
+- Poison Touch
+What ability is this? https://i.imgur.com/XcI5kLq.png: # [2]
+- Shallow Grave
+What ability is this? https://i.imgur.com/cjnqKID.png: # [3]
+- Shadow Wave
+# What ability is this? https://i.imgur.com/0000000: # [ULT]
+# - Nothl Projection
 # Death Prophet
-What ability is this? https://i.imgur.com/4m1JoUa.png: # [4]
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Witchcraft
+What ability is this? https://i.imgur.com/PtOHt8w.png: # [1]
+- Crypt Swarm
+What ability is this? https://i.imgur.com/tI1UsiQ.png: # [2]
+- Silence
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Spirit Siphon
+What ability is this? https://i.imgur.com/4m1JoUa.png: # [ULT]
 - Exorcism
 # Disruptor
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Electromagnetic Repulsion
 What ability is this? https://i.imgur.com/2MbrJ06.png: # [1]
 - Thunder Strike
+What ability is this? https://i.imgur.com/fPFw0GN.png: # [2]
+- Glimpse
 What ability is this? https://i.imgur.com/83gBZsI.png: # [3]
 - Kinetic Field
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Kinetic Fence
+What ability is this? https://i.imgur.com/jSljBqy.png: # [ULT]
+- Static Storm
 # Doom
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Lvl ? Pain
+What ability is this? https://i.imgur.com/nWUFTHd.png: # [1]
+- Devour
 What ability is this? https://i.imgur.com/6TDMoI5.png: # [2]
 - Scorched Earth
+What ability is this? https://i.imgur.com/BYqGIYR.png: # [3]
+- Infernal Blade
+What ability is this? https://i.imgur.com/YcRnO2n.png: # [4]
+- Doom
 # Dragon Knight
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Dragon Blood
+What ability is this? https://i.imgur.com/GAsnKv8.png: # [1]
+- Breathe Fire
+What ability is this? https://i.imgur.com/g95764l.png: # [2]
+- Dragon Tail
+What ability is this? https://i.imgur.com/kauXrGn.png: # [3]
+- Wyrm's Wrath
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Fireball
+What ability is this? https://i.imgur.com/Of6sQ1j.png: # [ULT]
+- Elder Dragon Form
 # Drow Ranger
+What innate ability is this? https://i.imgur.com/TmqS4Mw.png: # [IN]
+- Precision Aura
+What ability is this? https://i.imgur.com/dNUPxAC.png: # [1]
+- Frost Arrows
+What ability is this? https://i.imgur.com/N2Lg1Rx.png: # [2]
+- Gust
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Multishot
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Glacier
+What ability is this? https://i.imgur.com/YXdi6ph.png: # [ULT]
+- Marksmanship
 # Earth Spirit
+What innate ability is this? https://i.imgur.com/8z2ZykJ.png: # [IN]
+- Stone Remnant
 What ability is this? https://i.imgur.com/2SsNPbU.png: # [1]
 - Boulder Smash
+What ability is this? https://i.imgur.com/MuP6YSf.png: # [2]
+- Rolling Boulder
+What ability is this? https://i.imgur.com/PKn9vBX.png: # [3]
+- Geomagnetic Grip
+What ability is this? https://i.imgur.com/K4WMuoN.png: # [4]
+- Enchant Remnant
+What ability is this? https://i.imgur.com/h7sHNto.png: # [ULT]
+- Magnetize
 # Earthshaker
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Slugger
+What ability is this? https://i.imgur.com/UaS2DTP.png: # [1]
+- Fissure
+What ability is this? https://i.imgur.com/I2NvxE1.png: # [2]
+- Enchant Totem
+What ability is this? https://i.imgur.com/KAxGqvz.png: # [3]
+- Aftershock
+What ability is this? https://i.imgur.com/rJjuneV.png: # [4]
+- Echo Slam
 # Elder Titan
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Momentum
+What ability is this? https://i.imgur.com/hqA5et0.png: # [1]
+- Echo Stomp
+What ability is this? https://i.imgur.com/b7etRIZ.png: # [2]
+- Astral Spirit
+What ability is this? https://i.imgur.com/4dvJS0l.png: # [2](Alt)
+- Return Astral Spirit
+What ability is this? https://i.imgur.com/PTEQsbS.png: # [3]
+- Natural Order
+What ability is this? https://i.imgur.com/aMyPP53.png: # [ULT]
+- Earth Splitter
 # Ember Spirit
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Immolation
+What ability is this? https://i.imgur.com/WkXOAqL.png: # [1]
+- Searing Chains
+What ability is this? https://i.imgur.com/kkcrkoo.png: # [2]
+- Sleight of Fist
+What ability is this? https://i.imgur.com/Thg1NJH.png: # [3]
+- Flame Guard
+What ability is this? https://i.imgur.com/TAqbyTQ.png: # [4]
+- Activate Fire Remnant
+What ability is this? https://i.imgur.com/ctHMsSI.png: # [ULT]
+- Fire Remnant
 # Enchantress
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Rabble Rouser
+What ability is this? https://i.imgur.com/uMDJlnC.png: # [1]
+- Impetus
+What ability is this? https://i.imgur.com/IAa1bDZ.png: # [2]
+- Enchant
+What ability is this? https://i.imgur.com/MUv3Y5M.png: # [3]
+- Nature's Attendants
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Sproink
+# What ability is this? https://i.imgur.com/0000000: # [5]
+# - Little Friends
+What ability is this? https://i.imgur.com/E80vySv.png: # [ULT]
+- Untouchable
 # Enigma
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Event Horizon
 What ability is this? https://i.imgur.com/1eyhHyf.png: # [1]
 - Malefice
+What ability is this? https://i.imgur.com/tIqUdL0.png: # [2]
+- Demonic Summoning
+What ability is this? https://i.imgur.com/z2bBrD5.png: # [3]
+- Midnight Pulse
+What ability is this? https://i.imgur.com/YXTVCNd.png: # [ULT]
+- Black Hole
 # Faceless Void
-What ability is this? https://i.imgur.com/5oS4p6Z.png: # [4]
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Distortion Field
+What ability is this? https://i.imgur.com/xNqYfoK.png: # [1]
+- Time Walk
+What ability is this? https://i.imgur.com/gG7OwWD.png: # [2]
+- Time Dilation
+What ability is this? https://i.imgur.com/JVJs8VI.png: # [3]
+- Time Lock
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Reverse Time Walk
+What ability is this? https://i.imgur.com/5oS4p6Z.png: # [ULT]
 - Chronosphere
 # Grimstroke
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Ink Trail
+# What ability is this? https://i.imgur.com/0000000: # [1]
+# - Stroke of Fate
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Phantom's Embrace
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Ink Swell
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Dark Portrait
+# What ability is this? https://i.imgur.com/0000000: # [ULT]
+# - Soulbind
 # Gyrocopter
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Afterburner
+What ability is this? https://i.imgur.com/mPqYOHu.png: # [1]
+- Rocket Barrage
+What ability is this? https://i.imgur.com/Eb7OAcF.png: # [2]
+- Homing Missile
+What ability is this? https://i.imgur.com/jIKqZdq.png: # [3]
+- Flak Cannon
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Side Gunner
+What ability is this? https://i.imgur.com/nLpMXtX.png:
+- Call Down
 # Hoodwink
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Mistwoods Wayfarer
+# What ability is this? https://i.imgur.com/0000000: # [1]
+# - Acorn Shot
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Bushwhack
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Scurry
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Decoy
+# What ability is this? https://i.imgur.com/0000000: # [5]
+# - Hunter's Boomerang
+# What ability is this? https://i.imgur.com/0000000: # [ULT]
+# - Sharpshooter
 # Huskar
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Blood Magic
+# What ability is this? https://i.imgur.com/0000000: # [1]
+# - Inner Fire
+What ability is this? https://i.imgur.com/q4z8X5Z.png: # [2]
+- Burning Spear
+What ability is this? https://i.imgur.com/najZXYr.png: # [3]
+- Berserker's Blood
+What ability is this? https://i.imgur.com/kEjJIc9.png: # [4]
+- Life Break
 # Invoker
+What ability is this? https://i.imgur.com/QdDe9x2.png: # [1]
+- Quas
+What ability is this? https://i.imgur.com/CvmYu60.png: # [2]
+- Wex
+What ability is this? https://i.imgur.com/RcPV68i.png: # [3]
+- Exort
 What ability is this? https://i.imgur.com/0OBAWeC.png:
 - Forge Spirit
+What ability is this? https://i.imgur.com/3KNjwWX.png:
+- Ice Wall
+What ability is this? https://i.imgur.com/PB7Myh9.png:
+- Tornado
+What ability is this? https://i.imgur.com/v3J9FU6.png:
+- Sun Strike
+What ability is this? https://i.imgur.com/MRarlQa.png:
+- Ghost Walk
+What ability is this? https://i.imgur.com/coR1Ijo.png:
+- Cold Snap
+What ability is this? https://i.imgur.com/niWP4HN.png:
+- Alacrity
+What ability is this? https://i.imgur.com/WWaTmPl.png:
+- Chaos Meteor
+What ability is this? https://i.imgur.com/fp5mx0z.png:
+- Deafening Blast
+What ability is this? https://i.imgur.com/sJn6T9V.png:
+- EMP
+- E.M.P.
+What ability is this? https://i.imgur.com/aNzmXok.png: # [4]
+- Invoke
 # Io (Guardian Wisp)
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Equilibrium
+What ability is this? https://i.imgur.com/FzAhlnW.png: # [1]
+- Tether
+What ability is this? https://i.imgur.com/FQG66ec.png: # [1](Alt)
+- Break Tether
+What ability is this? https://i.imgur.com/nYiXreU.png: # [2]
+- Spirits
+What ability is this? https://i.imgur.com/QZAYWnX.png: # [3]
+- Overcharge
+What ability is this? https://i.imgur.com/bggFesK.png: # [4]
+- Spirits In
+What ability is this? https://i.imgur.com/PKCajV2.png: # [5]
+- Spirits Out
+What ability is this? https://i.imgur.com/4eYikmd.png:
+- Relocate
 # Jakiro
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Double Trouble
+What ability is this? https://i.imgur.com/Gl5CSub.png: # [1]
+- Dual Breath
+What ability is this? https://i.imgur.com/Of1XI1S.png: # [2]
+- Ice Path
+What ability is this? https://i.imgur.com/KMIx6dZ.png: # [3]
+- Liquid Fire
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Liquid Frost
+What ability is this? https://i.imgur.com/N479xl0.png: # [ULT]
+- Macropyre
 # Juggernaut
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Bladeform
 What ability is this? https://i.imgur.com/7Oh7bjv.png: # [1]
 - Blade Fury
+What ability is this? https://i.imgur.com/PtqRyJI.png: # [2]
+- Healing Ward
+What ability is this? https://i.imgur.com/4Mmu9H3.png: # [3]
+- Blade Dance
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Swiftslash
+What ability is this? https://i.imgur.com/uANCZtn.png: # [ULT]
+- Omnislash
 # Keeper of the Light
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Bright Speed
+What ability is this? https://i.imgur.com/Ydf1cL2.png: # [1]
+- Illuminate
+What ability is this? https://i.imgur.com/yUqvGUh.png: # [1](Alt)
+- Release Illuminate
+What ability is this? https://i.imgur.com/Md4o99D.png: # [1](Alt)
+- Illuminate Spirit Form
 What ability is this? https://i.imgur.com/0MYQSVF.png: # [2]
 - Blinding Light
+What ability is this? https://i.imgur.com/CBFlvIh.png: # [3]
+- Chakra Magic
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Solar Bind
+# What ability is this? https://i.imgur.com/0000000: # [5]
+# - Will-O-Wisp
+What ability is this? https://i.imgur.com/k1Qa44g.png: # [ULT]
+- Spirit Form
 # Kez
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Switch Discipline
+# What ability is this? https://i.imgur.com/0000000: # [1]
+# - Echo Slash
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Grappling Claw
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Kazurai Katana
+# What ability is this? https://i.imgur.com/0000000: # [ULT]
+# - Raptor Dance
+# What ability is this? https://i.imgur.com/0000000: # [1]
+# - Falcon Rush
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Talon Toss
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Shodo Sai
+# What ability is this? https://i.imgur.com/0000000: # [ULT]
+# - Raven's Veil
 # Kunkka
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Admiral's Rum
+What ability is this? https://i.imgur.com/hGaz2o5.png: # [1]
+- Torrent
+What ability is this? https://i.imgur.com/De4lTvg.png: # [2]
+- Tidebringer
+What ability is this? https://i.imgur.com/PdTLkou.png: # [3]
+- X Marks the Spot
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Tidal Wave
+What ability is this? https://i.imgur.com/bFGzR0w.png: # [ULT]
+- Ghostship
 # Largo
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Encore
+# What ability is this? https://i.imgur.com/0000000: # [1]
+# - Catchy Lick
+# What ability is this? https://i.imgur.com/0000000: # [1](Alt)
+# - Bullbelly Blitz
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Frogstomp
+# What ability is this? https://i.imgur.com/0000000: # [2](Alt)
+# - Hotfeet Hustle
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Croak of Genius
+# What ability is this? https://i.imgur.com/0000000: # [3](Alt)
+# - Island Elixir
+# What ability is this? https://i.imgur.com/0000000: # [ULT]
+# - Amphibian Rhapsody
 # Legion Commander
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Outfight Them!
+# - Outfight Them
+What ability is this? https://i.imgur.com/PLtRXis.png: # [1]
+- Overwhelming Odds
+What ability is this? https://i.imgur.com/bdTjwio.png: # [2]
+- Press the Attack
+What ability is this? https://i.imgur.com/FfRtCL3.png: # [3]
+- Moment of Courage
+What ability is this? https://i.imgur.com/nntd958.png: # [ULT]
+- Duel
 # Leshrac
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Defilement
+What ability is this? https://i.imgur.com/xxGhGa6.png: # [1]
+- Split Earth
+What ability is this? https://i.imgur.com/yv5tV1m.png: # [2]
+- Diabolic Edict
+What ability is this? https://i.imgur.com/jWSjV8d.png: # [3]
+- Lightning Storm
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Nihilism
+What ability is this? https://i.imgur.com/gLmeW4r.png: # [ULT]
+- Pulse Nova
 # Lich
-What ability is this? https://i.imgur.com/1HgJ1bn.png: # [4]
+What innate ability is this? https://i.imgur.com/rxOnMrk.png: # [IN]
+- Sacrifice
+What ability is this? https://i.imgur.com/CCGIDJA.png: # [1]
+- Frost Blast
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Frost Shield
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Sinister Gaze
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Ice Spire
+What ability is this? https://i.imgur.com/1HgJ1bn.png: # [ULT]
 - Chain Frost
 # Lifestealer
 What ability is this? https://i.imgur.com/0IQn6ug.png: # [1]
@@ -198,7 +690,7 @@ What ability is this? https://i.imgur.com/70nnwxH.png: # [3]
 What ability is this? https://i.imgur.com/32Nw3yf.png: # [3]
 - Savage Roar
 # Luna
-What ability is this? https://i.imgur.com/9pCeilj.png: # [4]
+What ability is this? https://i.imgur.com/9pCeilj.png: # [ULT]
 - Eclipse
 # Lycan
 What ability is this? https://i.imgur.com/261lk7J.png: # Ability 4 
@@ -212,7 +704,7 @@ What ability is this? https://i.imgur.com/2DPvUVw.png: # [2]
 # Meepo
 What ability is this? https://i.imgur.com/2aGSLwK.png: # [2]
 - Poof
-What ability is this? https://i.imgur.com/6aKdh41.png: # [4]
+What ability is this? https://i.imgur.com/6aKdh41.png: # [ULT]
 - Divided We Stand
 # Mirana
 # Monkey King
@@ -270,7 +762,7 @@ What ability is this? https://i.imgur.com/0bX5emr.png: # [3]
 # Rubick
 What ability is this? https://i.imgur.com/73c0X8u.png: # [1] (Alt)
 - Telekinesis Land
-What ability is this? https://i.imgur.com/6FMgz5M.png: # [4]
+What ability is this? https://i.imgur.com/6FMgz5M.png: # [ULT]
 - Spell Steal
 # Sand King
 What ability is this? https://i.imgur.com/4m16Vjf.png: # [1]
@@ -306,16 +798,16 @@ What ability is this? https://i.imgur.com/2lOdxvB.png: # [3]
 What innate ability is this? https://i.imgur.com/bggKiqU.png: # [IN]
 - Insurmountable
 # Treant Protector
-What ability is this? https://i.imgur.com/8BbsIDw.png: # [4]
+What ability is this? https://i.imgur.com/8BbsIDw.png: # [ULT]
 - Overgrowth
 # Troll Warlord
 # Tusk
 # Underlord
 # Undying
-What ability is this? https://i.imgur.com/374iVtN.png: # [4]
+What ability is this? https://i.imgur.com/374iVtN.png: # [ULT]
 - Flesh Golem
 # Ursa
-What ability is this? https://i.imgur.com/8VQoMYP.png: # [4]
+What ability is this? https://i.imgur.com/8VQoMYP.png: # [ULT]
 - Enrage
 # Vengeful Spirit
 # Venomancer
@@ -325,7 +817,7 @@ What ability is this? https://i.imgur.com/8VQoMYP.png: # [4]
 # Warlock
 # Weaver
 # Windranger
-What ability is this? https://i.imgur.com/2jZ4Uf1.png: # [4]
+What ability is this? https://i.imgur.com/2jZ4Uf1.png: # [ULT]
 - Focus Fire
 # Winter Wyvern
 What ability is this? https://i.imgur.com/0yVFHjI.png: # [2]
@@ -341,22 +833,12 @@ What ability is this? https://i.imgur.com/66IUX1V.png: # [2]
 What ability is this? https://i.imgur.com/1gH6M4C.png:
 - Minefield Sign
 
-
-
-What ability is this? https://i.imgur.com/3KNjwWX.png:
-- Ice Wall
-What ability is this? https://i.imgur.com/3btLBuJ.png:
-- X Marks The Spot
-
 What ability is this? https://i.imgur.com/4HDygyR.png:
 - Fervor
-What ability is this? https://i.imgur.com/4Mmu9H3.png:
-- Blade Dance
 
-What ability is this? https://i.imgur.com/4dvJS0l.png:
-- Return Astral Spirit
-What ability is this? https://i.imgur.com/4eYikmd.png:
-- Relocate
+
+
+
 What ability is this? https://i.imgur.com/4iLwPJz.png:
 - Chilling Touch
 What ability is this? https://i.imgur.com/4u98BUr.png:
@@ -370,12 +852,6 @@ What ability is this? https://i.imgur.com/5mYgGEw.png:
 
 
 
-#What ability is this? https://i.imgur.com/63fjMat.png: replaced with divine favor
-#- Test of Faith
-
-
-What ability is this? https://i.imgur.com/8c1qrax.png:
-- Jinada
 What ability is this? https://i.imgur.com/8dmL0Pl.png:
 - Blast off!
 - Blast off
@@ -385,13 +861,9 @@ What ability is this? https://i.imgur.com/8lfQ4e4.png:
 - Toggle Movement
 What ability is this? https://i.imgur.com/8rgi5BB.png:
 - Ignite
-What ability is this? https://i.imgur.com/8z2ZykJ.png:
-- Stone Remnant
+
 What ability is this? https://i.imgur.com/9QvvTjl.png:
 - Empower
-
-What ability is this? https://i.imgur.com/A4AbG8P.png:
-- Double Edge
 What ability is this? https://i.imgur.com/A7WrsBa.png:
 - Dream Coil
 What ability is this? https://i.imgur.com/AfySnUQ.png:
@@ -401,8 +873,7 @@ What ability is this? https://i.imgur.com/AmuABVC.png:
 
 What ability is this? https://i.imgur.com/AvqgsGb.png:
 - Fire Spirits
-What ability is this? https://i.imgur.com/B7bhmxH.png:
-- Spawn Spiderlings
+
 What ability is this? https://i.imgur.com/BHTULeO.png:
 - Summon Familiars
 What ability is this? https://i.imgur.com/BI7aszU.png:
@@ -410,21 +881,17 @@ What ability is this? https://i.imgur.com/BI7aszU.png:
 What ability is this? https://i.imgur.com/BJRUHS9.png:
 - Shadow Strike
 
-What ability is this? https://i.imgur.com/BMod0Q4.png:
-- Power Cogs
+
 
 What ability is this? https://i.imgur.com/BVme5AJ.png:
 - Cold Embrace
-What ability is this? https://i.imgur.com/BYqGIYR.png:
-- Infernal Blade
+
 What ability is this? https://i.imgur.com/Bq9M2l0.png:
 - Corrosive Skin
 What ability is this? https://i.imgur.com/C738s6Y.png:
 - Moonlight Shadow
-What ability is this? https://i.imgur.com/CBFlvIh.png:
-- Chakra Magic
-What ability is this? https://i.imgur.com/CCGIDJA.png:
-- Frost Blast
+
+
 What ability is this? https://i.imgur.com/CD69R7d.png:
 - Burrow
 What innate ability is this? https://i.imgur.com/CNmLmD7.png:
@@ -448,65 +915,48 @@ What ability is this? https://i.imgur.com/Cp1QCfC.png:
 - Timber Chain
 What ability is this? https://i.imgur.com/CqPbsOx.png:
 - Dispersion
-What ability is this? https://i.imgur.com/CvmYu60.png:
-- Wex
 What ability is this? https://i.imgur.com/D2Dw9AZ.png:
 - Blur
-What ability is this? https://i.imgur.com/DIto2eL.png:
-- Bloodrage
 
-What ability is this? https://i.imgur.com/DcA2Vez.png:
-- Skeleton Walk
-What ability is this? https://i.imgur.com/De4lTvg.png:
-- Tidebringer
+
+
+
 What ability is this? https://i.imgur.com/Du6xnAD.png:
 - Ethereal Jaunt
 
 What ability is this? https://i.imgur.com/E5xrzuV.png:
 - Winter's Curse
-What ability is this? https://i.imgur.com/E80vySv.png:
-- Untouchable
-What ability is this? https://i.imgur.com/E96ZJl3.png:
-- Primal Split
+
+
 What ability is this? https://i.imgur.com/EMV0rgv.png:
 - Invisibility (Lycan Wolf)
 - Invisibility
 - Lycan Wolf Invisibility
-What ability is this? https://i.imgur.com/Eb7OAcF.png:
-- Homing Missile
+
 What ability is this? https://i.imgur.com/ErBuVzh.png:
 - Primal Spring or Spring Early
 - Spring Early
 - Primal Spring
 What ability is this? https://i.imgur.com/EvFFPLW.png:
 - Ravage
-What ability is this? https://i.imgur.com/EwdOxlc.png:
-- Arcane Aura
+
 What ability is this? https://i.imgur.com/FCISu8S.png:
 - Smoke Screen
-What ability is this? https://i.imgur.com/FQG66ec.png:
-- Break Tether
+
 What ability is this? https://i.imgur.com/FZEYYYQ.png:
 - Adaptive Strike
 
 What innate ability is this? https://i.imgur.com/FcRJMtq.png:
 - Degen Aura
-What ability is this? https://i.imgur.com/FfRtCL3.png:
-- Moment of Courage
-What ability is this? https://i.imgur.com/FhPo2Dv.png:
-- Searing Arrows
-What ability is this? https://i.imgur.com/FzAhlnW.png:
-- Tether
-What ability is this? https://i.imgur.com/G3yMjte.png:
-- Spinner's Snare
-What ability is this? https://i.imgur.com/GAsnKv8.png:
-- Breathe Fire
+
+
+
+
+
 What ability is this? https://i.imgur.com/GPDCOGw.png:
 - Astral Imprisonment
-What ability is this? https://i.imgur.com/GST8fid.png:
-- Track
-What ability is this? https://i.imgur.com/Gl5CSub.png:
-- Dual Breath
+
+
 What ability is this? https://i.imgur.com/Gtu2ZHW.png:
 - Ensnare
 What ability is this? https://i.imgur.com/GwUQMwn.png:
@@ -523,10 +973,6 @@ What ability is this? https://i.imgur.com/HJUyVQ2.png:
 - Unrefined Fireblast
 What ability is this? https://i.imgur.com/Hjrd8PX.png:
 - Nature's Call
-What ability is this? https://i.imgur.com/I2NvxE1.png:
-- Enchant Totem
-What ability is this? https://i.imgur.com/IAa1bDZ.png:
-- Enchant
 What ability is this? https://i.imgur.com/IGGcNmg.png:
 - Leech Seed
 What ability is this? https://i.imgur.com/IMfMkKO.png:
@@ -537,8 +983,7 @@ What ability is this? https://i.imgur.com/IYziArw.png:
 - Sand Storm
 What ability is this? https://i.imgur.com/Ihhvhdx.png:
 - Pit of Malice
-What ability is this? https://i.imgur.com/IlLBqSY.png:
-- Bramble Maze
+
 What ability is this? https://i.imgur.com/Iu2brGN.png:
 - Avalanche
 What ability is this? https://i.imgur.com/J8iyl8n.png:
@@ -546,8 +991,7 @@ What ability is this? https://i.imgur.com/J8iyl8n.png:
 
 What ability is this? https://i.imgur.com/JJLAsfU.png:
 - Powershot
-What ability is this? https://i.imgur.com/JVJs8VI.png:
-- Time Lock
+
 What ability is this? https://i.imgur.com/JjFlCOL.png:
 - Chaotic Offering
 What ability is this? https://i.imgur.com/JvHLhJm.png:
@@ -558,24 +1002,14 @@ What ability is this? https://i.imgur.com/K3WXdiC.png:
 - God's Strength
 What ability is this? https://i.imgur.com/K3byHPk.png:
 - Rot
-What ability is this? https://i.imgur.com/K4WMuoN.png:
-- Enchant Remnant
-What ability is this? https://i.imgur.com/KAxGqvz.png:
-- Aftershock
-What ability is this? https://i.imgur.com/KMIx6dZ.png:
-- Liquid Fire
 What ability is this? https://i.imgur.com/KaFcFdb.png:
 - Grow
 What ability is this? https://i.imgur.com/KccdX1Q.png:
 - Nether Swap
-What ability is this? https://i.imgur.com/KcsKin0.png:
-- Bedlam
 What ability is this? https://i.imgur.com/KfQBVXv.png:
 - Guardian Angel
 What ability is this? https://i.imgur.com/KiTaZOv.png:
 - Psi Blades
-What ability is this? https://i.imgur.com/Kz1H0SU.png:
-- Penitence
 What ability is this? https://i.imgur.com/L4ILPLN.png:
 - Tree Grab
 What ability is this? https://i.imgur.com/L5DWehd.png:
@@ -589,28 +1023,15 @@ What ability is this? https://i.imgur.com/LVueVCR.png:
 
 What ability is this? https://i.imgur.com/LiPZwBR.png:
 - Atrophy Aura
-What ability is this? https://i.imgur.com/MRarlQa.png:
-- Ghost Walk
-What ability is this? https://i.imgur.com/MUv3Y5M.png:
-- Nature's Attendants
 What ability is this? https://i.imgur.com/MYC5guQ.png:
 - Shadow Dance
-What ability is this? https://i.imgur.com/Md4o99D.png:
-- Illuminate Spirit Form
+
 What ability is this? https://i.imgur.com/MpTqSAJ.png:
 - Impale
-What ability is this? https://i.imgur.com/MrZR4Fk.png:
-- Poison Touch
-What ability is this? https://i.imgur.com/MuP6YSf.png:
-- Rolling Boulder
 What ability is this? https://i.imgur.com/Mx2so6i.png:
 - Trap
 What ability is this? https://i.imgur.com/MzcTM8h.png:
 - True Form
-What ability is this? https://i.imgur.com/N2Lg1Rx.png:
-- Gust
-What ability is this? https://i.imgur.com/N479xl0.png:
-- Macropyre
 What ability is this? https://i.imgur.com/NTLxr4U.png:
 - Reaper's Scythe
 What ability is this? https://i.imgur.com/NXZtwjr.png:
@@ -627,13 +1048,8 @@ What ability is this? https://i.imgur.com/OLF3HYi.png:
 - The Swarm
 What ability is this? https://i.imgur.com/ORT7Dwy.png:
 - Tricks of the Trade
-
 What ability is this? https://i.imgur.com/OUY2hf6.png:
 - Phase Shift
-What ability is this? https://i.imgur.com/Of1XI1S.png:
-- Ice Path
-What ability is this? https://i.imgur.com/Of6sQ1j.png:
-- Elder Dragon Form
 What ability is this? https://i.imgur.com/OmnckhS.png:
 - Mana Drain
 What ability is this? https://i.imgur.com/OqgDu6w.png:
@@ -642,62 +1058,32 @@ What ability is this? https://i.imgur.com/OxRnBaf.png:
 - Laser
 What ability is this? https://i.imgur.com/Oz5sL6j.png:
 - Paralyzing Cask
-What ability is this? https://i.imgur.com/PB7Myh9.png:
-- Tornado
 What ability is this? https://i.imgur.com/PCrmtNx.png:
 - Walrus Punch
-What ability is this? https://i.imgur.com/PKCajV2.png:
-- Spirits Out
 
-What ability is this? https://i.imgur.com/PKn9vBX.png:
-- Geomagnetic Grip
-What ability is this? https://i.imgur.com/PLtRXis.png:
-- Overwhelming Odds
-What ability is this? https://i.imgur.com/PNH7ytm.png:
-- Incapacitating Bite
-What ability is this? https://i.imgur.com/PTEQsbS.png:
-- Natural Order
 What ability is this? https://i.imgur.com/PYIy1bG.png:
 - Death Pulse
-What ability is this? https://i.imgur.com/PdTLkou.png:
-- X Marks the Spot
+
 What ability is this? https://i.imgur.com/Pl1SRle.png:
 - Nether Blast
-What ability is this? https://i.imgur.com/PtOHt8w.png:
-- Crypt Swarm
-What ability is this? https://i.imgur.com/PtqRyJI.png:
-- Healing Ward
 What ability is this? https://i.imgur.com/Q2YMrCY.png:
 - Blink Strike
-What ability is this? https://i.imgur.com/Q5IWZ8w.png:
-- Strafe
 What ability is this? https://i.imgur.com/QCv66xU.png:
 - Cloak and Dagger
 What ability is this? https://i.imgur.com/QLDBMhR.png:
 - Focused Detonate
-
 What ability is this? https://i.imgur.com/QXReBGF.png:
 - Ancient Seal
-What ability is this? https://i.imgur.com/QZAYWnX.png:
-- Overcharge
-What ability is this? https://i.imgur.com/QdDe9x2.png:
-- Quas
 What ability is this? https://i.imgur.com/QgBVcd3.png:
 - Chakram
 What ability is this? https://i.imgur.com/QpPRO0v.png:
 - Meat Hook
-What ability is this? https://i.imgur.com/QpZ8h6A.png:
-- Frostbite
-
-
 What ability is this? https://i.imgur.com/RSgnSqT.png:
 - Sun Ray
 What ability is this? https://i.imgur.com/RY773PQ.png:
 - Germinate Attack
 What ability is this? https://i.imgur.com/RZWyifn.png:
 - Poison Attack
-What ability is this? https://i.imgur.com/RcPV68i.png:
-- Exort
 What ability is this? https://i.imgur.com/RrTFspK.png:
 - Berserker's Rage
 What ability is this? https://i.imgur.com/S885568.png:
@@ -706,28 +1092,12 @@ What ability is this? https://i.imgur.com/SI8IZFe.png:
 - Tree Dance
 What ability is this? https://i.imgur.com/SJ0ae9Z.png:
 - Heartstopper Aura
-What ability is this? https://i.imgur.com/SPqUual.png:
-- Surge
-What ability is this? https://i.imgur.com/SwcSLVf.png:
-- Drunken Brawler
 What ability is this? https://i.imgur.com/T5jvTy0.png:
 - Fate's Edict
-What ability is this? https://i.imgur.com/TAqbyTQ.png:
-- Activate Fire Remnant
-What ability is this? https://i.imgur.com/TYIYW4D.png:
-- Weave
 What ability is this? https://i.imgur.com/Tbum8Mm.png:
 - Wukong's Command
 What ability is this? https://i.imgur.com/TgFe0rb.png:
 - Spectral Dagger
-What ability is this? https://i.imgur.com/Thg1NJH.png:
-- Flame Guard
-What ability is this? https://i.imgur.com/TjIASfx.png:
-- Thirst
-What ability is this? https://i.imgur.com/TmqS4Mw.png:
-- Precision Aura
-What ability is this? https://i.imgur.com/TreGmRD.png:
-- Holy Persuasion
 What ability is this? https://i.imgur.com/TzUXaEc.png:
 - Gush
 What ability is this? https://i.imgur.com/U3qXiOR.png:
@@ -738,15 +1108,13 @@ What ability is this? https://i.imgur.com/UJ2SfUQ.png:
 - Spiked Carapace
 What ability is this? https://i.imgur.com/UJgFRGo.png:
 - Arctic Burn
-What ability is this? https://i.imgur.com/UaS2DTP.png:
-- Fissure
+
 What ability is this? https://i.imgur.com/UqFDO1o.png:
 - Vacuum
 What ability is this? https://i.imgur.com/V1roWyX.png:
 - Attribute Shift (Strength Gain)
 - Attribute Shift Strength Gain
-What ability is this? https://i.imgur.com/VEY99cQ.png:
-- Chaos Bolt
+
 What ability is this? https://i.imgur.com/VMkk6Q1.png:
 - Sunder
 What ability is this? https://i.imgur.com/VjCT9b4.png:
@@ -757,12 +1125,10 @@ What ability is this? https://i.imgur.com/Vm16ML0.png:
 - Supernova
 What ability is this? https://i.imgur.com/WQHV5aU.png:
 - Mass Serpent Ward
-What ability is this? https://i.imgur.com/WWaTmPl.png:
-- Chaos Meteor
+
 What ability is this? https://i.imgur.com/Wd8SgdN.png:
 - Eye of the Storm
-What ability is this? https://i.imgur.com/WkXOAqL.png:
-- Searing Chains
+
 What ability is this? https://i.imgur.com/WmUl5tV.png:
 - Headshot
 What ability is this? https://i.imgur.com/WuZE3vs.png:
@@ -771,30 +1137,14 @@ What ability is this? https://i.imgur.com/XDRJYGH.png:
 - Mystic Flare
 What ability is this? https://i.imgur.com/XGjIZ3l.png:
 - Overpower
-What ability is this? https://i.imgur.com/XPmJF9W.png:
-- Quill Spray
-What ability is this? https://i.imgur.com/XcI5kLq.png:
-- Shallow Grave
 What ability is this? https://i.imgur.com/XhcNvQ3.png:
 - Blink (Queen of Pain)
 - Blink
 - Queen of Pain Blink
 What ability is this? https://i.imgur.com/XluWp0x.png:
 - Druid Form
-What ability is this? https://i.imgur.com/Xwolrjn.png:
-- Thunder Clap
-What ability is this? https://i.imgur.com/XzPyTGf.png:
-- Blood Rite
 What ability is this? https://i.imgur.com/Y9BWxhg.png:
 - Global Silence
-What ability is this? https://i.imgur.com/YXTVCNd.png:
-- Black Hole
-What ability is this? https://i.imgur.com/YXdi6ph.png:
-- Marksmanship
-What ability is this? https://i.imgur.com/YcRnO2n.png:
-- Doom
-What ability is this? https://i.imgur.com/Ydf1cL2.png:
-- Illuminate
 What ability is this? https://i.imgur.com/YgcBkkl.png:
 - Consume
 What ability is this? https://i.imgur.com/YihLcCx.png:
@@ -822,63 +1172,34 @@ What ability is this? https://i.imgur.com/aB11d3Q.png:
 - Phantom Rush
 What ability is this? https://i.imgur.com/aHqmkB0.png:
 - Windrun
-What ability is this? https://i.imgur.com/aMyPP53.png:
-- Earth Splitter
-What ability is this? https://i.imgur.com/aNzmXok.png:
-- Invoke
 What ability is this? https://i.imgur.com/abLppb6.png:
 - Plague Ward
 What ability is this? https://i.imgur.com/abMUerv.png:
 - Reflection
 
-What ability is this? https://i.imgur.com/ai8I1Lr.png:
-- Terrorize
-What ability is this? https://i.imgur.com/b5IrqkC.png:
-- Rupture
-What ability is this? https://i.imgur.com/b7etRIZ.png:
-- Astral Spirit
-What ability is this? https://i.imgur.com/bFGzR0w.png:
-- Ghostship
 What ability is this? https://i.imgur.com/bUdXqyZ.png:
 - Tombstone
 What ability is this? https://i.imgur.com/bbr7ItL.png:
 - Charge of Darkness
-What ability is this? https://i.imgur.com/bdTjwio.png:
-- Press the Attack
-What ability is this? https://i.imgur.com/bggFesK.png:
-- Spirits In
+
 What ability is this? https://i.imgur.com/bt17jdZ.png:
 - Fade Bolt
-What ability is this? https://i.imgur.com/bvSHdHA.png:
-- Cursed Crown
 What ability is this? https://i.imgur.com/c21JoFw.png:
 - Refraction
 What ability is this? https://i.imgur.com/c3m8RuR.png:
 - Dark Pact
-
 What ability is this? https://i.imgur.com/c9ECJIK.png:
 - Launch Snowball
 What ability is this? https://i.imgur.com/cKpGa4P.png:
 - Juxtapose
 What ability is this? https://i.imgur.com/cgh0ET9.png:
 - Phantom Strike
-What ability is this? https://i.imgur.com/cjnqKID.png:
-- Shadow Wave
-What ability is this? https://i.imgur.com/clAB5hr.png:
-- Shadow Realm
-What ability is this? https://i.imgur.com/coR1Ijo.png:
-- Cold Snap
-What ability is this? https://i.imgur.com/ctHMsSI.png:
-- Fire Remnant
 What ability is this? https://i.imgur.com/dM5FqQi.png:
 - Ball Lightning
-What ability is this? https://i.imgur.com/dNUPxAC.png:
-- Frost Arrows
 What ability is this? https://i.imgur.com/dTYWEsH.png:
 - Living Armor
 What ability is this? https://i.imgur.com/da4HT66.png:
 - Life Drain
-
 What ability is this? https://i.imgur.com/diJCQOO.png:
 - Waveform
 What ability is this? https://i.imgur.com/djmPOx3.png:
@@ -887,21 +1208,13 @@ What ability is this? https://i.imgur.com/dq6rID6.png:
 - Presence of the Dark Lord
 What ability is this? https://i.imgur.com/dqFyNJi.png:
 - Battle Trance
-What ability is this? https://i.imgur.com/dwI4ZYX.png:
-- Wall of Replica
-What ability is this? https://i.imgur.com/e8NkVgl.png:
-- Crystal Nova
-
 What ability is this? https://i.imgur.com/e9pAwA8.png:
 - Shadowraze (Near)
 - Shadowraze Near
-What ability is this? https://i.imgur.com/eAwNPER.png:
-- Shadow Walk
 What ability is this? https://i.imgur.com/eHl6UcP.png:
 - Feast
 What ability is this? https://i.imgur.com/eKT4gKq.png:
 - Walrus Kick
-
 What ability is this? https://i.imgur.com/eaEmrUO.png:
 - Arc Lightning
 What ability is this? https://i.imgur.com/ehrPB5V.png:
@@ -910,44 +1223,31 @@ What ability is this? https://i.imgur.com/fH04Odc.png:
 - Fatal Bonds
 What ability is this? https://i.imgur.com/fKFtB6L.png:
 - Take Aim
-What ability is this? https://i.imgur.com/fPFw0GN.png:
-- Glimpse
 What ability is this? https://i.imgur.com/fRIFhEC.png:
 - Metamorphosis
-What ability is this? https://i.imgur.com/fp5mx0z.png:
-- Deafening Blast
 What ability is this? https://i.imgur.com/fpfaumU.png:
 - Rip Tide
 What ability is this? https://i.imgur.com/fzeIdiW.png:
 - Slithereen Crush
 What ability is this? https://i.imgur.com/fztqvAc.png:
 - Soul Catcher
-
-
-What ability is this? https://i.imgur.com/g95764l.png:
-- Dragon Tail
 What ability is this? https://i.imgur.com/gEv4Iju.png:
 - Reality
-What ability is this? https://i.imgur.com/gG7OwWD.png:
-- Time Dilation
+
 What ability is this? https://i.imgur.com/gI4wLvb.png:
 - Sprout
-What ability is this? https://i.imgur.com/gLmeW4r.png:
-- Pulse Nova
+
 What ability is this? https://i.imgur.com/gc4UKOO.png:
 - Last Word
-What ability is this? https://i.imgur.com/gfXcapt.png:
-- Hand of God
+
 What ability is this? https://i.imgur.com/glqk3lR.png:
 - Ice Armor
 What ability is this? https://i.imgur.com/gqWai5F.png:
 - Conjure Image
 What ability is this? https://i.imgur.com/gyK74ha.png:
 - Morph
-What ability is this? https://i.imgur.com/h7sHNto.png:
-- Magnetize
-What ability is this? https://i.imgur.com/hGaz2o5.png:
-- Torrent
+
+
 What ability is this? https://i.imgur.com/hHrloCO.png:
 - Shackles
 What ability is this? https://i.imgur.com/hJ456Zc.png:
@@ -960,10 +1260,8 @@ What ability is this? https://i.imgur.com/hNY3HEK.png:
 - Decay
 What ability is this? https://i.imgur.com/hfi7sEq.png:
 - Moon Glaive
-What ability is this? https://i.imgur.com/hqA5et0.png:
-- Echo Stomp
-What ability is this? https://i.imgur.com/i1JiCuX.png:
-- Stampede
+
+
 What ability is this? https://i.imgur.com/io4j5UF.png:
 - Bash
 
@@ -972,50 +1270,40 @@ What ability is this? https://i.imgur.com/jC4mbqh.png:
 - Hex
 What ability is this? https://i.imgur.com/jIKqZdq.png:
 - Flak Cannon
-What ability is this? https://i.imgur.com/jMwUoNI.png:
-- Shuriken Toss
+
 What ability is this? https://i.imgur.com/jSNNS25.png:
 - Recall
-What ability is this? https://i.imgur.com/jScsAtR.png:
-- Inner Vitality
-What ability is this? https://i.imgur.com/jSljBqy.png:
-- Static Storm
-What ability is this? https://i.imgur.com/jWSjV8d.png:
-- Lightning Storm
+
+
 What ability is this? https://i.imgur.com/jauB1Mi.png:
 - Song of the Siren End
-What ability is this? https://i.imgur.com/k1Qa44g.png:
-- Spirit Form
+
 What ability is this? https://i.imgur.com/k24O7Lp.png:
 - Leap
 What ability is this? https://i.imgur.com/k8bdwOs.png:
 - Overload
-What ability is this? https://i.imgur.com/kEjJIc9.png:
-- Life Break
+
 What ability is this? https://i.imgur.com/kFEb70C.png:
 - Amplify Damage
 What ability is this? https://i.imgur.com/kIpRoiL.png:
 - Stop Icarus Dive
 What ability is this? https://i.imgur.com/kOJ6Iit.png:
 - Spirit Lance
-What ability is this? https://i.imgur.com/kOlC0Gh.png:
-- Rocket Flare
+
 What ability is this? https://i.imgur.com/kRpniQ9.png:
 - Voodoo Restoration
 What ability is this? https://i.imgur.com/kTJTxSn.png:
 - Shield Crash
 What ability is this? https://i.imgur.com/kZPtBCV.png:
 - Bloodlust
-What ability is this? https://i.imgur.com/kauXrGn.png:
-- Dragon Blood
+
 What ability is this? https://i.imgur.com/kgo57gs.png:
 - Warcry
 What ability is this? https://i.imgur.com/kjv3jEv.png:
 - Ether Shock
 What ability is this? https://i.imgur.com/kkMA22I.png:
 - Morph Replicate
-What ability is this? https://i.imgur.com/kkcrkoo.png:
-- Sleight of Fist
+
 What ability is this? https://i.imgur.com/kypYgE5.png:
 - Earth Spike
 What ability is this? https://i.imgur.com/lG97CeO.png:
@@ -1034,45 +1322,34 @@ What ability is this? https://i.imgur.com/m6s6gTu.png:
 - Doppelganger
 What ability is this? https://i.imgur.com/m7a1mLv.png:
 - Scan
-What ability is this? https://i.imgur.com/mIV1Ekb.png:
-- Hookshot
+
 What ability is this? https://i.imgur.com/mMRslEc.png:
 - Arcane Bolt
 What ability is this? https://i.imgur.com/mNG28HG.png:
 - Wave of Terror
-What ability is this? https://i.imgur.com/mPqYOHu.png:
-- Rocket Barrage
+
 What ability is this? https://i.imgur.com/mVnb12R.png:
 - Necromastery
-What ability is this? https://i.imgur.com/mjKcsMe.png:
-- Ion Shell
+
 What ability is this? https://i.imgur.com/n84AW2C.png:
 - Concussive Shot
 What ability is this? https://i.imgur.com/nF0ug5I.png:
 - Earthbind
-What ability is this? https://i.imgur.com/nLpMXtX.png:
-- Call Down
-What ability is this? https://i.imgur.com/nWUFTHd.png:
-- Devour
 
-What ability is this? https://i.imgur.com/nYiXreU.png:
-- Spirits
-What ability is this? https://i.imgur.com/najZXYr.png:
-- Berserker's Blood
+
+
+
+
 What ability is this? https://i.imgur.com/nfMltKz.png:
 - Shukuchi
-What ability is this? https://i.imgur.com/niWP4HN.png:
-- Alacrity
+
 What ability is this? https://i.imgur.com/nis6xUN.png:
 - Battle Cry
 What ability is this? https://i.imgur.com/nl88bDE.png:
 - Unburrow
-What ability is this? https://i.imgur.com/nlhSakJ.png:
-- Reality Rift
-What ability is this? https://i.imgur.com/nntd958.png:
-- Duel
-What ability is this? https://i.imgur.com/o2qAqkE.png:
-- Death Pact
+
+
+
 What ability is this? https://i.imgur.com/o8E0WDX.png:
 - Regeneration Rune Buff
 What ability is this? https://i.imgur.com/o9KvFAt.png:
@@ -1105,8 +1382,7 @@ What ability is this? https://i.imgur.com/puHHZ8N.png:
 - Whirling Axes Ranged
 What ability is this? https://i.imgur.com/q1TZSqX.png:
 - Kraken Shell
-What ability is this? https://i.imgur.com/q4z8X5Z.png:
-- Burning Spear
+
 What ability is this? https://i.imgur.com/qFHbDVZ.png:
 - Proximity Mines
 What ability is this? https://i.imgur.com/qFeXDTy.png:
@@ -1120,24 +1396,20 @@ What ability is this? https://i.imgur.com/qwGGVkQ.png:
 - Haunt
 What ability is this? https://i.imgur.com/rIMd2yM.png:
 - Eject
-What ability is this? https://i.imgur.com/rJjuneV.png:
-- Echo Slam
+
 What ability is this? https://i.imgur.com/rOCPbQl.png:
 - Purification
 What ability is this? https://i.imgur.com/rSeefMY.png:
 - Icarus Dive
-What ability is this? https://i.imgur.com/rVxgLdC.png:
-- Hoof Stomp
+
 What ability is this? https://i.imgur.com/rW8u5w7.png:
 - Scream of Pain
 What ability is this? https://i.imgur.com/rmTHla6.png:
 - Pinpoint Detonate
-What ability is this? https://i.imgur.com/rxOnMrk.png:
-- Sacrifice
+
 What ability is this? https://i.imgur.com/sHFZoQg.png:
 - Magic Missile
-What ability is this? https://i.imgur.com/sJn6T9V.png:
-- EMP
+
 What ability is this? https://i.imgur.com/saKNr3L.png:
 - Frozen Sigil
 
@@ -1146,8 +1418,7 @@ What ability is this? https://i.imgur.com/scUQ1Vx.png:
 
 What ability is this? https://i.imgur.com/sz4ZZRf.png:
 - Shadow Poison Release
-What ability is this? https://i.imgur.com/tI1UsiQ.png:
-- Silence
+
 What ability is this? https://i.imgur.com/tIqUdL0.png:
 - Demonic Conversion
 What ability is this? https://i.imgur.com/tRgiIsx.png:
@@ -1161,10 +1432,8 @@ What ability is this? https://i.imgur.com/tns2s3U.png:
 - Return Chakram 2
 What ability is this? https://i.imgur.com/u3NhKrE.png:
 - Laguna Blade
-What ability is this? https://i.imgur.com/uANCZtn.png:
-- Omnislash
-What ability is this? https://i.imgur.com/uMDJlnC.png:
-- Impetus
+
+
 What ability is this? https://i.imgur.com/uMmwQ1a.png:
 - Summon Wolves
 What ability is this? https://i.imgur.com/uj1D3OE.png:
@@ -1177,8 +1446,7 @@ What ability is this? https://i.imgur.com/uzQb32K.png:
 - Skewer
 What ability is this? https://i.imgur.com/v0RLs2l.png:
 - Stone Gaze
-What ability is this? https://i.imgur.com/v3J9FU6.png:
-- Sun Strike
+
 What ability is this? https://i.imgur.com/vdHhJKt.png:
 - Sacred Arrow
 
@@ -1186,8 +1454,7 @@ What ability is this? https://i.imgur.com/vkc1MU1.png:
 - Stop Rolling
 What ability is this? https://i.imgur.com/wCbPETt.png:
 - Static Link
-What ability is this? https://i.imgur.com/wE3EDdL.png:
-- Phantasm
+
 What ability is this? https://i.imgur.com/wEuOQZi.png:
 - Howl
 What ability is this? https://i.imgur.com/wJwUbrH.png:
@@ -1202,26 +1469,20 @@ What ability is this? https://i.imgur.com/wjMDyPe.png:
 - Sonic Wave
 What ability is this? https://i.imgur.com/xGKIRUa.png:
 - Dark Rift
-What ability is this? https://i.imgur.com/xN1TWZh.png:
-- Insatiable Hunger
-What ability is this? https://i.imgur.com/xNqYfoK.png:
-- Time Walk
+
+
 What ability is this? https://i.imgur.com/xOSzlWY.png:
 - Telekinesis
 What ability is this? https://i.imgur.com/xYcEKmf.png:
 - Assimilate
 What ability is this? https://i.imgur.com/xa2sa4j.png:
 - Eyes in the Forest
-What ability is this? https://i.imgur.com/xeBkssG.png:
-- Return (Centaur Warrunner)
-- Return
-- Centaur Warrunner Return
+
 What ability is this? https://i.imgur.com/xivXaHo.png:
 - Hunter in the Night
 What ability is this? https://i.imgur.com/xxDj7GO.png:
 - Shackleshot
-What ability is this? https://i.imgur.com/xxGhGa6.png:
-- Split Earth
+
 What ability is this? https://i.imgur.com/y5RS5GM.png:
 - Whirling Axes (Melee)
 - Whirling Axes Melee
@@ -1233,8 +1494,7 @@ What ability is this? https://i.imgur.com/yRL9eLs.png:
 - Null Field
 What ability is this? https://i.imgur.com/yRs0y6A.png:
 - Reverse Polarity
-What ability is this? https://i.imgur.com/yUqvGUh.png:
-- Release Illuminate
+
 What ability is this? https://i.imgur.com/yVl4z4E.png:
 - Jingu Mastery
 What ability is this? https://i.imgur.com/yYv2ken.png:
@@ -1244,12 +1504,9 @@ What ability is this? https://i.imgur.com/ykXIKkP.png:
 - Grave Chill
 What ability is this? https://i.imgur.com/ylsYhYn.png:
 - Upheaval
-What ability is this? https://i.imgur.com/yqbbjpH.png:
-- Battery Assault
-What ability is this? https://i.imgur.com/yv5tV1m.png:
-- Diabolic Edict
-What ability is this? https://i.imgur.com/z2bBrD5.png:
-- Midnight Pulse
+
+
+
 What ability is this? https://i.imgur.com/zMYgF7b.png:
 - Hex
 What ability is this? https://i.imgur.com/zT3stw7.png:

--- a/redbot/cogs/trivia/data/lists/dota2abilities.yaml
+++ b/redbot/cogs/trivia/data/lists/dota2abilities.yaml
@@ -1,161 +1,379 @@
-AUTHOR: JennJenn
+AUTHOR: JennJenn, Eternalll
 DESCRIPTION: >-
-  A trivia about Dota 2 abilities. In this trivia, identify the ability
+  A trivia about Dota 2 abilities as of patch 7.41c. In this trivia, identify the ability
   from the image sent. Dota 2 is a multiplayer online battle arena video game by Valve.
-What ability is this? https://i.imgur.com/GaGZzRK.png:
+# Abaddon
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Withering Mist
+What ability is this? https://i.imgur.com/1DZxBnu.png: # [1]
+- Mist Coil
+What ability is this? https://i.imgur.com/RHRZzj6.png: # [2]
+- Aphotic Shield
+What ability is this? https://i.imgur.com/g42pVks.png: # [3]
+- Curse of Avernus
+What ability is this? https://i.imgur.com/g8vFvN6.png: # [4]
+- Borrowed Time
+# Alchemist
+What innate ability is this? https://i.imgur.com/J97FNqg.png: # [IN]
+- Greevil's Greed
+What ability is this? https://i.imgur.com/BUqQWji.png: # [1]
+- Acid Spray
+What ability is this? https://i.imgur.com/ROUKHNY.png: # [2]
+- Unstable Concoction
+What ability is this? https://i.imgur.com/ORiUzGL.png: # [2](Alt)
+- Unstable Concoction Throw
+# What ability is this? https://i.imgur.com/0000000: # [3]
+#- Corrosive Weaponry
+What ability is this? https://i.imgur.com/DJzNANM.png: # [4]
+- Chemical Rage
+# What ability is this? https://i.imgur.com/0000000: # [5]
+#- Berserk Potion
+# Ancient Apparition
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Bone Chill
+What ability is this? https://i.imgur.com/PKZ2cTp.png: # [1]
+- Cold Feet
+What ability is this? https://i.imgur.com/7wfVN6a.png: # [2]
+- Ice Vortex
+What ability is this? https://i.imgur.com/5lkslhd.png: # [4]
+- Ice Blast
+# Anti-Mage
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Persecutor
+What ability is this? https://i.imgur.com/nYi9uXc.png: # [1]
+- Mana Break
+What ability is this? https://i.imgur.com/j6tX9kQ.png: # [2]
+- Blink (Anti-Mage)
+- Blink
+- Anti-Mage Blink
+What ability is this? https://i.imgur.com/Dz7G2Ma.png: # [3] - image is a little out of date
+- Counterspell
+What ability is this? https://i.imgur.com/BLCIY3v.png: # [4]
+- Mana Void
+# Arc Warden
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Runic Infusion
+What ability is this? https://i.imgur.com/de1Solo.png: # [1]
+- Flux
+What ability is this? https://i.imgur.com/e9ipnhZ.png: # [2]
+- Magnetic Field
+What ability is this? https://i.imgur.com/syRZuJG.png: # [3]
+- Spark Wraith
+What ability is this? https://i.imgur.com/sbiDRM8.png: # [4]
+- Tempest Double
+# Axe
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - One Man Army
+What ability is this? https://i.imgur.com/5oihonX.png: # [1]
+- Berserker's Call
+What ability is this? https://i.imgur.com/FZML9xq.png: # [2]
+- Battle Hunger
+What ability is this? https://i.imgur.com/acHDcF3.png: # [3]
+- Counter Helix
+What ability is this? https://i.imgur.com/QPkeKvK.png: # [4]
+- Culling Blade
+# Bane
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Ichor of Nyctasha
+What ability is this? https://i.imgur.com/qiVf4dc.png: # [1]
+- Enfeeble
+What ability is this? https://i.imgur.com/AstYM5V.png: # [2]
+- Brain Sap
+What ability is this? https://i.imgur.com/ostwLWM.png: # [3]
+- Nightmare
+What ability is this? https://i.imgur.com/4U35Jam.png: # [3](Alt)
+- Nightmare End
+What ability is this? https://i.imgur.com/5mUEdUT.png: # [4]
+- Fiend's Grip
+# Batrider
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Smoldering Resin
+What ability is this? https://i.imgur.com/j7PzMhi.png: # [1]
+- Sticky Napalm
+What ability is this? https://i.imgur.com/ea88e97.png: # [2]
+- Flamebreak
+What ability is this? https://i.imgur.com/c6WTDXX.png: # [3]
+- Firefly
+What ability is this? https://i.imgur.com/5VYGT2S.png: # [4]
+- Flaming Lasso
+# Beastmaster
+What innate ability is this? https://i.imgur.com/4AoRrcX.png:
+- Inner Beast
+What ability is this? https://i.imgur.com/CjmqL6c.png: # [1]
+- Wild Axes
+What ability is this? https://i.imgur.com/3BaLwBw.png: # [2]
+- Summon Razorback
+What ability is this? https://i.imgur.com/GaGZzRK.png: # [3]
 - Summon Raptors
-What innate ability is this? https://i.imgur.com/bggKiqU.png:
-- Insurmountable
-What ability is this? https://i.imgur.com/0A8C7wM.png:
+What ability is this? https://i.imgur.com/Lh00eYb.png: # [4]
+- Primal Roar
+# What ability is this? https://i.imgur.com/0000000: # [5]
+# - Drums of Slom
+# Bloodseeker
+# Bounty Hunter
+# Brewmaster
+What ability is this? https://i.imgur.com/70eq5fC.png: # [2]
+- Cinder Brew
+# Bristleback
+What ability is this? https://i.imgur.com/0YpdsNT.png: # [1]
+- Viscous Nasal Goo
+What ability is this? https://i.imgur.com/1LmjfoY.png: # [3]
+- Bristleback
+What ability is this? https://i.imgur.com/2T8w9q2.png: # [4]
+- Warpath
+# Broodmother
+# Centaur Warrunner
+# Chaos Knight
+What ability is this? https://i.imgur.com/0A8C7wM.png: # [1]
 - Chaos Strike
-What ability is this? https://i.imgur.com/0IQn6ug.png:
+# Chen
+# Clinkz
+# Clockwork
+# Crystal Maiden
+What ability is this? https://i.imgur.com/17LrPpY.png: # [4]
+- Freezing Field
+# Dark Seer
+# Dark Willow
+# Dawnbreaker
+# Dazzle
+# Death Prophet
+What ability is this? https://i.imgur.com/4m1JoUa.png: # [4]
+- Exorcism
+# Disruptor
+What ability is this? https://i.imgur.com/2MbrJ06.png: # [1]
+- Thunder Strike
+What ability is this? https://i.imgur.com/83gBZsI.png: # [3]
+- Kinetic Field
+# Doom
+What ability is this? https://i.imgur.com/6TDMoI5.png: # [2]
+- Scorched Earth
+# Dragon Knight
+# Drow Ranger
+# Earth Spirit
+What ability is this? https://i.imgur.com/2SsNPbU.png: # [1]
+- Boulder Smash
+# Earthshaker
+# Elder Titan
+# Ember Spirit
+# Enchantress
+# Enigma
+What ability is this? https://i.imgur.com/1eyhHyf.png: # [1]
+- Malefice
+# Faceless Void
+What ability is this? https://i.imgur.com/5oS4p6Z.png: # [4]
+- Chronosphere
+# Grimstroke
+# Gyrocopter
+# Hoodwink
+# Huskar
+# Invoker
+What ability is this? https://i.imgur.com/0OBAWeC.png:
+- Forge Spirit
+# Io (Guardian Wisp)
+# Jakiro
+# Juggernaut
+What ability is this? https://i.imgur.com/7Oh7bjv.png: # [1]
+- Blade Fury
+# Keeper of the Light
+What ability is this? https://i.imgur.com/0MYQSVF.png: # [2]
+- Blinding Light
+# Kez
+# Kunkka
+# Largo
+# Legion Commander
+# Leshrac
+# Lich
+What ability is this? https://i.imgur.com/1HgJ1bn.png: # [4]
+- Chain Frost
+# Lifestealer
+What ability is this? https://i.imgur.com/0IQn6ug.png: # [1]
 - Rage
-What ability is this? https://i.imgur.com/0JGCqSu.png:
-- Crippling Fear
-What ability is this? https://i.imgur.com/0JwHDOJ.png:
+# Lina
+What ability is this? https://i.imgur.com/0JwHDOJ.png: # [2]
 - Light Strike Array
-What ability is this? https://i.imgur.com/0LSBunY.png:
+What ability is this? https://i.imgur.com/70nnwxH.png: # [3]
+- Fiery Soul
+# Lion
+# Lone Druid
+What ability is this? https://i.imgur.com/32Nw3yf.png: # [3]
+- Savage Roar
+# Luna
+What ability is this? https://i.imgur.com/9pCeilj.png: # [4]
+- Eclipse
+# Lycan
+What ability is this? https://i.imgur.com/261lk7J.png: # Ability 4 
+- Shapeshift
+# Magnus
+# Marci
+# Mars
+# Medusa
+What ability is this? https://i.imgur.com/2DPvUVw.png: # [2]
+- Mystic Snake
+# Meepo
+What ability is this? https://i.imgur.com/2aGSLwK.png: # [2]
+- Poof
+What ability is this? https://i.imgur.com/6aKdh41.png: # [4]
+- Divided We Stand
+# Mirana
+# Monkey King
+What ability is this? https://i.imgur.com/6sXFGUA.png: # [1]
+- Boundless Strike
+What ability is this? https://i.imgur.com/0V4SLoS.png: # Ability 6 (Alt)
+- Revert Form
+# Morphling
+What ability is this? https://i.imgur.com/0LSBunY.png: # [3]
 - Attribute Shift (Agility Gain)
 - Attribute Shift Agility Gain
 - Attribute Shift
-What ability is this? https://i.imgur.com/0MYQSVF.png:
-- Blinding Light
-What ability is this? https://i.imgur.com/0OBAWeC.png:
-- Forge Spirit
-What ability is this? https://i.imgur.com/0PiJYmp.png:
-- Decrepify
-What ability is this? https://i.imgur.com/0V4SLoS.png:
-- Revert Form
-What ability is this? https://i.imgur.com/0YpdsNT.png:
-- Viscous Nasal Goo
-What ability is this? https://i.imgur.com/0bX5emr.png:
-- Storm Surge
-What ability is this? https://i.imgur.com/0yVFHjI.png:
-- Splinter Blast
-What ability is this? https://i.imgur.com/13Bw6be.png:
+# Muerta
+# Naga Siren
+What ability is this? https://i.imgur.com/6clz8xq.png: # [1]
+- Mirror Image
+# Nature's Prophet
+# Necrophos
+# Night Stalker
+What ability is this? https://i.imgur.com/0JGCqSu.png: # [2]
+- Crippling Fear
+# Nyx Assassin
+# Ogre Magi
+What ability is this? https://i.imgur.com/13Bw6be.png: # [1]
 - Fireblast
-What ability is this? https://i.imgur.com/17LrPpY.png:
-- Freezing Field
-What ability is this? https://i.imgur.com/1DZxBnu.png:
-- Mist Coil
-What ability is this? https://i.imgur.com/1HgJ1bn.png:
-- Chain Frost
-What ability is this? https://i.imgur.com/1LmjfoY.png:
-- Bristleback
-What ability is this? https://i.imgur.com/1eyhHyf.png:
-- Malefice
+# Omniknight
+# Oracle
+# Outworld Destroyer
+# Pangolier
+# Phantom Assassin
+# Phantom Lancer
+# Phoenix
+What ability is this? https://i.imgur.com/21bnvvZ.png: # [2](Alt)
+- Launch Fire Spirit
+What ability is this? https://i.imgur.com/2U8fvM5.png: # [3] (Alt)
+- Stop Sun Ray
+# Primal Beast
+# Puck
+What ability is this? https://i.imgur.com/69dhFq0.png: # [2]
+- Waning Rift
+# Pudge
+# Pugna
+What ability is this? https://i.imgur.com/0PiJYmp.png: # [2]
+- Decrepify
+What ability is this? https://i.imgur.com/5zbDixI.png: # [3]
+- Nether Ward
+# Queen of Pain
+# Razor
+What ability is this? https://i.imgur.com/6l371xX.png: # [1]
+- Plasma Field
+What ability is this? https://i.imgur.com/0bX5emr.png: # [3]
+- Storm Surge
+# Riki
+# Ringmaster
+# Rubick
+What ability is this? https://i.imgur.com/73c0X8u.png: # [1] (Alt)
+- Telekinesis Land
+What ability is this? https://i.imgur.com/6FMgz5M.png: # [4]
+- Spell Steal
+# Sand King
+What ability is this? https://i.imgur.com/4m16Vjf.png: # [1]
+- Burrowstrike
+# Shadow Demon
+What ability is this? https://i.imgur.com/6ECNZuq.png: # [1]
+- Disruption
+# Shadow Fiend
+# Shadow Shaman
+# Silencer
+# Skywrath Mage
+# Slardar
+# Slark
+# Snapfire
+# Sniper
+# Spectre
+What innate ability is this? https://i.imgur.com/2ELk5Uw.png: # [IN]
+- Desolate
+# Spirit Breaker
+# Storm Spirit
+# Sven
+What ability is this? https://i.imgur.com/2oeoTNi.png: # [3]
+- Great Cleave
+# Techies
+# Templar Assassin
+# Terrorblade
+# Tidehunter
+What ability is this? https://i.imgur.com/2lOdxvB.png: # [3]
+- Anchor Smash
+# Timbersaw
+# Tinker
+# Tiny
+What innate ability is this? https://i.imgur.com/bggKiqU.png: # [IN]
+- Insurmountable
+# Treant Protector
+What ability is this? https://i.imgur.com/8BbsIDw.png: # [4]
+- Overgrowth
+# Troll Warlord
+# Tusk
+# Underlord
+# Undying
+What ability is this? https://i.imgur.com/374iVtN.png: # [4]
+- Flesh Golem
+# Ursa
+What ability is this? https://i.imgur.com/8VQoMYP.png: # [4]
+- Enrage
+# Vengeful Spirit
+# Venomancer
+# Viper
+# Visage
+# Void Spirit
+# Warlock
+# Weaver
+# Windranger
+What ability is this? https://i.imgur.com/2jZ4Uf1.png: # [4]
+- Focus Fire
+# Winter Wyvern
+What ability is this? https://i.imgur.com/0yVFHjI.png: # [2]
+- Splinter Blast
+# Witch Doctor
+# Wraith King
+What ability is this? https://i.imgur.com/66IUX1V.png: # [2]
+- Bone Guard
+# Zeus
+
+
+
 What ability is this? https://i.imgur.com/1gH6M4C.png:
 - Minefield Sign
-What ability is this? https://i.imgur.com/1yQcHcq.png:
-- Double Damage Rune Buff
-What ability is this? https://i.imgur.com/21bnvvZ.png:
-- Launch Fire Spirit
-What ability is this? https://i.imgur.com/261lk7J.png:
-- Shapeshift
-What ability is this? https://i.imgur.com/2DPvUVw.png:
-- Mystic Snake
-What innate ability is this? https://i.imgur.com/2ELk5Uw.png:
-- Desolate
-What ability is this? https://i.imgur.com/2MbrJ06.png:
-- Thunder Strike
-What ability is this? https://i.imgur.com/2SsNPbU.png:
-- Boulder Smash
-What ability is this? https://i.imgur.com/2T8w9q2.png:
-- Warpath
-What ability is this? https://i.imgur.com/2U8fvM5.png:
-- Stop Sun Ray
-What ability is this? https://i.imgur.com/2aGSLwK.png:
-- Poof
-What ability is this? https://i.imgur.com/2jZ4Uf1.png:
-- Focus Fire
-What ability is this? https://i.imgur.com/2lOdxvB.png:
-- Anchor Smash
-What ability is this? https://i.imgur.com/2oeoTNi.png:
-- Great Cleave
-What ability is this? https://i.imgur.com/32Nw3yf.png:
-- Savage Roar
-What ability is this? https://i.imgur.com/374iVtN.png:
-- Flesh Golem
-What ability is this? https://i.imgur.com/3BaLwBw.png:
-- Summon Razorback
+
+
+
 What ability is this? https://i.imgur.com/3KNjwWX.png:
 - Ice Wall
 What ability is this? https://i.imgur.com/3btLBuJ.png:
 - X Marks The Spot
-What innate ability is this? https://i.imgur.com/4AoRrcX.png:
-- Inner Beast
+
 What ability is this? https://i.imgur.com/4HDygyR.png:
 - Fervor
 What ability is this? https://i.imgur.com/4Mmu9H3.png:
 - Blade Dance
-What ability is this? https://i.imgur.com/4U35Jam.png:
-- Nightmare End
+
 What ability is this? https://i.imgur.com/4dvJS0l.png:
 - Return Astral Spirit
 What ability is this? https://i.imgur.com/4eYikmd.png:
 - Relocate
 What ability is this? https://i.imgur.com/4iLwPJz.png:
 - Chilling Touch
-What ability is this? https://i.imgur.com/4m16Vjf.png:
-- Burrowstrike
-What ability is this? https://i.imgur.com/4m1JoUa.png:
-- Exorcism
 What ability is this? https://i.imgur.com/4u98BUr.png:
 - March of the Machines
 #What ability is this? https://i.imgur.com/4wL249w.png: replaced with lucky shot
 #- Heartpiercer
 What ability is this? https://i.imgur.com/554WWRF.png:
 - Poison Sting
-What ability is this? https://i.imgur.com/5VYGT2S.png:
-- Flaming Lasso
-What ability is this? https://i.imgur.com/5lkslhd.png:
-- Ice Blast
-What ability is this? https://i.imgur.com/5mUEdUT.png:
-- Fiend's Grip
 What ability is this? https://i.imgur.com/5mYgGEw.png:
 - Starstorm
-What ability is this? https://i.imgur.com/5oS4p6Z.png:
-- Chronosphere
-What ability is this? https://i.imgur.com/5oihonX.png:
-- Berserker's Call
-What ability is this? https://i.imgur.com/5zbDixI.png:
-- Nether Ward
+
+
+
 #What ability is this? https://i.imgur.com/63fjMat.png: replaced with divine favor
 #- Test of Faith
-What ability is this? https://i.imgur.com/66IUX1V.png:
-- Bone Guard
-What ability is this? https://i.imgur.com/69dhFq0.png:
-- Waning Rift
-What ability is this? https://i.imgur.com/6ECNZuq.png:
-- Disruption
-What ability is this? https://i.imgur.com/6FMgz5M.png:
-- Spell Steal
-What ability is this? https://i.imgur.com/6TDMoI5.png:
-- Scorched Earth
-What ability is this? https://i.imgur.com/6aKdh41.png:
-- Divided We Stand
-What ability is this? https://i.imgur.com/6clz8xq.png:
-- Mirror Image
-What ability is this? https://i.imgur.com/6l371xX.png:
-- Plasma Field
-What ability is this? https://i.imgur.com/6sXFGUA.png:
-- Boundless Strike
-What ability is this? https://i.imgur.com/70eq5fC.png:
-- Drunken Haze
-What ability is this? https://i.imgur.com/70nnwxH.png:
-- Fiery Soul
-What ability is this? https://i.imgur.com/73c0X8u.png:
-- Telekinesis Land
-What ability is this? https://i.imgur.com/7Oh7bjv.png:
-- Blade Fury
-What ability is this? https://i.imgur.com/7wfVN6a.png:
-- Ice Vortex
-What ability is this? https://i.imgur.com/83gBZsI.png:
-- Kinetic Field
-What ability is this? https://i.imgur.com/8BbsIDw.png:
-- Overgrowth
-What ability is this? https://i.imgur.com/8VQoMYP.png:
-- Enrage
+
+
 What ability is this? https://i.imgur.com/8c1qrax.png:
 - Jinada
 What ability is this? https://i.imgur.com/8dmL0Pl.png:
@@ -171,8 +389,7 @@ What ability is this? https://i.imgur.com/8z2ZykJ.png:
 - Stone Remnant
 What ability is this? https://i.imgur.com/9QvvTjl.png:
 - Empower
-What ability is this? https://i.imgur.com/9pCeilj.png:
-- Eclipse
+
 What ability is this? https://i.imgur.com/A4AbG8P.png:
 - Double Edge
 What ability is this? https://i.imgur.com/A7WrsBa.png:
@@ -181,8 +398,7 @@ What ability is this? https://i.imgur.com/AfySnUQ.png:
 - Stifling Dagger
 What ability is this? https://i.imgur.com/AmuABVC.png:
 - Feral Impulse
-What ability is this? https://i.imgur.com/AstYM5V.png:
-- Brain Sap
+
 What ability is this? https://i.imgur.com/AvqgsGb.png:
 - Fire Spirits
 What ability is this? https://i.imgur.com/B7bhmxH.png:
@@ -193,12 +409,10 @@ What ability is this? https://i.imgur.com/BI7aszU.png:
 - Remote Mines
 What ability is this? https://i.imgur.com/BJRUHS9.png:
 - Shadow Strike
-What ability is this? https://i.imgur.com/BLCIY3v.png:
-- Mana Void
+
 What ability is this? https://i.imgur.com/BMod0Q4.png:
 - Power Cogs
-What ability is this? https://i.imgur.com/BUqQWji.png:
-- Acid Spray
+
 What ability is this? https://i.imgur.com/BVme5AJ.png:
 - Cold Embrace
 What ability is this? https://i.imgur.com/BYqGIYR.png:
@@ -225,8 +439,7 @@ What ability is this? https://i.imgur.com/CbvZ4aS.png:
 #- Berserker's Rage
 What ability is this? https://i.imgur.com/Cgg4m1S.png:
 - Vengeance Aura
-What ability is this? https://i.imgur.com/CjmqL6c.png:
-- Wild Axes
+
 What ability is this? https://i.imgur.com/Cl9msdJ.png:
 - Demonic Purge
 What ability is this? https://i.imgur.com/ConFPLo.png:
@@ -241,16 +454,14 @@ What ability is this? https://i.imgur.com/D2Dw9AZ.png:
 - Blur
 What ability is this? https://i.imgur.com/DIto2eL.png:
 - Bloodrage
-What ability is this? https://i.imgur.com/DJzNANM.png:
-- Chemical Rage
+
 What ability is this? https://i.imgur.com/DcA2Vez.png:
 - Skeleton Walk
 What ability is this? https://i.imgur.com/De4lTvg.png:
 - Tidebringer
 What ability is this? https://i.imgur.com/Du6xnAD.png:
 - Ethereal Jaunt
-What ability is this? https://i.imgur.com/Dz7G2Ma.png:
-- Spell Shield
+
 What ability is this? https://i.imgur.com/E5xrzuV.png:
 - Winter's Curse
 What ability is this? https://i.imgur.com/E80vySv.png:
@@ -277,8 +488,7 @@ What ability is this? https://i.imgur.com/FQG66ec.png:
 - Break Tether
 What ability is this? https://i.imgur.com/FZEYYYQ.png:
 - Adaptive Strike
-What ability is this? https://i.imgur.com/FZML9xq.png:
-- Battle Hunger
+
 What innate ability is this? https://i.imgur.com/FcRJMtq.png:
 - Degen Aura
 What ability is this? https://i.imgur.com/FfRtCL3.png:
@@ -333,8 +543,7 @@ What ability is this? https://i.imgur.com/Iu2brGN.png:
 - Avalanche
 What ability is this? https://i.imgur.com/J8iyl8n.png:
 - Fortune's End
-What ability is this? https://i.imgur.com/J97FNqg.png:
-- Greevil's Greed
+
 What ability is this? https://i.imgur.com/JJLAsfU.png:
 - Powershot
 What ability is this? https://i.imgur.com/JVJs8VI.png:
@@ -377,8 +586,7 @@ What ability is this? https://i.imgur.com/LUgtrxC.png:
 - Illusory Orb
 What ability is this? https://i.imgur.com/LVueVCR.png:
 - Dismember
-What ability is this? https://i.imgur.com/Lh00eYb.png:
-- Primal Roar
+
 What ability is this? https://i.imgur.com/LiPZwBR.png:
 - Atrophy Aura
 What ability is this? https://i.imgur.com/MRarlQa.png:
@@ -419,8 +627,7 @@ What ability is this? https://i.imgur.com/OLF3HYi.png:
 - The Swarm
 What ability is this? https://i.imgur.com/ORT7Dwy.png:
 - Tricks of the Trade
-What ability is this? https://i.imgur.com/ORiUzGL.png:
-- Unstable Concoction Throw
+
 What ability is this? https://i.imgur.com/OUY2hf6.png:
 - Phase Shift
 What ability is this? https://i.imgur.com/Of1XI1S.png:
@@ -441,8 +648,7 @@ What ability is this? https://i.imgur.com/PCrmtNx.png:
 - Walrus Punch
 What ability is this? https://i.imgur.com/PKCajV2.png:
 - Spirits Out
-What ability is this? https://i.imgur.com/PKZ2cTp.png:
-- Cold Feet
+
 What ability is this? https://i.imgur.com/PKn9vBX.png:
 - Geomagnetic Grip
 What ability is this? https://i.imgur.com/PLtRXis.png:
@@ -469,8 +675,7 @@ What ability is this? https://i.imgur.com/QCv66xU.png:
 - Cloak and Dagger
 What ability is this? https://i.imgur.com/QLDBMhR.png:
 - Focused Detonate
-What ability is this? https://i.imgur.com/QPkeKvK.png:
-- Culling Blade
+
 What ability is this? https://i.imgur.com/QXReBGF.png:
 - Ancient Seal
 What ability is this? https://i.imgur.com/QZAYWnX.png:
@@ -483,10 +688,8 @@ What ability is this? https://i.imgur.com/QpPRO0v.png:
 - Meat Hook
 What ability is this? https://i.imgur.com/QpZ8h6A.png:
 - Frostbite
-What ability is this? https://i.imgur.com/RHRZzj6.png:
-- Aphotic Shield
-What ability is this? https://i.imgur.com/ROUKHNY.png:
-- Unstable Concoction
+
+
 What ability is this? https://i.imgur.com/RSgnSqT.png:
 - Sun Ray
 What ability is this? https://i.imgur.com/RY773PQ.png:
@@ -627,8 +830,7 @@ What ability is this? https://i.imgur.com/abLppb6.png:
 - Plague Ward
 What ability is this? https://i.imgur.com/abMUerv.png:
 - Reflection
-What ability is this? https://i.imgur.com/acHDcF3.png:
-- Counter Helix
+
 What ability is this? https://i.imgur.com/ai8I1Lr.png:
 - Terrorize
 What ability is this? https://i.imgur.com/b5IrqkC.png:
@@ -653,8 +855,7 @@ What ability is this? https://i.imgur.com/c21JoFw.png:
 - Refraction
 What ability is this? https://i.imgur.com/c3m8RuR.png:
 - Dark Pact
-What ability is this? https://i.imgur.com/c6WTDXX.png:
-- Firefly
+
 What ability is this? https://i.imgur.com/c9ECJIK.png:
 - Launch Snowball
 What ability is this? https://i.imgur.com/cKpGa4P.png:
@@ -677,8 +878,7 @@ What ability is this? https://i.imgur.com/dTYWEsH.png:
 - Living Armor
 What ability is this? https://i.imgur.com/da4HT66.png:
 - Life Drain
-What ability is this? https://i.imgur.com/de1Solo.png:
-- Flux
+
 What ability is this? https://i.imgur.com/diJCQOO.png:
 - Waveform
 What ability is this? https://i.imgur.com/djmPOx3.png:
@@ -691,8 +891,7 @@ What ability is this? https://i.imgur.com/dwI4ZYX.png:
 - Wall of Replica
 What ability is this? https://i.imgur.com/e8NkVgl.png:
 - Crystal Nova
-What ability is this? https://i.imgur.com/e9ipnhZ.png:
-- Magnetic Field
+
 What ability is this? https://i.imgur.com/e9pAwA8.png:
 - Shadowraze (Near)
 - Shadowraze Near
@@ -702,8 +901,7 @@ What ability is this? https://i.imgur.com/eHl6UcP.png:
 - Feast
 What ability is this? https://i.imgur.com/eKT4gKq.png:
 - Walrus Kick
-What ability is this? https://i.imgur.com/ea88e97.png:
-- Flamebreak
+
 What ability is this? https://i.imgur.com/eaEmrUO.png:
 - Arc Lightning
 What ability is this? https://i.imgur.com/ehrPB5V.png:
@@ -724,10 +922,8 @@ What ability is this? https://i.imgur.com/fzeIdiW.png:
 - Slithereen Crush
 What ability is this? https://i.imgur.com/fztqvAc.png:
 - Soul Catcher
-What ability is this? https://i.imgur.com/g42pVks.png:
-- Curse of Avernus
-What ability is this? https://i.imgur.com/g8vFvN6.png:
-- Borrowed Time
+
+
 What ability is this? https://i.imgur.com/g95764l.png:
 - Dragon Tail
 What ability is this? https://i.imgur.com/gEv4Iju.png:
@@ -770,12 +966,8 @@ What ability is this? https://i.imgur.com/i1JiCuX.png:
 - Stampede
 What ability is this? https://i.imgur.com/io4j5UF.png:
 - Bash
-What ability is this? https://i.imgur.com/j6tX9kQ.png:
-- Blink (Anti-Mage)
-- Blink
-- Anti-Mage Blink
-What ability is this? https://i.imgur.com/j7PzMhi.png:
-- Sticky Napalm
+
+
 What ability is this? https://i.imgur.com/jC4mbqh.png:
 - Hex
 What ability is this? https://i.imgur.com/jIKqZdq.png:
@@ -862,8 +1054,7 @@ What ability is this? https://i.imgur.com/nLpMXtX.png:
 - Call Down
 What ability is this? https://i.imgur.com/nWUFTHd.png:
 - Devour
-What ability is this? https://i.imgur.com/nYi9uXc.png:
-- Mana Break
+
 What ability is this? https://i.imgur.com/nYiXreU.png:
 - Spirits
 What ability is this? https://i.imgur.com/najZXYr.png:
@@ -894,8 +1085,7 @@ What ability is this? https://i.imgur.com/oN6udOB.png:
 - Ice Shards
 What ability is this? https://i.imgur.com/oWv1tOU.png:
 - Meld
-What ability is this? https://i.imgur.com/ostwLWM.png:
-- Nightmare
+
 What ability is this? https://i.imgur.com/oxFjjYm.png:
 - Rolling Thunder
 What ability is this? https://i.imgur.com/oxgU2Xi.png:
@@ -925,8 +1115,7 @@ What ability is this? https://i.imgur.com/qX892tV.png:
 - False Promise
 What ability is this? https://i.imgur.com/qdL0SAD.png:
 - Coup de Grace
-What ability is this? https://i.imgur.com/qiVf4dc.png:
-- Enfeeble
+
 What ability is this? https://i.imgur.com/qwGGVkQ.png:
 - Haunt
 What ability is this? https://i.imgur.com/rIMd2yM.png:
@@ -951,12 +1140,10 @@ What ability is this? https://i.imgur.com/sJn6T9V.png:
 - EMP
 What ability is this? https://i.imgur.com/saKNr3L.png:
 - Frozen Sigil
-What ability is this? https://i.imgur.com/sbiDRM8.png:
-- Tempest Double
+
 What ability is this? https://i.imgur.com/scUQ1Vx.png:
 - Mortal Strike
-What ability is this? https://i.imgur.com/syRZuJG.png:
-- Spark Wraith
+
 What ability is this? https://i.imgur.com/sz4ZZRf.png:
 - Shadow Poison Release
 What ability is this? https://i.imgur.com/tI1UsiQ.png:
@@ -994,8 +1181,7 @@ What ability is this? https://i.imgur.com/v3J9FU6.png:
 - Sun Strike
 What ability is this? https://i.imgur.com/vdHhJKt.png:
 - Sacred Arrow
-What ability is this? https://i.imgur.com/vjN869j.png:
-- Mana Shield
+
 What ability is this? https://i.imgur.com/vkc1MU1.png:
 - Stop Rolling
 What ability is this? https://i.imgur.com/wCbPETt.png:

--- a/redbot/cogs/trivia/data/lists/dota2abilities.yaml
+++ b/redbot/cogs/trivia/data/lists/dota2abilities.yaml
@@ -16,6 +16,7 @@ What ability is this? https://i.imgur.com/g8vFvN6.png: # [ULT]
 # Alchemist
 What innate ability is this? https://i.imgur.com/J97FNqg.png: # [IN]
 - Greevil's Greed
+- Greevils Greed
 What ability is this? https://i.imgur.com/BUqQWji.png: # [1]
 - Acid Spray
 What ability is this? https://i.imgur.com/ROUKHNY.png: # [2]
@@ -67,6 +68,7 @@ What ability is this? https://i.imgur.com/sbiDRM8.png: # [ULT]
 # - One Man Army
 What ability is this? https://i.imgur.com/5oihonX.png: # [1]
 - Berserker's Call
+- Berserkers Call
 What ability is this? https://i.imgur.com/FZML9xq.png: # [2]
 - Battle Hunger
 What ability is this? https://i.imgur.com/acHDcF3.png: # [3]
@@ -86,6 +88,7 @@ What ability is this? https://i.imgur.com/4U35Jam.png: # [3](Alt)
 - Nightmare End
 What ability is this? https://i.imgur.com/5mUEdUT.png: # [ULT]
 - Fiend's Grip
+- Fiends Grip
 # Batrider
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
 # - Smoldering Resin
@@ -162,6 +165,7 @@ What ability is this? https://i.imgur.com/2T8w9q2.png: # [ULT]
 # Broodmother
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
 # - Spider's Milk
+# - Spiders Milk
 What ability is this? https://i.imgur.com/xN1TWZh.png: # [1]
 - Insatiable Hunger
 What ability is this? https://i.imgur.com/G3yMjte.png: # [2]
@@ -170,6 +174,7 @@ What ability is this? https://i.imgur.com/PNH7ytm.png: # [3]
 - Incapacitating Bite
 # What ability is this? https://i.imgur.com/0000000: # [4]
 # - Spinner's Snare
+# - Spinners Snare
 What ability is this? https://i.imgur.com/B7bhmxH.png: # [ULT]
 - Spawn Spiderlings
 # Centaur Warrunner
@@ -344,6 +349,7 @@ What ability is this? https://i.imgur.com/g95764l.png: # [2]
 - Dragon Tail
 What ability is this? https://i.imgur.com/kauXrGn.png: # [3]
 - Wyrm's Wrath
+- Wyrms Wrath
 # What ability is this? https://i.imgur.com/0000000: # [4]
 # - Fireball
 What ability is this? https://i.imgur.com/Of6sQ1j.png: # [ULT]
@@ -422,6 +428,7 @@ What ability is this? https://i.imgur.com/IAa1bDZ.png: # [2]
 - Enchant
 What ability is this? https://i.imgur.com/MUv3Y5M.png: # [3]
 - Nature's Attendants
+- Natures Attendants
 # What ability is this? https://i.imgur.com/0000000: # [4]
 # - Sproink
 # What ability is this? https://i.imgur.com/0000000: # [5]
@@ -461,6 +468,7 @@ What ability is this? https://i.imgur.com/5oS4p6Z.png: # [ULT]
 # - Stroke of Fate
 # What ability is this? https://i.imgur.com/0000000: # [2]
 # - Phantom's Embrace
+# - Phantoms Embrace
 # What ability is this? https://i.imgur.com/0000000: # [3]
 # - Ink Swell
 # What ability is this? https://i.imgur.com/0000000: # [4]
@@ -494,6 +502,7 @@ What ability is this? https://i.imgur.com/nLpMXtX.png:
 # - Decoy
 # What ability is this? https://i.imgur.com/0000000: # [5]
 # - Hunter's Boomerang
+# - Hunters Boomerang
 # What ability is this? https://i.imgur.com/0000000: # [ULT]
 # - Sharpshooter
 # Huskar
@@ -505,6 +514,7 @@ What ability is this? https://i.imgur.com/q4z8X5Z.png: # [2]
 - Burning Spear
 What ability is this? https://i.imgur.com/najZXYr.png: # [3]
 - Berserker's Blood
+- Berserkers Blood
 What ability is this? https://i.imgur.com/kEjJIc9.png: # [4]
 - Life Break
 - Lifebreak
@@ -622,9 +632,11 @@ What ability is this? https://i.imgur.com/k1Qa44g.png: # [ULT]
 # - Shodo Sai
 # What ability is this? https://i.imgur.com/0000000: # [ULT]
 # - Raven's Veil
+# - Ravens Veil
 # Kunkka
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
 # - Admiral's Rum
+# - Admirals Rum
 What ability is this? https://i.imgur.com/hGaz2o5.png: # [1]
 - Torrent
 What ability is this? https://i.imgur.com/De4lTvg.png: # [2]
@@ -793,6 +805,7 @@ What ability is this? https://i.imgur.com/yRs0y6A.png:
 # - Spear of Mars
 # What ability is this? https://i.imgur.com/0000000: # [2]
 # - God's Rebuke
+# - Gods Rebuke
 # What ability is this? https://i.imgur.com/0000000: # [3]
 # - Bulwark
 # What ability is this? https://i.imgur.com/0000000: # [ULT]
@@ -806,6 +819,7 @@ What ability is this? https://i.imgur.com/2DPvUVw.png: # [2]
 - Mystic Snake
 # What ability is this? https://i.imgur.com/0000000: # [3]
 # - Gorgon's Grasp
+# - Gorgons Grasp
 # What ability is this? https://i.imgur.com/0000000: # [4]
 # - Cold Blooded
 What ability is this? https://i.imgur.com/v0RLs2l.png: # [ULT]
@@ -855,6 +869,7 @@ What ability is this? https://i.imgur.com/yVl4z4E.png: # [4]
 - Jingu Mastery
 What ability is this? https://i.imgur.com/Tbum8Mm.png: # [ULT]
 - Wukong's Command
+- Wukongs Command
 # Morphling
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
 # - Ebb and Flow
@@ -911,6 +926,7 @@ What ability is this? https://i.imgur.com/yFkkXar.png: # [2]
 - Teleportation
 What ability is this? https://i.imgur.com/Hjrd8PX.png: # [3]
 - Nature's Call
+- Natures Call
 # What ability is this? https://i.imgur.com/0000000: # [4]
 # - Curse of the Oldgrowth
 What ability is this? https://i.imgur.com/p6shYfB.png: # [ULT]
@@ -928,6 +944,7 @@ What ability is this? https://i.imgur.com/SJ0ae9Z.png: # [3]
 # - Death Seeker
 What ability is this? https://i.imgur.com/NTLxr4U.png: # [ULT]
 - Reaper's Scythe
+- Reapers Scythe
 # Night Stalker
 What innate ability is this? https://i.imgur.com/xivXaHo.png: # [IN]
 - Hunter in the Night
@@ -986,8 +1003,10 @@ What ability is this? https://i.imgur.com/KfQBVXv.png: # [ULT]
 # - Prognosticate
 What ability is this? https://i.imgur.com/J8iyl8n.png: # [1]
 - Fortune's End
+- Fortunes End
 What ability is this? https://i.imgur.com/T5jvTy0.png: # [2]
 - Fate's Edict
+- Fates Edict
 What ability is this? https://i.imgur.com/WuZE3vs.png: # [3]
 - Purifying Flames
 What ability is this? https://i.imgur.com/qX892tV.png: # [ULT]
@@ -1003,6 +1022,7 @@ What ability is this? https://i.imgur.com/GPDCOGw.png: # [2]
 # - Objurgation
 What ability is this? https://i.imgur.com/O0qMgc4.png: # [ULT]
 - Sanity's Eclipse
+- Sanitys Eclipse
 # Pangolier
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
 # - Fortune Favors the Bold
@@ -1039,6 +1059,7 @@ What ability is this? https://i.imgur.com/kOJ6Iit.png: # [1]
 - Spirit Lance
 What ability is this? https://i.imgur.com/m6s6gTu.png: # [2]
 - Doppelganger
+- Doppleganger # typo
 What ability is this? https://i.imgur.com/aB11d3Q.png: # [3]
 - Phantom Rush
 What ability is this? https://i.imgur.com/cKpGa4P.png: # [ULT]
@@ -1370,6 +1391,7 @@ What ability is this? https://i.imgur.com/kgo57gs.png: # [3]
 - War cry
 What ability is this? https://i.imgur.com/K3WXdiC.png: # [ULT]
 - God's Strength
+- Gods Strength
 # Techies
 What ability is this? https://i.imgur.com/BI7aszU.png: # [IN]
  - M.A.D.
@@ -1423,6 +1445,7 @@ What ability is this? https://i.imgur.com/VMkk6Q1.png: # [ULT]
 # Tidehunter
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
 # - Leviathan's Catch
+# - Leviathans Catch
 What ability is this? https://i.imgur.com/TzUXaEc.png: # [1]
 - Gush
 What ability is this? https://i.imgur.com/q1TZSqX.png: # [2]
@@ -1482,8 +1505,10 @@ What ability is this? https://i.imgur.com/KaFcFdb.png: # [ULT]
 # Treant Protector
 What innate ability is this? https://i.imgur.com/liSYifa.png: # [IN]
 - Nature's Guise
+- Natures Guise
 # What ability is this? https://i.imgur.com/0000000: # [1]
 # - Nature's Grasp
+# - Natures Grasp
 What ability is this? https://i.imgur.com/IGGcNmg.png: # [2]
 - Leech Seed
 What ability is this? https://i.imgur.com/dTYWEsH.png: # [3]
@@ -1538,6 +1563,7 @@ What ability is this? https://i.imgur.com/LiPZwBR.png: # [3]
 - Atrophy Aura
 # What ability is this? https://i.imgur.com/0000000: # [ULT]
 # - Fiend's Gate
+# - Fiends Gate
 # Undying
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
 # - Ceaseless Dirge
@@ -1607,6 +1633,7 @@ What ability is this? https://i.imgur.com/IMfMkKO.png: # [2]
 - Soul Assumption
 What ability is this? https://i.imgur.com/CSH4JMc.png: # [3]
 - Gravekeeper's Cloak
+- Gravekeepers Cloak
 # What ability is this? https://i.imgur.com/0000000: # [4]
 # - Stone Form
 What ability is this? https://i.imgur.com/BHTULeO.png: # [ULT]
@@ -1664,6 +1691,7 @@ What ability is this? https://i.imgur.com/2jZ4Uf1.png: # [ULT]
 # Winter Wyvern
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
 # - Eldwurm's Edda
+# - Eldwurms Edda
 What ability is this? https://i.imgur.com/UJgFRGo.png: # [1]
 - Arctic Burn
 What ability is this? https://i.imgur.com/0yVFHjI.png: # [2]
@@ -1672,6 +1700,7 @@ What ability is this? https://i.imgur.com/BVme5AJ.png: # [3]
 - Cold Embrace
 What ability is this? https://i.imgur.com/E5xrzuV.png: # [ULT]
 - Winter's Curse
+- Winters Curse
 # Witch Doctor
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
 # - Gris-Gris
@@ -1709,3 +1738,4 @@ What ability is this? https://i.imgur.com/prsRq3G.png: # [2]
 # - Nimbus
 What ability is this? https://i.imgur.com/Gzl5hkS.png: # [ULT]
 - Thundergod's Wrath
+- Thundergods Wrath

--- a/redbot/cogs/trivia/data/lists/dota2abilities.yaml
+++ b/redbot/cogs/trivia/data/lists/dota2abilities.yaml
@@ -2,32 +2,22 @@ AUTHOR: JennJenn
 DESCRIPTION: >-
   A trivia about Dota 2 abilities. In this trivia, identify the ability
   from the image sent. Dota 2 is a multiplayer online battle arena video game by Valve.
-What ability is this? (removed from game) https://i.imgur.com/0KZLUdJ.png:
-- Sadist
-What ability is this? (removed from game) https://i.imgur.com/GaGZzRK.png:
-- "Call of the Wild: Hawk"
-- Call of the Wild Hawk
-What ability is this? (removed from game) https://i.imgur.com/bggKiqU.png:
-- Craggy Exterior
-What ability is this? (removed from game) https://i.imgur.com/x0iTmMq.png:
-- Test of Faith (Teleport)
-- Test of Faith Teleport
-What ability is this? (removed from game) https://i.imgur.com/z93qGEx.png:
-- Suicide Squad, Attack!
-- suicide squad attack
+What ability is this? https://i.imgur.com/GaGZzRK.png:
+- Summon Raptors
+What innate ability is this? https://i.imgur.com/bggKiqU.png:
+- Insurmountable
 What ability is this? https://i.imgur.com/0A8C7wM.png:
 - Chaos Strike
 What ability is this? https://i.imgur.com/0IQn6ug.png:
 - Rage
 What ability is this? https://i.imgur.com/0JGCqSu.png:
-- Cripple (Lycan Wolf)
-- Cripple
-- Lycan Wolf Cripple
+- Crippling Fear
 What ability is this? https://i.imgur.com/0JwHDOJ.png:
 - Light Strike Array
 What ability is this? https://i.imgur.com/0LSBunY.png:
 - Attribute Shift (Agility Gain)
 - Attribute Shift Agility Gain
+- Attribute Shift
 What ability is this? https://i.imgur.com/0MYQSVF.png:
 - Blinding Light
 What ability is this? https://i.imgur.com/0OBAWeC.png:
@@ -39,9 +29,7 @@ What ability is this? https://i.imgur.com/0V4SLoS.png:
 What ability is this? https://i.imgur.com/0YpdsNT.png:
 - Viscous Nasal Goo
 What ability is this? https://i.imgur.com/0bX5emr.png:
-- Unstable Current
-What ability is this? https://i.imgur.com/0oH1UdI.png:
-- Mana Leak
+- Storm Surge
 What ability is this? https://i.imgur.com/0yVFHjI.png:
 - Splinter Blast
 What ability is this? https://i.imgur.com/13Bw6be.png:
@@ -66,7 +54,7 @@ What ability is this? https://i.imgur.com/261lk7J.png:
 - Shapeshift
 What ability is this? https://i.imgur.com/2DPvUVw.png:
 - Mystic Snake
-What ability is this? https://i.imgur.com/2ELk5Uw.png:
+What innate ability is this? https://i.imgur.com/2ELk5Uw.png:
 - Desolate
 What ability is this? https://i.imgur.com/2MbrJ06.png:
 - Thunder Strike
@@ -78,10 +66,6 @@ What ability is this? https://i.imgur.com/2U8fvM5.png:
 - Stop Sun Ray
 What ability is this? https://i.imgur.com/2aGSLwK.png:
 - Poof
-What ability is this? https://i.imgur.com/2amS4fv.png:
-- Empowering Haste
-What ability is this? https://i.imgur.com/2dq65g2.png:
-- Haste Rune Buff
 What ability is this? https://i.imgur.com/2jZ4Uf1.png:
 - Focus Fire
 What ability is this? https://i.imgur.com/2lOdxvB.png:
@@ -93,14 +77,12 @@ What ability is this? https://i.imgur.com/32Nw3yf.png:
 What ability is this? https://i.imgur.com/374iVtN.png:
 - Flesh Golem
 What ability is this? https://i.imgur.com/3BaLwBw.png:
-- Call of the Wild
+- Summon Razorback
 What ability is this? https://i.imgur.com/3KNjwWX.png:
 - Ice Wall
 What ability is this? https://i.imgur.com/3btLBuJ.png:
-- Return (Kunkka)
-- Return
-- Kunkka Return
-What ability is this? https://i.imgur.com/4AoRrcX.png:
+- X Marks The Spot
+What innate ability is this? https://i.imgur.com/4AoRrcX.png:
 - Inner Beast
 What ability is this? https://i.imgur.com/4HDygyR.png:
 - Fervor
@@ -120,14 +102,10 @@ What ability is this? https://i.imgur.com/4m1JoUa.png:
 - Exorcism
 What ability is this? https://i.imgur.com/4u98BUr.png:
 - March of the Machines
-What ability is this? https://i.imgur.com/4wL249w.png:
-- Heartpiercer
+#What ability is this? https://i.imgur.com/4wL249w.png: replaced with lucky shot
+#- Heartpiercer
 What ability is this? https://i.imgur.com/554WWRF.png:
 - Poison Sting
-What ability is this? https://i.imgur.com/57j9kYQ.png:
-- Chakram 2
-What ability is this? https://i.imgur.com/5QwTEzF.png:
-- Rabid
 What ability is this? https://i.imgur.com/5VYGT2S.png:
 - Flaming Lasso
 What ability is this? https://i.imgur.com/5lkslhd.png:
@@ -142,10 +120,10 @@ What ability is this? https://i.imgur.com/5oihonX.png:
 - Berserker's Call
 What ability is this? https://i.imgur.com/5zbDixI.png:
 - Nether Ward
-What ability is this? https://i.imgur.com/63fjMat.png:
-- Test of Faith
+#What ability is this? https://i.imgur.com/63fjMat.png: replaced with divine favor
+#- Test of Faith
 What ability is this? https://i.imgur.com/66IUX1V.png:
-- Vampiric Aura
+- Bone Guard
 What ability is this? https://i.imgur.com/69dhFq0.png:
 - Waning Rift
 What ability is this? https://i.imgur.com/6ECNZuq.png:
@@ -170,14 +148,10 @@ What ability is this? https://i.imgur.com/73c0X8u.png:
 - Telekinesis Land
 What ability is this? https://i.imgur.com/7Oh7bjv.png:
 - Blade Fury
-What ability is this? https://i.imgur.com/7dch06I.png:
-- Invisibility Rune Buff
 What ability is this? https://i.imgur.com/7wfVN6a.png:
 - Ice Vortex
 What ability is this? https://i.imgur.com/83gBZsI.png:
 - Kinetic Field
-What ability is this? https://i.imgur.com/8Am3jdR.png:
-- Illusion
 What ability is this? https://i.imgur.com/8BbsIDw.png:
 - Overgrowth
 What ability is this? https://i.imgur.com/8VQoMYP.png:
@@ -229,8 +203,6 @@ What ability is this? https://i.imgur.com/BVme5AJ.png:
 - Cold Embrace
 What ability is this? https://i.imgur.com/BYqGIYR.png:
 - Infernal Blade
-What ability is this? https://i.imgur.com/BaU4IDv.png:
-- Arcane Rune Buff
 What ability is this? https://i.imgur.com/Bq9M2l0.png:
 - Corrosive Skin
 What ability is this? https://i.imgur.com/C738s6Y.png:
@@ -241,16 +213,16 @@ What ability is this? https://i.imgur.com/CCGIDJA.png:
 - Frost Blast
 What ability is this? https://i.imgur.com/CD69R7d.png:
 - Burrow
-What ability is this? https://i.imgur.com/CNmLmD7.png:
+What innate ability is this? https://i.imgur.com/CNmLmD7.png:
 - Mana Burn
 What ability is this? https://i.imgur.com/CSH4JMc.png:
 - Gravekeeper's Cloak
-What ability is this? https://i.imgur.com/CWHpnWs.png:
-- Stasis Trap
+#What ability is this? https://i.imgur.com/CWHpnWs.png: needs replacing with reactive taser
+#- Stasis Trap
 What ability is this? https://i.imgur.com/CbvZ4aS.png:
 - Open Wounds
-What ability is this? https://i.imgur.com/CcspPBT.png:
-- Berserker's Rage
+#What ability is this? https://i.imgur.com/CcspPBT.png: outdated image for ability
+#- Berserker's Rage
 What ability is this? https://i.imgur.com/Cgg4m1S.png:
 - Vengeance Aura
 What ability is this? https://i.imgur.com/CjmqL6c.png:
@@ -271,8 +243,6 @@ What ability is this? https://i.imgur.com/DIto2eL.png:
 - Bloodrage
 What ability is this? https://i.imgur.com/DJzNANM.png:
 - Chemical Rage
-What ability is this? https://i.imgur.com/DKKCqFM.png:
-- Hybrid
 What ability is this? https://i.imgur.com/DcA2Vez.png:
 - Skeleton Walk
 What ability is this? https://i.imgur.com/De4lTvg.png:
@@ -287,8 +257,6 @@ What ability is this? https://i.imgur.com/E80vySv.png:
 - Untouchable
 What ability is this? https://i.imgur.com/E96ZJl3.png:
 - Primal Split
-What ability is this? https://i.imgur.com/EGAhadB.png:
-- Control
 What ability is this? https://i.imgur.com/EMV0rgv.png:
 - Invisibility (Lycan Wolf)
 - Invisibility
@@ -308,11 +276,10 @@ What ability is this? https://i.imgur.com/FCISu8S.png:
 What ability is this? https://i.imgur.com/FQG66ec.png:
 - Break Tether
 What ability is this? https://i.imgur.com/FZEYYYQ.png:
-- Adaptive Strike (Agility)
-- Adaptive Strike Agility
+- Adaptive Strike
 What ability is this? https://i.imgur.com/FZML9xq.png:
 - Battle Hunger
-What ability is this? https://i.imgur.com/FcRJMtq.png:
+What innate ability is this? https://i.imgur.com/FcRJMtq.png:
 - Degen Aura
 What ability is this? https://i.imgur.com/FfRtCL3.png:
 - Moment of Courage
@@ -321,7 +288,7 @@ What ability is this? https://i.imgur.com/FhPo2Dv.png:
 What ability is this? https://i.imgur.com/FzAhlnW.png:
 - Tether
 What ability is this? https://i.imgur.com/G3yMjte.png:
-- Spin Web
+- Spinner's Snare
 What ability is this? https://i.imgur.com/GAsnKv8.png:
 - Breathe Fire
 What ability is this? https://i.imgur.com/GPDCOGw.png:
@@ -336,7 +303,7 @@ What ability is this? https://i.imgur.com/GwUQMwn.png:
 - Static Remnant
 What ability is this? https://i.imgur.com/Gzl5hkS.png:
 - Thundergod's Wrath
-What ability is this? https://i.imgur.com/H0eo0j3.png:
+What innate ability is this? https://i.imgur.com/H0eo0j3.png:
 - Caustic Finale
 What ability is this? https://i.imgur.com/H8rCDYl.png:
 - Invulnerability

--- a/redbot/cogs/trivia/data/lists/dota2abilities.yaml
+++ b/redbot/cogs/trivia/data/lists/dota2abilities.yaml
@@ -1,7 +1,7 @@
 AUTHOR: JennJenn, Eternalll
 DESCRIPTION: >-
   A trivia about Dota 2 abilities as of patch 7.41c. In this trivia, identify the ability
-  from the image sent. Dota 2 is a multiplayer online battle arena video game by Valve.
+  from the image sent. Dota 2 is a multiplayer online battle arena (MOBA) video game by Valve.
 # Abaddon
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
 # - Withering Mist
@@ -46,11 +46,9 @@ What ability is this? https://i.imgur.com/5lkslhd.png: # [ULT]
 What ability is this? https://i.imgur.com/nYi9uXc.png: # [1]
 - Mana Break
 What ability is this? https://i.imgur.com/j6tX9kQ.png: # [2]
-- Blink (Anti-Mage)
 - Blink
-- Anti-Mage Blink
-What ability is this? https://i.imgur.com/Dz7G2Ma.png: # [3] - image is a little out of date
-- Counterspell
+# What innate ability is this? https://i.imgur.com/0000000: # [3]
+# - Counterspell
 What ability is this? https://i.imgur.com/BLCIY3v.png: # [ULT]
 - Mana Void
 # Arc Warden
@@ -119,6 +117,7 @@ What ability is this? https://i.imgur.com/DIto2eL.png: # [1]
 - Bloodrage
 What ability is this? https://i.imgur.com/XzPyTGf.png: # [2]
 - Blood Rite
+- Bloodrite
 What ability is this? https://i.imgur.com/TjIASfx.png: # [3]
 - Thirst
 What ability is this? https://i.imgur.com/b5IrqkC.png: # [ULT]
@@ -165,12 +164,12 @@ What ability is this? https://i.imgur.com/2T8w9q2.png: # [ULT]
 # - Spider's Milk
 What ability is this? https://i.imgur.com/xN1TWZh.png: # [1]
 - Insatiable Hunger
-# What ability is this? https://i.imgur.com/0000000: # [2]
-# - Spin Web
+What ability is this? https://i.imgur.com/G3yMjte.png: # [2]
+- Spin Web
 What ability is this? https://i.imgur.com/PNH7ytm.png: # [3]
 - Incapacitating Bite
-What ability is this? https://i.imgur.com/G3yMjte.png: # [4]
-- Spinner's Snare
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Spinner's Snare
 What ability is this? https://i.imgur.com/B7bhmxH.png: # [ULT]
 - Spawn Spiderlings
 # Centaur Warrunner
@@ -217,6 +216,7 @@ What ability is this? https://i.imgur.com/FhPo2Dv.png: # [2]
 - Searing Arrows
 What ability is this? https://i.imgur.com/o2qAqkE.png: # [3]
 - Death Pact
+- Deathpact
 # What ability is this? https://i.imgur.com/0000000: # [4]
 # - Burning Army
 # What ability is this? https://i.imgur.com/0000000: # [5]
@@ -315,6 +315,7 @@ What ability is this? https://i.imgur.com/4m1JoUa.png: # [ULT]
 # - Electromagnetic Repulsion
 What ability is this? https://i.imgur.com/2MbrJ06.png: # [1]
 - Thunder Strike
+- Thunderstrike
 What ability is this? https://i.imgur.com/fPFw0GN.png: # [2]
 - Glimpse
 What ability is this? https://i.imgur.com/83gBZsI.png: # [3]
@@ -382,6 +383,7 @@ What ability is this? https://i.imgur.com/I2NvxE1.png: # [2]
 - Enchant Totem
 What ability is this? https://i.imgur.com/KAxGqvz.png: # [3]
 - Aftershock
+- After shock
 What ability is this? https://i.imgur.com/rJjuneV.png: # [4]
 - Echo Slam
 # Elder Titan
@@ -406,6 +408,7 @@ What ability is this? https://i.imgur.com/kkcrkoo.png: # [2]
 - Sleight of Fist
 What ability is this? https://i.imgur.com/Thg1NJH.png: # [3]
 - Flame Guard
+- Flameguard
 What ability is this? https://i.imgur.com/TAqbyTQ.png: # [4]
 - Activate Fire Remnant
 What ability is this? https://i.imgur.com/ctHMsSI.png: # [ULT]
@@ -441,10 +444,12 @@ What ability is this? https://i.imgur.com/YXTVCNd.png: # [ULT]
 # - Distortion Field
 What ability is this? https://i.imgur.com/xNqYfoK.png: # [1]
 - Time Walk
+- Timewalk
 What ability is this? https://i.imgur.com/gG7OwWD.png: # [2]
 - Time Dilation
 What ability is this? https://i.imgur.com/JVJs8VI.png: # [3]
 - Time Lock
+- Timelock
 # What ability is this? https://i.imgur.com/0000000: # [4]
 # - Reverse Time Walk
 What ability is this? https://i.imgur.com/5oS4p6Z.png: # [ULT]
@@ -475,6 +480,7 @@ What ability is this? https://i.imgur.com/jIKqZdq.png: # [3]
 # - Side Gunner
 What ability is this? https://i.imgur.com/nLpMXtX.png:
 - Call Down
+- Calldown
 # Hoodwink
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
 # - Mistwoods Wayfarer
@@ -501,6 +507,7 @@ What ability is this? https://i.imgur.com/najZXYr.png: # [3]
 - Berserker's Blood
 What ability is this? https://i.imgur.com/kEjJIc9.png: # [4]
 - Life Break
+- Lifebreak
 # Invoker
 What ability is this? https://i.imgur.com/QdDe9x2.png: # [1]
 - Quas
@@ -566,6 +573,7 @@ What ability is this? https://i.imgur.com/N479xl0.png: # [ULT]
 # - Bladeform
 What ability is this? https://i.imgur.com/7Oh7bjv.png: # [1]
 - Blade Fury
+- Bladefury
 What ability is this? https://i.imgur.com/PtqRyJI.png: # [2]
 - Healing Ward
 What ability is this? https://i.imgur.com/4Mmu9H3.png: # [3]
@@ -582,7 +590,9 @@ What ability is this? https://i.imgur.com/Ydf1cL2.png: # [1]
 What ability is this? https://i.imgur.com/yUqvGUh.png: # [1](Alt)
 - Release Illuminate
 What ability is this? https://i.imgur.com/Md4o99D.png: # [1](Alt)
+- Illuminate (Spirit Form)
 - Illuminate Spirit Form
+- Illuminate
 What ability is this? https://i.imgur.com/0MYQSVF.png: # [2]
 - Blinding Light
 What ability is this? https://i.imgur.com/CBFlvIh.png: # [3]
@@ -855,11 +865,11 @@ What ability is this? https://i.imgur.com/FZEYYYQ.png: # [2]
 What ability is this? https://i.imgur.com/0LSBunY.png: # [3]
 - Attribute Shift (Agility Gain)
 - Attribute Shift Agility Gain
-- Attribute Shift
+- Attribute Shift Agility
 What ability is this? https://i.imgur.com/V1roWyX.png: # [4]
 - Attribute Shift (Strength Gain)
 - Attribute Shift Strength Gain
-- Attribute Shift
+- Attribute Shift Strength
 What ability is this? https://i.imgur.com/gyK74ha.png: # [ULT]
 - Morph
 What ability is this? https://i.imgur.com/kkMA22I.png: # [ULT](Alt)
@@ -959,6 +969,7 @@ What ability is this? https://i.imgur.com/HJUyVQ2.png: # [4]
 # - Fire Shield
 What ability is this? https://i.imgur.com/lG97CeO.png: # [ULT]
 - Multicast
+- Multi-cast
 # Omniknight
 What innate ability is this? https://i.imgur.com/FcRJMtq.png: # [IN]
 - Degen Aura
@@ -1045,6 +1056,7 @@ What ability is this? https://i.imgur.com/21bnvvZ.png: # [2](Alt)
 - Launch Fire Spirit
 What ability is this? https://i.imgur.com/RSgnSqT.png: # [3]
 - Sun Ray
+- Sunray
 What ability is this? https://i.imgur.com/2U8fvM5.png: # [3] (Alt)
 - Stop Sun Ray
 What ability is this? https://i.imgur.com/8lfQ4e4.png: # [4]
@@ -1108,8 +1120,6 @@ What ability is this? https://i.imgur.com/BJRUHS9.png: # [1]
 - Shadow Strike
 What ability is this? https://i.imgur.com/XhcNvQ3.png: # [2]
 - Blink
-- Blink (Queen of Pain)
-- Queen of Pain Blink
 What ability is this? https://i.imgur.com/rW8u5w7.png: # [3]
 - Scream of Pain
 What ability is this? https://i.imgur.com/wjMDyPe.png: # [ULT]
@@ -1130,12 +1140,13 @@ What ability is this? https://i.imgur.com/Wd8SgdN.png: # [ULT]
 # - Backstab
 What ability is this? https://i.imgur.com/FCISu8S.png: # [1]
 - Smoke Screen
+- Smokescreen
 What ability is this? https://i.imgur.com/Q2YMrCY.png: # [2]
 - Blink Strike
 What ability is this? https://i.imgur.com/ORT7Dwy.png: # [3]
 - Tricks of the Trade
-What ability is this? https://i.imgur.com/QCv66xU.png: # [ULT]
-- Cloak and Dagger
+#What ability is this? https://i.imgur.com/QCv66xU.png: # [ULT] - BROKEN URL
+#- Cloak and Dagger
 # Ringmaster
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
 # - Dark Carnival Barker
@@ -1179,6 +1190,7 @@ What innate ability is this? https://i.imgur.com/H0eo0j3.png: # [IN]
 - Caustic Finale
 What ability is this? https://i.imgur.com/4m16Vjf.png: # [1]
 - Burrowstrike
+- Burrow strike
 What ability is this? https://i.imgur.com/IYziArw.png:
 - Sand Storm
 # What ability is this? https://i.imgur.com/0000000: # [3]
@@ -1216,6 +1228,7 @@ What ability is this? https://i.imgur.com/YunlihM.png: # [1](Alt)
 # - Feast of Souls
 What ability is this? https://i.imgur.com/dq6rID6.png: # [4]
 - Presence of the Dark Lord
+- Presense of the Dark Lord # typo
 What ability is this? https://i.imgur.com/ConFPLo.png: # [ULT]
 - Requiem of Souls
 # Shadow Shaman
@@ -1231,7 +1244,6 @@ What ability is this? https://i.imgur.com/hHrloCO.png: # [3]
 # - Urnaconda
 What ability is this? https://i.imgur.com/WQHV5aU.png:
 - Mass Serpent Ward
-- Serpent Ward
 # Silencer
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
 # - Suffer In Silence
@@ -1355,6 +1367,7 @@ What ability is this? https://i.imgur.com/2oeoTNi.png: # [2]
 - Great Cleave
 What ability is this? https://i.imgur.com/kgo57gs.png: # [3]
 - Warcry
+- War cry
 What ability is this? https://i.imgur.com/K3WXdiC.png: # [ULT]
 - God's Strength
 # Techies
@@ -1501,8 +1514,9 @@ What ability is this? https://i.imgur.com/oN6udOB.png: # [1]
 - Ice Shards
 What ability is this? https://i.imgur.com/wJwUbrH.png: # [2]
 - Snowball
-What ability is this? https://i.imgur.com/c9ECJIK.png: # [2](Alt)
-- Launch Snowball
+- Snow ball
+- Launch Snowball # same icon
+- Launch Snow ball # same icon
 # What ability is this? https://i.imgur.com/0000000: # [3]
 # - Tag Team
 # What ability is this? https://i.imgur.com/0000000: # [4]
@@ -1517,6 +1531,7 @@ What ability is this? https://i.imgur.com/PCrmtNx.png: # [ULT]
 # - Invading Force
 What ability is this? https://i.imgur.com/JvHLhJm.png: # [1]
 - Firestorm
+- Fire storm
 What ability is this? https://i.imgur.com/Ihhvhdx.png: # [2]
 - Pit of Malice
 What ability is this? https://i.imgur.com/LiPZwBR.png: # [3]
@@ -1528,10 +1543,11 @@ What ability is this? https://i.imgur.com/LiPZwBR.png: # [3]
 # - Ceaseless Dirge
 What ability is this? https://i.imgur.com/hNY3HEK.png: # [1]
 - Decay
-What ability is this? https://i.imgur.com/ZUB9LCI.png: # [2]
-- Soul Rip
+# What ability is this? https://i.imgur.com/ZUB9LCI.png: # [2] - BROKEN URL
+# - Soul Rip
 What ability is this? https://i.imgur.com/bUdXqyZ.png: # [3]
 - Tombstone
+- Tomb stone
 What ability is this? https://i.imgur.com/374iVtN.png: # [ULT]
 - Flesh Golem
 # Ursa
@@ -1539,8 +1555,10 @@ What ability is this? https://i.imgur.com/374iVtN.png: # [ULT]
 # - Maul
 What ability is this? https://i.imgur.com/pQV2JLt.png: # [1]
 - Earthshock
+- Earth shock
 What ability is this? https://i.imgur.com/XGjIZ3l.png: # [2]
 - Overpower
+- Over power
 What ability is this? https://i.imgur.com/tdEXOZF.png: # [3]
 - Fury Swipes
 What ability is this? https://i.imgur.com/8VQoMYP.png: # [ULT]
@@ -1624,6 +1642,7 @@ What ability is this? https://i.imgur.com/nfMltKz.png: # [2]
 - Shukuchi
 What ability is this? https://i.imgur.com/RY773PQ.png: # [3]
 - Geminate Attack
+- Germinate Attack # purposeful typo
 What ability is this? https://i.imgur.com/ehrPB5V.png: # [ULT]
 - Time Lapse
 # Windranger
@@ -1631,10 +1650,13 @@ What ability is this? https://i.imgur.com/ehrPB5V.png: # [ULT]
 # - Tailwind
 What ability is this? https://i.imgur.com/xxDj7GO.png: # [1]
 - Shackleshot
+- Shackle shot
 What ability is this? https://i.imgur.com/JJLAsfU.png: # [2]
 - Powershot
+- Power shot
 What ability is this? https://i.imgur.com/aHqmkB0.png: # [3]
 - Windrun
+- Wind run
 # What ability is this? https://i.imgur.com/0000000: # [4]
 # - Gale Force
 What ability is this? https://i.imgur.com/2jZ4Uf1.png: # [ULT]

--- a/redbot/cogs/trivia/data/lists/dota2abilities.yaml
+++ b/redbot/cogs/trivia/data/lists/dota2abilities.yaml
@@ -35,8 +35,11 @@ What ability is this? https://i.imgur.com/PKZ2cTp.png: # [1]
 - Cold Feet
 What ability is this? https://i.imgur.com/7wfVN6a.png: # [2]
 - Ice Vortex
+What ability is this? https://i.imgur.com/4iLwPJz.png: # [3]
+- Chilling Touch
 What ability is this? https://i.imgur.com/5lkslhd.png: # [ULT]
 - Ice Blast
+- Release # same icon
 # Anti-Mage
 # What innate ability is this? https://i.imgur.com/0000000: # [IN]
 # - Persecutor
@@ -303,8 +306,8 @@ What ability is this? https://i.imgur.com/PtOHt8w.png: # [1]
 - Crypt Swarm
 What ability is this? https://i.imgur.com/tI1UsiQ.png: # [2]
 - Silence
-# What ability is this? https://i.imgur.com/0000000: # [3]
-# - Spirit Siphon
+What ability is this? https://i.imgur.com/NXZtwjr.png: # [3]
+- Spirit Siphon
 What ability is this? https://i.imgur.com/4m1JoUa.png: # [ULT]
 - Exorcism
 # Disruptor
@@ -678,842 +681,1009 @@ What ability is this? https://i.imgur.com/CCGIDJA.png: # [1]
 What ability is this? https://i.imgur.com/1HgJ1bn.png: # [ULT]
 - Chain Frost
 # Lifestealer
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Ghoul Frenzy
 What ability is this? https://i.imgur.com/0IQn6ug.png: # [1]
 - Rage
+What ability is this? https://i.imgur.com/CbvZ4aS.png: # [2]
+- Open Wounds
+What ability is this? https://i.imgur.com/eHl6UcP.png: # [3]
+- Feast
+What ability is this? https://i.imgur.com/uj1D3OE.png: # [ULT]
+- Infest
+What ability is this? https://i.imgur.com/YgcBkkl.png: # [ULT](Alt)
+- Consume
 # Lina
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Slow Burn
+What ability is this? https://i.imgur.com/U3qXiOR.png: # [1]
+- Dragon Slave
 What ability is this? https://i.imgur.com/0JwHDOJ.png: # [2]
 - Light Strike Array
 What ability is this? https://i.imgur.com/70nnwxH.png: # [3]
 - Fiery Soul
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Flame Cloak
+What ability is this? https://i.imgur.com/u3NhKrE.png: # [ULT]
+- Laguna Blade
 # Lion
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - To Hell and Back
+What ability is this? https://i.imgur.com/kypYgE5.png: # [1]
+- Earth Spike
+What ability is this? https://i.imgur.com/zMYgF7b.png: # [2]
+- Hex
+What ability is this? https://i.imgur.com/OmnckhS.png: # [3]
+- Mana Drain
+What ability is this? https://i.imgur.com/ZVli0sA.png: # [4]
+- Finger of Death
 # Lone Druid
+What innate ability is this? https://i.imgur.com/ZzwIY1H.png: # [IN]
+- Summon Spirit Bear
+# What ability is this? https://i.imgur.com/0000000: # [1]
+# - Entangle
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Spirit Link
 What ability is this? https://i.imgur.com/32Nw3yf.png: # [3]
 - Savage Roar
+What ability is this? https://i.imgur.com/MzcTM8h.png: # [ULT]
+- True Form
 # Luna
+What innate ability is this? https://i.imgur.com/lUURpuL.png: # [IN]
+- Lunar Blessing
+What ability is this? https://i.imgur.com/OqgDu6w.png: # [1]
+- Lucent Beam
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Lunar Orbit
+What ability is this? https://i.imgur.com/hfi7sEq.png: # [3]
+- Moon Glaives
 What ability is this? https://i.imgur.com/9pCeilj.png: # [ULT]
 - Eclipse
 # Lycan
-What ability is this? https://i.imgur.com/261lk7J.png: # Ability 4 
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Apex Predator
+What ability is this? https://i.imgur.com/uMmwQ1a.png: # [1]
+- Summon Wolves
+What ability is this? https://i.imgur.com/wEuOQZi.png: # [2]
+- Howl
+What ability is this? https://i.imgur.com/AmuABVC.png: # [3]
+- Feral Impulse
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Wolf Bite
+What ability is this? https://i.imgur.com/261lk7J.png: # [ULT]
 - Shapeshift
 # Magnus
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Solid Core
+What ability is this? https://i.imgur.com/zuJRDuj.png: # [1]
+- Shockwave
+What ability is this? https://i.imgur.com/9QvvTjl.png: # [2]
+- Empower
+What ability is this? https://i.imgur.com/uzQb32K.png: # [3]
+- Skewer
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Horn Toss
+What ability is this? https://i.imgur.com/yRs0y6A.png:
+- Reverse Polarity
 # Marci
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Special Delivery
+# What ability is this? https://i.imgur.com/0000000: # [1]
+# - Dispose
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Rebound
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Bodyguard
+# What ability is this? https://i.imgur.com/0000000: # [ULT]
+# - Unleash
 # Mars
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Dauntless
+# What ability is this? https://i.imgur.com/0000000: # [1]
+# - Spear of Mars
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - God's Rebuke
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Bulwark
+# What ability is this? https://i.imgur.com/0000000: # [ULT]
+# - Arena of Blood
 # Medusa
+What innate ability is this? https://i.imgur.com/vjN869j.png: # [INT]
+- Mana Shield
+What ability is this? https://i.imgur.com/K38Heb1.png: # [1]
+- Split Shot
 What ability is this? https://i.imgur.com/2DPvUVw.png: # [2]
 - Mystic Snake
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Gorgon's Grasp
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Cold Blooded
+What ability is this? https://i.imgur.com/v0RLs2l.png: # [ULT]
+- Stone Gaze
 # Meepo
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Geomancy
+What ability is this? https://i.imgur.com/nF0ug5I.png: # [1]
+- Earthbind
 What ability is this? https://i.imgur.com/2aGSLwK.png: # [2]
 - Poof
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Ransack
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Dig
+# What ability is this? https://i.imgur.com/0000000: # [5]
+# - MegaMeepo
+# What ability is this? https://i.imgur.com/0000000: # [5](Alt)
+# - MegaMeepo Fling
 What ability is this? https://i.imgur.com/6aKdh41.png: # [ULT]
 - Divided We Stand
 # Mirana
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Celestial Quiver
+What ability is this? https://i.imgur.com/5mYgGEw.png: # [1]
+- Starstorm
+What ability is this? https://i.imgur.com/vdHhJKt.png: # [2]
+- Sacred Arrow
+What ability is this? https://i.imgur.com/k24O7Lp.png: # [3]
+- Leap
+What ability is this? https://i.imgur.com/C738s6Y.png: # [4]
+- Moonlight Shadow
 # Monkey King
+What innate ability is this? https://i.imgur.com/lrKdZ5N.png: # [IN]
+- Mischief
+What ability is this? https://i.imgur.com/0V4SLoS.png: # [IN](Alt)
+- Revert Form
 What ability is this? https://i.imgur.com/6sXFGUA.png: # [1]
 - Boundless Strike
-What ability is this? https://i.imgur.com/0V4SLoS.png: # Ability 6 (Alt)
-- Revert Form
+What ability is this? https://i.imgur.com/SI8IZFe.png: # [2]
+- Tree Dance
+What ability is this? https://i.imgur.com/ErBuVzh.png: # [3]
+- Primal Spring or Spring Early
+- Spring Early
+- Primal Spring
+What ability is this? https://i.imgur.com/yVl4z4E.png: # [4]
+- Jingu Mastery
+What ability is this? https://i.imgur.com/Tbum8Mm.png: # [ULT]
+- Wukong's Command
 # Morphling
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Ebb and Flow
+What ability is this? https://i.imgur.com/diJCQOO.png: # [1]
+- Waveform
+What ability is this? https://i.imgur.com/FZEYYYQ.png: # [2]
+- Adaptive Strike
 What ability is this? https://i.imgur.com/0LSBunY.png: # [3]
 - Attribute Shift (Agility Gain)
 - Attribute Shift Agility Gain
 - Attribute Shift
+What ability is this? https://i.imgur.com/V1roWyX.png: # [4]
+- Attribute Shift (Strength Gain)
+- Attribute Shift Strength Gain
+- Attribute Shift
+What ability is this? https://i.imgur.com/gyK74ha.png: # [ULT]
+- Morph
+What ability is this? https://i.imgur.com/kkMA22I.png: # [ULT](Alt)
+- Morph Replicate
 # Muerta
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Supernatural
+# What ability is this? https://i.imgur.com/0000000: # [1]
+# - Dead Shot
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - The Calling
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Gunslinger
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Spectral Slug
+# What ability is this? https://i.imgur.com/0000000: # [ULT]
+# - Pierce the Veil
 # Naga Siren
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Eelskin
 What ability is this? https://i.imgur.com/6clz8xq.png: # [1]
 - Mirror Image
+What ability is this? https://i.imgur.com/Gtu2ZHW.png: # [2]
+- Ensnare
+What ability is this? https://i.imgur.com/fpfaumU.png: # [3]
+- Rip Tide
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Reel In
+What ability is this? https://i.imgur.com/lS7P0QI.png: # [ULT]
+- Song of the Siren
+What ability is this? https://i.imgur.com/jauB1Mi.png: # [ULT](Alt)
+- Song of the Siren End
 # Nature's Prophet
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Spirit of the Forest
+What ability is this? https://i.imgur.com/gI4wLvb.png: # [1]
+- Sprout
+What ability is this? https://i.imgur.com/yFkkXar.png: # [2]
+- Teleportation
+What ability is this? https://i.imgur.com/Hjrd8PX.png: # [3]
+- Nature's Call
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Curse of the Oldgrowth
+What ability is this? https://i.imgur.com/p6shYfB.png: # [ULT]
+- Wrath of Nature
 # Necrophos
+What innate ability is this? https://i.imgur.com/0KZLUdJ.png: # [IN]
+- Sadist
+What ability is this? https://i.imgur.com/PYIy1bG.png: # [1]
+- Death Pulse
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Ghost Shroud
+What ability is this? https://i.imgur.com/SJ0ae9Z.png: # [3]
+- Heartstopper Aura
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Death Seeker
+What ability is this? https://i.imgur.com/NTLxr4U.png: # [ULT]
+- Reaper's Scythe
 # Night Stalker
+What innate ability is this? https://i.imgur.com/xivXaHo.png: # [IN]
+- Hunter in the Night
+What ability is this? https://i.imgur.com/S885568.png: # [1]
+- Void
 What ability is this? https://i.imgur.com/0JGCqSu.png: # [2]
 - Crippling Fear
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Midnight Feast
+# What ability is this? https://i.imgur.com/0000000: # [ULT]
+# - Dark Ascension
 # Nyx Assassin
+What innate ability is this? https://i.imgur.com/CNmLmD7.png: # [IN]
+- Mana Burn
+What ability is this? https://i.imgur.com/MpTqSAJ.png: # [1]
+- Impale
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Mind Flare
+What ability is this? https://i.imgur.com/UJ2SfUQ.png: # [3]
+- Spiked Carapace
+What ability is this? https://i.imgur.com/CD69R7d.png: # [4]
+- Burrow
+What ability is this? https://i.imgur.com/nl88bDE.png: # [4](Alt)
+- Unburrow
+What ability is this? https://i.imgur.com/o9KvFAt.png: # [ULT]
+- Vendetta
 # Ogre Magi
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Dumb Luck
 What ability is this? https://i.imgur.com/13Bw6be.png: # [1]
 - Fireblast
+What ability is this? https://i.imgur.com/8rgi5BB.png: # [2]
+- Ignite
+What ability is this? https://i.imgur.com/kZPtBCV.png: # [3]
+- Bloodlust
+What ability is this? https://i.imgur.com/HJUyVQ2.png: # [4]
+- Unrefined Fireblast
+# What ability is this? https://i.imgur.com/0000000: # [5]
+# - Fire Shield
+What ability is this? https://i.imgur.com/lG97CeO.png: # [ULT]
+- Multicast
 # Omniknight
+What innate ability is this? https://i.imgur.com/FcRJMtq.png: # [IN]
+- Degen Aura
+What ability is this? https://i.imgur.com/rOCPbQl.png: # [1]
+- Purification
+What ability is this? https://i.imgur.com/IRoJC7B.png: # [2]
+- Repel
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Hammer of Purity
+What ability is this? https://i.imgur.com/KfQBVXv.png: # [ULT]
+- Guardian Angel
 # Oracle
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Prognosticate
+What ability is this? https://i.imgur.com/J8iyl8n.png: # [1]
+- Fortune's End
+What ability is this? https://i.imgur.com/T5jvTy0.png: # [2]
+- Fate's Edict
+What ability is this? https://i.imgur.com/WuZE3vs.png: # [3]
+- Purifying Flames
+What ability is this? https://i.imgur.com/qX892tV.png: # [ULT]
+- False Promise
 # Outworld Destroyer
+What innate ability is this? https://i.imgur.com/ZgXRY7u.png: # [IN]
+- Essence Flux
+What ability is this? https://i.imgur.com/OFYHQxv.png: # [1]
+- Arcane Orb
+What ability is this? https://i.imgur.com/GPDCOGw.png: # [2]
+- Astral Imprisonment
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Objurgation
+What ability is this? https://i.imgur.com/O0qMgc4.png: # [ULT]
+- Sanity's Eclipse
 # Pangolier
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Fortune Favors the Bold
+What ability is this? https://i.imgur.com/8jFinQN.png: # [1]
+- Swashbuckle
+What ability is this? https://i.imgur.com/kTJTxSn.png: # [2]
+- Shield Crash
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Lucky Shot
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Roll Up
+What ability is this? https://i.imgur.com/oxFjjYm.png: # [ULT]
+- Rolling Thunder
+What ability is this? https://i.imgur.com/vkc1MU1.png: # [ULT/4](Alt)
+- Stop Rolling
+- End Roll Up # Same icon
 # Phantom Assassin
+What innate ability is this? https://i.imgur.com/D2Dw9AZ.png: # [IN]
+- Blur
+What ability is this? https://i.imgur.com/AfySnUQ.png: # [1]
+- Stifling Dagger
+What ability is this? https://i.imgur.com/cgh0ET9.png: # [2]
+- Phantom Strike
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Immaterial
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Fan of Knives
+What ability is this? https://i.imgur.com/qdL0SAD.png: # [ULT]
+- Coup de Grace
 # Phantom Lancer
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Illusory Armaments
+What ability is this? https://i.imgur.com/kOJ6Iit.png: # [1]
+- Spirit Lance
+What ability is this? https://i.imgur.com/m6s6gTu.png: # [2]
+- Doppelganger
+What ability is this? https://i.imgur.com/aB11d3Q.png: # [3]
+- Phantom Rush
+What ability is this? https://i.imgur.com/cKpGa4P.png: # [ULT]
+- Juxtapose
 # Phoenix
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Dying Light
+What ability is this? https://i.imgur.com/rSeefMY.png: # [1]
+- Icarus Dive
+What ability is this? https://i.imgur.com/kIpRoiL.png: # [1](Alt)
+- Stop Icarus Dive
+What ability is this? https://i.imgur.com/AvqgsGb.png: # [2]
+- Fire Spirits
 What ability is this? https://i.imgur.com/21bnvvZ.png: # [2](Alt)
 - Launch Fire Spirit
+What ability is this? https://i.imgur.com/RSgnSqT.png: # [3]
+- Sun Ray
 What ability is this? https://i.imgur.com/2U8fvM5.png: # [3] (Alt)
 - Stop Sun Ray
+What ability is this? https://i.imgur.com/8lfQ4e4.png: # [4]
+- Toggle Movement
+What ability is this? https://i.imgur.com/Vm16ML0.png: # [ULT]
+- Supernova
 # Primal Beast
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Colossal
+# What ability is this? https://i.imgur.com/0000000: # [1]
+# - Onslaught
+# What ability is this? https://i.imgur.com/0000000: # [1](Alt)
+# - Begin Onslaught
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Trample
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Uproar
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Rock Throw
+# What ability is this? https://i.imgur.com/0000000: # [ULT]
+# - Pulverize
 # Puck
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Puckish
+What ability is this? https://i.imgur.com/LUgtrxC.png: # [1]
+- Illusory Orb
 What ability is this? https://i.imgur.com/69dhFq0.png: # [2]
 - Waning Rift
+What ability is this? https://i.imgur.com/OUY2hf6.png: # [3]
+- Phase Shift
+What ability is this? https://i.imgur.com/Du6xnAD.png: # [4]
+- Ethereal Jaunt
+What ability is this? https://i.imgur.com/A7WrsBa.png: # [ULT]
+- Dream Coil
 # Pudge
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Flesh Heap
+What ability is this? https://i.imgur.com/QpPRO0v.png: # [1]
+- Meat Hook
+What ability is this? https://i.imgur.com/K3byHPk.png: # [2]
+- Rot
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Meat Shield
+What ability is this? https://i.imgur.com/LVueVCR.png: # [ULT]
+- Dismember
 # Pugna
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Oblivion Savant
+What ability is this? https://i.imgur.com/Pl1SRle.png: # [1]
+- Nether Blast
 What ability is this? https://i.imgur.com/0PiJYmp.png: # [2]
 - Decrepify
 What ability is this? https://i.imgur.com/5zbDixI.png: # [3]
 - Nether Ward
+What ability is this? https://i.imgur.com/da4HT66.png:
+- Life Drain
 # Queen of Pain
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Succubus
+What ability is this? https://i.imgur.com/BJRUHS9.png: # [1]
+- Shadow Strike
+What ability is this? https://i.imgur.com/XhcNvQ3.png: # [2]
+- Blink
+- Blink (Queen of Pain)
+- Queen of Pain Blink
+What ability is this? https://i.imgur.com/rW8u5w7.png: # [3]
+- Scream of Pain
+What ability is this? https://i.imgur.com/wjMDyPe.png: # [ULT]
+- Sonic Wave
 # Razor
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Unstable Current
 What ability is this? https://i.imgur.com/6l371xX.png: # [1]
 - Plasma Field
+What ability is this? https://i.imgur.com/wCbPETt.png: # [2]
+- Static Link
 What ability is this? https://i.imgur.com/0bX5emr.png: # [3]
 - Storm Surge
+What ability is this? https://i.imgur.com/Wd8SgdN.png: # [ULT]
+- Eye of the Storm
 # Riki
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Backstab
+What ability is this? https://i.imgur.com/FCISu8S.png: # [1]
+- Smoke Screen
+What ability is this? https://i.imgur.com/Q2YMrCY.png: # [2]
+- Blink Strike
+What ability is this? https://i.imgur.com/ORT7Dwy.png: # [3]
+- Tricks of the Trade
+What ability is this? https://i.imgur.com/QCv66xU.png: # [ULT]
+- Cloak and Dagger
 # Ringmaster
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Dark Carnival Barker
+# What ability is this? https://i.imgur.com/0000000: # [1]
+# - Tame the Beasts
+# What ability is this? https://i.imgur.com/0000000: # [1](Alt)
+# - Crack
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Escape Act
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Impalement Arts
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Souvenir Slot
+# What ability is this? https://i.imgur.com/0000000: # [4](Alt)
+# - Funhouse Mirror
+# What ability is this? https://i.imgur.com/0000000: # [4](Alt)
+# - Whoopee Cushion
+# What ability is this? https://i.imgur.com/0000000: # [4](Alt)
+# - Strongman Tonic
+# What ability is this? https://i.imgur.com/0000000: # [4](Alt)
+# - Unicycle
+# What ability is this? https://i.imgur.com/0000000: # [5]
+# - Spotlight
+# What ability is this? https://i.imgur.com/0000000: # [ULT]
+# - Wheel of Wonder
 # Rubick
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Curiosity
+What ability is this? https://i.imgur.com/xOSzlWY.png:
+- Telekinesis
 What ability is this? https://i.imgur.com/73c0X8u.png: # [1] (Alt)
 - Telekinesis Land
+What ability is this? https://i.imgur.com/bt17jdZ.png: # [2]
+- Fade Bolt
+What ability is this? https://i.imgur.com/yRL9eLs.png: # [3]
+- Arcane Supremacy
 What ability is this? https://i.imgur.com/6FMgz5M.png: # [ULT]
 - Spell Steal
 # Sand King
+What innate ability is this? https://i.imgur.com/H0eo0j3.png: # [IN]
+- Caustic Finale
 What ability is this? https://i.imgur.com/4m16Vjf.png: # [1]
 - Burrowstrike
+What ability is this? https://i.imgur.com/IYziArw.png:
+- Sand Storm
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Stinger
+What ability is this? https://i.imgur.com/YihLcCx.png: # [ULT]
+- Epicenter
 # Shadow Demon
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Menace
 What ability is this? https://i.imgur.com/6ECNZuq.png: # [1]
 - Disruption
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Disseminate
+What ability is this? https://i.imgur.com/hJIHCa8.png: # [3]
+- Shadow Poison
+What ability is this? https://i.imgur.com/sz4ZZRf.png: # [3](Alt)
+- Shadow Poison Release
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Demonic Cleanse
+What ability is this? https://i.imgur.com/Cl9msdJ.png: # [ULT]
+- Demonic Purge
 # Shadow Fiend
+What ability is this? https://i.imgur.com/mVnb12R.png: # [IN]
+- Necromastery
+What ability is this? https://i.imgur.com/e9pAwA8.png: # [1]
+- Shadowraze (Near)
+- Shadowraze Near
+What ability is this? https://i.imgur.com/tRgiIsx.png: # [1](Alt)
+- Shadowraze (Medium)
+- Shadowraze Medium
+What ability is this? https://i.imgur.com/YunlihM.png: # [1](Alt)
+- Shadowraze (Far)
+- Shadowraze Far
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Feast of Souls
+What ability is this? https://i.imgur.com/dq6rID6.png: # [4]
+- Presence of the Dark Lord
+What ability is this? https://i.imgur.com/ConFPLo.png: # [ULT]
+- Requiem of Souls
 # Shadow Shaman
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Fowl Play
+What ability is this? https://i.imgur.com/kjv3jEv.png: # [1]
+- Ether Shock
+What ability is this? https://i.imgur.com/jC4mbqh.png: # [2]
+- Hex
+What ability is this? https://i.imgur.com/hHrloCO.png: # [3]
+- Shackles
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Urnaconda
+What ability is this? https://i.imgur.com/WQHV5aU.png:
+- Mass Serpent Ward
+- Serpent Ward
 # Silencer
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Suffer In Silence
+What ability is this? https://i.imgur.com/hMWSfgA.png: # [1]
+- Arcane Curse
+What ability is this? https://i.imgur.com/uvXNeIA.png: # [2]
+- Glaives of Wisdom
+What ability is this? https://i.imgur.com/gc4UKOO.png: # [3]
+- Last Word
+What ability is this? https://i.imgur.com/Y9BWxhg.png: # [ULT]
+- Global Silence
 # Skywrath Mage
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Shield of the Scion
+What ability is this? https://i.imgur.com/mMRslEc.png: # [1]
+- Arcane Bolt
+What ability is this? https://i.imgur.com/n84AW2C.png: # [2]
+- Concussive Shot
+What ability is this? https://i.imgur.com/QXReBGF.png: # [3]
+- Ancient Seal
+What ability is this? https://i.imgur.com/XDRJYGH.png: # [ULT]
+- Mystic Flare
 # Slardar
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Seaborn Sentinel
+What ability is this? https://i.imgur.com/oKlUHE6.png: # [1]
+- Guardian Sprint
+What ability is this? https://i.imgur.com/fzeIdiW.png: # [2]
+- Slithereen Crush
+What ability is this? https://i.imgur.com/io4j5UF.png: # [3]
+- Bash of the Deep
+What ability is this? https://i.imgur.com/kFEb70C.png: # [ULT]
+- Amplify Damage
 # Slark
+What innate ability is this? https://i.imgur.com/ZimJssI.png: # [IN]
+- Essence Shift
+What ability is this? https://i.imgur.com/c3m8RuR.png: # [1]
+- Dark Pact
+What ability is this? https://i.imgur.com/wjAqjQd.png: # [2]
+- Pounce
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Saltwater Shiv
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Depth Shroud
+What ability is this? https://i.imgur.com/MYC5guQ.png: # [ULT]
+- Shadow Dance
 # Snapfire
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Boomstick
+# What ability is this? https://i.imgur.com/0000000: # [1]
+# - Scatterblast
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Firesnap Cookie
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Lil' Shredder
+# - Lil Shredder
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Gobble Up
+# What ability is this? https://i.imgur.com/0000000: # [4](Alt)
+# - Spit Out
+# What ability is this? https://i.imgur.com/0000000: # [ULT]
+# - Mortimer Kisses
+# - Mortimer's Kisses
+# - Mortimers Kisses
 # Sniper
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Keen Scope
+What ability is this? https://i.imgur.com/th8jPI6.png: # [1]
+- Shrapnel
+What ability is this? https://i.imgur.com/WmUl5tV.png: # [2]
+- Headshot
+What ability is this? https://i.imgur.com/fKFtB6L.png: # [3]
+- Take Aim
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Concussive Grenade
+What ability is this? https://i.imgur.com/ZzhZsww.png: # [ULT]
+- Assassinate
 # Spectre
 What innate ability is this? https://i.imgur.com/2ELk5Uw.png: # [IN]
 - Desolate
+What ability is this? https://i.imgur.com/TgFe0rb.png: # [1]
+- Spectral Dagger
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Shadow Step
+What ability is this? https://i.imgur.com/CqPbsOx.png: # [3]
+- Dispersion
+What ability is this? https://i.imgur.com/qwGGVkQ.png: # [ULT]
+- Haunt
+What ability is this? https://i.imgur.com/gEv4Iju.png: # [ULT](Alt)
+- Reality
 # Spirit Breaker
+What innate ability is this? https://i.imgur.com/2amS4fv.png: # [IN]
+- Empowering Haste
+What ability is this? https://i.imgur.com/bbr7ItL.png: # [1]
+- Charge of Darkness
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Bulldoze
+What ability is this? https://i.imgur.com/wdq0Eyi.png: # [3]
+- Greater Bash
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Planar Pocket
+What ability is this? https://i.imgur.com/NwrHpIF.png: # [ULT]
+- Nether Strike
 # Storm Spirit
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Galvanized
+What ability is this? https://i.imgur.com/GwUQMwn.png: # [1]
+- Static Remnant
+What ability is this? https://i.imgur.com/zvT3GY2.png: # [2]
+- Electric Vortex
+What ability is this? https://i.imgur.com/k8bdwOs.png: # [3]
+- Overload
+What ability is this? https://i.imgur.com/dM5FqQi.png: # [ULT]
+- Ball Lightning
 # Sven
-What ability is this? https://i.imgur.com/2oeoTNi.png: # [3]
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Wrath of God
+What ability is this? https://i.imgur.com/hJ456Zc.png: # [1]
+- Storm Hammer
+What ability is this? https://i.imgur.com/2oeoTNi.png: # [2]
 - Great Cleave
+What ability is this? https://i.imgur.com/kgo57gs.png: # [3]
+- Warcry
+What ability is this? https://i.imgur.com/K3WXdiC.png: # [ULT]
+- God's Strength
 # Techies
+What ability is this? https://i.imgur.com/BI7aszU.png: # [IN]
+ - M.A.D.
+ - MAD
+What ability is this? https://i.imgur.com/QLDBMhR.png: # [IN](Alt)
+ - Detonate M.A.D.
+ - Detonate MAD
+# What ability is this? https://i.imgur.com/0000000: # [1]
+# - Sticky Bomb
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Reactive Tazer
+# What ability is this? https://i.imgur.com/0000000: # [2](Alt)
+# - Detonate Tazer
+What ability is this? https://i.imgur.com/8dmL0Pl.png: # [3]
+- Blast off!
+- Blast off
+What ability is this? https://i.imgur.com/1gH6M4C.png: # [5]
+- Minefield Sign
+What ability is this? https://i.imgur.com/qFHbDVZ.png: # [ULT]
+- Proximity Mines
 # Templar Assassin
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Inner Peace
+What ability is this? https://i.imgur.com/c21JoFw.png: # [1]
+- Refraction
+What ability is this? https://i.imgur.com/oWv1tOU.png: # [2]
+- Meld
+What ability is this? https://i.imgur.com/KiTaZOv.png: # [3]
+- Psi Blades
+What ability is this? https://i.imgur.com/Mx2so6i.png: # [4]
+- Trap
+# What ability is this? https://i.imgur.com/0000000: # [5]
+# - Psionic Projection
+What ability is this? https://i.imgur.com/pUtDfHr.png: # [ULT]
+- Psionic Trap
 # Terrorblade
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Dark Unity
+What ability is this? https://i.imgur.com/abMUerv.png: # [1]
+- Reflection
+What ability is this? https://i.imgur.com/gqWai5F.png: # [2]
+- Conjure Image
+What ability is this? https://i.imgur.com/fRIFhEC.png: # [3]
+- Metamorphosis
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Demon Zeal
+# What ability is this? https://i.imgur.com/0000000: # [5]
+# - Terror Wave
+What ability is this? https://i.imgur.com/VMkk6Q1.png: # [ULT]
+- Sunder
 # Tidehunter
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Leviathan's Catch
+What ability is this? https://i.imgur.com/TzUXaEc.png: # [1]
+- Gush
+What ability is this? https://i.imgur.com/q1TZSqX.png: # [2]
+- Kraken Shell
 What ability is this? https://i.imgur.com/2lOdxvB.png: # [3]
 - Anchor Smash
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Dead in the Water
+What ability is this? https://i.imgur.com/EvFFPLW.png: # [ULT]
+- Ravage
 # Timbersaw
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Exposure Therapy
+What ability is this? https://i.imgur.com/HG378HE.png: # [1]
+- Whirling Death
+What ability is this? https://i.imgur.com/Cp1QCfC.png: # [2]
+- Timber Chain
+What ability is this? https://i.imgur.com/YsqyC0Z.png: # [3]
+- Reactive Armor
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Flamethrower
+What ability is this? https://i.imgur.com/QgBVcd3.png: # [ULT]
+- Chakram
+What ability is this? https://i.imgur.com/VjCT9b4.png: # [ULT](Alt)
+- Return Chakram
 # Tinker
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Eureka!
+# - Eureka
+What ability is this? https://i.imgur.com/OxRnBaf.png: # [1]
+- Laser
+What ability is this? https://i.imgur.com/4u98BUr.png: # [2]
+- March of the Machines
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Deploy Turrets
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Warp Flare
+# What ability is this? https://i.imgur.com/0000000: # [5]
+# - Keen Conveyance
+What ability is this? https://i.imgur.com/NxFVXPI.png: # [ULT]
+- Rearm
 # Tiny
 What innate ability is this? https://i.imgur.com/bggKiqU.png: # [IN]
 - Insurmountable
+What ability is this? https://i.imgur.com/Iu2brGN.png: # [1]
+- Avalanche
+What ability is this? https://i.imgur.com/djmPOx3.png: # [2]
+- Toss
+What ability is this? https://i.imgur.com/L4ILPLN.png: # [3]
+- Tree Grab
+What ability is this? https://i.imgur.com/pNqzxeA.png: # [3](Alt)
+- Tree Throw
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Tree Volley
+What ability is this? https://i.imgur.com/KaFcFdb.png: # [ULT]
+- Grow
 # Treant Protector
+What innate ability is this? https://i.imgur.com/liSYifa.png: # [IN]
+- Nature's Guise
+# What ability is this? https://i.imgur.com/0000000: # [1]
+# - Nature's Grasp
+What ability is this? https://i.imgur.com/IGGcNmg.png: # [2]
+- Leech Seed
+What ability is this? https://i.imgur.com/dTYWEsH.png: # [3]
+- Living Armor
+What ability is this? https://i.imgur.com/xa2sa4j.png: # [4]
+- Eyes in the Forest
 What ability is this? https://i.imgur.com/8BbsIDw.png: # [ULT]
 - Overgrowth
 # Troll Warlord
+What innate ability is this? https://i.imgur.com/RrTFspK.png: # [IN]
+- Battle Stance
+What ability is this? https://i.imgur.com/puHHZ8N.png: # [2]
+- Whirling Axes (Ranged)
+- Whirling Axes Ranged
+What ability is this? https://i.imgur.com/y5RS5GM.png: # [2]
+- Whirling Axes (Melee)
+- Whirling Axes Melee
+What ability is this? https://i.imgur.com/4HDygyR.png: # [3]
+- Fervor
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Berserker’s Rage
+What ability is this? https://i.imgur.com/dqFyNJi.png: # [ULT]
+- Battle Trance
 # Tusk
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Bitter Chill
+What ability is this? https://i.imgur.com/oN6udOB.png: # [1]
+- Ice Shards
+What ability is this? https://i.imgur.com/wJwUbrH.png: # [2]
+- Snowball
+What ability is this? https://i.imgur.com/c9ECJIK.png: # [2](Alt)
+- Launch Snowball
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Tag Team
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Drinking Buddies
+What ability is this? https://i.imgur.com/eKT4gKq.png: # [5]
+- Walrus Kick
+What ability is this? https://i.imgur.com/PCrmtNx.png: # [ULT]
+- Walrus PUNCH!
+- Walrus Punch
 # Underlord
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Invading Force
+What ability is this? https://i.imgur.com/JvHLhJm.png: # [1]
+- Firestorm
+What ability is this? https://i.imgur.com/Ihhvhdx.png: # [2]
+- Pit of Malice
+What ability is this? https://i.imgur.com/LiPZwBR.png: # [3]
+- Atrophy Aura
+# What ability is this? https://i.imgur.com/0000000: # [ULT]
+# - Fiend's Gate
 # Undying
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Ceaseless Dirge
+What ability is this? https://i.imgur.com/hNY3HEK.png: # [1]
+- Decay
+What ability is this? https://i.imgur.com/ZUB9LCI.png: # [2]
+- Soul Rip
+What ability is this? https://i.imgur.com/bUdXqyZ.png: # [3]
+- Tombstone
 What ability is this? https://i.imgur.com/374iVtN.png: # [ULT]
 - Flesh Golem
 # Ursa
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Maul
+What ability is this? https://i.imgur.com/pQV2JLt.png: # [1]
+- Earthshock
+What ability is this? https://i.imgur.com/XGjIZ3l.png: # [2]
+- Overpower
+What ability is this? https://i.imgur.com/tdEXOZF.png: # [3]
+- Fury Swipes
 What ability is this? https://i.imgur.com/8VQoMYP.png: # [ULT]
 - Enrage
 # Vengeful Spirit
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Retribution
+What ability is this? https://i.imgur.com/sHFZoQg.png: # [1]
+- Magic Missile
+What ability is this? https://i.imgur.com/mNG28HG.png: # [2]
+- Wave of Terror
+What ability is this? https://i.imgur.com/Cgg4m1S.png: # [3]
+- Vengeance Aura
+What ability is this? https://i.imgur.com/KccdX1Q.png: # [ULT]
+- Nether Swap
 # Venomancer
+What innate ability is this? https://i.imgur.com/554WWRF.png: # [IN]
+- Poison Sting
+What ability is this? https://i.imgur.com/U6wNAFy.png: # [1]
+- Venomous Gale
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Snakebite
+What ability is this? https://i.imgur.com/abLppb6.png: # [3]
+- Plague Ward
+# What ability is this? https://i.imgur.com/0000000: # [ULT]
+# - Noxious Plague
 # Viper
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Predator
+What ability is this? https://i.imgur.com/RZWyifn.png: # [1]
+- Poison Attack
+What ability is this? https://i.imgur.com/oxgU2Xi.png: # [2]
+- Nethertoxin
+What ability is this? https://i.imgur.com/Bq9M2l0.png: # [3]
+- Corrosive Skin
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Nosedive
+What ability is this? https://i.imgur.com/zT3stw7.png: # [ULT]
+- Viper Strike
 # Visage
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Silent as the Grave
+What ability is this? https://i.imgur.com/ykXIKkP.png: # [1]
+- Grave Chill
+What ability is this? https://i.imgur.com/IMfMkKO.png: # [2]
+- Soul Assumption
+What ability is this? https://i.imgur.com/CSH4JMc.png: # [3]
+- Gravekeeper's Cloak
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Stone Form
+What ability is this? https://i.imgur.com/BHTULeO.png: # [ULT]
+- Summon Familiars
 # Void Spirit
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Intrinsic Edge
+# What ability is this? https://i.imgur.com/0000000: # [1]
+# - Aether Remnant
+# What ability is this? https://i.imgur.com/0000000: # [2]
+# - Dissimilate
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Resonant Pulse
+# What ability is this? https://i.imgur.com/0000000: # [ULT]
+# - Astral Step
 # Warlock
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Eldritch Summoning
+What ability is this? https://i.imgur.com/fH04Odc.png: # [1]
+- Fatal Bonds
+What ability is this? https://i.imgur.com/L5DWehd.png: # [2]
+- Shadow Word
+What ability is this? https://i.imgur.com/ylsYhYn.png: # [3]
+- Upheaval
+What ability is this? https://i.imgur.com/JjFlCOL.png: # [ULT]
+- Chaotic Offering
 # Weaver
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Threads of Fate
+What ability is this? https://i.imgur.com/OLF3HYi.png: # [1]
+- The Swarm
+What ability is this? https://i.imgur.com/nfMltKz.png: # [2]
+- Shukuchi
+What ability is this? https://i.imgur.com/RY773PQ.png: # [3]
+- Geminate Attack
+What ability is this? https://i.imgur.com/ehrPB5V.png: # [ULT]
+- Time Lapse
 # Windranger
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Tailwind
+What ability is this? https://i.imgur.com/xxDj7GO.png: # [1]
+- Shackleshot
+What ability is this? https://i.imgur.com/JJLAsfU.png: # [2]
+- Powershot
+What ability is this? https://i.imgur.com/aHqmkB0.png: # [3]
+- Windrun
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Gale Force
 What ability is this? https://i.imgur.com/2jZ4Uf1.png: # [ULT]
 - Focus Fire
 # Winter Wyvern
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Eldwurm's Edda
+What ability is this? https://i.imgur.com/UJgFRGo.png: # [1]
+- Arctic Burn
 What ability is this? https://i.imgur.com/0yVFHjI.png: # [2]
 - Splinter Blast
+What ability is this? https://i.imgur.com/BVme5AJ.png: # [3]
+- Cold Embrace
+What ability is this? https://i.imgur.com/E5xrzuV.png: # [ULT]
+- Winter's Curse
 # Witch Doctor
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Gris-Gris
+What ability is this? https://i.imgur.com/Oz5sL6j.png: # [1]
+- Paralyzing Cask
+What ability is this? https://i.imgur.com/kRpniQ9.png: # [2]
+- Voodoo Restoration
+What ability is this? https://i.imgur.com/yOQ9gBX.png: # [3]
+- Maledict
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Voodoo Switcheroo
+What ability is this? https://i.imgur.com/lIxrQpo.png: # [ULT]
+- Death Ward
 # Wraith King
+# What innate ability is this? https://i.imgur.com/0000000: # [IN]
+# - Vampiric Spirit
+What ability is this? https://i.imgur.com/wZiSIAb.png: # [1]
+- Wraithfire Blast
 What ability is this? https://i.imgur.com/66IUX1V.png: # [2]
 - Bone Guard
-# Zeus
-
-
-
-What ability is this? https://i.imgur.com/1gH6M4C.png:
-- Minefield Sign
-
-What ability is this? https://i.imgur.com/4HDygyR.png:
-- Fervor
-
-
-
-
-What ability is this? https://i.imgur.com/4iLwPJz.png:
-- Chilling Touch
-What ability is this? https://i.imgur.com/4u98BUr.png:
-- March of the Machines
-#What ability is this? https://i.imgur.com/4wL249w.png: replaced with lucky shot
-#- Heartpiercer
-What ability is this? https://i.imgur.com/554WWRF.png:
-- Poison Sting
-What ability is this? https://i.imgur.com/5mYgGEw.png:
-- Starstorm
-
-
-
-What ability is this? https://i.imgur.com/8dmL0Pl.png:
-- Blast off!
-- Blast off
-What ability is this? https://i.imgur.com/8jFinQN.png:
-- Swashbuckle
-What ability is this? https://i.imgur.com/8lfQ4e4.png:
-- Toggle Movement
-What ability is this? https://i.imgur.com/8rgi5BB.png:
-- Ignite
-
-What ability is this? https://i.imgur.com/9QvvTjl.png:
-- Empower
-What ability is this? https://i.imgur.com/A7WrsBa.png:
-- Dream Coil
-What ability is this? https://i.imgur.com/AfySnUQ.png:
-- Stifling Dagger
-What ability is this? https://i.imgur.com/AmuABVC.png:
-- Feral Impulse
-
-What ability is this? https://i.imgur.com/AvqgsGb.png:
-- Fire Spirits
-
-What ability is this? https://i.imgur.com/BHTULeO.png:
-- Summon Familiars
-What ability is this? https://i.imgur.com/BI7aszU.png:
-- Remote Mines
-What ability is this? https://i.imgur.com/BJRUHS9.png:
-- Shadow Strike
-
-
-
-What ability is this? https://i.imgur.com/BVme5AJ.png:
-- Cold Embrace
-
-What ability is this? https://i.imgur.com/Bq9M2l0.png:
-- Corrosive Skin
-What ability is this? https://i.imgur.com/C738s6Y.png:
-- Moonlight Shadow
-
-
-What ability is this? https://i.imgur.com/CD69R7d.png:
-- Burrow
-What innate ability is this? https://i.imgur.com/CNmLmD7.png:
-- Mana Burn
-What ability is this? https://i.imgur.com/CSH4JMc.png:
-- Gravekeeper's Cloak
-#What ability is this? https://i.imgur.com/CWHpnWs.png: needs replacing with reactive taser
-#- Stasis Trap
-What ability is this? https://i.imgur.com/CbvZ4aS.png:
-- Open Wounds
-#What ability is this? https://i.imgur.com/CcspPBT.png: outdated image for ability
-#- Berserker's Rage
-What ability is this? https://i.imgur.com/Cgg4m1S.png:
-- Vengeance Aura
-
-What ability is this? https://i.imgur.com/Cl9msdJ.png:
-- Demonic Purge
-What ability is this? https://i.imgur.com/ConFPLo.png:
-- Requiem of Souls
-What ability is this? https://i.imgur.com/Cp1QCfC.png:
-- Timber Chain
-What ability is this? https://i.imgur.com/CqPbsOx.png:
-- Dispersion
-What ability is this? https://i.imgur.com/D2Dw9AZ.png:
-- Blur
-
-
-
-
-What ability is this? https://i.imgur.com/Du6xnAD.png:
-- Ethereal Jaunt
-
-What ability is this? https://i.imgur.com/E5xrzuV.png:
-- Winter's Curse
-
-
-What ability is this? https://i.imgur.com/EMV0rgv.png:
-- Invisibility (Lycan Wolf)
-- Invisibility
-- Lycan Wolf Invisibility
-
-What ability is this? https://i.imgur.com/ErBuVzh.png:
-- Primal Spring or Spring Early
-- Spring Early
-- Primal Spring
-What ability is this? https://i.imgur.com/EvFFPLW.png:
-- Ravage
-
-What ability is this? https://i.imgur.com/FCISu8S.png:
-- Smoke Screen
-
-What ability is this? https://i.imgur.com/FZEYYYQ.png:
-- Adaptive Strike
-
-What innate ability is this? https://i.imgur.com/FcRJMtq.png:
-- Degen Aura
-
-
-
-
-
-What ability is this? https://i.imgur.com/GPDCOGw.png:
-- Astral Imprisonment
-
-
-What ability is this? https://i.imgur.com/Gtu2ZHW.png:
-- Ensnare
-What ability is this? https://i.imgur.com/GwUQMwn.png:
-- Static Remnant
-What ability is this? https://i.imgur.com/Gzl5hkS.png:
-- Thundergod's Wrath
-What innate ability is this? https://i.imgur.com/H0eo0j3.png:
-- Caustic Finale
-What ability is this? https://i.imgur.com/H8rCDYl.png:
-- Invulnerability
-What ability is this? https://i.imgur.com/HG378HE.png:
-- Whirling Death
-What ability is this? https://i.imgur.com/HJUyVQ2.png:
-- Unrefined Fireblast
-What ability is this? https://i.imgur.com/Hjrd8PX.png:
-- Nature's Call
-What ability is this? https://i.imgur.com/IGGcNmg.png:
-- Leech Seed
-What ability is this? https://i.imgur.com/IMfMkKO.png:
-- Soul Assumption
-What ability is this? https://i.imgur.com/IRoJC7B.png:
-- Repel
-What ability is this? https://i.imgur.com/IYziArw.png:
-- Sand Storm
-What ability is this? https://i.imgur.com/Ihhvhdx.png:
-- Pit of Malice
-
-What ability is this? https://i.imgur.com/Iu2brGN.png:
-- Avalanche
-What ability is this? https://i.imgur.com/J8iyl8n.png:
-- Fortune's End
-
-What ability is this? https://i.imgur.com/JJLAsfU.png:
-- Powershot
-
-What ability is this? https://i.imgur.com/JjFlCOL.png:
-- Chaotic Offering
-What ability is this? https://i.imgur.com/JvHLhJm.png:
-- Firestorm
-What ability is this? https://i.imgur.com/K38Heb1.png:
-- Split Shot
-What ability is this? https://i.imgur.com/K3WXdiC.png:
-- God's Strength
-What ability is this? https://i.imgur.com/K3byHPk.png:
-- Rot
-What ability is this? https://i.imgur.com/KaFcFdb.png:
-- Grow
-What ability is this? https://i.imgur.com/KccdX1Q.png:
-- Nether Swap
-What ability is this? https://i.imgur.com/KfQBVXv.png:
-- Guardian Angel
-What ability is this? https://i.imgur.com/KiTaZOv.png:
-- Psi Blades
-What ability is this? https://i.imgur.com/L4ILPLN.png:
-- Tree Grab
-What ability is this? https://i.imgur.com/L5DWehd.png:
-- Shadow Word
-What ability is this? https://i.imgur.com/LTF0Xz5.png:
-- Darkness
-What ability is this? https://i.imgur.com/LUgtrxC.png:
-- Illusory Orb
-What ability is this? https://i.imgur.com/LVueVCR.png:
-- Dismember
-
-What ability is this? https://i.imgur.com/LiPZwBR.png:
-- Atrophy Aura
-What ability is this? https://i.imgur.com/MYC5guQ.png:
-- Shadow Dance
-
-What ability is this? https://i.imgur.com/MpTqSAJ.png:
-- Impale
-What ability is this? https://i.imgur.com/Mx2so6i.png:
-- Trap
-What ability is this? https://i.imgur.com/MzcTM8h.png:
-- True Form
-What ability is this? https://i.imgur.com/NTLxr4U.png:
-- Reaper's Scythe
-What ability is this? https://i.imgur.com/NXZtwjr.png:
-- Spirit Siphon
-What ability is this? https://i.imgur.com/NwrHpIF.png:
-- Nether Strike
-What ability is this? https://i.imgur.com/NxFVXPI.png:
-- Rearm
-What ability is this? https://i.imgur.com/O0qMgc4.png:
-- Sanity's Eclipse
-What ability is this? https://i.imgur.com/OFYHQxv.png:
-- Arcane Orb
-What ability is this? https://i.imgur.com/OLF3HYi.png:
-- The Swarm
-What ability is this? https://i.imgur.com/ORT7Dwy.png:
-- Tricks of the Trade
-What ability is this? https://i.imgur.com/OUY2hf6.png:
-- Phase Shift
-What ability is this? https://i.imgur.com/OmnckhS.png:
-- Mana Drain
-What ability is this? https://i.imgur.com/OqgDu6w.png:
-- Lucent Beam
-What ability is this? https://i.imgur.com/OxRnBaf.png:
-- Laser
-What ability is this? https://i.imgur.com/Oz5sL6j.png:
-- Paralyzing Cask
-What ability is this? https://i.imgur.com/PCrmtNx.png:
-- Walrus Punch
-
-What ability is this? https://i.imgur.com/PYIy1bG.png:
-- Death Pulse
-
-What ability is this? https://i.imgur.com/Pl1SRle.png:
-- Nether Blast
-What ability is this? https://i.imgur.com/Q2YMrCY.png:
-- Blink Strike
-What ability is this? https://i.imgur.com/QCv66xU.png:
-- Cloak and Dagger
-What ability is this? https://i.imgur.com/QLDBMhR.png:
-- Focused Detonate
-What ability is this? https://i.imgur.com/QXReBGF.png:
-- Ancient Seal
-What ability is this? https://i.imgur.com/QgBVcd3.png:
-- Chakram
-What ability is this? https://i.imgur.com/QpPRO0v.png:
-- Meat Hook
-What ability is this? https://i.imgur.com/RSgnSqT.png:
-- Sun Ray
-What ability is this? https://i.imgur.com/RY773PQ.png:
-- Germinate Attack
-What ability is this? https://i.imgur.com/RZWyifn.png:
-- Poison Attack
-What ability is this? https://i.imgur.com/RrTFspK.png:
-- Berserker's Rage
-What ability is this? https://i.imgur.com/S885568.png:
-- Void
-What ability is this? https://i.imgur.com/SI8IZFe.png:
-- Tree Dance
-What ability is this? https://i.imgur.com/SJ0ae9Z.png:
-- Heartstopper Aura
-What ability is this? https://i.imgur.com/T5jvTy0.png:
-- Fate's Edict
-What ability is this? https://i.imgur.com/Tbum8Mm.png:
-- Wukong's Command
-What ability is this? https://i.imgur.com/TgFe0rb.png:
-- Spectral Dagger
-What ability is this? https://i.imgur.com/TzUXaEc.png:
-- Gush
-What ability is this? https://i.imgur.com/U3qXiOR.png:
-- Dragon Slave
-What ability is this? https://i.imgur.com/U6wNAFy.png:
-- Venomous Gale
-What ability is this? https://i.imgur.com/UJ2SfUQ.png:
-- Spiked Carapace
-What ability is this? https://i.imgur.com/UJgFRGo.png:
-- Arctic Burn
-
-What ability is this? https://i.imgur.com/UqFDO1o.png:
-- Vacuum
-What ability is this? https://i.imgur.com/V1roWyX.png:
-- Attribute Shift (Strength Gain)
-- Attribute Shift Strength Gain
-
-What ability is this? https://i.imgur.com/VMkk6Q1.png:
-- Sunder
-What ability is this? https://i.imgur.com/VjCT9b4.png:
-- Return Chakram
-What ability is this? https://i.imgur.com/Vlyw1iV.png:
-- Flesh Heap
-What ability is this? https://i.imgur.com/Vm16ML0.png:
-- Supernova
-What ability is this? https://i.imgur.com/WQHV5aU.png:
-- Mass Serpent Ward
-
-What ability is this? https://i.imgur.com/Wd8SgdN.png:
-- Eye of the Storm
-
-What ability is this? https://i.imgur.com/WmUl5tV.png:
-- Headshot
-What ability is this? https://i.imgur.com/WuZE3vs.png:
-- Purifying Flames
-What ability is this? https://i.imgur.com/XDRJYGH.png:
-- Mystic Flare
-What ability is this? https://i.imgur.com/XGjIZ3l.png:
-- Overpower
-What ability is this? https://i.imgur.com/XhcNvQ3.png:
-- Blink (Queen of Pain)
-- Blink
-- Queen of Pain Blink
-What ability is this? https://i.imgur.com/XluWp0x.png:
-- Druid Form
-What ability is this? https://i.imgur.com/Y9BWxhg.png:
-- Global Silence
-What ability is this? https://i.imgur.com/YgcBkkl.png:
-- Consume
-What ability is this? https://i.imgur.com/YihLcCx.png:
-- Epicenter
-What ability is this? https://i.imgur.com/YsqyC0Z.png:
-- Reactive Armor
-What ability is this? https://i.imgur.com/YunlihM.png:
-- Shadowraze (Far)
-- Shadowraze Far
-What ability is this? https://i.imgur.com/ZUB9LCI.png:
-- Soul Rip
-What ability is this? https://i.imgur.com/ZVli0sA.png:
-- Finger of Death
-What ability is this? https://i.imgur.com/ZZjgKYx.png:
-- Release
-What ability is this? https://i.imgur.com/ZgXRY7u.png:
-- Essence Aura
-What ability is this? https://i.imgur.com/ZimJssI.png:
-- Essence Shift
-What ability is this? https://i.imgur.com/ZzhZsww.png:
-- Assassinate
-What ability is this? https://i.imgur.com/ZzwIY1H.png:
-- Summon Spirit Bear
-What ability is this? https://i.imgur.com/aB11d3Q.png:
-- Phantom Rush
-What ability is this? https://i.imgur.com/aHqmkB0.png:
-- Windrun
-What ability is this? https://i.imgur.com/abLppb6.png:
-- Plague Ward
-What ability is this? https://i.imgur.com/abMUerv.png:
-- Reflection
-
-What ability is this? https://i.imgur.com/bUdXqyZ.png:
-- Tombstone
-What ability is this? https://i.imgur.com/bbr7ItL.png:
-- Charge of Darkness
-
-What ability is this? https://i.imgur.com/bt17jdZ.png:
-- Fade Bolt
-What ability is this? https://i.imgur.com/c21JoFw.png:
-- Refraction
-What ability is this? https://i.imgur.com/c3m8RuR.png:
-- Dark Pact
-What ability is this? https://i.imgur.com/c9ECJIK.png:
-- Launch Snowball
-What ability is this? https://i.imgur.com/cKpGa4P.png:
-- Juxtapose
-What ability is this? https://i.imgur.com/cgh0ET9.png:
-- Phantom Strike
-What ability is this? https://i.imgur.com/dM5FqQi.png:
-- Ball Lightning
-What ability is this? https://i.imgur.com/dTYWEsH.png:
-- Living Armor
-What ability is this? https://i.imgur.com/da4HT66.png:
-- Life Drain
-What ability is this? https://i.imgur.com/diJCQOO.png:
-- Waveform
-What ability is this? https://i.imgur.com/djmPOx3.png:
-- Toss
-What ability is this? https://i.imgur.com/dq6rID6.png:
-- Presence of the Dark Lord
-What ability is this? https://i.imgur.com/dqFyNJi.png:
-- Battle Trance
-What ability is this? https://i.imgur.com/e9pAwA8.png:
-- Shadowraze (Near)
-- Shadowraze Near
-What ability is this? https://i.imgur.com/eHl6UcP.png:
-- Feast
-What ability is this? https://i.imgur.com/eKT4gKq.png:
-- Walrus Kick
-What ability is this? https://i.imgur.com/eaEmrUO.png:
-- Arc Lightning
-What ability is this? https://i.imgur.com/ehrPB5V.png:
-- Time Lapse
-What ability is this? https://i.imgur.com/fH04Odc.png:
-- Fatal Bonds
-What ability is this? https://i.imgur.com/fKFtB6L.png:
-- Take Aim
-What ability is this? https://i.imgur.com/fRIFhEC.png:
-- Metamorphosis
-What ability is this? https://i.imgur.com/fpfaumU.png:
-- Rip Tide
-What ability is this? https://i.imgur.com/fzeIdiW.png:
-- Slithereen Crush
-What ability is this? https://i.imgur.com/fztqvAc.png:
-- Soul Catcher
-What ability is this? https://i.imgur.com/gEv4Iju.png:
-- Reality
-
-What ability is this? https://i.imgur.com/gI4wLvb.png:
-- Sprout
-
-What ability is this? https://i.imgur.com/gc4UKOO.png:
-- Last Word
-
-What ability is this? https://i.imgur.com/glqk3lR.png:
-- Ice Armor
-What ability is this? https://i.imgur.com/gqWai5F.png:
-- Conjure Image
-What ability is this? https://i.imgur.com/gyK74ha.png:
-- Morph
-
-
-What ability is this? https://i.imgur.com/hHrloCO.png:
-- Shackles
-What ability is this? https://i.imgur.com/hJ456Zc.png:
-- Storm Hammer
-What ability is this? https://i.imgur.com/hJIHCa8.png:
-- Shadow Poison
-What ability is this? https://i.imgur.com/hMWSfgA.png:
-- Arcane Curse
-What ability is this? https://i.imgur.com/hNY3HEK.png:
-- Decay
-What ability is this? https://i.imgur.com/hfi7sEq.png:
-- Moon Glaive
-
-
-What ability is this? https://i.imgur.com/io4j5UF.png:
-- Bash
-
-
-What ability is this? https://i.imgur.com/jC4mbqh.png:
-- Hex
-What ability is this? https://i.imgur.com/jIKqZdq.png:
-- Flak Cannon
-
-What ability is this? https://i.imgur.com/jSNNS25.png:
-- Recall
-
-
-What ability is this? https://i.imgur.com/jauB1Mi.png:
-- Song of the Siren End
-
-What ability is this? https://i.imgur.com/k24O7Lp.png:
-- Leap
-What ability is this? https://i.imgur.com/k8bdwOs.png:
-- Overload
-
-What ability is this? https://i.imgur.com/kFEb70C.png:
-- Amplify Damage
-What ability is this? https://i.imgur.com/kIpRoiL.png:
-- Stop Icarus Dive
-What ability is this? https://i.imgur.com/kOJ6Iit.png:
-- Spirit Lance
-
-What ability is this? https://i.imgur.com/kRpniQ9.png:
-- Voodoo Restoration
-What ability is this? https://i.imgur.com/kTJTxSn.png:
-- Shield Crash
-What ability is this? https://i.imgur.com/kZPtBCV.png:
-- Bloodlust
-
-What ability is this? https://i.imgur.com/kgo57gs.png:
-- Warcry
-What ability is this? https://i.imgur.com/kjv3jEv.png:
-- Ether Shock
-What ability is this? https://i.imgur.com/kkMA22I.png:
-- Morph Replicate
-
-What ability is this? https://i.imgur.com/kypYgE5.png:
-- Earth Spike
-What ability is this? https://i.imgur.com/lG97CeO.png:
-- Multicast
-What ability is this? https://i.imgur.com/lIxrQpo.png:
-- Death Ward
-What ability is this? https://i.imgur.com/lS7P0QI.png:
-- Song of the Siren
-What ability is this? https://i.imgur.com/lUURpuL.png:
-- Lunar Blessing
-What ability is this? https://i.imgur.com/liSYifa.png:
-- Nature's Guise
-What ability is this? https://i.imgur.com/lrKdZ5N.png:
-- Mischief
-What ability is this? https://i.imgur.com/m6s6gTu.png:
-- Doppelganger
-What ability is this? https://i.imgur.com/m7a1mLv.png:
-- Scan
-
-What ability is this? https://i.imgur.com/mMRslEc.png:
-- Arcane Bolt
-What ability is this? https://i.imgur.com/mNG28HG.png:
-- Wave of Terror
-
-What ability is this? https://i.imgur.com/mVnb12R.png:
-- Necromastery
-
-What ability is this? https://i.imgur.com/n84AW2C.png:
-- Concussive Shot
-What ability is this? https://i.imgur.com/nF0ug5I.png:
-- Earthbind
-
-
-
-
-
-What ability is this? https://i.imgur.com/nfMltKz.png:
-- Shukuchi
-
-What ability is this? https://i.imgur.com/nis6xUN.png:
-- Battle Cry
-What ability is this? https://i.imgur.com/nl88bDE.png:
-- Unburrow
-
-
-
-What ability is this? https://i.imgur.com/o8E0WDX.png:
-- Regeneration Rune Buff
-What ability is this? https://i.imgur.com/o9KvFAt.png:
-- Vendetta
-What ability is this? https://i.imgur.com/oElP1im.png:
-- Static Field
-What ability is this? https://i.imgur.com/oKlUHE6.png:
-- Sprint
-What ability is this? https://i.imgur.com/oN6udOB.png:
-- Ice Shards
-What ability is this? https://i.imgur.com/oWv1tOU.png:
-- Meld
-
-What ability is this? https://i.imgur.com/oxFjjYm.png:
-- Rolling Thunder
-What ability is this? https://i.imgur.com/oxgU2Xi.png:
-- Nethertoxin
-What ability is this? https://i.imgur.com/p6shYfB.png:
-- Wrath of Nature
-What ability is this? https://i.imgur.com/pNqzxeA.png:
-- Tree Throw
-What ability is this? https://i.imgur.com/pQV2JLt.png:
-- Earthshock
-What ability is this? https://i.imgur.com/pUtDfHr.png:
-- Psionic Trap
-What ability is this? https://i.imgur.com/prsRq3G.png:
-- Lightning Bolt
-What ability is this? https://i.imgur.com/puHHZ8N.png:
-- Whirling Axes (Ranged)
-- Whirling Axes Ranged
-What ability is this? https://i.imgur.com/q1TZSqX.png:
-- Kraken Shell
-
-What ability is this? https://i.imgur.com/qFHbDVZ.png:
-- Proximity Mines
-What ability is this? https://i.imgur.com/qFeXDTy.png:
-- Poison Nova
-What ability is this? https://i.imgur.com/qX892tV.png:
-- False Promise
-What ability is this? https://i.imgur.com/qdL0SAD.png:
-- Coup de Grace
-
-What ability is this? https://i.imgur.com/qwGGVkQ.png:
-- Haunt
-What ability is this? https://i.imgur.com/rIMd2yM.png:
-- Eject
-
-What ability is this? https://i.imgur.com/rOCPbQl.png:
-- Purification
-What ability is this? https://i.imgur.com/rSeefMY.png:
-- Icarus Dive
-
-What ability is this? https://i.imgur.com/rW8u5w7.png:
-- Scream of Pain
-What ability is this? https://i.imgur.com/rmTHla6.png:
-- Pinpoint Detonate
-
-What ability is this? https://i.imgur.com/sHFZoQg.png:
-- Magic Missile
-
-What ability is this? https://i.imgur.com/saKNr3L.png:
-- Frozen Sigil
-
-What ability is this? https://i.imgur.com/scUQ1Vx.png:
+What ability is this? https://i.imgur.com/scUQ1Vx.png: # [3]
 - Mortal Strike
-
-What ability is this? https://i.imgur.com/sz4ZZRf.png:
-- Shadow Poison Release
-
-What ability is this? https://i.imgur.com/tIqUdL0.png:
-- Demonic Conversion
-What ability is this? https://i.imgur.com/tRgiIsx.png:
-- Shadowraze (Medium)
-- Shadowraze Medium
-What ability is this? https://i.imgur.com/tdEXOZF.png:
-- Fury Swipes
-What ability is this? https://i.imgur.com/th8jPI6.png:
-- Shrapnel
-What ability is this? https://i.imgur.com/tns2s3U.png:
-- Return Chakram 2
-What ability is this? https://i.imgur.com/u3NhKrE.png:
-- Laguna Blade
-
-
-What ability is this? https://i.imgur.com/uMmwQ1a.png:
-- Summon Wolves
-What ability is this? https://i.imgur.com/uj1D3OE.png:
-- Infest
-What ability is this? https://i.imgur.com/umvWi1p.png:
-- Geostrike
-What ability is this? https://i.imgur.com/uvXNeIA.png:
-- Glaives of Wisdom
-What ability is this? https://i.imgur.com/uzQb32K.png:
-- Skewer
-What ability is this? https://i.imgur.com/v0RLs2l.png:
-- Stone Gaze
-
-What ability is this? https://i.imgur.com/vdHhJKt.png:
-- Sacred Arrow
-
-What ability is this? https://i.imgur.com/vkc1MU1.png:
-- Stop Rolling
-What ability is this? https://i.imgur.com/wCbPETt.png:
-- Static Link
-
-What ability is this? https://i.imgur.com/wEuOQZi.png:
-- Howl
-What ability is this? https://i.imgur.com/wJwUbrH.png:
-- Snowball
-What ability is this? https://i.imgur.com/wZiSIAb.png:
-- Wraithfire Blast
-What ability is this? https://i.imgur.com/wdq0Eyi.png:
-- Greater Bash
-What ability is this? https://i.imgur.com/wjAqjQd.png:
-- Pounce
-What ability is this? https://i.imgur.com/wjMDyPe.png:
-- Sonic Wave
-What ability is this? https://i.imgur.com/xGKIRUa.png:
-- Dark Rift
-
-
-What ability is this? https://i.imgur.com/xOSzlWY.png:
-- Telekinesis
-What ability is this? https://i.imgur.com/xYcEKmf.png:
-- Assimilate
-What ability is this? https://i.imgur.com/xa2sa4j.png:
-- Eyes in the Forest
-
-What ability is this? https://i.imgur.com/xivXaHo.png:
-- Hunter in the Night
-What ability is this? https://i.imgur.com/xxDj7GO.png:
-- Shackleshot
-
-What ability is this? https://i.imgur.com/y5RS5GM.png:
-- Whirling Axes (Melee)
-- Whirling Axes Melee
-What ability is this? https://i.imgur.com/yFkkXar.png:
-- Teleportation
-What ability is this? https://i.imgur.com/yOQ9gBX.png:
-- Maledict
-What ability is this? https://i.imgur.com/yRL9eLs.png:
-- Null Field
-What ability is this? https://i.imgur.com/yRs0y6A.png:
-- Reverse Polarity
-
-What ability is this? https://i.imgur.com/yVl4z4E.png:
-- Jingu Mastery
-What ability is this? https://i.imgur.com/yYv2ken.png:
-- Adaptive Strike (Strength)
-- Adaptive Strike Strength
-What ability is this? https://i.imgur.com/ykXIKkP.png:
-- Grave Chill
-What ability is this? https://i.imgur.com/ylsYhYn.png:
-- Upheaval
-
-
-
-What ability is this? https://i.imgur.com/zMYgF7b.png:
-- Hex
-What ability is this? https://i.imgur.com/zT3stw7.png:
-- Viper Strike
-What ability is this? https://i.imgur.com/zaHBNSk.png:
-- Heat Seeking Missile
-What ability is this? https://i.imgur.com/zuJRDuj.png:
-- Shockwave
-What ability is this? https://i.imgur.com/zvT3GY2.png:
-- Electric Vortex
+# What ability is this? https://i.imgur.com/0000000: # [ULT]
+# - Reincarnation
+# Zeus
+What innate ability is this? https://i.imgur.com/oElP1im.png: # [INT]
+- Static Field
+What ability is this? https://i.imgur.com/eaEmrUO.png: # [1]
+- Arc Lightning
+What ability is this? https://i.imgur.com/prsRq3G.png: # [2]
+- Lightning Bolt
+# What ability is this? https://i.imgur.com/0000000: # [3]
+# - Heavenly Jump
+# What ability is this? https://i.imgur.com/0000000: # [4]
+# - Nimbus
+What ability is this? https://i.imgur.com/Gzl5hkS.png: # [ULT]
+- Thundergod's Wrath


### PR DESCRIPTION
### Description of the changes

- Description updated to reflect which patch changes were last made to trivia (patch 7.41c)
- Removed abilities no longer in the game
- Added all heroes and abilities
  - Heroes/abilities that do not have an image asset are commented out with template, ready for URL insert and uncommenting
  - No new images were added
- Innate abilities are denoted in question
- Abilities grouped by hero with ability position commented in brackets
- Every existing image verified and commented out broken image URLs
- Add QOL changes to answers for better user experience such as:
  - Apostrophe not required if possessive (e.g. Reaper's Scythe & Reapers Scythe valid)
  - Accept intentional typos for some abilities (e.g. Doppelganger & Doppleganger valid)
  - Some abilities accept spaced and combined as answers (e.g. Life Break & Lifebreak valid)
  - If image asset for ability is the same as the sub-ability, do not confuse user with a separate question (e.g. Ice Blast & Release valid)

Updates made using internal knowledge and heavy referencing of https://liquipedia.net/dota2/

### Have the changes in this PR been tested?

Yes