### PR TITLE
Fix log messages for unknown cog installation commits

### DIFF
--- a/redbot/core/_downloader/__init__.py
+++ b/redbot/core/_downloader/__init__.py
@@ -988,12 +988,14 @@ async def _restore_from_backup() -> None:
                     cog = last_cog_occurrence
                     log.warning(
                         "The commit that %r cog was installed from is unknown"
-                        " - will try to reinstall from latest commit where it's still available."
+                        " - will try to reinstall from latest commit where it's still available.",
+                        cog.name,
                     )
                 else:
                     log.error(
                         "The commit that %r cog was installed from is unknown"
-                        " and it could not be found in the repo."
+                        " and it could not be found in the repo.",
+                        cog.name,
                     )
                     continue
 
@@ -1065,6 +1067,7 @@ async def _restore_from_backup() -> None:
             if install_result.failed_libs:
                 log.error(
                     "Failed to reinstall shared libraries for %r cog from %r repo: %s",
+                    cog.name,
                     cog.repo.name,
                     ", ".join([lib.name for lib in install_result.failed_libs]),
                 )


### PR DESCRIPTION
Fixes #6792.

### Description of the changes

Pass `cog.name` to the two missing-commit diagnostics and to the failed shared-library reinstall error so every format placeholder has a value.

### Have the changes in this PR been tested?

Yes, verified on Ubuntu 24.04 in an isolated Python 3.11 Docker container: `python -m compileall ./redbot/cogs` passed; `pytest -q tests/core/_downloader/test_downloader.py` — 23 passed; `pytest -q` — 313 passed, 7 skipped. GitHub Actions also completed successfully: 18/18 checks passed, including Python 3.8–3.11, PostgreSQL, docs, and style.