### PR TITLE
Bump redbot-update wrapper to 1.2.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -76,7 +76,7 @@ red-commons==1.0.0
     #   red-lavalink
 red-lavalink==0.11.1
     # via -r base.in
-redbot-update==1.1.0
+redbot-update==1.2.0
     # via -r base.in
 rich==14.3.3
     # via


### PR DESCRIPTION
### Description of the changes

This should hopefully address the issues with Windows showing the UAC prompt:
<img width="586" height="621" alt="image" src="https://github.com/user-attachments/assets/0aa00480-3219-444b-a3fe-1501b77199d0" />

The important part about this prompt is not the "unknown publisher" part - even if the exe were signed, we'd still get one, just slightly different:
<img width="449" height="331" alt="image" src="https://github.com/user-attachments/assets/fd0b7b2a-6505-4e6a-8edb-b1db00e605eb" />

The reason for this wasn't the app being unsigned but rather Windows treating it as the installer per [their "Installer Detection Technology" documentation](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-vista/cc709628(v=ws.10)?redirectedfrom=MSDN#installer-detection-technology). This uses a bunch of heuristics to determine, if something is an installer - and if it is, requesting admin rights. `redbot-update` was treated as an installer due to presence of the word "update" in the name of the executable.
Installer Detection Technology is only used for executables that don't already set the `requestedExecutionLevel`. As such, redbot-update 1.2.0 now includes an app manifest with `requestedExecutionLevel` defined to use the "asInvoker" level - "The application runs at the same permission level as the process that started it":
https://github.com/Cog-Creators/redbot-update-wrapper/blob/1e9c39708d21badd3d0b3af5cceb072f93754a73/go/cmd/redbot-update/resources/base/app.manifest.tmpl#L7

### Have the changes in this PR been tested?

Yes