### PR TITLE
Fix force-reinstall edge case not allowing current version

### DIFF
--- a/redbot/_update/updater.py
+++ b/redbot/_update/updater.py
@@ -312,7 +312,10 @@ class Updater:
         )
 
         if self.options.red_version:
-            if self.options.red_version <= self.current_version:
+            if self.options.red_version < self.current_version or (
+                not self.options.force_reinstall
+                and self.options.red_version == self.current_version
+            ):
                 common.print_with_prefix_column(
                     common.ICON_ERROR, "You can only update to a newer version of Red."
                 )


### PR DESCRIPTION
### Description of the changes

Specifying `--red-version 3.5.25` in `redbot-update` while being on 3.5.25 was rejected regardless of whether `--force-reinstall` is specified. See https://discord.com/channels/133049272517001216/466064935676411914/1506629208229548174 for background.

### Have the changes in this PR been tested?

No