### PR TITLE
Fix missing status.stop() call when restoring venv

### DIFF
--- a/redbot/_update/internal.py
+++ b/redbot/_update/internal.py
@@ -421,6 +421,7 @@ def reinstall(
                 common.ICON_ERROR, "Failed to restore old virtual environment."
             )
         else:
+            status.stop()
             common.print_with_prefix_column(
                 common.ICON_INFO, "The old virtual environment has been restored."
             )


### PR DESCRIPTION
### Description of the changes

Should address the wrong order when restoring venv after failure:
<img width="809" height="287" alt="image" src="https://github.com/user-attachments/assets/f2222467-18ee-4981-a907-05e64ad67ead" />

### Have the changes in this PR been tested?

No