### PR TITLE
[Mod] Add per-channel overrides for deleterepeats

### DIFF
--- a/redbot/cogs/mod/events.py
+++ b/redbot/cogs/mod/events.py
@@ -19,21 +19,23 @@ class Events(MixinMeta):
     """
 
     async def check_duplicates(self, message):
-        guild = message.guild
-        author = message.author
-
-        guild_cache = self.cache.get(guild.id, None)
-        if guild_cache is None:
-            repeats = await self.config.guild(guild).delete_repeats()
-            if repeats == -1:
-                return False
-            guild_cache = self.cache[guild.id] = defaultdict(lambda: deque(maxlen=repeats))
-
         if not message.content:
             return False
 
-        guild_cache[author].append(message.content)
-        msgs = guild_cache[author]
+        channel = message.channel
+        author = message.author
+
+        channel_cache = self.cache.get(channel.id, None)
+        if channel_cache is None:
+            repeats = await self.config.channel(channel).delete_repeats()
+            if repeats is None:
+                repeats = await self.config.guild(message.guild).delete_repeats()
+            if repeats == -1:
+                return False
+            channel_cache = self.cache[channel.id] = defaultdict(lambda: deque(maxlen=repeats))
+
+        channel_cache[author].append(message.content)
+        msgs = channel_cache[author]
         if len(msgs) == msgs.maxlen and len(set(msgs)) == 1:
             try:
                 await message.delete()

--- a/redbot/cogs/mod/mod.py
+++ b/redbot/cogs/mod/mod.py
@@ -66,7 +66,7 @@ class Mod(
         "ban_extra_embed_contents": "Please set me",
     }
 
-    default_channel_settings = {"ignored": False}
+    default_channel_settings = {"ignored": False, "delete_repeats": None}
 
     default_member_settings = {"past_nicks": [], "perms_cache": {}, "banned_until": False}
 

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -1,10 +1,10 @@
 import asyncio
-from collections import defaultdict, deque
 from datetime import timedelta
 
+import discord
 from redbot.core import commands, i18n
 from redbot.core.utils import AsyncIter
-from redbot.core.utils.chat_formatting import box, humanize_timedelta, inline
+from redbot.core.utils.chat_formatting import box, humanize_timedelta, inline, pagify
 
 from .abc import MixinMeta
 
@@ -294,45 +294,123 @@ class ModSettings(MixinMeta):
 
     @modset.command()
     @commands.guild_only()
-    async def deleterepeats(self, ctx: commands.Context, repeats: int = None):
+    async def deleterepeats(
+        self,
+        ctx: commands.Context,
+        repeats: int = None,
+        *channels: discord.TextChannel,
+    ):
         """Enable auto-deletion of repeated messages.
 
-        Must be between 2 and 20.
+        Repeats must be between 2 and 20.
 
         Set to -1 to disable this feature.
+
+        Channel specific overrides can be created by using this command
+        with a passed in value for `channels`.
+
+        If one or more channels are provided, `repeats` can be set to 0
+        to make those channels use the server default.
         """
         guild = ctx.guild
-        if repeats is not None:
-            if repeats == -1:
-                await self.config.guild(guild).delete_repeats.set(repeats)
-                self.cache.pop(guild.id, None)  # remove cache with old repeat limits
-                await ctx.send(_("Repeated messages will be ignored."))
-            elif 2 <= repeats <= 20:
-                await self.config.guild(guild).delete_repeats.set(repeats)
-                # purge and update cache to new repeat limits
-                self.cache[guild.id] = defaultdict(lambda: deque(maxlen=repeats))
-                await ctx.send(
-                    _("Messages repeated up to {num} times will be deleted.").format(num=repeats)
+        if repeats is None:
+            if channels:
+                await self._deleterepeats_show(ctx, channels)
+            else:
+                await self._deleterepeats_show(ctx, [None])
+            return
+
+        if channels:
+            if repeats == 0:
+                for channel in channels:
+                    await self.config.channel(channel).delete_repeats.set(None)
+                    self.cache.pop(channel.id, None)
+                await self._send_paginated(
+                    ctx,
+                    _("The following channels will now use the server default: {channels}").format(
+                        channels=", ".join(c.mention for c in channels)
+                    ),
                 )
+            elif repeats == -1 or 2 <= repeats <= 20:
+                for channel in channels:
+                    await self.config.channel(channel).delete_repeats.set(repeats)
+                    self.cache.pop(channel.id, None)
+                if repeats == -1:
+                    await self._send_paginated(
+                        ctx,
+                        _("Repeated messages will be ignored in: {channels}").format(
+                            channels=", ".join(c.mention for c in channels)
+                        ),
+                    )
+                else:
+                    await self._send_paginated(
+                        ctx,
+                        _(
+                            "Messages repeated up to {num} times will be deleted in: {channels}"
+                        ).format(num=repeats, channels=", ".join(c.mention for c in channels)),
+                    )
             else:
                 await ctx.send(
                     _(
-                        "Number of repeats must be between 2 and 20"
-                        " or equal to -1 if you want to disable this feature!"
+                        "Number of repeats must be between 2 and 20, -1 to disable this"
+                        " feature, or 0 to use the server default for those channels."
                     )
                 )
+            return
+
+        if repeats == -1:
+            await self.config.guild(guild).delete_repeats.set(repeats)
+            for guild_channel in guild.text_channels:
+                self.cache.pop(guild_channel.id, None)
+            await ctx.send(_("Repeated messages will be ignored."))
+        elif 2 <= repeats <= 20:
+            await self.config.guild(guild).delete_repeats.set(repeats)
+            for guild_channel in guild.text_channels:
+                self.cache.pop(guild_channel.id, None)
+            await ctx.send(
+                _("Messages repeated up to {num} times will be deleted.").format(num=repeats)
+            )
         else:
-            repeats = await self.config.guild(guild).delete_repeats()
-            if repeats != -1:
-                await ctx.send(
-                    _(
-                        "Bot will delete repeated messages after"
-                        " {num} repeats. Set this value to -1 to"
-                        " ignore repeated messages"
-                    ).format(num=repeats)
+            await ctx.send(
+                _(
+                    "Number of repeats must be between 2 and 20"
+                    " or equal to -1 if you want to disable this feature!"
                 )
+            )
+
+    async def _deleterepeats_show(self, ctx, channels):
+        guild = ctx.guild
+        guild_repeats = await self.config.guild(guild).delete_repeats()
+        lines = []
+        for channel in channels:
+            if channel is None:
+                repeats = guild_repeats
+                label = _("Server default")
             else:
-                await ctx.send(_("Repeated messages will be ignored."))
+                repeats = await self.config.channel(channel).delete_repeats()
+                label = channel.mention
+                if repeats is None:
+                    lines.append(
+                        _("{label}: follows the server default ({num_or_off})").format(
+                            label=label,
+                            num_or_off=_("disabled")
+                            if guild_repeats == -1
+                            else _("after {num} repeats").format(num=guild_repeats),
+                        )
+                    )
+                    continue
+            if repeats == -1:
+                lines.append(_("{label}: disabled").format(label=label))
+            else:
+                lines.append(
+                    _("{label}: deletes after {num} repeats").format(label=label, num=repeats)
+                )
+        for page in pagify("\n".join(lines)):
+            await ctx.send(box(page))
+
+    async def _send_paginated(self, ctx, text: str):
+        for page in pagify(text):
+            await ctx.send(page)
 
     @modset.command()
     @commands.guild_only()

--- a/redbot/cogs/mod/settings.py
+++ b/redbot/cogs/mod/settings.py
@@ -313,104 +313,105 @@ class ModSettings(MixinMeta):
         to make those channels use the server default.
         """
         guild = ctx.guild
-        if repeats is None:
-            if channels:
-                await self._deleterepeats_show(ctx, channels)
+
+        if repeats is None and not channels:
+            repeats = await self.config.guild(guild).delete_repeats()
+            if repeats != -1:
+                await ctx.send(
+                    _(
+                        "Bot will delete repeated messages after"
+                        " {num} repeats. Set this value to -1 to"
+                        " ignore repeated messages"
+                    ).format(num=repeats)
+                )
             else:
-                await self._deleterepeats_show(ctx, [None])
+                await ctx.send(_("Repeated messages will be ignored."))
             return
 
-        if channels:
-            if repeats == 0:
-                for channel in channels:
-                    await self.config.channel(channel).delete_repeats.set(None)
-                    self.cache.pop(channel.id, None)
-                await self._send_paginated(
-                    ctx,
-                    _("The following channels will now use the server default: {channels}").format(
-                        channels=", ".join(c.mention for c in channels)
-                    ),
-                )
-            elif repeats == -1 or 2 <= repeats <= 20:
-                for channel in channels:
-                    await self.config.channel(channel).delete_repeats.set(repeats)
-                    self.cache.pop(channel.id, None)
-                if repeats == -1:
-                    await self._send_paginated(
-                        ctx,
-                        _("Repeated messages will be ignored in: {channels}").format(
-                            channels=", ".join(c.mention for c in channels)
-                        ),
+        if repeats is None:
+            guild_repeats = await self.config.guild(guild).delete_repeats()
+            lines = []
+            for channel in channels:
+                channel_repeats = await self.config.channel(channel).delete_repeats()
+                if channel_repeats is None:
+                    default_label = (
+                        _("disabled")
+                        if guild_repeats == -1
+                        else _("after {num} repeats").format(num=guild_repeats)
                     )
+                    lines.append(
+                        _("{channel}: follows the server default ({default})").format(
+                            channel=channel.mention, default=default_label
+                        )
+                    )
+                elif channel_repeats == -1:
+                    lines.append(_("{channel}: disabled").format(channel=channel.mention))
                 else:
-                    await self._send_paginated(
-                        ctx,
-                        _(
-                            "Messages repeated up to {num} times will be deleted in: {channels}"
-                        ).format(num=repeats, channels=", ".join(c.mention for c in channels)),
+                    lines.append(
+                        _("{channel}: deletes after {num} repeats").format(
+                            channel=channel.mention, num=channel_repeats
+                        )
                     )
+            for page in pagify("\n".join(lines)):
+                await ctx.send(box(page))
+            return
+
+        if not channels:
+            if repeats == -1:
+                await self.config.guild(guild).delete_repeats.set(repeats)
+                for guild_channel in guild.text_channels:
+                    self.cache.pop(guild_channel.id, None)
+                await ctx.send(_("Repeated messages will be ignored."))
+            elif 2 <= repeats <= 20:
+                await self.config.guild(guild).delete_repeats.set(repeats)
+                for guild_channel in guild.text_channels:
+                    self.cache.pop(guild_channel.id, None)
+                await ctx.send(
+                    _("Messages repeated up to {num} times will be deleted.").format(num=repeats)
+                )
             else:
                 await ctx.send(
                     _(
-                        "Number of repeats must be between 2 and 20, -1 to disable this"
-                        " feature, or 0 to use the server default for those channels."
+                        "Number of repeats must be between 2 and 20"
+                        " or equal to -1 if you want to disable this feature!"
                     )
                 )
             return
 
-        if repeats == -1:
-            await self.config.guild(guild).delete_repeats.set(repeats)
-            for guild_channel in guild.text_channels:
-                self.cache.pop(guild_channel.id, None)
-            await ctx.send(_("Repeated messages will be ignored."))
-        elif 2 <= repeats <= 20:
-            await self.config.guild(guild).delete_repeats.set(repeats)
-            for guild_channel in guild.text_channels:
-                self.cache.pop(guild_channel.id, None)
-            await ctx.send(
-                _("Messages repeated up to {num} times will be deleted.").format(num=repeats)
+        if repeats == 0:
+            for channel in channels:
+                await self.config.channel(channel).delete_repeats.set(None)
+                self.cache.pop(channel.id, None)
+            text = _("The following channels will now use the server default: {channels}").format(
+                channels=", ".join(c.mention for c in channels)
             )
-        else:
-            await ctx.send(
-                _(
-                    "Number of repeats must be between 2 and 20"
-                    " or equal to -1 if you want to disable this feature!"
-                )
-            )
+            for page in pagify(text):
+                await ctx.send(page)
+            return
 
-    async def _deleterepeats_show(self, ctx, channels):
-        guild = ctx.guild
-        guild_repeats = await self.config.guild(guild).delete_repeats()
-        lines = []
-        for channel in channels:
-            if channel is None:
-                repeats = guild_repeats
-                label = _("Server default")
-            else:
-                repeats = await self.config.channel(channel).delete_repeats()
-                label = channel.mention
-                if repeats is None:
-                    lines.append(
-                        _("{label}: follows the server default ({num_or_off})").format(
-                            label=label,
-                            num_or_off=_("disabled")
-                            if guild_repeats == -1
-                            else _("after {num} repeats").format(num=guild_repeats),
-                        )
-                    )
-                    continue
+        if repeats == -1 or 2 <= repeats <= 20:
+            for channel in channels:
+                await self.config.channel(channel).delete_repeats.set(repeats)
+                self.cache.pop(channel.id, None)
+            channels_str = ", ".join(c.mention for c in channels)
             if repeats == -1:
-                lines.append(_("{label}: disabled").format(label=label))
-            else:
-                lines.append(
-                    _("{label}: deletes after {num} repeats").format(label=label, num=repeats)
+                text = _("Repeated messages will be ignored in: {channels}").format(
+                    channels=channels_str
                 )
-        for page in pagify("\n".join(lines)):
-            await ctx.send(box(page))
+            else:
+                text = _(
+                    "Messages repeated up to {num} times will be deleted in: {channels}"
+                ).format(num=repeats, channels=channels_str)
+            for page in pagify(text):
+                await ctx.send(page)
+            return
 
-    async def _send_paginated(self, ctx, text: str):
-        for page in pagify(text):
-            await ctx.send(page)
+        await ctx.send(
+            _(
+                "Number of repeats must be between 2 and 20, -1 to disable this"
+                " feature, or 0 to use the server default for those channels."
+            )
+        )
 
     @modset.command()
     @commands.guild_only()


### PR DESCRIPTION
### Description of the changes

resolves #4721.

adds optional channel args to `deleterepeats` so you can override the repeat threshold per channel instead of just guild-wide. 0 clears an override back to the server default.

### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
No
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->
