### PR TITLE
Add warning about status of openSUSE Leap 15.6 instructions

### DIFF
--- a/docs/install_guides/opensuse-leap-15.rst
+++ b/docs/install_guides/opensuse-leap-15.rst
@@ -1,22 +1,8 @@
 .. _install-opensuse-leap-15:
-.. os-image-location::
 
-    [opensuse-leap-156]
-    download_type = 'checksum-file'
-    url = 'https://download.opensuse.org/distribution/leap/15.6/appliances/openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud.qcow2.sha256'
-    filename_pattern = '.*\.qcow2'
-    expected_java_version = 21
-
-    [opensuse-leap-156-arm]
-    download_type = 'checksum-file'
-    arch = 'aarch64'
-    url = 'https://download.opensuse.org/distribution/leap/15.6/appliances/openSUSE-Leap-15.6-Minimal-VM.aarch64-Cloud.qcow2.sha256'
-    filename_pattern = '.*\.qcow2'
-    expected_java_version = 21
-
-=====================================
-Installing Red on openSUSE Leap 15.6+
-=====================================
+====================================
+Installing Red on openSUSE Leap 15.6
+====================================
 
 .. include:: _includes/supported-arch-x64+aarch64.rst
 
@@ -26,7 +12,13 @@ Installing Red on openSUSE Leap 15.6+
 Installing the pre-requirements
 -------------------------------
 
-openSUSE Leap 15.6+ has all required dependencies available in official repositories. Install them
+.. warning::
+
+    openSUSE Leap 15.6 has reached end of life and these instructions may not work.
+    We will start supporting openSUSE Leap 16.0 in Red 3.6.0 but until then,
+    you may need to use another OS, if you run into difficulties.
+
+openSUSE Leap 15.6 has all required dependencies available in official repositories. Install them
 with zypper:
 
 .. prompt:: bash


### PR DESCRIPTION
### Description of the changes

These instructions haven't really worked as is [since March](https://github.com/Jackenmen/Red-Install-Tests/commit/08d5da7560c0b8ee7159385b5677e5c40dbc4db3), but I've recently relearned about this due to reimplementing the test harness for install instructions. The problem is that openSUSE Leap 15.6 is EOL, and the repos appear to permanently have not a fully compatible set of packages when trying to install Base Development packages (devil_basis pattern):
```
    Problem: 1: the to be installed pattern:devel_basis-20170319-lp156.3.2.x86_64 requires 'patterns-devel-base-devel_basis', but this requirement cannot be provided
    not installable providers: patterns-devel-base-devel_basis-20170319-lp156.3.2.x86_64[repo-oss]

     Solution 1: downgrade of libncurses6-6.1-150000.5.33.1.x86_64 to libncurses6-6.1-150000.5.30.1.x86_64
     Solution 2: do not install pattern:devel_basis-20170319-lp156.3.2.x86_64
     Solution 3: break pattern:devel_basis-20170319-lp156.3.2.x86_64 by ignoring some of its dependencies

    Choose from above solutions by number or cancel [1/2/3/c/d/?] (c):
```

That install command works fine on openSUSE Leap 16.0, but we can't yet support it due to a lack of support for Python 3.13 (which is the version that openSUSE Leap 16 provides in its repos)

### Have the changes in this PR been tested?

Yes