### PR TITLE
Privlieged intent changes

### DIFF
--- a/docs/bot_application_guide.rst
+++ b/docs/bot_application_guide.rst
@@ -81,7 +81,7 @@ Enabling Privileged Intents
 
 .. warning::
 
-    Red bots with over 100 servers require `bot verification <https://support.discord.com/hc/en-us/articles/360040720412>`_ which is not covered in this guide.
+    Red bots with over 10,000 users requires `bot verification <https://support-dev.discord.com/hc/en-us/articles/6207308062871-What-are-Privileged-Intents>`_ which is not covered in this guide.
     Remember that :ref:`we do not support public bots <intents>`. We encourage you to read that page before scaling up your bot.
 
 *Parts of this guide have been adapted from* `discord.py intro <https://discordpy.readthedocs.io/en/stable/discord.html#discord-intro>`_ *and* `discord.py privileged intents <https://discordpy.readthedocs.io/en/stable/intents.html#privileged-intents>`_.

--- a/docs/bot_application_guide.rst
+++ b/docs/bot_application_guide.rst
@@ -81,7 +81,9 @@ Enabling Privileged Intents
 
 .. warning::
 
-    Red bots with over 10,000 users requires `bot verification <https://support-dev.discord.com/hc/en-us/articles/6207308062871-What-are-Privileged-Intents>`_ which is not covered in this guide.
+    Red bots with 100 servers requires `bot verification <https://support-dev.discord.com/hc/en-us/articles/6207308062871-What-are-Privileged-Intents>`_ and
+    Red bots that are accessible to over 10,000 unique users requires `review for access <https://support-dev.discord.com/hc/en-us/articles/6207308062871-What-are-Privileged-Intents>`_,  
+    both of which are not covered in this guide.
     Remember that :ref:`we do not support public bots <intents>`. We encourage you to read that page before scaling up your bot.
 
 *Parts of this guide have been adapted from* `discord.py intro <https://discordpy.readthedocs.io/en/stable/discord.html#discord-intro>`_ *and* `discord.py privileged intents <https://discordpy.readthedocs.io/en/stable/intents.html#privileged-intents>`_.

--- a/docs/intents.rst
+++ b/docs/intents.rst
@@ -12,11 +12,11 @@ our stance regarding "public bots", and the discord bot verification process.
 
 To clarify:
 
-- **Small bots** are bots under 100 servers. They currently do not need to undergo Discord's
-  bot verification process
-- **Public bots** (or big bots) are bots that have reached 100 servers. They need to be
+- **Small bots** are bots accessible to fewer than 10,000 unique users. They currently do not need to undergo Discord's
+  bot verification process.
+- **Public bots** (or big bots) are bots that have reached 10,000 total unique users. They need to be
   `verified <https://support-dev.discord.com/hc/en-us/articles/23926564536471-How-Do-I-Get-My-App-Verified>`_
-  by Discord to join more than 100 servers and gain privileged intents
+  by Discord to gain privileged intents.
 
 .. warning::
 
@@ -51,7 +51,7 @@ Bot verification process
 ------------------------
 
 When your bot ceases to be a small bot Discord will require you to verify your bot before allowing
-it to join more servers and gain privileged intents. If you've read the previous section,
+it to continue using privileged intents. If you've read the previous section,
 you will know that we do **not** support public bots. Logically, we also do not provide help for
 the verification process.
 

--- a/docs/intents.rst
+++ b/docs/intents.rst
@@ -12,9 +12,9 @@ our stance regarding "public bots", and the discord bot verification process.
 
 To clarify:
 
-- **Small bots** are bots accessible to fewer than 10,000 unique users. They currently do not need to undergo Discord's
+- **Small bots** are bots under 100 servers. They currently do not need to undergo Discord's
   bot verification process.
-- **Public bots** (or big bots) are bots that have reached 10,000 total unique users. They need to be
+- **Public bots** (or big bots) are bots that have reached 100 servers. They need to be
   `verified <https://support-dev.discord.com/hc/en-us/articles/23926564536471-How-Do-I-Get-My-App-Verified>`_
   by Discord to gain privileged intents.
 
@@ -51,7 +51,7 @@ Bot verification process
 ------------------------
 
 When your bot ceases to be a small bot Discord will require you to verify your bot before allowing
-it to continue using privileged intents. If you've read the previous section,
+it to join more servers and gain privileged intents. If you've read the previous section,
 you will know that we do **not** support public bots. Logically, we also do not provide help for
 the verification process.
 


### PR DESCRIPTION
### Description of the changes

Update the documentation surrounding privileged intents based off Discord's latest announcement.

I am not sure of whether or not bots can now be in more than 100 servers without verification as long as the unique member count remains below 10,000. I have went ahead and removed it until clarification is added on that. I don't see it any longer.

This also updates the bot verification article which currently leads to a 404.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
