### PR TITLE
Downloader: report repo folders that fail to load, instead of silent drop

### DIFF
--- a/redbot/cogs/downloader/downloader.py
+++ b/redbot/cogs/downloader/downloader.py
@@ -247,6 +247,10 @@ class Downloader(commands.Cog):
                     ),
                 )
 
+        failed_to_load = _downloader._repo_manager.repos_failed_to_load
+        if failed_to_load:
+            joined += "\n" + self.format_repos_failed_to_load(failed_to_load)
+
         for page in pagify(joined, ["\n"], shorten_by=16):
             await ctx.send(page)
 
@@ -821,6 +825,10 @@ class Downloader(commands.Cog):
         if update_result.failed_repos:
             message += "\n" + self.format_failed_repos(update_result.failed_repos)
 
+        failed_to_load = _downloader._repo_manager.repos_failed_to_load
+        if failed_to_load:
+            message += "\n" + self.format_repos_failed_to_load(failed_to_load)
+
         repos_with_libs = {
             inline(module.repo.name)
             for module in update_result.updated_modules
@@ -1250,6 +1258,39 @@ class Downloader(commands.Cog):
         message += _(
             "The repository's branch might have been removed or"
             " the repository is no longer accessible at set url."
+            " See logs for more information."
+        )
+        return message
+
+    @staticmethod
+    def format_repos_failed_to_load(failed: Collection[str]) -> str:
+        """Format collection of repo folder names that could not be loaded as repos.
+
+        Parameters
+        ----------
+        failed : Collection
+            Collection of repo folder names.
+
+        Returns
+        -------
+        str
+            formatted message
+        """
+
+        message = (
+            _(
+                "The following folders in your repos folder could not be loaded"
+                " as installed repos:"
+            )
+            if len(failed) > 1
+            else _(
+                "The following folder in your repos folder could not be loaded"
+                " as an installed repo:"
+            )
+        )
+        message += " " + humanize_list(tuple(map(inline, failed))) + "\n"
+        message += _(
+            "This can happen if, for example, the folder's permissions were changed."
             " See logs for more information."
         )
         return message

--- a/redbot/core/_downloader/repo_manager.py
+++ b/redbot/core/_downloader/repo_manager.py
@@ -1018,6 +1018,7 @@ class RepoManager:
 
     def __init__(self) -> None:
         self._repos: Dict[str, Repo] = {}
+        self._repos_failed_to_load: Tuple[str, ...] = ()
         self.config = Config.get_conf(self, identifier=170708480, force_registration=True)
         self.config.register_global(repos={})
 
@@ -1093,6 +1094,18 @@ class RepoManager:
     @property
     def repos(self) -> Tuple[Repo, ...]:
         return tuple(self._repos.values())
+
+    @property
+    def repos_failed_to_load(self) -> Tuple[str, ...]:
+        """Names of folders in the repos folder that could not be loaded as repos.
+
+        This is refreshed every time repos are (re)loaded, i.e. on bot startup.
+        A non-empty value usually means something is preventing Downloader from
+        reading one or more installed repos (such as incorrect file permissions
+        on the repos folder or one of its subfolders). See the bot's logs for
+        the actual error(s).
+        """
+        return self._repos_failed_to_load
 
     def get_all_repo_names(self) -> Tuple[str, ...]:
         """Get all repo names.
@@ -1212,6 +1225,7 @@ class RepoManager:
 
     async def _load_repos(self, set_repos: bool = False) -> Dict[str, Repo]:
         ret = {}
+        failed_to_load = []
         self.repos_folder.mkdir(parents=True, exist_ok=True)
         for folder in self.repos_folder.iterdir():
             if not folder.is_dir():
@@ -1221,8 +1235,18 @@ class RepoManager:
                 ret[folder.name] = await Repo.from_folder(folder, branch)
                 if branch == "":
                     await self.config.repos.set_raw(folder.name, value=ret[folder.name].branch)
-            except errors.NoRemoteURL:
-                log.warning("A remote URL does not exist for repo %s", folder.name)
+            except errors.NoRemoteURL as err:
+                log.warning(
+                    "A remote URL does not exist for repo %s."
+                    " If this is unexpected, this may indicate a problem (such as"
+                    " incorrect file permissions on this repo's folder) preventing"
+                    " Downloader from reading it rather than the folder actually"
+                    " lacking a git remote - see the error logged above, if any,"
+                    " for more information.",
+                    folder.name,
+                    exc_info=err,
+                )
+                failed_to_load.append(folder.name)
             except errors.DownloaderException as err:
                 log.error("Ignoring repo %s due to error.", folder.name, exc_info=err)
                 # Downloader should NOT remove the repo on generic errors like this one.
@@ -1230,7 +1254,9 @@ class RepoManager:
                 # but it's quite destructive for such a generic error.
                 # We can't **expect** that this error will always mean git repository is broken.
                 # GH-3867
+                failed_to_load.append(folder.name)
 
+        self._repos_failed_to_load = tuple(failed_to_load)
         if set_repos:
             self._repos = ret
         return ret

--- a/tests/core/_downloader/test_downloader.py
+++ b/tests/core/_downloader/test_downloader.py
@@ -15,6 +15,7 @@ from redbot.core._downloader.errors import (
     AmbiguousRevision,
     ExistingGitRepo,
     GitException,
+    NoRemoteURL,
     UnknownRevision,
 )
 
@@ -413,3 +414,43 @@ def test_tree_url_non_github(repo_manager):
 
     for test_case in cases:
         assert test_case["expected"] == repo_manager._parse_url(*test_case["input"])
+
+
+async def test_load_repos_reports_repos_that_fail_to_load(mocker, repo_manager, tmp_path):
+    """Regression test for GH-6635.
+
+    A folder in the repos directory that Downloader can't read as a repo (for
+    example because of a permission error) must not just silently vanish -
+    its name should end up in ``RepoManager.repos_failed_to_load`` so command
+    output (e.g. ``[p]repo list``) can point the bot owner at the logs instead
+    of just claiming there are no repos installed.
+    """
+    repos_folder = tmp_path / "repos"
+    mocker.patch.object(
+        type(repo_manager),
+        "repos_folder",
+        new_callable=mocker.PropertyMock,
+        return_value=repos_folder,
+    )
+    (repos_folder / "good_repo").mkdir(parents=True)
+    (repos_folder / "broken_repo").mkdir()
+
+    async def fake_current_url(self, folder=None):
+        if self.name == "broken_repo":
+            # This is what `Repo.current_url()` actually raises when the
+            # underlying `git remote get-url origin` call fails for any
+            # reason, including a permission error that stops git from
+            # reading the repo folder at all.
+            raise NoRemoteURL("Unable to discover a repo URL.", "git remote get-url origin")
+        return "https://example.com/example/good_repo.git"
+
+    mocker.patch.object(Repo, "current_url", autospec=True, side_effect=fake_current_url)
+    mocker.patch.object(Repo, "current_branch", autospec=True, return_value="main")
+    mocker.patch.object(Repo, "_update_available_modules", autospec=True, return_value=())
+
+    ret = await repo_manager._load_repos(set_repos=True)
+
+    assert set(ret) == {"good_repo"}
+    assert repo_manager.repos_failed_to_load == ("broken_repo",)
+    assert repo_manager.get_repo("good_repo") is not None
+    assert repo_manager.get_repo("broken_repo") is None


### PR DESCRIPTION
Fixes #6635.

When Downloader loads repos on startup, any folder it can't turn into a working `Repo` gets silently dropped from `RepoManager._load_repos` - only trace left is a startup log line. Nothing reaches the commands people actually check: `[p]repo list` just says "There are no repos installed," `[p]cog update` says "There were no cogs to check," no hint anything went wrong.

Traced what happens when someone chowns their repos folder (per the issue's repro): `Repo.from_folder` calls `current_url()`, which runs `git config --get remote.origin.url`; git can't read the folder, so it exits non-zero, and `current_url()` turns any non-zero exit into `NoRemoteURL` regardless of cause - a real permission error and "not a git repo at all" look identical to `_load_repos`, both just a quiet warning with no detail.

Kept `_load_repos`'s existing swallow-and-continue behavior as-is (deliberately generic per GH-3867 - Downloader shouldn't assume one repo's load failure means it's actually broken) rather than trying to classify git errors more precisely. `RepoManager` now keeps a `repos_failed_to_load` tuple, populated on every `_load_repos` call; `[p]repo list` and `[p]cog update`/`updateallcogs` append a note listing those folders and pointing at the logs when it's non-empty, following the existing `format_failed_repos`/`failed_repos` pattern this cog already uses for update failures. Also added `exc_info` to the `NoRemoteURL` warning so the actual git failure is easier to correlate with which repo triggered it.

Added `test_load_repos_reports_repos_that_fail_to_load`: mocks `Repo.current_url` to raise the exact `NoRemoteURL` the real code hits for an unreadable folder, checks the broken folder lands in `repos_failed_to_load` while still excluded from loaded repos. Confirmed it fails with `AttributeError: 'RepoManager' object has no attribute 'repos_failed_to_load'` against current code, passes with this change.

Co-authored with Claude Code (Anthropic); reviewed by @si-kui-a before submission.

