### PR TITLE
[Audio] Fix `seek 00:00` issue.

### DIFF
--- a/redbot/cogs/audio/core/commands/controller.py
+++ b/redbot/cogs/audio/core/commands/controller.py
@@ -350,8 +350,16 @@ class PlayerControllerCommands(MixinMeta, metaclass=CompositeMetaClass):
                     abs_position = False
                 except ValueError:
                     abs_position = True
+                    assert isinstance(seconds, str)
+                    parts = seconds.split(":")
+                    if not (2 <= len(parts) <= 3 and all(p.isdigit() for p in parts)):
+                        return await self.send_embed_msg(
+                            ctx,
+                            title=_("Unable To Seek Tracks"),
+                            description=_("Invalid input for the time to seek."),
+                        )
                     seconds = self.time_convert(seconds)
-                if seconds == 0:
+                if seconds == 0 and not abs_position:
                     return await self.send_embed_msg(
                         ctx,
                         title=_("Unable To Seek Tracks"),


### PR DESCRIPTION
### Description of the changes

Closes #6789

`[p]seek 00:00` was rejected as invalid because `time_convert` returns `0` for it, which was also used to detect invalid input. Added format validation before calling `time_convert` and restricted the `== 0` guard to relative seeks only

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
