### PR TITLE
[Audio] Truncate Track Error embed description to fit Discord limit

### DIFF
--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -14,6 +14,8 @@ from ...errors import DatabaseError, TrackEnqueueError
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
+MAX_EMBED_DESCRIPTION_LENGTH = 4096
+
 log = getLogger("red.cogs.Audio.cog.Events.lavalink")
 ws_audio_log = getLogger("red.Audio.WS.Audio")
 
@@ -330,6 +332,10 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                             asyncio.create_task(
                                 self.api_interface.global_cache_api.report_invalid(current_id)
                             )
+                    if embed.description and len(embed.description) > MAX_EMBED_DESCRIPTION_LENGTH:
+                        embed.description = (
+                            embed.description[: MAX_EMBED_DESCRIPTION_LENGTH - 3] + "..."
+                        )
                     await message_channel.send(embed=embed)
             if player.node.ready:
                 await player.skip()


### PR DESCRIPTION
### Description of the changes

Lavalink error messages can exceed Discord's 4096-character embed description limit, so the Track Error / Track Stuck notification fails with `400 Bad Request (error code: 50035): In embeds.0.description: Must be 4096 or fewer in length.` and the channel never sees the error.

This truncates the embed description to 4096 characters (with a `...` marker) before sending, so the notification is always delivered.

Fixes #6794

### Have the changes in this PR been tested?

Yes

Verified the truncation logic against `discord.Embed` directly (a 10k-character description is cut to exactly 4096 ending in `...`); not reproduced against a live Lavalink node.

AI disclosure: this change was drafted with Devin (Cognition); I reviewed and validated it.
