### PR TITLE
docs: Document SetApiView/SetApiModal in Shared API Keys guide

### DIFF
--- a/docs/framework_apikeys.rst
+++ b/docs/framework_apikeys.rst
@@ -54,7 +54,7 @@ Prompting for API Keys
 
 The primary way to set keys is ``[p]set api``. Run on its own, with no service or tokens, it opens a secure modal for the owner to fill in, so a cog does not need to add its own command for this.
 
-``SetApiView`` (from ``redbot.core.utils.views``) is most useful as a fallback when a required key is missing. When a command needs a key that has not been set, reply with the error and attach the button so the owner can set it in place. ``default_service`` and ``default_keys`` pre-fill the modal with the service and key names the cog expects.
+`SetApiView` is most useful as a fallback when a required key is missing. When a command needs a key that has not been set, a reply with the error message that includes this view will include a button that allows the owner to instantly open the secure modal. The parameters ``default_service`` and ``default_keys`` can be configured to pre-fill the modal with the service and key names the cog expects.
 
 .. code-block:: python
 
@@ -64,7 +64,7 @@ The primary way to set keys is ``[p]set api``. Run on its own, with no service o
         @commands.command()
         async def weather(self, ctx: commands.Context, *, city: str):
             tokens = await self.bot.get_shared_api_tokens("weather")
-            if not tokens.get("api_key"):
+            if tokens.get("api_key") is None:
                 view = SetApiView(default_service="weather", default_keys={"api_key": ""})
                 await ctx.send(
                     "The weather API key has not been set. "
@@ -74,9 +74,9 @@ The primary way to set keys is ``[p]set api``. Run on its own, with no service o
                 return
             # use tokens["api_key"] as normal
 
-``default_service`` pre-fills and locks the service name. ``default_keys`` is a mapping of the key names the service expects (values may be empty) and pre-populates the modal. The owner enters one ``key value`` pair per line, keeping the key label; for the example above the field is pre-filled with ``api_key YOUR_API_KEY``, and replacing the line with just the value is rejected. On submit the tokens are saved with ``set_shared_api_tokens``.
+``default_service`` pre-fills and locks the service name. ``default_keys`` is a mapping of the key names the service expects (values may be empty) and pre-populates the modal. The owner enters one ``key value`` pair per line, keeping the key label; for the example above the field is pre-filled with ``api_key YOUR_API_KEY``, and replacing the line with just the value is rejected. On submit the tokens are saved with `Red.set_shared_api_tokens`.
 
-To embed the prompt in a custom ``discord.ui.View``, use ``SetApiModal`` directly and send it with ``interaction.response.send_modal(...)``. ``SetApiView`` and ``SetApiModal`` are both owner-only.
+To embed the prompt in a custom `discord.ui.View`, use `SetApiModal` directly and send it with ``interaction.response.send_modal(...)``. `SetApiView` and `SetApiModal` are both owner-only.
 
 
 ***************

--- a/docs/framework_apikeys.rst
+++ b/docs/framework_apikeys.rst
@@ -52,25 +52,31 @@ Basic Usage
 Prompting for API Keys
 **********************
 
-Instead of asking the bot owner to type ``[p]set api ...`` by hand, a cog can prompt them with a secure button using ``SetApiView`` from ``redbot.core.utils.views``. It shows an owner-only button that opens a modal where the keys are entered, and saves them with ``set_shared_api_tokens`` when submitted.
+The primary way to set keys is ``[p]set api``. Run on its own, with no service or tokens, it opens a secure modal for the owner to fill in, so a cog does not need to add its own command for this.
+
+``SetApiView`` (from ``redbot.core.utils.views``) is most useful as a fallback when a required key is missing. When a command needs a key that has not been set, reply with the error and attach the button so the owner can set it in place. ``default_service`` and ``default_keys`` pre-fill the modal with the service and key names the cog expects.
 
 .. code-block:: python
 
     from redbot.core.utils.views import SetApiView
 
     class MyCog(commands.Cog):
-        @commands.is_owner()
         @commands.command()
-        async def setyoutube(self, ctx: commands.Context):
-            default_keys = {"api_key": ""}
-            view = SetApiView(default_service="youtube", default_keys=default_keys)
-            await ctx.send("Use the button below to enter your YouTube API key.", view=view)
+        async def weather(self, ctx: commands.Context, *, city: str):
+            tokens = await self.bot.get_shared_api_tokens("weather")
+            if not tokens.get("api_key"):
+                view = SetApiView(default_service="weather", default_keys={"api_key": ""})
+                await ctx.send(
+                    "The weather API key has not been set. "
+                    "Use the button below to set it (bot owner only).",
+                    view=view,
+                )
+                return
+            # use tokens["api_key"] as normal
 
-``default_service`` pre-fills and locks the service name, so the owner only enters the keys. Omit it to let the owner choose the service themselves. ``default_keys`` is a mapping of the key names the service expects (the values may be empty); it pre-populates the modal and restricts saving to those key names.
+``default_service`` pre-fills and locks the service name. ``default_keys`` is a mapping of the key names the service expects (values may be empty) and pre-populates the modal. The owner enters one ``key value`` pair per line, keeping the key label; for the example above the field is pre-filled with ``api_key YOUR_API_KEY``, and replacing the line with just the value is rejected. On submit the tokens are saved with ``set_shared_api_tokens``.
 
-The owner enters one ``key value`` pair per line in the modal. For the example above the field is pre-filled with ``api_key YOUR_API_KEY``, and the ``api_key`` label must be kept when replacing the placeholder value. On submit, the tokens are saved for the service the same way as ``set_shared_api_tokens``.
-
-To embed the prompt in a custom ``discord.ui.View``, use ``SetApiModal`` directly and send it with ``interaction.response.send_modal(...)``. Both ``SetApiView`` and ``SetApiModal`` are owner-only.
+To embed the prompt in a custom ``discord.ui.View``, use ``SetApiModal`` directly and send it with ``interaction.response.send_modal(...)``. ``SetApiView`` and ``SetApiModal`` are both owner-only.
 
 
 ***************

--- a/docs/framework_apikeys.rst
+++ b/docs/framework_apikeys.rst
@@ -48,6 +48,31 @@ Basic Usage
             # Use the API key to access content as you normally would
 
 
+**********************
+Prompting for API Keys
+**********************
+
+Instead of asking the bot owner to type ``[p]set api ...`` by hand, a cog can prompt them with a secure button using ``SetApiView`` from ``redbot.core.utils.views``. It shows an owner-only button that opens a modal where the keys are entered, and saves them with ``set_shared_api_tokens`` when submitted.
+
+.. code-block:: python
+
+    from redbot.core.utils.views import SetApiView
+
+    class MyCog(commands.Cog):
+        @commands.is_owner()
+        @commands.command()
+        async def setyoutube(self, ctx: commands.Context):
+            default_keys = {"api_key": ""}
+            view = SetApiView(default_service="youtube", default_keys=default_keys)
+            await ctx.send("Use the button below to enter your YouTube API key.", view=view)
+
+``default_service`` pre-fills and locks the service name, so the owner only enters the keys. Omit it to let the owner choose the service themselves. ``default_keys`` is a mapping of the key names the service expects (the values may be empty); it pre-populates the modal and restricts saving to those key names.
+
+The owner enters one ``key value`` pair per line in the modal. For the example above the field is pre-filled with ``api_key YOUR_API_KEY``, and the ``api_key`` label must be kept when replacing the placeholder value. On submit, the tokens are saved for the service the same way as ``set_shared_api_tokens``.
+
+To embed the prompt in a custom ``discord.ui.View``, use ``SetApiModal`` directly and send it with ``interaction.response.send_modal(...)``. Both ``SetApiView`` and ``SetApiModal`` are owner-only.
+
+
 ***************
 Event Reference
 ***************

--- a/docs/framework_apikeys.rst
+++ b/docs/framework_apikeys.rst
@@ -39,7 +39,7 @@ Basic Usage
 
 .. code-block:: python
 
-    class MyCog:
+    class MyCog(commands.Cog):
         @commands.command()
         async def youtube(self, ctx, user: str):
             youtube_keys = await self.bot.get_shared_api_tokens("youtube")


### PR DESCRIPTION
Adds a "Prompting for API Keys" section to the Shared API Keys guide, covering `SetApiView` / `SetApiModal`.

Closes #6114

### Description of the changes

The guide only covers the `[p]set api` route and reading tokens back in code - nothing about `SetApiView`/`SetApiModal` in `redbot.core.utils.views`, which are a handy way to let a cog prompt the owner for keys via a secure button + modal instead of typing them in chat.

The new section covers:

- `SetApiView` with `default_service` / `default_keys` to prompt for a service's keys
- the modal's `key value`-per-line format, and that you keep the pre-filled key label (typing just the value gets rejected - this caught me out at first)
- `SetApiModal` for embedding in a custom `discord.ui.View`
- both being owner-only

Docs only, no code changes.

### Have the changes in this PR been tested?

Yes
