### PR TITLE
Truncate Audio error embeds to Discord's description limit

### DIFF
--- a/redbot/cogs/audio/core/events/lavalink.py
+++ b/redbot/cogs/audio/core/events/lavalink.py
@@ -11,6 +11,7 @@ from red_commons.logging import getLogger
 
 from redbot.core.i18n import Translator, set_contextual_locales_from_guild
 from ...errors import DatabaseError, TrackEnqueueError
+from ...utils import truncate
 from ..abc import MixinMeta
 from ..cog_utils import CompositeMetaClass
 
@@ -18,6 +19,9 @@ log = getLogger("red.cogs.Audio.cog.Events.lavalink")
 ws_audio_log = getLogger("red.Audio.WS.Audio")
 
 _ = Translator("Audio", Path(__file__))
+
+# Discord rejects embeds whose description is longer than 4096 characters.
+EMBED_DESCRIPTION_MAX_LENGTH = 4096
 
 
 class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
@@ -314,16 +318,20 @@ class LavalinkEvents(MixinMeta, metaclass=CompositeMetaClass):
                         embed = discord.Embed(
                             colour=await self.bot.get_embed_color(message_channel),
                             title=_("Track Stuck"),
-                            description=_(
-                                "Playback of the song has stopped due to an unexpected error.\n{error}"
-                            ).format(error=description),
+                            description=truncate(
+                                _(
+                                    "Playback of the song has stopped due to an unexpected error.\n{error}"
+                                ).format(error=description),
+                                max_length=EMBED_DESCRIPTION_MAX_LENGTH,
+                            ),
                         )
                     else:
                         embed = discord.Embed(
                             title=_("Track Error"),
                             colour=await self.bot.get_embed_color(message_channel),
-                            description="{}\n{}".format(
-                                extra["message"].replace("\n", ""), description
+                            description=truncate(
+                                "{}\n{}".format(extra["message"].replace("\n", ""), description),
+                                max_length=EMBED_DESCRIPTION_MAX_LENGTH,
                             ),
                         )
                         if current_id:

--- a/redbot/cogs/audio/utils.py
+++ b/redbot/cogs/audio/utils.py
@@ -75,6 +75,21 @@ def sizeof_fmt(num: Union[float, int]) -> str:
     return f"{num:.1f}Y"
 
 
+def truncate(text: str, *, max_length: int, placeholder: str = "\N{HORIZONTAL ELLIPSIS}") -> str:
+    """Shorten ``text`` so that it is at most ``max_length`` characters long.
+
+    When ``text`` is too long it is cut and ``placeholder`` is appended, so that the
+    returned string (placeholder included) never goes over ``max_length``. Unlike
+    ``textwrap.shorten`` this leaves the text untouched, without collapsing whitespace,
+    which we want when the text is something like a Lavalink traceback.
+    """
+    if len(text) <= max_length:
+        return text
+    if max_length <= len(placeholder):
+        return placeholder[:max_length]
+    return text[: max_length - len(placeholder)] + placeholder
+
+
 class CacheLevel:
     __slots__ = ("value",)
 

--- a/tests/cogs/audio/test_utils.py
+++ b/tests/cogs/audio/test_utils.py
@@ -1,0 +1,42 @@
+from redbot.cogs.audio.utils import truncate
+
+ELLIPSIS = "\N{HORIZONTAL ELLIPSIS}"
+
+
+def test_truncate_leaves_short_text_untouched():
+    assert truncate("hello", max_length=10) == "hello"
+
+
+def test_truncate_keeps_text_at_the_limit():
+    text = "x" * 10
+    assert truncate(text, max_length=10) == text
+
+
+def test_truncate_shortens_long_text_and_adds_placeholder():
+    result = truncate("x" * 20, max_length=10)
+    assert len(result) == 10
+    assert result == "x" * 9 + ELLIPSIS
+
+
+def test_truncate_uses_a_custom_placeholder():
+    result = truncate("abcdefghij", max_length=6, placeholder="...")
+    assert result == "abc..."
+    assert len(result) == 6
+
+
+def test_truncate_when_placeholder_does_not_fit():
+    assert truncate("abcdef", max_length=2, placeholder="...") == ".."
+
+
+def test_truncate_does_not_collapse_whitespace():
+    text = "line one\n\n   line two"
+    assert truncate(text, max_length=100) == text
+
+
+def test_truncate_fits_a_long_error_in_a_discord_embed():
+    # Discord rejects embed descriptions longer than 4096 characters.
+    long_error = "Traceback line\n" * 1000
+    result = truncate(long_error, max_length=4096)
+    assert len(result) == 4096
+    assert result.startswith("Traceback line")
+    assert result.endswith(ELLIPSIS)


### PR DESCRIPTION
### Description of the changes

Resolves #6794. When a track errors, Audio puts the Lavalink message straight into an embed description. Some of those messages (long tracebacks) go well past Discord's 4096 character limit, so the send raises `HTTPException` and the error report never makes it to the channel.

I added a small `truncate` helper to the audio utils and used it on the Track Error and Track Stuck embeds, so the description is always capped and gets an ellipsis when it has to be cut. The Track Error embed is the one from the issue, but Track Stuck interpolates text of unknown length too, so I capped both. Added tests for the helper.

### Have the changes in this PR been tested?

Yes
