### PR TITLE
[Audio] Handle non-JSON responses from the Spotify API

### DIFF
--- a/redbot/cogs/audio/apis/spotify.py
+++ b/redbot/cogs/audio/apis/spotify.py
@@ -100,7 +100,18 @@ class SpotifyWrapper:
         if params is None:
             params = {}
         async with self.session.request("GET", url, params=params, headers=headers) as r:
-            data = await r.json(loads=json.loads)
+            try:
+                data = await r.json(loads=json.loads)
+            except (aiohttp.ContentTypeError, json.JSONDecodeError):
+                log.verbose(
+                    "Issue making GET request to %r: [%s] %r", url, r.status, await r.text()
+                )
+                raise SpotifyFetchError(
+                    message=_(
+                        "The Spotify API returned an unexpected response. "
+                        "Try again in a few minutes."
+                    )
+                )
             if r.status != 200:
                 log.verbose("Issue making GET request to %r: [%s] %r", url, r.status, data)
             return data
@@ -154,7 +165,18 @@ class SpotifyWrapper:
     ) -> MutableMapping:
         """Make a POST call to spotify."""
         async with self.session.post(url, data=payload, headers=headers) as r:
-            data = await r.json(loads=json.loads)
+            try:
+                data = await r.json(loads=json.loads)
+            except (aiohttp.ContentTypeError, json.JSONDecodeError):
+                log.verbose(
+                    "Issue making POST request to %r: [%s] %r", url, r.status, await r.text()
+                )
+                raise SpotifyFetchError(
+                    message=_(
+                        "The Spotify API returned an unexpected response. "
+                        "Try again in a few minutes."
+                    )
+                )
             if r.status != 200:
                 log.verbose("Issue making POST request to %r: [%s] %r", url, r.status, data)
             return data


### PR DESCRIPTION
### Description of the changes

When Spotify responds with a non-JSON body (typically an HTML error page on 5xx, or a failed token request), `SpotifyWrapper.get`/`SpotifyWrapper.post` called `response.json()` unconditionally and crashed with an unhandled `aiohttp.ContentTypeError`. Now both methods catch the decode failure, log the status and body, and raise `SpotifyFetchError` with a user-facing message, which the play/enqueue/genre command paths already catch and turn into an embed instead of a traceback.

Fixes #6776

### Have the changes in this PR been tested?

Yes

Exercised `get` and `post` against a local aiohttp test server: JSON responses still parse as before, and an HTML 503 body now raises `SpotifyFetchError` instead of `ContentTypeError`. Existing audio tests pass and black is clean.